### PR TITLE
Include custom meals in Product/Food search results

### DIFF
--- a/lib/core/utils/locator.dart
+++ b/lib/core/utils/locator.dart
@@ -170,7 +170,7 @@ Future<void> initLocator() async {
     () => AddUserUsecase(locator()),
   );
   locator.registerLazySingleton<SearchProductsUseCase>(
-    () => SearchProductsUseCase(locator()),
+    () => SearchProductsUseCase(locator(), locator()),
   );
   locator.registerLazySingleton<SearchProductByBarcodeUseCase>(
     () => SearchProductByBarcodeUseCase(locator()),

--- a/lib/features/add_meal/domain/usecase/search_products_usecase.dart
+++ b/lib/features/add_meal/domain/usecase/search_products_usecase.dart
@@ -1,10 +1,12 @@
+import 'package:opennutritracker/core/domain/usecase/get_intake_usecase.dart';
 import 'package:opennutritracker/features/add_meal/data/repository/products_repository.dart';
 import 'package:opennutritracker/features/add_meal/domain/entity/meal_entity.dart';
 
 class SearchProductsUseCase {
   final ProductsRepository _productsRepository;
+  final GetIntakeUsecase _getIntakeUsecase;
 
-  SearchProductsUseCase(this._productsRepository);
+  SearchProductsUseCase(this._productsRepository, this._getIntakeUsecase);
 
   Future<List<MealEntity>> searchOFFProductsByString(
     String searchString,
@@ -12,13 +14,52 @@ class SearchProductsUseCase {
     final products = await _productsRepository.getOFFProductsByString(
       searchString,
     );
-    return products;
+    return _prependMatchingCustomMeals(searchString, products);
   }
 
   Future<List<MealEntity>> searchFDCFoodByString(String searchString) async {
     final foods = await _productsRepository.getSupabaseFDCFoodsByString(
       searchString,
     );
-    return foods;
+    return _prependMatchingCustomMeals(searchString, foods);
+  }
+
+  Future<List<MealEntity>> _prependMatchingCustomMeals(
+    String searchString,
+    List<MealEntity> remoteResults,
+  ) async {
+    final normalizedSearchString = searchString.trim().toLowerCase();
+    if (normalizedSearchString.isEmpty) {
+      return remoteResults;
+    }
+
+    final recentIntake = await _getIntakeUsecase.getRecentIntake();
+    final customMeals = recentIntake
+        .map((intake) => intake.meal)
+        .where((meal) => meal.source == MealSourceEntity.custom)
+        .where((meal) => _mealMatchesSearch(meal, normalizedSearchString))
+        .toList();
+
+    return _deduplicateMeals([...customMeals, ...remoteResults]);
+  }
+
+  bool _mealMatchesSearch(MealEntity meal, String normalizedSearchString) {
+    return (meal.name?.toLowerCase().contains(normalizedSearchString) ??
+            false) ||
+        (meal.brands?.toLowerCase().contains(normalizedSearchString) ?? false);
+  }
+
+  List<MealEntity> _deduplicateMeals(List<MealEntity> meals) {
+    final seenKeys = <String>{};
+    final uniqueMeals = <MealEntity>[];
+
+    for (final meal in meals) {
+      final key = '${meal.source.name}:${meal.code ?? meal.name ?? ''}';
+      if (seenKeys.add(key)) {
+        uniqueMeals.add(meal);
+      }
+    }
+
+    return uniqueMeals;
   }
 }

--- a/test/unit_test/search_products_usecase_test.dart
+++ b/test/unit_test/search_products_usecase_test.dart
@@ -1,0 +1,119 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:mockito/mockito.dart';
+import 'package:opennutritracker/core/domain/entity/intake_entity.dart';
+import 'package:opennutritracker/core/domain/entity/intake_type_entity.dart';
+import 'package:opennutritracker/core/domain/usecase/get_intake_usecase.dart';
+import 'package:opennutritracker/features/add_meal/data/repository/products_repository.dart';
+import 'package:opennutritracker/features/add_meal/domain/entity/meal_entity.dart';
+import 'package:opennutritracker/features/add_meal/domain/entity/meal_nutriments_entity.dart';
+import 'package:opennutritracker/features/add_meal/domain/usecase/search_products_usecase.dart';
+
+class MockProductsRepository extends Mock implements ProductsRepository {}
+
+class MockGetIntakeUsecase extends Mock implements GetIntakeUsecase {}
+
+void main() {
+  group('SearchProductsUseCase', () {
+    late MockProductsRepository productsRepository;
+    late MockGetIntakeUsecase getIntakeUsecase;
+    late SearchProductsUseCase useCase;
+
+    setUp(() {
+      productsRepository = MockProductsRepository();
+      getIntakeUsecase = MockGetIntakeUsecase();
+      useCase = SearchProductsUseCase(productsRepository, getIntakeUsecase);
+    });
+
+    test('prepends matching custom meals for OFF search', () async {
+      final customMatch = _meal(
+          code: 'custom-1', name: 'Tofu Bowl', source: MealSourceEntity.custom);
+      final customNoMatch = _meal(
+          code: 'custom-2',
+          name: 'Lentil Soup',
+          source: MealSourceEntity.custom);
+      final offMatchFromHistory = _meal(
+          code: 'off-history',
+          name: 'Tofu Snack',
+          source: MealSourceEntity.off);
+      final offApiResult = _meal(
+          code: 'off-api', name: 'Tofu Product', source: MealSourceEntity.off);
+
+      when(productsRepository.getOFFProductsByString('tofu'))
+          .thenAnswer((_) async => [offApiResult]);
+      when(getIntakeUsecase.getRecentIntake()).thenAnswer((_) async => [
+            _intake('i1', customNoMatch),
+            _intake('i2', offMatchFromHistory),
+            _intake('i3', customMatch),
+          ]);
+
+      final result = await useCase.searchOFFProductsByString('tofu');
+
+      expect(result, [customMatch, offApiResult]);
+    });
+
+    test('deduplicates repeated custom meals for FDC search', () async {
+      final customMatch = _meal(
+          code: 'custom-apple',
+          name: 'Apple Mix',
+          source: MealSourceEntity.custom);
+      final fdcApiResult = _meal(
+          code: 'fdc-api',
+          name: 'Apple Nutrition',
+          source: MealSourceEntity.fdc);
+
+      when(productsRepository.getSupabaseFDCFoodsByString('apple'))
+          .thenAnswer((_) async => [fdcApiResult]);
+      when(getIntakeUsecase.getRecentIntake()).thenAnswer((_) async => [
+            _intake('i1', customMatch),
+            _intake('i2', customMatch),
+          ]);
+
+      final result = await useCase.searchFDCFoodByString('apple');
+
+      expect(result, [customMatch, fdcApiResult]);
+    });
+
+    test('does not query recent intake for blank search strings', () async {
+      final offApiResult = _meal(
+          code: 'off-api', name: 'Any Product', source: MealSourceEntity.off);
+
+      when(productsRepository.getOFFProductsByString('   '))
+          .thenAnswer((_) async => [offApiResult]);
+
+      final result = await useCase.searchOFFProductsByString('   ');
+
+      expect(result, [offApiResult]);
+      verifyNever(getIntakeUsecase.getRecentIntake());
+    });
+  });
+}
+
+MealEntity _meal(
+    {required String code,
+    required String name,
+    required MealSourceEntity source}) {
+  return MealEntity(
+      code: code,
+      name: name,
+      brands: null,
+      thumbnailImageUrl: null,
+      mainImageUrl: null,
+      url: null,
+      mealQuantity: null,
+      mealUnit: 'g',
+      servingQuantity: null,
+      servingUnit: 'g',
+      servingSize: null,
+      nutriments: MealNutrimentsEntity.empty(),
+      source: source);
+}
+
+IntakeEntity _intake(String id, MealEntity meal) {
+  return IntakeEntity(
+      id: id,
+      unit: 'g',
+      amount: 100,
+      type: IntakeTypeEntity.breakfast,
+      meal: meal,
+      dateTime: DateTime.utc(2024, 1, 1));
+}

--- a/test/unit_test/search_products_usecase_test.dart
+++ b/test/unit_test/search_products_usecase_test.dart
@@ -85,6 +85,69 @@ void main() {
       expect(result, [offApiResult]);
       verifyNever(getIntakeUsecase.getRecentIntake());
     });
+
+    test('matches custom meals by brand case-insensitively', () async {
+      final customBrandMatch = MealEntity(
+          code: 'custom-brand',
+          name: 'Snack',
+          brands: 'Almond Co',
+          thumbnailImageUrl: null,
+          mainImageUrl: null,
+          url: null,
+          mealQuantity: null,
+          mealUnit: 'g',
+          servingQuantity: null,
+          servingUnit: 'g',
+          servingSize: null,
+          nutriments: MealNutrimentsEntity.empty(),
+          source: MealSourceEntity.custom);
+      final fdcApiResult = _meal(
+          code: 'fdc-api',
+          name: 'Almond Product',
+          source: MealSourceEntity.fdc);
+
+      when(productsRepository.getSupabaseFDCFoodsByString('ALMOND'))
+          .thenAnswer((_) async => [fdcApiResult]);
+      when(getIntakeUsecase.getRecentIntake())
+          .thenAnswer((_) async => [_intake('i1', customBrandMatch)]);
+
+      final result = await useCase.searchFDCFoodByString('ALMOND');
+
+      expect(result, [customBrandMatch, fdcApiResult]);
+    });
+
+    test('deduplicates custom meals when code is missing by fallback name key',
+        () async {
+      final customNoCode = MealEntity(
+          code: null,
+          name: 'Peanut Butter',
+          brands: null,
+          thumbnailImageUrl: null,
+          mainImageUrl: null,
+          url: null,
+          mealQuantity: null,
+          mealUnit: 'g',
+          servingQuantity: null,
+          servingUnit: 'g',
+          servingSize: null,
+          nutriments: MealNutrimentsEntity.empty(),
+          source: MealSourceEntity.custom);
+      final offApiResult = _meal(
+          code: 'off-api',
+          name: 'Peanut Product',
+          source: MealSourceEntity.off);
+
+      when(productsRepository.getOFFProductsByString('peanut'))
+          .thenAnswer((_) async => [offApiResult]);
+      when(getIntakeUsecase.getRecentIntake()).thenAnswer((_) async => [
+            _intake('i1', customNoCode),
+            _intake('i2', customNoCode),
+          ]);
+
+      final result = await useCase.searchOFFProductsByString('peanut');
+
+      expect(result, [customNoCode, offApiResult]);
+    });
   });
 }
 

