### PR TITLE
Add a minimal implementation of Harvard meal guidelines

### DIFF
--- a/lib/generated/intl/messages_en.dart
+++ b/lib/generated/intl/messages_en.dart
@@ -68,7 +68,7 @@ class MessageLookup extends MessageLookupByLibrary {
         "buttonStartLabel": MessageLookupByLibrary.simpleMessage("START"),
         "buttonYesLabel": MessageLookupByLibrary.simpleMessage("YES"),
         "calculationsMacronutrientsDistributionLabel":
-            MessageLookupByLibrary.simpleMessage("Macros distribution"),
+            MessageLookupByLibrary.simpleMessage("Meal guidelines"),
         "calculationsMacrosDistribution": m1,
         "calculationsRecommendedLabel":
             MessageLookupByLibrary.simpleMessage("(recommended)"),


### PR DESCRIPTION
Please, ignore this PR until it is no longer a draft. I have zero experience with this tech stack, so it is going to take me a while to figure things out.

To do:
-   [ ] Rename “Macros distribution” to “Meal guidelines”.
    -   [x] Do it wrong.
    -   [ ] Figure how internationalization works and/or how to trigger an update of the `generated` folder, and make the change properly, also renaming the message ID accordingly.
-   [ ] Implement a “Harvard (experimental)” entry under “Meal guidelines”.
-   [ ] Harvard: remove the [carbohydrate](https://www.hsph.harvard.edu/nutritionsource/carbohydrates/) requirement, to be replaced with other requirements later.
-   [ ] Harvard: replace fats with poly fats, and [require 0.08 of energy](https://www.hsph.harvard.edu/nutritionsource/what-should-you-eat/fats-and-cholesterol/types-of-fat/).
-   [ ] Harvard: calculate min protein as [max(0.1 of energy, 0.8 g * weight in kg)](https://www.hsph.harvard.edu/nutritionsource/what-should-you-eat/fats-and-cholesterol/types-of-fat/).
-   [ ] Harvard: add a [25 g of fiber requirement](https://www.hsph.harvard.edu/nutritionsource/carbohydrates/fiber/).