### PR TITLE
Input validation

### DIFF
--- a/lib/core/utils/bounds/ranges_const.dart
+++ b/lib/core/utils/bounds/ranges_const.dart
@@ -1,0 +1,28 @@
+import 'package:opennutritracker/core/utils/calc/unit_calc.dart';
+
+class Ranges{
+  static test(){
+  }
+  //first_page
+  static const Duration maxDurationForBirthdayIntoTheFuture = Duration(days: -1); //values < 0 result a Date in the past
+  static const Duration maxAge = Duration(days: 365 * 130);
+  //second_page
+  static const double maxHeight = 300;
+  static const double minHeight = 30;
+  static const double maxWeight = 640;
+  static const double minWeight = 2;
+  static const bool cmAllowDecimalPlaces = false;
+  static const bool feetAllowDecimalPlaces = true;
+  static const bool kgAllowDecimalPlaces = true;
+  static const bool lbsAllowDecimalPlaces = true;
+
+  //generated
+  static final RegExp cmRegExp = cmAllowDecimalPlaces ? RegExp(r'^[0-9]+([.,][0-9])?$') : RegExp(r'^[0-9]+$');
+  static final RegExp feetRegExp = feetAllowDecimalPlaces ? RegExp(r'^[0-9]+([.,][0-9])?$') : RegExp(r'^[0-9]+$');
+  static final RegExp kgRegExp = kgAllowDecimalPlaces ? RegExp(r'^[0-9]+([.,][0-9])?$') : RegExp(r'^[0-9]+$');
+  static final RegExp lbsRegExp = lbsAllowDecimalPlaces ? RegExp(r'^[0-9]+([.,][0-9])?$') : RegExp(r'^[0-9]+$');
+  static final double maxHeightInFeet = UnitCalc.cmToFeet(maxHeight);
+  static final double minHeightInFeet = UnitCalc.cmToFeet(minHeight);
+  static final double maxWeightInLbs = UnitCalc.kgToLbs(maxWeight);
+  static final double minWeightInLbs = UnitCalc.kgToLbs(minWeight);
+}

--- a/lib/core/utils/bounds/ranges_const.dart
+++ b/lib/core/utils/bounds/ranges_const.dart
@@ -1,26 +1,28 @@
 import 'package:opennutritracker/core/utils/calc/unit_calc.dart';
 
