### PR TITLE
docs: add CLAUDE.md and update GettingStarted for FVM

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -48,13 +48,24 @@ After editing `.env`, run `just build` to regenerate `lib/core/utils/env.g.dart`
 
 ## Code Generation
 
-The project uses `build_runner` to generate code for three things:
+Run `just build` (i.e. `dart run build_runner build --delete-conflicting-outputs`) whenever you add or modify any of the source files listed below. Every generated file starts with `// GENERATED CODE - DO NOT MODIFY BY HAND` or an equivalent header — never edit them directly.
 
-- **Hive adapters** — `*.g.dart` next to every DBO file (database objects)
-- **JSON serialization** — `*.g.dart` next to every DTO file (API response objects)
-- **Env secrets** — `lib/core/utils/env.g.dart` from `.env` via `envied`
+### What gets generated and when
 
-Run `just build` whenever you add/modify a DBO, DTO, or the `.env` file.
+| Trigger                            | Generated file(s)                                                                                         | Tool                |
+| ---------------------------------- | --------------------------------------------------------------------------------------------------------- | ------------------- |
+| Any `@HiveType` / `@HiveField` DBO | `<dbo_file>.g.dart` alongside the source                                                                  | `hive_ce_generator` |
+| Any new DBO added anywhere         | `lib/hive_registrar.g.dart` — the `HiveRegistrar` extension that calls `registerAdapter()` for every type | `hive_ce_generator` |
+| Any `@JsonSerializable` DTO        | `<dto_file>.g.dart` alongside the source                                                                  | `json_serializable` |
+| `.env` file edited                 | `lib/core/utils/env.g.dart` (**gitignored** — must regenerate after every clone)                          | `envied_generator`  |
+
+**DBO files** live in `lib/core/data/dbo/` and `lib/core/data/data_source/` (one `.g.dart` per file). Whenever you add a `@HiveField` or change a field's type, regenerate — otherwise the binary reader/writer will be out of sync.
+
+**`lib/hive_registrar.g.dart`** is checked in to version control (it has no machine-specific content). Regenerate it any time you add or remove a DBO type. The `HiveDBProvider` registers adapters by calling `Hive.registerAdapters()` which delegates to this file.
+
+**DTO files** live under `lib/features/add_meal/data/dto/` (OFF, FDC, and Supabase FDC subfolders). Regenerate when you add or change API response fields.
+
+**`lib/core/utils/env.g.dart`** is the only generated file that is gitignored. After a fresh clone, run `just build` with a valid `.env` file before the app will compile.
 
 ## Localization
 

--- a/GettingStarted.md
+++ b/GettingStarted.md
@@ -1,8 +1,11 @@
 # Getting started
+
 ## Android development with Windows 11
+
 This IDE setup is tested on Windows 11.
 
 For setup first you need the following things:
+
 - Android SDK and Android Emulator
 - Flutter
 - IDE like Android Studio or VS Code with Flutter Plugin installed.
@@ -10,39 +13,50 @@ For setup first you need the following things:
 Use paths for SDKs without spaces and special characters.
 
 ### Setup Android SDK and Emulator
+
 1. Download Android Studio from https://developer.android.com/studio and install. Keep "Android Virtual Device" checked. Start Android Studio after installation.
 
 2. Install the Android SDK when asked.
 
-3. After finishing the SDK installation you should the "Welcome to Android Studio" Screen. Click on "More Actions" -> "SDK Manager", switch to "SDK Tools" tab and check "Android SDK Command-line Tools (latest)", click "OK" and install the tools. 
+3. After finishing the SDK installation you should the "Welcome to Android Studio" Screen. Click on "More Actions" -> "SDK Manager", switch to "SDK Tools" tab and check "Android SDK Command-line Tools (latest)", click "OK" and install the tools.
 
 4. Check under "More Actions" -> "Virtual Device Manager" if a virtual phone was set up, if not create one, e.g. a Medium Phone with Default Settings.
 
 5. Close Android Studio.
 
 ### Setup Flutter SDK
-1. Download Flutter 3.27.1 from https://docs.flutter.dev/install/archive and extract.
 
-2. Add the bin folder in the folder where you extracted Flutter to the Path variable in "Advanced System Settings" -> "Environment Variables..." -> "System variables" -> "Path"
+This project uses [FVM](https://fvm.app/) to pin the Flutter version. FVM reads `.fvmrc` in the repo root and installs the correct SDK automatically.
+
+1. Install FVM by following the instructions at [fvm.app/documentation/getting-started/installation](https://fvm.app/documentation/getting-started/installation).
+
+2. In the cloned repository folder, run:
+
+```sh
+fvm install
+```
+
+This downloads the pinned Flutter version (defined in `.fvmrc`) and creates a `.fvm/flutter_sdk` symlink in the project folder. VS Code picks this up automatically via the `dart.flutterSdkPath` setting in `.vscode/settings.json`.
 
 ### Setup the Workspace in Visual Studio Code (VSC)
+
 1. Create a new folder, open the folder in VSC.
 
 2. Configure the Android SDK path for Flutter:
 
-```flutter config --android-sdk "e:\path\to\androidSDK"```
+`flutter config --android-sdk "e:\path\to\androidSDK"`
 
 3.⁠ ⁠Clone the repository with git in a VSC terminal (make sure the active folder in the terminal is your created folder from step 1):
 
-```git clone https://github.com/simonoppowa/OpenNutriTracker.git .```
+`git clone https://github.com/simonoppowa/OpenNutriTracker.git .`
 
 4.⁠ ⁠Get Dependencies.
 
-```flutter pub get```
+`flutter pub get`
 
 5.⁠ ⁠Run Build Runner to generate Files.
 
-```dart run build_runner build```
+`dart run build_runner build`
 
 At the best revert all the visible generated files now, only env.g.dart is needed, it is not checked in because it is in .gitignore.
 


### PR DESCRIPTION
## Summary

- Adds `CLAUDE.md` — comprehensive codebase guidance for Claude Code covering commands, architecture, DI patterns, Hive boxes, food data sources, TDEE/macro calculations, and code generation
- Expands the code generation section with a per-file breakdown of what `build_runner` generates, when to regenerate, and which files are gitignored vs checked in (including the previously undocumented `lib/hive_registrar.g.dart`)
- Updates `GettingStarted.md` to replace the manual Flutter 3.27.1 download step with FVM setup instructions, so contributors automatically get the correct pinned version from `.fvmrc`

## Notes

If `dart run build_runner build` fails with `PackageNotFoundException: hive` on an older checkout, the build cache is stale from before the `hive` → `hive_ce` migration. Fix: `rm -rf .dart_tool/build && dart run build_runner build`.

## Test plan

- [x] `just build` regenerates all `.g.dart` files cleanly (67 outputs)
- [x] `flutter test` passes (24 unit tests)
- [x] FVM setup instructions tested on a fresh Windows environment