### PR TITLE
fix(onboarding): advance focus from height to weight input

### DIFF
--- a/lib/features/onboarding/presentation/widgets/onboarding_second_page_body.dart
+++ b/lib/features/onboarding/presentation/widgets/onboarding_second_page_body.dart
@@ -21,11 +21,20 @@ class OnboardingSecondPageBody extends StatefulWidget {
 class _OnboardingSecondPageBodyState extends State<OnboardingSecondPageBody> {
   final _heightFormKey = GlobalKey<FormState>();
   final _weightFormKey = GlobalKey<FormState>();
+  final _heightFocusNode = FocusNode();
+  final _weightFocusNode = FocusNode();
   final _isUnitSelected = [true, false];
   double? _parsedHeight;
   double? _parsedWeight;
 
   bool get _isImperialSelected => _isUnitSelected[1];
+
+  @override
+  void dispose() {
+    _heightFocusNode.dispose();
+    _weightFocusNode.dispose();
+    super.dispose();
+  }
 
   @override
   Widget build(BuildContext context) {
@@ -47,6 +56,7 @@ class _OnboardingSecondPageBodyState extends State<OnboardingSecondPageBody> {
           Form(
             key: _heightFormKey,
             child: TextFormField(
+              focusNode: _heightFocusNode,
               onChanged: (text) {
                 if (_heightFormKey.currentState!.validate()) {
                   _parsedHeight = double.tryParse(text.replaceAll(',', '.'));
@@ -55,6 +65,9 @@ class _OnboardingSecondPageBodyState extends State<OnboardingSecondPageBody> {
                   _parsedHeight = null;
                   checkCorrectInput();
                 }
+              },
+              onFieldSubmitted: (_) {
+                FocusScope.of(context).requestFocus(_weightFocusNode);
               },
               validator: validateHeight,
               decoration: InputDecoration(
@@ -67,7 +80,8 @@ class _OnboardingSecondPageBodyState extends State<OnboardingSecondPageBody> {
                   borderRadius: BorderRadius.circular(10),
                 ),
               ),
-              keyboardType: TextInputType.numberWithOptions(decimal: true),
+              keyboardType: const TextInputType.numberWithOptions(decimal: true),
+              textInputAction: TextInputAction.next,
               inputFormatters: [
                 !_isImperialSelected
                     ? FilteringTextInputFormatter.digitsOnly
@@ -117,6 +131,7 @@ class _OnboardingSecondPageBodyState extends State<OnboardingSecondPageBody> {
           Form(
             key: _weightFormKey,
             child: TextFormField(
+              focusNode: _weightFocusNode,
               onChanged: (text) {
                 if (_weightFormKey.currentState!.validate()) {
                   _parsedWeight = double.tryParse(text);
@@ -124,6 +139,9 @@ class _OnboardingSecondPageBodyState extends State<OnboardingSecondPageBody> {
                 } else {
                   checkCorrectInput();
                 }
+              },
+              onFieldSubmitted: (_) {
+                FocusScope.of(context).unfocus();
               },
               validator: validateWeight,
               decoration: InputDecoration(
@@ -139,6 +157,7 @@ class _OnboardingSecondPageBodyState extends State<OnboardingSecondPageBody> {
                 ),
               ),
               keyboardType: TextInputType.number,
+              textInputAction: TextInputAction.done,
               inputFormatters: [FilteringTextInputFormatter.digitsOnly],
             ),
           ),


### PR DESCRIPTION
## Summary
Improve onboarding form keyboard flow so pressing `Next` on the height field moves focus directly to the weight field.

Closes #243

## Changes
- Added dedicated `FocusNode`s for height and weight fields.
- Set height input `textInputAction` to `next` and wired `onFieldSubmitted` to focus the weight field.
- Set weight input `textInputAction` to `done` and dismiss keyboard on submit.
- Added proper `dispose()` cleanup for both focus nodes.

## Why
This aligns onboarding behavior with expected mobile form UX and removes the extra tap needed to continue data entry.

## Validation
I could not run Flutter/Dart tests in this environment because `flutter` and `dart` CLIs are not installed here.