-class Ranges{
-  static test(){
-  }
-  //first_page
-  static const Duration maxDurationForBirthdayIntoTheFuture = Duration(days: -1); //values < 0 result a Date in the past
+class Ranges {
+  static const Duration maxDurationForBirthdayIntoTheFuture = Duration(days: -1);
   static const Duration maxAge = Duration(days: 365 * 130);
-  //second_page
+
   static const double maxHeight = 300;
   static const double minHeight = 30;
   static const double maxWeight = 640;
   static const double minWeight = 2;
+
   static const bool cmAllowDecimalPlaces = false;
   static const bool feetAllowDecimalPlaces = true;
   static const bool kgAllowDecimalPlaces = true;
   static const bool lbsAllowDecimalPlaces = true;
 
-  //generated
-  static final RegExp cmRegExp = cmAllowDecimalPlaces ? RegExp(r'^[0-9]+([.,][0-9])?$') : RegExp(r'^[0-9]+$');
-  static final RegExp feetRegExp = feetAllowDecimalPlaces ? RegExp(r'^[0-9]+([.,][0-9])?$') : RegExp(r'^[0-9]+$');
-  static final RegExp kgRegExp = kgAllowDecimalPlaces ? RegExp(r'^[0-9]+([.,][0-9])?$') : RegExp(r'^[0-9]+$');
-  static final RegExp lbsRegExp = lbsAllowDecimalPlaces ? RegExp(r'^[0-9]+([.,][0-9])?$') : RegExp(r'^[0-9]+$');
+  static final RegExp cmRegExp =
+      cmAllowDecimalPlaces ? RegExp(r'^[0-9]+([.,][0-9])?$') : RegExp(r'^[0-9]+$');
+  static final RegExp feetRegExp =
+      feetAllowDecimalPlaces ? RegExp(r'^[0-9]+([.,][0-9])?$') : RegExp(r'^[0-9]+$');
+  static final RegExp kgRegExp =
+      kgAllowDecimalPlaces ? RegExp(r'^[0-9]+([.,][0-9])?$') : RegExp(r'^[0-9]+$');
+  static final RegExp lbsRegExp =
+      lbsAllowDecimalPlaces ? RegExp(r'^[0-9]+([.,][0-9])?$') : RegExp(r'^[0-9]+$');
+
   static final double maxHeightInFeet = UnitCalc.cmToFeet(maxHeight);
   static final double minHeightInFeet = UnitCalc.cmToFeet(minHeight);
   static final double maxWeightInLbs = UnitCalc.kgToLbs(maxWeight);

--- a/lib/core/utils/bounds/validator.dart
+++ b/lib/core/utils/bounds/validator.dart
@@ -1,0 +1,76 @@
+import 'package:opennutritracker/core/utils/bounds/ranges_const.dart';
+
+import '../calc/unit_calc.dart';
+
+class ValueValidator{
+
+  static String? heightStringValidator(String? value, String wrongHeightLabel, {bool isImperial = false}){
+    if(value == null) return wrongHeightLabel;
+
+    if (isImperial) {
+      if (value.isEmpty || !Ranges.feetRegExp.hasMatch(value)) {
+        return wrongHeightLabel;
+      } else {
+        return null;
+      }
+    } else {
+      if (value.isEmpty || !Ranges.cmRegExp.hasMatch(value)) {
+        return wrongHeightLabel;
+      } else {
+        return null;
+      }
+    }
+  }
+
+  static String? weightStringValidator(String? value, String wrongWeightLabel, {bool isImperial = false}){
+    if(value == null) return wrongWeightLabel;
+
+    if (isImperial) {
+      if (value.isEmpty || !Ranges.lbsRegExp.hasMatch(value)) {
+        return wrongWeightLabel;
+      } else {
+        return null;
+      }
+    } else {
+      if (value.isEmpty || !Ranges.kgRegExp.hasMatch(value)) {
+        return wrongWeightLabel;
+      } else {
+        return null;
+      }
+    }
+  }
+
+  static double? parseHeightInCm(double? height, {bool isImperial = false}){
+    if(height == null) return null;
+    if(isImperial
+        ? height < Ranges.minHeightInFeet
+        : height < Ranges.minHeight
+    || isImperial
+        ? height > Ranges.maxHeightInFeet
+        : height > Ranges.maxHeight) {
+      return null;
+    }
+    return !isImperial ? height : UnitCalc.feetToCm(height);
+  }
+
+  static double? parseWeightInKg(double? weight, {bool isImperial = false}){
+    if(weight == null) return null;
+    if(isImperial
+        ? weight < Ranges.minWeightInLbs
+        : weight < Ranges.minWeight
+    || isImperial
+        ? weight > Ranges.maxWeightInLbs
+        : weight > Ranges.maxWeight) {
+      return null;
+    }
+    return !isImperial ? weight : UnitCalc.lbsToKg(weight);
+  }
+
+  static DateTime getFirstDate(){
+    return DateTime.now().subtract(Ranges.maxAge);
+  }
+
+  static DateTime getLastDate(){
+    return DateTime.now().add(Ranges.maxDurationForBirthdayIntoTheFuture);
+  }
+}

--- a/lib/core/utils/bounds/validator.dart
+++ b/lib/core/utils/bounds/validator.dart
@@ -42,12 +42,10 @@ class ValueValidator{
 
   static double? parseHeightInCm(double? height, {bool isImperial = false}){
     if(height == null) return null;
-    if(isImperial
-        ? height < Ranges.minHeightInFeet
-        : height < Ranges.minHeight
-    || isImperial
-        ? height > Ranges.maxHeightInFeet
-        : height > Ranges.maxHeight) {
+    bool isBelowMin = isImperial ? height < Ranges.minHeightInFeet : height < Ranges.minHeight;
+    bool isAboveMax = isImperial ? height > Ranges.maxHeightInFeet : height > Ranges.maxHeight;
+
+    if (isBelowMin || isAboveMax) {
       return null;
     }
     return !isImperial ? height : UnitCalc.feetToCm(height);
@@ -55,12 +53,10 @@ class ValueValidator{
 
   static double? parseWeightInKg(double? weight, {bool isImperial = false}){
     if(weight == null) return null;
-    if(isImperial
-        ? weight < Ranges.minWeightInLbs
-        : weight < Ranges.minWeight
-    || isImperial
-        ? weight > Ranges.maxWeightInLbs
-        : weight > Ranges.maxWeight) {
+    bool isBelowMin = isImperial ? weight < Ranges.minWeightInLbs : weight < Ranges.minWeight;
+    bool isAboveMax = isImperial ? weight > Ranges.maxWeightInLbs : weight > Ranges.maxWeight;
+
+    if (isBelowMin || isAboveMax) {
       return null;
     }
     return !isImperial ? weight : UnitCalc.lbsToKg(weight);

--- a/lib/core/utils/bounds/validator.dart
+++ b/lib/core/utils/bounds/validator.dart
@@ -1,72 +1,65 @@
 import 'package:opennutritracker/core/utils/bounds/ranges_const.dart';
+import 'package:opennutritracker/core/utils/calc/unit_calc.dart';
 
-import '../calc/unit_calc.dart';
-
-class ValueValidator{
-
-  static String? heightStringValidator(String? value, String wrongHeightLabel, {bool isImperial = false}){
-    if(value == null) return wrongHeightLabel;
-
+class ValueValidator {
+  static String? heightStringValidator(
+    String? value,
+    String wrongHeightLabel, {
+    bool isImperial = false,
+  }) {
+    if (value == null) return wrongHeightLabel;
     if (isImperial) {
       if (value.isEmpty || !Ranges.feetRegExp.hasMatch(value)) {
         return wrongHeightLabel;
-      } else {
-        return null;
       }
     } else {
       if (value.isEmpty || !Ranges.cmRegExp.hasMatch(value)) {
         return wrongHeightLabel;
-      } else {
-        return null;
       }
     }
+    return null;
   }
 
-  static String? weightStringValidator(String? value, String wrongWeightLabel, {bool isImperial = false}){
-    if(value == null) return wrongWeightLabel;
-
+  static String? weightStringValidator(
+    String? value,
+    String wrongWeightLabel, {
+    bool isImperial = false,
+  }) {
+    if (value == null) return wrongWeightLabel;
     if (isImperial) {
       if (value.isEmpty || !Ranges.lbsRegExp.hasMatch(value)) {
         return wrongWeightLabel;
-      } else {
-        return null;
       }
     } else {
       if (value.isEmpty || !Ranges.kgRegExp.hasMatch(value)) {
         return wrongWeightLabel;
-      } else {
-        return null;
       }
     }
+    return null;
   }
 
-  static double? parseHeightInCm(double? height, {bool isImperial = false}){
-    if(height == null) return null;
-    bool isBelowMin = isImperial ? height < Ranges.minHeightInFeet : height < Ranges.minHeight;
-    bool isAboveMax = isImperial ? height > Ranges.maxHeightInFeet : height > Ranges.maxHeight;
-
-    if (isBelowMin || isAboveMax) {
-      return null;
-    }
-    return !isImperial ? height : UnitCalc.feetToCm(height);
+  static double? parseHeightInCm(double? height, {bool isImperial = false}) {
+    if (height == null) return null;
+    final belowMin =
+        isImperial ? height < Ranges.minHeightInFeet : height < Ranges.minHeight;
+    final aboveMax =
+        isImperial ? height > Ranges.maxHeightInFeet : height > Ranges.maxHeight;
+    if (belowMin || aboveMax) return null;
+    return isImperial ? UnitCalc.feetToCm(height) : height;
   }
 
-  static double? parseWeightInKg(double? weight, {bool isImperial = false}){
-    if(weight == null) return null;
-    bool isBelowMin = isImperial ? weight < Ranges.minWeightInLbs : weight < Ranges.minWeight;
-    bool isAboveMax = isImperial ? weight > Ranges.maxWeightInLbs : weight > Ranges.maxWeight;
-
-    if (isBelowMin || isAboveMax) {
-      return null;
-    }
-    return !isImperial ? weight : UnitCalc.lbsToKg(weight);
+  static double? parseWeightInKg(double? weight, {bool isImperial = false}) {
+    if (weight == null) return null;
+    final belowMin =
+        isImperial ? weight < Ranges.minWeightInLbs : weight < Ranges.minWeight;
+    final aboveMax =
+        isImperial ? weight > Ranges.maxWeightInLbs : weight > Ranges.maxWeight;
+    if (belowMin || aboveMax) return null;
+    return isImperial ? UnitCalc.lbsToKg(weight) : weight;
   }
 
-  static DateTime getFirstDate(){
-    return DateTime.now().subtract(Ranges.maxAge);
-  }
+  static DateTime getFirstDate() => DateTime.now().subtract(Ranges.maxAge);
 
-  static DateTime getLastDate(){
-    return DateTime.now().add(Ranges.maxDurationForBirthdayIntoTheFuture);
-  }
+  static DateTime getLastDate() =>
+      DateTime.now().add(Ranges.maxDurationForBirthdayIntoTheFuture);
 }

--- a/lib/features/onboarding/presentation/widgets/onboarding_first_page_body.dart
+++ b/lib/features/onboarding/presentation/widgets/onboarding_first_page_body.dart
@@ -1,5 +1,6 @@
 import 'package:flutter/material.dart';
 import 'package:intl/intl.dart';
+import 'package:opennutritracker/core/utils/bounds/validator.dart';
 import 'package:opennutritracker/features/onboarding/domain/entity/user_gender_selection_entity.dart';
 import 'package:opennutritracker/generated/l10n.dart';
 
@@ -96,9 +97,9 @@ class _OnboardingFirstPageBodyState extends State<OnboardingFirstPageBody> {
   void onDateInputClicked() async {
     final pickedDate = await showDatePicker(
       context: context,
-      initialDate: DateTime.now(),
-      firstDate: DateTime(1900),
-      lastDate: DateTime(2100),
+      initialDate: ValueValidator.getLastDate(),
+      firstDate: ValueValidator.getFirstDate(),
+      lastDate: ValueValidator.getLastDate(),
     );
     if (pickedDate != null) {
       String formattedDate = DateFormat('yyyy-MM-dd').format(pickedDate);
@@ -117,11 +118,8 @@ class _OnboardingFirstPageBodyState extends State<OnboardingFirstPageBody> {
     } else if (_femaleSelected) {
       selectedGender = UserGenderSelectionEntity.genderFemale;
     }
-
-    if (selectedGender != null && _selectedDate != null) {
-      widget.setPageContent(true, selectedGender, _selectedDate);
-    } else {
-      widget.setPageContent(false, null, null);
-    }
+    selectedGender != null && _selectedDate != null
+        ? widget.setPageContent(true, selectedGender, _selectedDate)
+        : widget.setPageContent(false, null, null);
   }
 }

--- a/lib/features/onboarding/presentation/widgets/onboarding_first_page_body.dart
+++ b/lib/features/onboarding/presentation/widgets/onboarding_first_page_body.dart
@@ -100,15 +100,14 @@ class _OnboardingFirstPageBodyState extends State<OnboardingFirstPageBody> {
       firstDate: ValueValidator.getFirstDate(),
       lastDate: ValueValidator.getLastDate(),
     );
-    if (pickedDate != null) {
-      final MaterialLocalizations localizations = MaterialLocalizations.of(context);
-      String formattedDate = localizations.formatCompactDate(pickedDate);
-      setState(() {
-        _selectedDate = pickedDate;
-        _dateInput.text = formattedDate;
-        checkCorrectInput();
-      });
-    }
+    if (pickedDate == null || !mounted) return;
+    final localizations = MaterialLocalizations.of(context);
+    final formattedDate = localizations.formatCompactDate(pickedDate);
+    setState(() {
+      _selectedDate = pickedDate;
+      _dateInput.text = formattedDate;
+      checkCorrectInput();
+    });
   }
 
   void checkCorrectInput() {

--- a/lib/features/onboarding/presentation/widgets/onboarding_first_page_body.dart
+++ b/lib/features/onboarding/presentation/widgets/onboarding_first_page_body.dart
@@ -1,5 +1,4 @@
 import 'package:flutter/material.dart';
-import 'package:intl/intl.dart';
 import 'package:opennutritracker/core/utils/bounds/validator.dart';
 import 'package:opennutritracker/features/onboarding/domain/entity/user_gender_selection_entity.dart';
 import 'package:opennutritracker/generated/l10n.dart';
@@ -102,7 +101,8 @@ class _OnboardingFirstPageBodyState extends State<OnboardingFirstPageBody> {
       lastDate: ValueValidator.getLastDate(),
     );
     if (pickedDate != null) {
-      String formattedDate = DateFormat('yyyy-MM-dd').format(pickedDate);
+      final MaterialLocalizations localizations = MaterialLocalizations.of(context);
+      String formattedDate = localizations.formatCompactDate(pickedDate);
       setState(() {
         _selectedDate = pickedDate;
         _dateInput.text = formattedDate;

--- a/lib/features/onboarding/presentation/widgets/onboarding_second_page_body.dart
+++ b/lib/features/onboarding/presentation/widgets/onboarding_second_page_body.dart
@@ -206,19 +206,27 @@ class _OnboardingSecondPageBodyState extends State<OnboardingSecondPageBody> {
   }
 
   String? validateHeight(String? value) {
-    return ValueValidator.heightStringValidator(
-      value,
-      S.of(context).onboardingWrongHeightLabel,
-      isImperial: _isImperialSelected,
-    );
+    final label = S.of(context).onboardingWrongHeightLabel;
+    if (ValueValidator.heightStringValidator(value, label, isImperial: _isImperialSelected) != null) {
+      return label;
+    }
+    final parsed = double.tryParse(value!.replaceAll(',', '.'));
+    if (ValueValidator.parseHeightInCm(parsed, isImperial: _isImperialSelected) == null) {
+      return label;
+    }
+    return null;
   }
 
   String? validateWeight(String? value) {
-    return ValueValidator.weightStringValidator(
-      value,
-      S.of(context).onboardingWrongWeightLabel,
-      isImperial: _isImperialSelected,
-    );
+    final label = S.of(context).onboardingWrongWeightLabel;
+    if (ValueValidator.weightStringValidator(value, label, isImperial: _isImperialSelected) != null) {
+      return label;
+    }
+    final parsed = double.tryParse(value!);
+    if (ValueValidator.parseWeightInKg(parsed, isImperial: _isImperialSelected) == null) {
+      return label;
+    }
+    return null;
   }
 
   void checkCorrectInput() {

--- a/lib/features/onboarding/presentation/widgets/onboarding_second_page_body.dart
+++ b/lib/features/onboarding/presentation/widgets/onboarding_second_page_body.dart
@@ -1,6 +1,6 @@
 import 'package:flutter/material.dart';
 import 'package:flutter/services.dart';
-import 'package:opennutritracker/core/utils/calc/unit_calc.dart';
+import 'package:opennutritracker/core/utils/bounds/validator.dart';
 import 'package:opennutritracker/generated/l10n.dart';
 
 class OnboardingSecondPageBody extends StatefulWidget {
@@ -66,7 +66,10 @@ class _OnboardingSecondPageBodyState extends State<OnboardingSecondPageBody> {
               focusNode: _heightFocusNode,
               onChanged: (text) {
                 if (_heightFormKey.currentState!.validate()) {
-                  _parsedHeight = double.tryParse(text.replaceAll(',', '.'));
+                  _parsedHeight = ValueValidator.parseHeightInCm(
+                    double.tryParse(text.replaceAll(',', '.')),
+                    isImperial: _isImperialSelected,
+                  );
                   checkCorrectInput();
                 } else {
                   _parsedHeight = null;
@@ -105,7 +108,6 @@ class _OnboardingSecondPageBodyState extends State<OnboardingSecondPageBody> {
               isSelected: _isUnitSelected,
               onPressed: (int index) {
                 setState(() {
-                  // Toggle height unit
                   for (int i = 0; i < _isUnitSelected.length; i++) {
                     _isUnitSelected[i] = i == index;
                   }
@@ -141,9 +143,13 @@ class _OnboardingSecondPageBodyState extends State<OnboardingSecondPageBody> {
               focusNode: _weightFocusNode,
               onChanged: (text) {
                 if (_weightFormKey.currentState!.validate()) {
-                  _parsedWeight = double.tryParse(text);
+                  _parsedWeight = ValueValidator.parseWeightInKg(
+                    double.tryParse(text),
+                    isImperial: _isImperialSelected,
+                  );
                   checkCorrectInput();
                 } else {
+                  _parsedWeight = null;
                   checkCorrectInput();
                 }
               },
@@ -175,7 +181,6 @@ class _OnboardingSecondPageBodyState extends State<OnboardingSecondPageBody> {
               isSelected: _isUnitSelected,
               onPressed: (int index) {
                 setState(() {
-                  // Toggle height unit
                   for (int i = 0; i < _isUnitSelected.length; i++) {
                     _isUnitSelected[i] = i == index;
                   }
@@ -201,52 +206,27 @@ class _OnboardingSecondPageBodyState extends State<OnboardingSecondPageBody> {
   }
 
   String? validateHeight(String? value) {
-    if (value == null) return S.of(context).onboardingWrongHeightLabel;
-
-    if (_isImperialSelected) {
-      // Regex for feet and inches
-      if (value.isEmpty || !RegExp(r'^[0-9]+([.,][0-9])?$').hasMatch(value)) {
-        return S.of(context).onboardingWrongHeightLabel;
-      } else {
-        return null;
-      }
-    } else {
-      // Regex for cm
-      if (value.isEmpty || !RegExp(r'^[0-9]+$').hasMatch(value)) {
-        return S.of(context).onboardingWrongHeightLabel;
-      } else {
-        return null;
-      }
-    }
+    return ValueValidator.heightStringValidator(
+      value,
+      S.of(context).onboardingWrongHeightLabel,
+      isImperial: _isImperialSelected,
+    );
   }
 
   String? validateWeight(String? value) {
-    if (value == null) return S.of(context).onboardingWrongWeightLabel;
-    if (value.isEmpty || !RegExp(r'^[0-9]').hasMatch(value)) {
-      return S.of(context).onboardingWrongWeightLabel;
-    } else {
-      return null;
-    }
+    return ValueValidator.weightStringValidator(
+      value,
+      S.of(context).onboardingWrongWeightLabel,
+      isImperial: _isImperialSelected,
+    );
   }
 
-  /// Check if the input is correct and update the button content
   void checkCorrectInput() {
     final isHeightValid = _heightFormKey.currentState?.validate() ?? false;
     final isWeightValid = _weightFormKey.currentState?.validate() ?? false;
 
-    if (isHeightValid && isWeightValid) {
-      if (_parsedHeight != null && _parsedWeight != null) {
-        final heightCm = _isImperialSelected
-            ? UnitCalc.feetToCm(_parsedHeight!)
-            : _parsedHeight!;
-        final weightKg = _isImperialSelected
-            ? UnitCalc.lbsToKg(_parsedWeight!)
-            : _parsedWeight!;
-
-        widget.setButtonContent(true, heightCm, weightKg, _isImperialSelected);
-      } else {
-        widget.setButtonContent(false, null, null, _isImperialSelected);
-      }
+    if (isHeightValid && isWeightValid && _parsedHeight != null && _parsedWeight != null) {
+      widget.setButtonContent(true, _parsedHeight, _parsedWeight, _isImperialSelected);
     } else {
       widget.setButtonContent(false, null, null, _isImperialSelected);
     }


### PR DESCRIPTION
## Summary

Fixes missing input validation on the onboarding screens (issues #199, #200, #201, #204).

- **Birthday** (page 1): date picker now restricts selection to past dates only — future birthdays can no longer be selected
- **Height** (page 2): rejects `0`, non-numeric input, and values outside 30–300 cm (1.0–9.8 ft)
- **Weight** (page 2): rejects `0`, non-numeric input, and values outside 2–640 kg (4–1411 lbs)
- Date field now displays the date in the locale format used by the picker (via `MaterialLocalizations.formatCompactDate`) rather than the hardcoded `yyyy-MM-dd` format

### New shared utilities

- `lib/core/utils/bounds/ranges_const.dart` — `Ranges` class with min/max constants and compiled `RegExp` patterns for all four units (cm, ft, kg, lbs)
- `lib/core/utils/bounds/validator.dart` — `ValueValidator` with static methods for string validation, range-clamped parsing, and date boundary helpers

### What is NOT changed

- `set_weight_dialog.dart` — already fixed by #303 with proper bounds via `ProfilePickerBounds`; this PR's original patch targeted a now-removed `StatelessWidget` version and has been dropped

## Test plan

- [x] Onboarding page 1: open date picker, verify dates from tomorrow onward are greyed out / unselectable
- [x] Onboarding page 2 (metric): type `0` in height → error label shown, Next button stays disabled
- [x] Onboarding page 2 (metric): type `0` in weight → error label shown, Next button stays disabled
- [x] Onboarding page 2 (imperial): same checks in ft / lbs
- [x] Onboarding page 2: enter a valid height + weight → Next button enables
- [x] Profile weight dialog: still opens and saves correctly (unchanged)
- [x] `fvm flutter analyze` → no issues
- [x] `flutter test` → all tests pass

Fixes #199. Fixes #200. Fixes #201. Fixes #204.