### PR TITLE
Increase default limit for recentlyAddedIntake to 100.

### DIFF
--- a/lib/core/data/data_source/intake_data_source.dart
+++ b/lib/core/data/data_source/intake_data_source.dart
@@ -34,7 +34,7 @@ class IntakeDataSource {
         .toList();
   }
 
-  Future<List<IntakeDBO>> getRecentlyAddedIntake({int number = 20}) async {
+  Future<List<IntakeDBO>> getRecentlyAddedIntake({int number = 100}) async {
     final intakeList = _intakeBox.values.toList().reversed;
 
     //  sort list by date and filter unique intake


### PR DESCRIPTION
We are using the app quite intensively and would love to have a quick solution for not having our recents disappear after a day or two.

In the next week I can try to change it to have the list reload more items when it reaches the bottom. This would also be useful for the other lists. But this PR would already help us so much.