### PR TITLE
docs: fix build_runner command and document stale cache workaround

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -48,7 +48,14 @@ After editing `.env`, run `just build` to regenerate `lib/core/utils/env.g.dart`
 
 ## Code Generation
 
-Run `just build` (i.e. `dart run build_runner build --delete-conflicting-outputs`) whenever you add or modify any of the source files listed below. Every generated file starts with `// GENERATED CODE - DO NOT MODIFY BY HAND` or an equivalent header — never edit them directly.
+Run `just build` (i.e. `dart run build_runner build`) whenever you add or modify any of the source files listed below. Every generated file starts with `// GENERATED CODE - DO NOT MODIFY BY HAND` or an equivalent header — never edit them directly.
+
+If `build_runner` fails with `PackageNotFoundException: hive` after pulling from an older checkout, the build cache is stale from the pre-`hive_ce` days. Fix it with:
+
+```sh
+rm -rf .dart_tool/build
+dart run build_runner build
+```
 
 ### What gets generated and when
 


### PR DESCRIPTION
## Summary

- Removes the `--delete-conflicting-outputs` flag from the `just build` description in `CLAUDE.md` — this flag was removed in build_runner 2.x and causes the command to fail
- Documents the `PackageNotFoundException: hive` failure that occurs on checkouts that pre-date the `hive` → `hive_ce` migration, with the fix (`rm -rf .dart_tool/build`)

## Test plan

- [x] `dart run build_runner build` runs cleanly after clearing `.dart_tool/build` (67 outputs)
- [x] `flutter test` passes (24 unit tests)

🤖 Generated with [Claude Code](https://claude.com/claude-code)