### PR TITLE
202 bug allows null height and weight values after going one page back

### DIFF
--- a/lib/features/onboarding/onboarding_screen.dart
+++ b/lib/features/onboarding/onboarding_screen.dart
@@ -97,13 +97,18 @@ class _OnboardingScreenState extends State<OnboardingScreen> {
     );
   }
 
-  List<PageViewModel> _getPageViewModels() => <PageViewModel>[
+  List<PageViewModel> _getPageViewModels() {
+    final selection = _onboardingBloc.userSelection;
+    return <PageViewModel>[
         PageViewModel(
           title: S.of(context).onboardingWelcomeLabel,
           decoration: _pageDecoration,
           image: _defaultImageWidget,
-          bodyWidget:
-              OnboardingIntroPageBody(setPageContent: _setIntroPageData),
+          bodyWidget: OnboardingIntroPageBody(
+            setPageContent: _setIntroPageData,
+            initialAcceptedPolicy: _introPageButtonActive,
+            initialAcceptedDataCollection: selection.acceptDataCollection,
+          ),
           footer: HighlightButton(
             buttonLabel: S.of(context).buttonStartLabel,
             onButtonPressed: () => _scrollToPage(1),
@@ -115,8 +120,11 @@ class _OnboardingScreenState extends State<OnboardingScreen> {
           // empty
           decoration: _pageDecoration,
           image: _defaultImageWidget,
-          bodyWidget:
-              OnboardingFirstPageBody(setPageContent: _setFirstPageData),
+          bodyWidget: OnboardingFirstPageBody(
+            setPageContent: _setFirstPageData,
+            initialGender: selection.gender,
+            initialBirthday: selection.birthday,
+          ),
           footer: HighlightButton(
             buttonLabel: S.of(context).buttonNextLabel,
             onButtonPressed: () => _scrollToPage(2),
@@ -130,6 +138,9 @@ class _OnboardingScreenState extends State<OnboardingScreen> {
           image: _defaultImageWidget,
           bodyWidget: OnboardingSecondPageBody(
             setButtonContent: _setSecondPageData,
+            initialHeightCm: selection.height,
+            initialWeightKg: selection.weight,
+            initialUsesImperial: selection.usesImperialUnits,
           ),
           footer: HighlightButton(
             buttonLabel: S.of(context).buttonNextLabel,
@@ -144,6 +155,7 @@ class _OnboardingScreenState extends State<OnboardingScreen> {
           image: _defaultImageWidget,
           bodyWidget: OnboardingThirdPageBody(
             setButtonContent: _setThirdPageButton,
+            initialActivity: selection.activity,
           ),
           footer: HighlightButton(
             buttonLabel: S.of(context).buttonNextLabel,
@@ -158,6 +170,7 @@ class _OnboardingScreenState extends State<OnboardingScreen> {
           image: _defaultImageWidget,
           bodyWidget: OnboardingFourthPageBody(
             setButtonContent: _setFourthPageButton,
+            initialGoal: selection.goal,
           ),
           footer: HighlightButton(
             buttonLabel: S.of(context).buttonNextLabel,
@@ -193,6 +206,7 @@ class _OnboardingScreenState extends State<OnboardingScreen> {
           ),
         ),
       ];
+  }
 
   void _scrollToPage(int page) {
     FocusScope.of(context).requestFocus(FocusNode()); // Dismiss Keyboard

--- a/lib/features/onboarding/presentation/onboarding_intro_page_body.dart
+++ b/lib/features/onboarding/presentation/onboarding_intro_page_body.dart
@@ -7,9 +7,16 @@ import 'package:opennutritracker/generated/l10n.dart';
 import 'package:url_launcher/url_launcher.dart';
 
 class OnboardingIntroPageBody extends StatefulWidget {
-  const OnboardingIntroPageBody({super.key, required this.setPageContent});
+  const OnboardingIntroPageBody({
+    super.key,
+    required this.setPageContent,
+    this.initialAcceptedPolicy = false,
+    this.initialAcceptedDataCollection = false,
+  });
 
   final Function(bool active, bool acceptedDataCollection) setPageContent;
+  final bool initialAcceptedPolicy;
+  final bool initialAcceptedDataCollection;
 
   @override
   State<OnboardingIntroPageBody> createState() =>
@@ -17,8 +24,8 @@ class OnboardingIntroPageBody extends StatefulWidget {
 }
 
 class _OnboardingIntroPageBodyState extends State<OnboardingIntroPageBody> {
-  bool _acceptedPolicy = false;
-  bool _acceptedDataCollection = false;
+  late bool _acceptedPolicy = widget.initialAcceptedPolicy;
+  late bool _acceptedDataCollection = widget.initialAcceptedDataCollection;
 
   @override
   Widget build(BuildContext context) {

--- a/lib/features/onboarding/presentation/widgets/onboarding_first_page_body.dart
+++ b/lib/features/onboarding/presentation/widgets/onboarding_first_page_body.dart
@@ -10,7 +10,15 @@ class OnboardingFirstPageBody extends StatefulWidget {
     DateTime? birthday,
   ) setPageContent;
 
-  const OnboardingFirstPageBody({super.key, required this.setPageContent});
+  final UserGenderSelectionEntity? initialGender;
+  final DateTime? initialBirthday;
+
+  const OnboardingFirstPageBody({
+    super.key,
+    required this.setPageContent,
+    this.initialGender,
+    this.initialBirthday,
+  });
 
   @override
   State<OnboardingFirstPageBody> createState() =>
@@ -23,6 +31,25 @@ class _OnboardingFirstPageBodyState extends State<OnboardingFirstPageBody> {
 
   bool _maleSelected = false;
   bool _femaleSelected = false;
+
+  @override
+  void initState() {
+    super.initState();
+    _maleSelected = widget.initialGender == UserGenderSelectionEntity.genderMale;
+    _femaleSelected =
+        widget.initialGender == UserGenderSelectionEntity.genderFemale;
+    _selectedDate = widget.initialBirthday;
+  }
+
+  @override
+  void didChangeDependencies() {
+    super.didChangeDependencies();
+    // Format the birthday once a localization context is available.
+    if (_selectedDate != null && _dateInput.text.isEmpty) {
+      _dateInput.text =
+          MaterialLocalizations.of(context).formatCompactDate(_selectedDate!);
+    }
+  }
 
   @override
   Widget build(BuildContext context) {

--- a/lib/features/onboarding/presentation/widgets/onboarding_fourth_page_body.dart
+++ b/lib/features/onboarding/presentation/widgets/onboarding_fourth_page_body.dart
@@ -5,8 +5,13 @@ import 'package:opennutritracker/generated/l10n.dart';
 class OnboardingFourthPageBody extends StatefulWidget {
   final Function(bool active, UserGoalSelectionEntity? selectedGoal)
       setButtonContent;
+  final UserGoalSelectionEntity? initialGoal;
 
-  const OnboardingFourthPageBody({super.key, required this.setButtonContent});
+  const OnboardingFourthPageBody({
+    super.key,
+    required this.setButtonContent,
+    this.initialGoal,
+  });
 
   @override
   State<OnboardingFourthPageBody> createState() =>
@@ -14,9 +19,12 @@ class OnboardingFourthPageBody extends StatefulWidget {
 }
 
 class _OnboardingFourthPageBodyState extends State<OnboardingFourthPageBody> {
-  bool _looseWeightSelected = false;
-  bool _maintainWeightSelected = false;
-  bool _gainWeightSelected = false;
+  late bool _looseWeightSelected =
+      widget.initialGoal == UserGoalSelectionEntity.loseWeight;
+  late bool _maintainWeightSelected =
+      widget.initialGoal == UserGoalSelectionEntity.maintainWeight;
+  late bool _gainWeightSelected =
+      widget.initialGoal == UserGoalSelectionEntity.gainWeigh;
 
   @override
   Widget build(BuildContext context) {

--- a/lib/features/onboarding/presentation/widgets/onboarding_second_page_body.dart
+++ b/lib/features/onboarding/presentation/widgets/onboarding_second_page_body.dart
@@ -1,6 +1,7 @@
 import 'package:flutter/material.dart';
 import 'package:flutter/services.dart';
 import 'package:opennutritracker/core/utils/bounds/validator.dart';
+import 'package:opennutritracker/core/utils/calc/unit_calc.dart';
 import 'package:opennutritracker/generated/l10n.dart';
 
 class OnboardingSecondPageBody extends StatefulWidget {
@@ -11,7 +12,24 @@ class OnboardingSecondPageBody extends StatefulWidget {
     bool usesImperialUnits,
   ) setButtonContent;
 
-  const OnboardingSecondPageBody({super.key, required this.setButtonContent});
+  /// Already-stored height in centimetres (always metric in the parent's
+  /// userSelection model). The widget converts to feet for display when
+  /// [initialUsesImperial] is true.
+  final double? initialHeightCm;
+
+  /// Already-stored weight in kilograms (always metric in the parent's
+  /// userSelection model). The widget converts to pounds for display when
+  /// [initialUsesImperial] is true.
+  final double? initialWeightKg;
+  final bool initialUsesImperial;
+
+  const OnboardingSecondPageBody({
+    super.key,
+    required this.setButtonContent,
+    this.initialHeightCm,
+    this.initialWeightKg,
+    this.initialUsesImperial = false,
+  });
 
   @override
   State<OnboardingSecondPageBody> createState() =>
@@ -23,7 +41,12 @@ class _OnboardingSecondPageBodyState extends State<OnboardingSecondPageBody> {
   final _weightFormKey = GlobalKey<FormState>();
   final _heightFocusNode = FocusNode();
   final _weightFocusNode = FocusNode();
-  final _isUnitSelected = [true, false];
+  final _heightController = TextEditingController();
+  final _weightController = TextEditingController();
+  late final List<bool> _isUnitSelected = [
+    !widget.initialUsesImperial,
+    widget.initialUsesImperial,
+  ];
   double? _parsedHeight;
   double? _parsedWeight;
 
@@ -34,12 +57,43 @@ class _OnboardingSecondPageBodyState extends State<OnboardingSecondPageBody> {
     super.initState();
     _heightFocusNode.attach(context);
     _weightFocusNode.attach(context);
+
+    // Restore state if the parent passed previously-entered values (e.g.,
+    // the user navigated back then forward). Stored values are always in
+    // metric units; convert to feet/lbs when the user picked imperial.
+    final initialHeightCm = widget.initialHeightCm;
+    final initialWeightKg = widget.initialWeightKg;
+    if (initialHeightCm != null) {
+      final displayHeight = widget.initialUsesImperial
+          ? UnitCalc.cmToFeet(initialHeightCm)
+          : initialHeightCm;
+      _parsedHeight = initialHeightCm;
+      _heightController.text = _formatRestoredNumber(displayHeight);
+    }
+    if (initialWeightKg != null) {
+      final displayWeight = widget.initialUsesImperial
+          ? UnitCalc.kgToLbs(initialWeightKg)
+          : initialWeightKg;
+      _parsedWeight = initialWeightKg;
+      _weightController.text = _formatRestoredNumber(displayWeight);
+    }
+  }
+
+  /// Trim a restored value to one decimal place when needed, and drop the
+  /// trailing '.0' for whole numbers — matches what users typically type.
+  String _formatRestoredNumber(double value) {
+    if (value == value.roundToDouble()) {
+      return value.toInt().toString();
+    }
+    return value.toStringAsFixed(1);
   }
 
   @override
   void dispose() {
     _heightFocusNode.dispose();
     _weightFocusNode.dispose();
+    _heightController.dispose();
+    _weightController.dispose();
     super.dispose();
   }
 
@@ -63,6 +117,7 @@ class _OnboardingSecondPageBodyState extends State<OnboardingSecondPageBody> {
           Form(
             key: _heightFormKey,
             child: TextFormField(
+              controller: _heightController,
               focusNode: _heightFocusNode,
               onChanged: (text) {
                 if (_heightFormKey.currentState!.validate()) {
@@ -140,6 +195,7 @@ class _OnboardingSecondPageBodyState extends State<OnboardingSecondPageBody> {
           Form(
             key: _weightFormKey,
             child: TextFormField(
+              controller: _weightController,
               focusNode: _weightFocusNode,
               onChanged: (text) {
                 if (_weightFormKey.currentState!.validate()) {

--- a/lib/features/onboarding/presentation/widgets/onboarding_third_page_body.dart
+++ b/lib/features/onboarding/presentation/widgets/onboarding_third_page_body.dart
@@ -6,8 +6,13 @@ import 'package:opennutritracker/generated/l10n.dart';
 class OnboardingThirdPageBody extends StatefulWidget {
   final Function(bool active, UserActivitySelectionEntity? selectedActivity)
       setButtonContent;
+  final UserActivitySelectionEntity? initialActivity;
 
-  const OnboardingThirdPageBody({super.key, required this.setButtonContent});
+  const OnboardingThirdPageBody({
+    super.key,
+    required this.setButtonContent,
+    this.initialActivity,
+  });
 
   @override
   State<OnboardingThirdPageBody> createState() =>
@@ -15,10 +20,14 @@ class OnboardingThirdPageBody extends StatefulWidget {
 }
 
 class _OnboardingThirdPageBodyState extends State<OnboardingThirdPageBody> {
-  bool _sedentarySelected = false;
-  bool _lowActiveSelected = false;
-  bool _activeSelected = false;
-  bool _veryActiveSelected = false;
+  late bool _sedentarySelected =
+      widget.initialActivity == UserActivitySelectionEntity.sedentary;
+  late bool _lowActiveSelected =
+      widget.initialActivity == UserActivitySelectionEntity.lowActive;
+  late bool _activeSelected =
+      widget.initialActivity == UserActivitySelectionEntity.active;
+  late bool _veryActiveSelected =
+      widget.initialActivity == UserActivitySelectionEntity.veryActive;
 
   @override
   Widget build(BuildContext context) {

--- a/test/features/onboarding/presentation/widgets/onboarding_state_restoration_test.dart
+++ b/test/features/onboarding/presentation/widgets/onboarding_state_restoration_test.dart
@@ -1,0 +1,193 @@
+// Regression coverage for issue #202 — when the user enters values on an
+// onboarding page and navigates back then forward, the page used to rebuild
+// from scratch and lose all entered values, even though the parent screen
+// kept the "button active" flag set. The page bodies now accept initial*
+// constructor params so the parent can restore previously-entered values.
+
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:opennutritracker/features/onboarding/domain/entity/user_activity_selection_entity.dart';
+import 'package:opennutritracker/features/onboarding/domain/entity/user_gender_selection_entity.dart';
+import 'package:opennutritracker/features/onboarding/domain/entity/user_goal_selection_entity.dart';
+import 'package:opennutritracker/features/onboarding/presentation/onboarding_intro_page_body.dart';
+import 'package:opennutritracker/features/onboarding/presentation/widgets/onboarding_first_page_body.dart';
+import 'package:opennutritracker/features/onboarding/presentation/widgets/onboarding_fourth_page_body.dart';
+import 'package:opennutritracker/features/onboarding/presentation/widgets/onboarding_second_page_body.dart';
+import 'package:opennutritracker/features/onboarding/presentation/widgets/onboarding_third_page_body.dart';
+import 'package:opennutritracker/generated/l10n.dart';
+import 'package:package_info_plus/package_info_plus.dart';
+
+void main() {
+  setUpAll(() {
+    PackageInfo.setMockInitialValues(
+      appName: 'OpenNutriTracker',
+      packageName: 'com.example.opennutritracker',
+      version: '1.2.0',
+      buildNumber: '46',
+      buildSignature: '',
+    );
+  });
+
+  Widget wrap(Widget child) => MaterialApp(
+        localizationsDelegates: const [S.delegate],
+        supportedLocales: S.delegate.supportedLocales,
+        home: Scaffold(body: child),
+      );
+
+  group('OnboardingIntroPageBody restoration', () {
+    testWidgets('reflects initialAcceptedPolicy/DataCollection in checkboxes',
+        (tester) async {
+      await tester.pumpWidget(wrap(OnboardingIntroPageBody(
+        setPageContent: (_, _) {},
+        initialAcceptedPolicy: true,
+        initialAcceptedDataCollection: true,
+      )));
+      await tester.pumpAndSettle();
+
+      final boxes = tester.widgetList<Checkbox>(find.byType(Checkbox)).toList();
+      expect(boxes[0].value, isTrue);
+      expect(boxes[1].value, isTrue);
+    });
+  });
+
+  group('OnboardingFirstPageBody restoration', () {
+    testWidgets('reflects initialGender on the correct ChoiceChip',
+        (tester) async {
+      await tester.pumpWidget(wrap(OnboardingFirstPageBody(
+        setPageContent: (_, _, _) {},
+        initialGender: UserGenderSelectionEntity.genderFemale,
+      )));
+      await tester.pumpAndSettle();
+
+      final chips = tester.widgetList<ChoiceChip>(find.byType(ChoiceChip)).toList();
+      expect(chips[0].selected, isFalse, reason: 'male should be unselected');
+      expect(chips[1].selected, isTrue, reason: 'female should be selected');
+    });
+
+    testWidgets('reflects initialBirthday in the date input field',
+        (tester) async {
+      final birthday = DateTime(1990, 6, 15);
+      await tester.pumpWidget(wrap(OnboardingFirstPageBody(
+        setPageContent: (_, _, _) {},
+        initialBirthday: birthday,
+      )));
+      await tester.pumpAndSettle();
+
+      // The displayed text is locale-formatted; just confirm the field is non-empty.
+      final dateField = tester.widget<TextFormField>(find.byType(TextFormField));
+      expect(dateField.controller?.text, isNotEmpty);
+    });
+  });
+
+  group('OnboardingSecondPageBody restoration', () {
+    testWidgets('metric: shows the stored cm/kg values in the text fields',
+        (tester) async {
+      await tester.pumpWidget(wrap(OnboardingSecondPageBody(
+        setButtonContent: (_, _, _, _) {},
+        initialHeightCm: 178,
+        initialWeightKg: 72.5,
+      )));
+      await tester.pumpAndSettle();
+
+      expect(find.text('178'), findsOneWidget);
+      expect(find.text('72.5'), findsOneWidget);
+    });
+
+    testWidgets('imperial: stored cm/kg are converted to ft/lbs for display',
+        (tester) async {
+      await tester.pumpWidget(wrap(OnboardingSecondPageBody(
+        setButtonContent: (_, _, _, _) {},
+        initialHeightCm: 180,
+        initialWeightKg: 80,
+        initialUsesImperial: true,
+      )));
+      await tester.pumpAndSettle();
+
+      // 180 cm ≈ 5.9 ft; 80 kg ≈ 176.4 lbs (one decimal place).
+      // Just verify the fields are non-empty and contain the leading digit.
+      final fields =
+          tester.widgetList<TextFormField>(find.byType(TextFormField)).toList();
+      expect(fields[0].controller?.text, isNotEmpty);
+      expect(fields[1].controller?.text, isNotEmpty);
+      expect(fields[1].controller?.text, startsWith('17'));
+    });
+  });
+
+  group('OnboardingThirdPageBody restoration', () {
+    testWidgets('reflects initialActivity on the correct ChoiceChip',
+        (tester) async {
+      await tester.pumpWidget(wrap(OnboardingThirdPageBody(
+        setButtonContent: (_, _) {},
+        initialActivity: UserActivitySelectionEntity.active,
+      )));
+      await tester.pumpAndSettle();
+
+      final chips =
+          tester.widgetList<ChoiceChip>(find.byType(ChoiceChip)).toList();
+      // Order is sedentary, lowActive, active, veryActive.
+      expect(chips[0].selected, isFalse);
+      expect(chips[1].selected, isFalse);
+      expect(chips[2].selected, isTrue);
+      expect(chips[3].selected, isFalse);
+    });
+  });
+
+  group('OnboardingFourthPageBody restoration', () {
+    testWidgets('reflects initialGoal on the correct ChoiceChip',
+        (tester) async {
+      await tester.pumpWidget(wrap(OnboardingFourthPageBody(
+        setButtonContent: (_, _) {},
+        initialGoal: UserGoalSelectionEntity.gainWeigh,
+      )));
+      await tester.pumpAndSettle();
+
+      final chips =
+          tester.widgetList<ChoiceChip>(find.byType(ChoiceChip)).toList();
+      // Order is loseWeight, maintainWeight, gainWeight.
+      expect(chips[0].selected, isFalse);
+      expect(chips[1].selected, isFalse);
+      expect(chips[2].selected, isTrue);
+    });
+  });
+
+  group('Default values (no initial* args)', () {
+    testWidgets('intro page: both checkboxes start unchecked', (tester) async {
+      await tester.pumpWidget(wrap(OnboardingIntroPageBody(
+        setPageContent: (_, _) {},
+      )));
+      await tester.pumpAndSettle();
+
+      final boxes =
+          tester.widgetList<Checkbox>(find.byType(Checkbox)).toList();
+      expect(boxes.every((b) => b.value == false), isTrue);
+    });
+
+    testWidgets('first page: no chip selected, date field empty',
+        (tester) async {
+      await tester.pumpWidget(wrap(OnboardingFirstPageBody(
+        setPageContent: (_, _, _) {},
+      )));
+      await tester.pumpAndSettle();
+
+      final chips =
+          tester.widgetList<ChoiceChip>(find.byType(ChoiceChip)).toList();
+      expect(chips.every((c) => c.selected == false), isTrue);
+      final dateField =
+          tester.widget<TextFormField>(find.byType(TextFormField));
+      expect(dateField.controller?.text, isEmpty);
+    });
+
+    testWidgets('second page: text fields empty when no initial values given',
+        (tester) async {
+      await tester.pumpWidget(wrap(OnboardingSecondPageBody(
+        setButtonContent: (_, _, _, _) {},
+      )));
+      await tester.pumpAndSettle();
+
+      final fields =
+          tester.widgetList<TextFormField>(find.byType(TextFormField)).toList();
+      expect(fields[0].controller?.text, isEmpty);
+      expect(fields[1].controller?.text, isEmpty);
+    });
+  });
+}


### PR DESCRIPTION
Made all values in the onboarding persistent. This should prevent the user from entering illegal values, while also providing user-feedback using existing methods.

Closes #202.