### PR TITLE
Enable decimal keyboard for edit meal on ios

### DIFF
--- a/lib/features/edit_meal/presentation/edit_meal_screen.dart
+++ b/lib/features/edit_meal/presentation/edit_meal_screen.dart
@@ -135,7 +135,7 @@ class _EditMealScreenState extends State<EditMealScreen> {
             decoration: InputDecoration(
                 labelText: S.of(context).mealSizeLabel,
                 border: const OutlineInputBorder()),
-            keyboardType: TextInputType.number,
+            keyboardType: TextInputType.numberWithOptions(decimal: true),
           ),
           const SizedBox(height: 16),
           TextFormField(
@@ -144,7 +144,7 @@ class _EditMealScreenState extends State<EditMealScreen> {
             decoration: InputDecoration(
                 labelText: S.of(context).servingSizeLabel,
                 border: const OutlineInputBorder()),
-            keyboardType: TextInputType.number,
+            keyboardType: TextInputType.numberWithOptions(decimal: true),
           ),
           const SizedBox(height: 16),
           DropdownButtonFormField(
@@ -164,7 +164,7 @@ class _EditMealScreenState extends State<EditMealScreen> {
             decoration: InputDecoration(
                 labelText: S.of(context).mealKcalLabel,
                 border: const OutlineInputBorder()),
-            keyboardType: TextInputType.number,
+            keyboardType: TextInputType.numberWithOptions(decimal: true),
           ),
           const SizedBox(height: 16),
           TextFormField(
@@ -173,7 +173,7 @@ class _EditMealScreenState extends State<EditMealScreen> {
             decoration: InputDecoration(
                 labelText: S.of(context).mealCarbsLabel,
                 border: const OutlineInputBorder()),
-            keyboardType: TextInputType.number,
+            keyboardType: TextInputType.numberWithOptions(decimal: true),
           ),
           const SizedBox(height: 16),
           TextFormField(
@@ -182,7 +182,7 @@ class _EditMealScreenState extends State<EditMealScreen> {
             decoration: InputDecoration(
                 labelText: S.of(context).mealFatLabel,
                 border: const OutlineInputBorder()),
-            keyboardType: TextInputType.number,
+            keyboardType: TextInputType.numberWithOptions(decimal: true),
           ),
           const SizedBox(height: 16),
           TextFormField(
@@ -191,7 +191,7 @@ class _EditMealScreenState extends State<EditMealScreen> {
             decoration: InputDecoration(
                 labelText: S.of(context).mealProteinLabel,
                 border: const OutlineInputBorder()),
-            keyboardType: TextInputType.number,
+            keyboardType: TextInputType.numberWithOptions(decimal: true),
           ),
         ],
       ),


### PR DESCRIPTION
When creating a custom meal, I cannot add decimal numbers to kcal/carbs/fat/protein.

Took a look at https://api.flutter.dev/flutter/services/TextInputType/decimal.html on how to edit the text input to support decimals. 

### Before

![image](https://github.com/simonoppowa/OpenNutriTracker/assets/51903586/c60f62b1-25f1-4ac3-bb29-0b8f4d3f5a70)

### After
![image](https://github.com/simonoppowa/OpenNutriTracker/assets/51903586/082cd76c-71b9-4692-a3ea-cca6f1fa05ba)