--- a/test/unit_test/search_products_usecase_test.dart
+++ b/test/unit_test/search_products_usecase_test.dart
@@ -1,5 +1,4 @@
 import 'package:flutter_test/flutter_test.dart';
-import 'package:mockito/mockito.dart';
 import 'package:opennutritracker/core/domain/entity/intake_entity.dart';
 import 'package:opennutritracker/core/domain/entity/intake_type_entity.dart';
 import 'package:opennutritracker/core/domain/usecase/get_intake_usecase.dart';
@@ -8,19 +7,58 @@ import 'package:opennutritracker/features/add_meal/domain/entity/meal_entity.dar
 import 'package:opennutritracker/features/add_meal/domain/entity/meal_nutriments_entity.dart';
 import 'package:opennutritracker/features/add_meal/domain/usecase/search_products_usecase.dart';
 
-class MockProductsRepository extends Mock implements ProductsRepository {}
+class _FakeProductsRepository implements ProductsRepository {
+  final Map<String, List<MealEntity>> offResults = {};
+  final Map<String, List<MealEntity>> fdcResults = {};
 
-class MockGetIntakeUsecase extends Mock implements GetIntakeUsecase {}
+  @override
+  Future<List<MealEntity>> getOFFProductsByString(String searchString) async =>
+      offResults[searchString] ?? const [];
+
+  @override
+  Future<List<MealEntity>> getSupabaseFDCFoodsByString(
+    String searchString,
+  ) async =>
+      fdcResults[searchString] ?? const [];
+
+  // Other ProductsRepository methods aren't exercised here — throw via
+  // noSuchMethod if anything unexpectedly hits them.
+  @override
+  dynamic noSuchMethod(Invocation invocation) {
+    throw UnimplementedError(
+      'Unexpected call: ${invocation.memberName}',
+    );
+  }
+}
+
+class _FakeGetIntakeUsecase implements GetIntakeUsecase {
+  List<IntakeEntity> recentIntake = const [];
+  int recentIntakeCallCount = 0;
+
+  @override
+  Future<List<IntakeEntity>> getRecentIntake() async {
+    recentIntakeCallCount++;
+    return recentIntake;
+  }
+
+  // Stub everything else — only getRecentIntake is exercised here.
+  @override
+  dynamic noSuchMethod(Invocation invocation) {
+    throw UnimplementedError(
+      'Unexpected call: ${invocation.memberName}',
+    );
+  }
+}
 
 void main() {
   group('SearchProductsUseCase', () {
-    late MockProductsRepository productsRepository;
-    late MockGetIntakeUsecase getIntakeUsecase;
+    late _FakeProductsRepository productsRepository;
+    late _FakeGetIntakeUsecase getIntakeUsecase;
     late SearchProductsUseCase useCase;
 
     setUp(() {
-      productsRepository = MockProductsRepository();
-      getIntakeUsecase = MockGetIntakeUsecase();
+      productsRepository = _FakeProductsRepository();
+      getIntakeUsecase = _FakeGetIntakeUsecase();
       useCase = SearchProductsUseCase(productsRepository, getIntakeUsecase);
     });
 
@@ -38,13 +76,12 @@ void main() {
       final offApiResult = _meal(
           code: 'off-api', name: 'Tofu Product', source: MealSourceEntity.off);
 
-      when(productsRepository.getOFFProductsByString('tofu'))
-          .thenAnswer((_) async => [offApiResult]);
-      when(getIntakeUsecase.getRecentIntake()).thenAnswer((_) async => [
-            _intake('i1', customNoMatch),
-            _intake('i2', offMatchFromHistory),
-            _intake('i3', customMatch),
-          ]);
+      productsRepository.offResults['tofu'] = [offApiResult];
+      getIntakeUsecase.recentIntake = [
+        _intake('i1', customNoMatch),
+        _intake('i2', offMatchFromHistory),
+        _intake('i3', customMatch),
+      ];
 
       final result = await useCase.searchOFFProductsByString('tofu');
 
@@ -61,12 +98,11 @@ void main() {
           name: 'Apple Nutrition',
           source: MealSourceEntity.fdc);
 
-      when(productsRepository.getSupabaseFDCFoodsByString('apple'))
-          .thenAnswer((_) async => [fdcApiResult]);
-      when(getIntakeUsecase.getRecentIntake()).thenAnswer((_) async => [
-            _intake('i1', customMatch),
-            _intake('i2', customMatch),
-          ]);
+      productsRepository.fdcResults['apple'] = [fdcApiResult];
+      getIntakeUsecase.recentIntake = [
+        _intake('i1', customMatch),
+        _intake('i2', customMatch),
+      ];
 
       final result = await useCase.searchFDCFoodByString('apple');
 
@@ -77,13 +113,12 @@ void main() {
       final offApiResult = _meal(
           code: 'off-api', name: 'Any Product', source: MealSourceEntity.off);
 
-      when(productsRepository.getOFFProductsByString('   '))
-          .thenAnswer((_) async => [offApiResult]);
+      productsRepository.offResults['   '] = [offApiResult];
 
       final result = await useCase.searchOFFProductsByString('   ');
 
       expect(result, [offApiResult]);
-      verifyNever(getIntakeUsecase.getRecentIntake());
+      expect(getIntakeUsecase.recentIntakeCallCount, 0);
     });
 
     test('matches custom meals by brand case-insensitively', () async {
@@ -106,10 +141,8 @@ void main() {
           name: 'Almond Product',
           source: MealSourceEntity.fdc);
 
-      when(productsRepository.getSupabaseFDCFoodsByString('ALMOND'))
-          .thenAnswer((_) async => [fdcApiResult]);
-      when(getIntakeUsecase.getRecentIntake())
-          .thenAnswer((_) async => [_intake('i1', customBrandMatch)]);
+      productsRepository.fdcResults['ALMOND'] = [fdcApiResult];
+      getIntakeUsecase.recentIntake = [_intake('i1', customBrandMatch)];
 
       final result = await useCase.searchFDCFoodByString('ALMOND');
 
@@ -137,12 +170,11 @@ void main() {
           name: 'Peanut Product',
           source: MealSourceEntity.off);
 
-      when(productsRepository.getOFFProductsByString('peanut'))
-          .thenAnswer((_) async => [offApiResult]);
-      when(getIntakeUsecase.getRecentIntake()).thenAnswer((_) async => [
-            _intake('i1', customNoCode),
-            _intake('i2', customNoCode),
-          ]);
+      productsRepository.offResults['peanut'] = [offApiResult];
+      getIntakeUsecase.recentIntake = [
+        _intake('i1', customNoCode),
+        _intake('i2', customNoCode),
+      ];
 
       final result = await useCase.searchOFFProductsByString('peanut');
 
@@ -151,32 +183,35 @@ void main() {
   });
 }
 
-MealEntity _meal(
-    {required String code,
-    required String name,
-    required MealSourceEntity source}) {
+MealEntity _meal({
+  required String code,
+  required String name,
+  required MealSourceEntity source,
+}) {
   return MealEntity(
-      code: code,
-      name: name,
-      brands: null,
-      thumbnailImageUrl: null,
-      mainImageUrl: null,
-      url: null,
-      mealQuantity: null,
-      mealUnit: 'g',
-      servingQuantity: null,
-      servingUnit: 'g',
-      servingSize: null,
-      nutriments: MealNutrimentsEntity.empty(),
-      source: source);
+    code: code,
+    name: name,
+    brands: null,
+    thumbnailImageUrl: null,
+    mainImageUrl: null,
+    url: null,
+    mealQuantity: null,
+    mealUnit: 'g',
+    servingQuantity: null,
+    servingUnit: 'g',
+    servingSize: null,
+    nutriments: MealNutrimentsEntity.empty(),
+    source: source,
+  );
 }
 
 IntakeEntity _intake(String id, MealEntity meal) {
   return IntakeEntity(
-      id: id,
-      unit: 'g',
-      amount: 100,
-      type: IntakeTypeEntity.breakfast,
-      meal: meal,
-      dateTime: DateTime.utc(2024, 1, 1));
+    id: id,
+    unit: 'g',
+    amount: 100,
+    type: IntakeTypeEntity.breakfast,
+    meal: meal,
+    dateTime: DateTime.utc(2024, 1, 1),
+  );
 }


### PR DESCRIPTION
## Summary
Custom meals were only discoverable in the **Recently added** tab, because Product/Food search paths queried remote OFF/FDC sources only. This made reusing manually created meals hard, as reported in #267.

This PR includes matching custom meals from recent intake at the top of both Product and Food search results.

## Changes
- Extend `SearchProductsUseCase` to read recent intake via `GetIntakeUsecase`.
- For non-empty search strings:
  - filter recent meals to `MealSourceEntity.custom`
  - match on name/brand case-insensitively
  - prepend matches before remote OFF/FDC results
  - deduplicate by `source + code/name`
- Update DI wiring in `locator.dart` for the new use case dependency.
- Add `search_products_usecase_test.dart` covering:
  - custom meal inclusion in OFF search
  - deduplication behavior
  - no local lookup for blank queries

## Notes
I could not execute Flutter tests in this environment because `flutter` is not installed (`command not found`).
