### PR TITLE
fix(profile): preserve decimal weight in profile display

### DIFF
--- a/lib/features/profile/presentation/bloc/profile_bloc.dart
+++ b/lib/features/profile/presentation/bloc/profile_bloc.dart
@@ -95,10 +95,19 @@ class ProfileBloc extends Bloc<ProfileEvent, ProfileState> {
 
   /// Returns the user's weight in kg or lbs based on the user's config
   String getDisplayWeight(UserEntity user, bool usesImperialUnits) {
-    if (usesImperialUnits) {
-      return UnitCalc.kgToLbs(user.weightKG).toStringAsFixed(0);
-    } else {
-      return user.weightKG.roundToDouble().toStringAsFixed(0);
+    final displayWeight = usesImperialUnits
+        ? UnitCalc.kgToLbs(user.weightKG)
+        : user.weightKG;
+
+    return _formatWeight(displayWeight);
+  }
+
+  /// Format weight with one decimal precision when needed, without trailing `.0`.
+  String _formatWeight(double weight) {
+    final roundedToOneDecimal = double.parse(weight.toStringAsFixed(1));
+    if (roundedToOneDecimal == roundedToOneDecimal.roundToDouble()) {
+      return roundedToOneDecimal.toStringAsFixed(0);
     }
+    return roundedToOneDecimal.toStringAsFixed(1);
   }
 }

--- a/lib/features/profile/presentation/bloc/profile_bloc.dart
+++ b/lib/features/profile/presentation/bloc/profile_bloc.dart
@@ -13,6 +13,7 @@ import 'package:opennutritracker/core/utils/locator.dart';
 import 'package:opennutritracker/features/diary/presentation/bloc/calendar_day_bloc.dart';
 import 'package:opennutritracker/features/diary/presentation/bloc/diary_bloc.dart';
 import 'package:opennutritracker/features/home/presentation/bloc/home_bloc.dart';
+import 'package:opennutritracker/features/profile/presentation/utils/profile_display_format.dart';
 
 part 'profile_event.dart';
 
@@ -99,15 +100,6 @@ class ProfileBloc extends Bloc<ProfileEvent, ProfileState> {
         ? UnitCalc.kgToLbs(user.weightKG)
         : user.weightKG;
 
-    return _formatWeight(displayWeight);
-  }
-
-  /// Format weight with one decimal precision when needed, without trailing `.0`.
-  String _formatWeight(double weight) {
-    final roundedToOneDecimal = double.parse(weight.toStringAsFixed(1));
-    if (roundedToOneDecimal == roundedToOneDecimal.roundToDouble()) {
-      return roundedToOneDecimal.toStringAsFixed(0);
-    }
-    return roundedToOneDecimal.toStringAsFixed(1);
+    return formatProfileWeight(displayWeight);
   }
 }

--- a/lib/features/profile/presentation/utils/profile_display_format.dart
+++ b/lib/features/profile/presentation/utils/profile_display_format.dart
@@ -1,0 +1,7 @@
+String formatProfileWeight(double weight) {
+  final roundedToOneDecimal = double.parse(weight.toStringAsFixed(1));
+  if (roundedToOneDecimal == roundedToOneDecimal.roundToDouble()) {
+    return roundedToOneDecimal.toStringAsFixed(0);
+  }
+  return roundedToOneDecimal.toStringAsFixed(1);
+}

--- a/test/unit_test/profile_display_format_test.dart
+++ b/test/unit_test/profile_display_format_test.dart
@@ -1,0 +1,22 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:opennutritracker/features/profile/presentation/utils/profile_display_format.dart';
+
+void main() {
+  group('formatProfileWeight', () {
+    test('shows whole numbers without decimal suffix', () {
+      expect(formatProfileWeight(80.0), '80');
+    });
+
+    test('preserves one decimal place for fractional values', () {
+      expect(formatProfileWeight(80.5), '80.5');
+    });
+
+    test('normalizes floating-point noise around whole values', () {
+      expect(formatProfileWeight(154.0000001), '154');
+    });
+
+    test('rounds values to one decimal place', () {
+      expect(formatProfileWeight(154.25), '154.3');
+    });
+  });
+}


### PR DESCRIPTION
## Summary
Fix profile weight display so decimal weights remain visible instead of always being rounded to whole numbers.

Closes #244

## What changed
- Updated `ProfileBloc.getDisplayWeight()` to format based on value precision:
  - show no decimal for whole-number weights (for example `80`)
  - show one decimal for fractional weights (for example `80.5`)
- Added a small internal formatter that first rounds to one decimal place to avoid float noise, then suppresses trailing `.0`.

## Why
Issue #244 reports that selecting a decimal weight is possible in the weight picker but profile display rounds it away. This change preserves user-selected decimal precision in the profile subtitle.

## Validation
I could not run Flutter/Dart tests in this environment because `flutter` and `dart` CLIs are not installed here.
