### PR TITLE
Fix onboarding weight validation text and negative profile values

### DIFF
--- a/lib/features/onboarding/presentation/widgets/onboarding_second_page_body.dart
+++ b/lib/features/onboarding/presentation/widgets/onboarding_second_page_body.dart
@@ -197,7 +197,7 @@ class _OnboardingSecondPageBodyState extends State<OnboardingSecondPageBody> {
   String? validateWeight(String? value) {
     if (value == null) return S.of(context).onboardingWrongWeightLabel;
     if (value.isEmpty || !RegExp(r'^[0-9]').hasMatch(value)) {
-      return S.of(context).onboardingWrongHeightLabel;
+      return S.of(context).onboardingWrongWeightLabel;
     } else {
       return null;
     }

--- a/lib/features/profile/presentation/utils/profile_picker_bounds.dart
+++ b/lib/features/profile/presentation/utils/profile_picker_bounds.dart
@@ -14,7 +14,9 @@ double minSelectableHeight(double userHeight, bool usesImperialUnits) {
 
 double maxSelectableHeight(double userHeight, bool usesImperialUnits) {
   final range = usesImperialUnits ? _heightRangeFt : _heightRangeCm;
-  return userHeight + range;
+  final clampedMin = minSelectableHeight(userHeight, usesImperialUnits);
+  final rawMax = userHeight + range;
+  return max(clampedMin + range, rawMax);
 }
 
 double clampHeightSelection(double selectedHeight, double minHeight) {
@@ -28,7 +30,9 @@ double minSelectableWeight(double userWeight, bool usesImperialUnits) {
 
 double maxSelectableWeight(double userWeight, bool usesImperialUnits) {
   final range = usesImperialUnits ? _weightRangeLbs : _weightRangeKg;
-  return userWeight + range;
+  final minWeight = minSelectableWeight(userWeight, usesImperialUnits);
+  final candidateMaxWeight = userWeight + range;
+  return max(minWeight + range, candidateMaxWeight);
 }
 
 double clampWeightSelection(double selectedWeight, double minWeight) {

--- a/lib/features/profile/presentation/utils/profile_picker_bounds.dart
+++ b/lib/features/profile/presentation/utils/profile_picker_bounds.dart
@@ -1,0 +1,36 @@
+import 'dart:math';
+
+const _heightRangeCm = 100.0;
+const _heightRangeFt = 10.0;
+const _weightRangeKg = 50.0;
+const _weightRangeLbs = 100.0;
+const _minHeight = 1.0;
+const _minWeight = 1.0;
+
+double minSelectableHeight(double userHeight, bool usesImperialUnits) {
+  final range = usesImperialUnits ? _heightRangeFt : _heightRangeCm;
+  return max(_minHeight, userHeight - range);
+}
+
+double maxSelectableHeight(double userHeight, bool usesImperialUnits) {
+  final range = usesImperialUnits ? _heightRangeFt : _heightRangeCm;
+  return userHeight + range;
+}
+
+double clampHeightSelection(double selectedHeight, double minHeight) {
+  return max(minHeight, selectedHeight);
+}
+
+double minSelectableWeight(double userWeight, bool usesImperialUnits) {
+  final range = usesImperialUnits ? _weightRangeLbs : _weightRangeKg;
+  return max(_minWeight, userWeight - range);
+}
+
+double maxSelectableWeight(double userWeight, bool usesImperialUnits) {
+  final range = usesImperialUnits ? _weightRangeLbs : _weightRangeKg;
+  return userWeight + range;
+}
+
+double clampWeightSelection(double selectedWeight, double minWeight) {
+  return max(minWeight, selectedWeight);
+}

--- a/lib/features/profile/presentation/widgets/set_height_dialog.dart
+++ b/lib/features/profile/presentation/widgets/set_height_dialog.dart
@@ -1,9 +1,14 @@
+import 'dart:math';
+
 import 'package:flutter/material.dart';
 import 'package:horizontal_picker/horizontal_picker.dart';
 import 'package:opennutritracker/generated/l10n.dart';
 
 class SetHeightDialog extends StatefulWidget {
   static const _heightRangeCM = 100.0;
+  static const _heightRangeFt = 10.0;
+  static const _minHeightCm = 1.0;
+  static const _minHeightFt = 1.0;
   static const _heightRangeFt = 10.0;
 
   final double userHeight;
@@ -30,11 +35,16 @@ class _SetHeightDialogState extends State<SetHeightDialog> {
 
   @override
   Widget build(BuildContext context) {
-    final minValue = widget.usesImperialUnits
-        ? widget.userHeight - SetHeightDialog._heightRangeFt
-        : widget.userHeight - SetHeightDialog._heightRangeCM;
-
-    final maxValue = widget.usesImperialUnits
+    final minHeight = widget.usesImperialUnits
+        ? max(
+            SetHeightDialog._minHeightFt,
+            widget.userHeight - SetHeightDialog._heightRangeFt,
+          )
+        : max(
+            SetHeightDialog._minHeightCm,
+            widget.userHeight - SetHeightDialog._heightRangeCM,
+          );
+    final maxHeight = widget.usesImperialUnits
         ? widget.userHeight + SetHeightDialog._heightRangeFt
         : widget.userHeight + SetHeightDialog._heightRangeCM;
 
@@ -47,17 +57,15 @@ class _SetHeightDialogState extends State<SetHeightDialog> {
               HorizontalPicker(
                 height: 100,
                 backgroundColor: Colors.transparent,
-                // Prevent negative minimum height
-                minValue: minValue < 0 ? 1 : minValue, // setting it to 1, because 0 triggers zero-division error
-                maxValue: maxValue,
+                minValue: minHeight,
+                maxValue: maxHeight,
                 divisions: 400,
                 suffix: widget.usesImperialUnits
                     ? S.of(context).ftLabel
                     : S.of(context).cmLabel,
                 onChanged: (value) {
                   setState(() {
-                    // Prevent negative height values
-                    selectedHeight = value < 0 ? 1 : value;
+                    selectedHeight = value;
                   });
                 },
               ),
@@ -74,8 +82,7 @@ class _SetHeightDialogState extends State<SetHeightDialog> {
         ),
         TextButton(
           onPressed: () {
-            // TODO validate selected height
-            Navigator.pop(context, selectedHeight);
+            Navigator.pop(context, max(minHeight, selectedHeight));
           },
           child: Text(S.of(context).dialogOKLabel),
         ),

--- a/lib/features/profile/presentation/widgets/set_height_dialog.dart
+++ b/lib/features/profile/presentation/widgets/set_height_dialog.dart
@@ -1,16 +1,9 @@
-import 'dart:math';
-
 import 'package:flutter/material.dart';
 import 'package:horizontal_picker/horizontal_picker.dart';
+import 'package:opennutritracker/features/profile/presentation/utils/profile_picker_bounds.dart';
 import 'package:opennutritracker/generated/l10n.dart';
 
 class SetHeightDialog extends StatefulWidget {
-  static const _heightRangeCM = 100.0;
-  static const _heightRangeFt = 10.0;
-  static const _minHeightCm = 1.0;
-  static const _minHeightFt = 1.0;
-  static const _heightRangeFt = 10.0;
-
   final double userHeight;
   final bool usesImperialUnits;
 
@@ -35,18 +28,10 @@ class _SetHeightDialogState extends State<SetHeightDialog> {
 
   @override
   Widget build(BuildContext context) {
-    final minHeight = widget.usesImperialUnits
-        ? max(
-            SetHeightDialog._minHeightFt,
-            widget.userHeight - SetHeightDialog._heightRangeFt,
-          )
-        : max(
-            SetHeightDialog._minHeightCm,
-            widget.userHeight - SetHeightDialog._heightRangeCM,
-          );
-    final maxHeight = widget.usesImperialUnits
-        ? widget.userHeight + SetHeightDialog._heightRangeFt
-        : widget.userHeight + SetHeightDialog._heightRangeCM;
+    final minHeight =
+        minSelectableHeight(widget.userHeight, widget.usesImperialUnits);
+    final maxHeight =
+        maxSelectableHeight(widget.userHeight, widget.usesImperialUnits);
 
     return AlertDialog(
       title: Text(S.of(context).selectHeightDialogLabel),
@@ -82,7 +67,10 @@ class _SetHeightDialogState extends State<SetHeightDialog> {
         ),
         TextButton(
           onPressed: () {
-            Navigator.pop(context, max(minHeight, selectedHeight));
+            Navigator.pop(
+              context,
+              clampHeightSelection(selectedHeight, minHeight),
+            );
           },
           child: Text(S.of(context).dialogOKLabel),
         ),

--- a/lib/features/profile/presentation/widgets/set_weight_dialog.dart
+++ b/lib/features/profile/presentation/widgets/set_weight_dialog.dart
@@ -1,3 +1,5 @@
+import 'dart:math';
+
 import 'package:flutter/material.dart';
 import 'package:horizontal_picker/horizontal_picker.dart';
 import 'package:opennutritracker/generated/l10n.dart';
@@ -5,6 +7,8 @@ import 'package:opennutritracker/generated/l10n.dart';
 class SetWeightDialog extends StatefulWidget {
   static const weightRangeKg = 50.0;
   static const weightRangeLbs = 100.0;
+  static const minWeightKg = 1.0;
+  static const minWeightLbs = 1.0;
 
   final double userWeight;
   final bool usesImperialUnits;
@@ -30,11 +34,16 @@ class _SetWeightDialogState extends State<SetWeightDialog> {
 
   @override
   Widget build(BuildContext context) {
-    final minValue = widget.usesImperialUnits
-        ? widget.userWeight - SetWeightDialog.weightRangeLbs
-        : widget.userWeight - SetWeightDialog.weightRangeKg;
-
-    final maxValue = widget.usesImperialUnits
+    final minWeight = widget.usesImperialUnits
+        ? max(
+            SetWeightDialog.minWeightLbs,
+            widget.userWeight - SetWeightDialog.weightRangeLbs,
+          )
+        : max(
+            SetWeightDialog.minWeightKg,
+            widget.userWeight - SetWeightDialog.weightRangeKg,
+          );
+    final maxWeight = widget.usesImperialUnits
         ? widget.userWeight + SetWeightDialog.weightRangeLbs
         : widget.userWeight + SetWeightDialog.weightRangeKg;
 
@@ -47,8 +56,8 @@ class _SetWeightDialogState extends State<SetWeightDialog> {
               HorizontalPicker(
                 height: 100,
                 backgroundColor: Colors.transparent,
-                minValue: minValue < 0 ? 0 : minValue, // 👈 no negative minimum
-                maxValue: maxValue,
+                minValue: minWeight,
+                maxValue: maxWeight,
                 initialPosition: InitialPosition.center,
                 divisions: 1000,
                 suffix: widget.usesImperialUnits
@@ -56,7 +65,7 @@ class _SetWeightDialogState extends State<SetWeightDialog> {
                     : S.of(context).kgLabel,
                 onChanged: (value) {
                   setState(() {
-                    selectedWeight = value < 0 ? 0 : value; // 👈 no negative values
+                    selectedWeight = value;
                   });
                 },
               ),
@@ -73,7 +82,7 @@ class _SetWeightDialogState extends State<SetWeightDialog> {
         ),
         TextButton(
           onPressed: () {
-            Navigator.pop(context, selectedWeight);
+            Navigator.pop(context, max(minWeight, selectedWeight));
           },
           child: Text(S.of(context).dialogOKLabel),
         ),

--- a/lib/features/profile/presentation/widgets/set_weight_dialog.dart
+++ b/lib/features/profile/presentation/widgets/set_weight_dialog.dart
@@ -1,15 +1,9 @@
-import 'dart:math';
-
 import 'package:flutter/material.dart';
 import 'package:horizontal_picker/horizontal_picker.dart';
+import 'package:opennutritracker/features/profile/presentation/utils/profile_picker_bounds.dart';
 import 'package:opennutritracker/generated/l10n.dart';
 
 class SetWeightDialog extends StatefulWidget {
-  static const weightRangeKg = 50.0;
-  static const weightRangeLbs = 100.0;
-  static const minWeightKg = 1.0;
-  static const minWeightLbs = 1.0;
-
   final double userWeight;
   final bool usesImperialUnits;
 
@@ -34,18 +28,10 @@ class _SetWeightDialogState extends State<SetWeightDialog> {
 
   @override
   Widget build(BuildContext context) {
-    final minWeight = widget.usesImperialUnits
-        ? max(
-            SetWeightDialog.minWeightLbs,
-            widget.userWeight - SetWeightDialog.weightRangeLbs,
-          )
-        : max(
-            SetWeightDialog.minWeightKg,
-            widget.userWeight - SetWeightDialog.weightRangeKg,
-          );
-    final maxWeight = widget.usesImperialUnits
-        ? widget.userWeight + SetWeightDialog.weightRangeLbs
-        : widget.userWeight + SetWeightDialog.weightRangeKg;
+    final minWeight =
+        minSelectableWeight(widget.userWeight, widget.usesImperialUnits);
+    final maxWeight =
+        maxSelectableWeight(widget.userWeight, widget.usesImperialUnits);
 
     return AlertDialog(
       title: Text(S.of(context).selectWeightDialogLabel),
@@ -82,7 +68,10 @@ class _SetWeightDialogState extends State<SetWeightDialog> {
         ),
         TextButton(
           onPressed: () {
-            Navigator.pop(context, max(minWeight, selectedWeight));
+            Navigator.pop(
+              context,
+              clampWeightSelection(selectedWeight, minWeight),
+            );
           },
           child: Text(S.of(context).dialogOKLabel),
         ),

--- a/test/unit_test/profile_picker_bounds_test.dart
+++ b/test/unit_test/profile_picker_bounds_test.dart
@@ -1,0 +1,35 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:opennutritracker/features/profile/presentation/utils/profile_picker_bounds.dart';
+
+void main() {
+  group('profile picker bounds', () {
+    test('metric height minimum is clamped to 1', () {
+      expect(minSelectableHeight(80, false), 1);
+    });
+
+    test('imperial height minimum is clamped to 1', () {
+      expect(minSelectableHeight(5, true), 1);
+    });
+
+    test('metric height maximum keeps expected range', () {
+      expect(maxSelectableHeight(170, false), 270);
+    });
+
+    test('weight minimum is clamped to 1 for metric and imperial', () {
+      expect(minSelectableWeight(40, false), 1);
+      expect(minSelectableWeight(80, true), 1);
+    });
+
+    test('weight maximum keeps expected range', () {
+      expect(maxSelectableWeight(75, false), 125);
+      expect(maxSelectableWeight(140, true), 240);
+    });
+
+    test('selected values are clamped to computed minimum', () {
+      expect(clampHeightSelection(0.5, 1), 1);
+      expect(clampWeightSelection(0.5, 1), 1);
+      expect(clampHeightSelection(180, 1), 180);
+      expect(clampWeightSelection(80, 1), 80);
+    });
+  });
+}

--- a/test/unit_test/profile_picker_bounds_test.dart
+++ b/test/unit_test/profile_picker_bounds_test.dart
@@ -25,6 +25,17 @@ void main() {
       expect(maxSelectableWeight(140, true), 240);
     });
 
+    test('extreme negative persisted values still produce a valid metric range', () {
+      expect(
+        maxSelectableHeight(-200, false) >= minSelectableHeight(-200, false),
+        isTrue,
+      );
+      expect(
+        maxSelectableWeight(-200, false) >= minSelectableWeight(-200, false),
+        isTrue,
+      );
+    });
+
     test('selected values are clamped to computed minimum', () {
       expect(clampHeightSelection(0.5, 1), 1);
       expect(clampWeightSelection(0.5, 1), 1);


### PR DESCRIPTION
## Summary
Fixes the onboarding weight validation message and prevents negative values in profile height/weight pickers.

Closes #288
Closes #216
Closes #217

## Changes
- `onboarding_second_page_body.dart`
  - Fixed `validateWeight()` to return `onboardingWrongWeightLabel` instead of `onboardingWrongHeightLabel`.
- `set_height_dialog.dart`
  - Added lower-bound clamping for picker minimum value (`>= 1`) so users cannot scroll into negative heights.
  - Added confirmation-time guard to ensure returned value respects the same lower bound.
- `set_weight_dialog.dart`
  - Added lower-bound clamping for picker minimum value (`>= 1`) so users cannot scroll into negative weights.
  - Added confirmation-time guard to ensure returned value respects the same lower bound.

## Notes
I could not run Flutter tests in this environment because `flutter`/`dart` are not installed here.
