### PR TITLE
chore: bump version to 1.2.0+46

### DIFF
--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -15,7 +15,7 @@ publish_to: 'none' # Remove this line if you wish to publish to pub.dev
 # In iOS, build-name is used as CFBundleShortVersionString while build-number is used as CFBundleVersion.
 # Read more about iOS versioning at
 # https://developer.apple.com/library/archive/documentation/General/Reference/InfoPlistKeyReference/Articles/CoreFoundationKeys.html
-version: 1.1.1+45
+version: 1.2.0+46
 
 environment:
   sdk: '>=3.11.0 <4.0.0'


### PR DESCRIPTION
## Summary

- Bumps version `1.1.1+45` → `1.2.0+46`
- Minor bump: PR #332 introduced **meal sharing via QR code**, a new user-facing feature
- Build number incremented by 1

## Why minor (not patch)

Per the versioning guide: new user-facing features and new screens/flows → minor bump. The QR share/import flow added in #332 qualifies.

🤖 Generated with [Claude Code](https://claude.com/claude-code)