### PR TITLE
feat(search): automatic retry for OFF and Supabase FDC data sources

### DIFF
--- a/lib/core/utils/retry_util.dart
+++ b/lib/core/utils/retry_util.dart
@@ -1,0 +1,18 @@
+/// Retries [fn] up to [attempts] times with exponential backoff (1 s, 2 s, 4 s…).
+/// If [shouldRetry] is provided, only retries when it returns true for the thrown error.
+Future<T> withRetry<T>(
+  Future<T> Function() fn, {
+  int attempts = 3,
+  bool Function(Object)? shouldRetry,
+}) async {
+  for (var i = 0; i < attempts; i++) {
+    try {
+      return await fn();
+    } catch (e) {
+      final isLast = i == attempts - 1;
+      if (isLast || (shouldRetry != null && !shouldRetry(e))) rethrow;
+      await Future.delayed(Duration(seconds: 1 << i));
+    }
+  }
+  throw StateError('unreachable');
+}

--- a/lib/features/add_meal/data/data_sources/off_data_source.dart
+++ b/lib/features/add_meal/data/data_sources/off_data_source.dart
@@ -5,6 +5,7 @@ import 'package:logging/logging.dart';
 import 'package:opennutritracker/core/utils/app_const.dart';
 import 'package:opennutritracker/core/utils/off_const.dart';
 import 'package:opennutritracker/core/utils/ont_http_client.dart';
+import 'package:opennutritracker/core/utils/retry_util.dart';
 import 'package:opennutritracker/features/add_meal/data/dto/off/off_product_response_dto.dart';
 import 'package:opennutritracker/features/add_meal/data/dto/off/off_word_response_dto.dart';
 import 'package:opennutritracker/features/scanner/data/product_not_found_exception.dart';
@@ -16,23 +17,23 @@ class OFFDataSource {
 
   Future<OFFWordResponseDTO> fetchSearchWordResults(String searchString) async {
     try {
-      final searchUrlString = OFFConst.getOffWordSearchUrl(searchString);
-      final userAgentString = await AppConst.getUserAgentString();
-      final httpClient = ONTHttpClient(userAgentString, http.Client());
-
-      final response =
-          await httpClient.get(searchUrlString).timeout(_timeoutDuration);
-      log.fine('Fetching OFF results from: $searchUrlString');
-      if (response.statusCode == OFFConst.offHttpSuccessCode) {
-        final wordResponse = OFFWordResponseDTO.fromJson(
-          jsonDecode(response.body),
-        );
-        log.fine('Successful response from OFF');
-        return wordResponse;
-      } else {
+      return await withRetry(() async {
+        final searchUrlString = OFFConst.getOffWordSearchUrl(searchString);
+        final userAgentString = await AppConst.getUserAgentString();
+        final httpClient = ONTHttpClient(userAgentString, http.Client());
+        final response =
+            await httpClient.get(searchUrlString).timeout(_timeoutDuration);
+        log.fine('Fetching OFF results from: $searchUrlString');
+        if (response.statusCode == OFFConst.offHttpSuccessCode) {
+          final wordResponse = OFFWordResponseDTO.fromJson(
+            jsonDecode(response.body),
+          );
+          log.fine('Successful response from OFF');
+          return wordResponse;
+        }
         log.warning('Failed OFF call: ${response.statusCode}');
-        return Future.error(response.statusCode);
-      }
+        throw Exception('OFF HTTP ${response.statusCode}');
+      });
     } catch (exception, stacktrace) {
       log.severe('Exception while getting OFF word search $exception');
       Sentry.captureException(exception, stackTrace: stacktrace);
@@ -42,26 +43,29 @@ class OFFDataSource {
 
   Future<OFFProductResponseDTO> fetchBarcodeResults(String barcode) async {
     try {
-      final searchUrl = OFFConst.getOffBarcodeSearchUri(barcode);
-      final userAgentString = await AppConst.getUserAgentString();
-      final httpClient = ONTHttpClient(userAgentString, http.Client());
-
-      final response =
-          await httpClient.get(searchUrl).timeout(_timeoutDuration);
-      log.fine('Fetching OFF result from: $searchUrl');
-      if (response.statusCode == OFFConst.offHttpSuccessCode) {
-        final productResponse = OFFProductResponseDTO.fromJson(
-          jsonDecode(response.body),
-        );
-        log.fine('Successful response from OFF');
-        return productResponse;
-      } else if (response.statusCode == OFFConst.offProductNotFoundCode) {
-        log.warning("404 OFF Product not found");
-        return Future.error(ProductNotFoundException);
-      } else {
-        log.warning('Failed OFF call: ${response.statusCode}');
-        return Future.error(response.statusCode);
-      }
+      return await withRetry(
+        () async {
+          final searchUrl = OFFConst.getOffBarcodeSearchUri(barcode);
+          final userAgentString = await AppConst.getUserAgentString();
+          final httpClient = ONTHttpClient(userAgentString, http.Client());
+          final response =
+              await httpClient.get(searchUrl).timeout(_timeoutDuration);
+          log.fine('Fetching OFF result from: $searchUrl');
+          if (response.statusCode == OFFConst.offHttpSuccessCode) {
+            final productResponse = OFFProductResponseDTO.fromJson(
+              jsonDecode(response.body),
+            );
+            log.fine('Successful response from OFF');
+            return productResponse;
+          } else if (response.statusCode == OFFConst.offProductNotFoundCode) {
+            log.warning('404 OFF Product not found');
+            throw ProductNotFoundException();
+          }
+          log.warning('Failed OFF call: ${response.statusCode}');
+          throw Exception('OFF HTTP ${response.statusCode}');
+        },
+        shouldRetry: (e) => e is! ProductNotFoundException,
+      );
     } catch (exception, stacktrace) {
       log.severe('Exception while getting OFF barcode search $exception');
       Sentry.captureException(exception, stackTrace: stacktrace);

--- a/lib/features/add_meal/data/data_sources/sp_fdc_data_source.dart
+++ b/lib/features/add_meal/data/data_sources/sp_fdc_data_source.dart
@@ -2,6 +2,7 @@ import 'dart:io';
 
 import 'package:logging/logging.dart';
 import 'package:opennutritracker/core/utils/locator.dart';
+import 'package:opennutritracker/core/utils/retry_util.dart';
 import 'package:opennutritracker/core/utils/supported_language.dart';
 import 'package:opennutritracker/features/add_meal/data/dto/fdc_sp/sp_const.dart';
 import 'package:opennutritracker/features/add_meal/data/dto/fdc_sp/sp_fdc_food_dto.dart';
@@ -13,29 +14,31 @@ class SpFdcDataSource {
 
   Future<List<SpFdcFoodDTO>> fetchSearchWordResults(String searchString) async {
     try {
-      log.fine('Fetching Supabase FDC results');
-      final supaBaseClient = locator<SupabaseClient>();
-      final queryDescriptionColumn = SPConst.getFdcFoodDescriptionColumnName(
-        SupportedLanguage.fromCode(Platform.localeName),
-      );
+      return await withRetry(() async {
+        log.fine('Fetching Supabase FDC results');
+        final supaBaseClient = locator<SupabaseClient>();
+        final queryDescriptionColumn = SPConst.getFdcFoodDescriptionColumnName(
+          SupportedLanguage.fromCode(Platform.localeName),
+        );
 
-      final response = await supaBaseClient
-          .from(SPConst.fdcFoodTableName)
-          .select(
-            '''fdc_id, $queryDescriptionColumn, fdc_portions ( measure_unit_id, amount, gram_weight ), fdc_nutrients ( nutrient_id, amount )''',
-          )
-          .textSearch(
-            queryDescriptionColumn,
-            searchString,
-            type: TextSearchType.websearch,
-          )
-          .limit(SPConst.maxNumberOfItems);
+        final response = await supaBaseClient
+            .from(SPConst.fdcFoodTableName)
+            .select(
+              '''fdc_id, $queryDescriptionColumn, fdc_portions ( measure_unit_id, amount, gram_weight ), fdc_nutrients ( nutrient_id, amount )''',
+            )
+            .textSearch(
+              queryDescriptionColumn,
+              searchString,
+              type: TextSearchType.websearch,
+            )
+            .limit(SPConst.maxNumberOfItems);
 
-      final fdcFoodItems =
-          response.map((fdcFood) => SpFdcFoodDTO.fromJson(fdcFood)).toList();
+        final fdcFoodItems =
+            response.map((fdcFood) => SpFdcFoodDTO.fromJson(fdcFood)).toList();
 
-      log.fine('Successful response from Supabase');
-      return fdcFoodItems;
+        log.fine('Successful response from Supabase');
+        return fdcFoodItems;
+      });
     } catch (exception, stacktrace) {
       log.severe('Exception while getting FDC word search $exception');
       Sentry.captureException(exception, stackTrace: stacktrace);

--- a/lib/features/home/presentation/screens/import_meal_scanner_screen.dart
+++ b/lib/features/home/presentation/screens/import_meal_scanner_screen.dart
@@ -3,6 +3,7 @@ import 'package:flutter/material.dart';
 import 'package:mobile_scanner/mobile_scanner.dart';
 import 'package:opennutritracker/core/domain/entity/intake_type_entity.dart';
 import 'package:opennutritracker/core/utils/locator.dart';
+import 'package:opennutritracker/core/utils/retry_util.dart';
 import 'package:opennutritracker/features/add_meal/presentation/add_meal_type.dart';
 import 'package:opennutritracker/features/scanner/domain/usecase/search_product_by_barcode_usecase.dart';
 import 'package:opennutritracker/features/diary/presentation/bloc/calendar_day_bloc.dart';
@@ -12,17 +13,6 @@ import 'package:opennutritracker/features/home/presentation/bloc/home_bloc.dart'
 import 'package:opennutritracker/features/meal_detail/presentation/bloc/meal_detail_bloc.dart';
 import 'package:opennutritracker/generated/l10n.dart';
 
-Future<T> _withRetry<T>(Future<T> Function() fn, {int attempts = 3}) async {
-  for (var i = 0; i < attempts; i++) {
-    try {
-      return await fn();
-    } catch (e) {
-      if (i == attempts - 1) rethrow;
-      await Future.delayed(Duration(seconds: 1 << i));
-    }
-  }
-  throw StateError('unreachable');
-}
 
 class ImportMealScannerArguments {
   final IntakeTypeEntity intakeTypeEntity;
@@ -194,7 +184,7 @@ class _ImportMealScannerScreenState extends State<ImportMealScannerScreen> {
 
     final offResults = await Future.wait(payload.offRefs.map((ref) async {
       try {
-        final meal = await _withRetry(
+        final meal = await withRetry(
           () => _searchProductByBarcodeUseCase.searchProductByBarcode(ref.barcode),
         );
         return (ref: ref, meal: meal);


### PR DESCRIPTION
## Summary

- Extracts the existing `_withRetry` helper from `import_meal_scanner_screen.dart` into a shared `lib/core/utils/retry_util.dart` utility
- Applies automatic retry (3 attempts, exponential backoff: 1 s / 2 s / 4 s) to `OFFDataSource.fetchSearchWordResults`, `OFFDataSource.fetchBarcodeResults` (404s are not retried), and `SpFdcDataSource.fetchSearchWordResults`
- Moves Sentry capture to after all retries are exhausted, so transient failures don't generate noise
- Fixes a pre-existing bug in `fetchBarcodeResults` where `ProductNotFoundException` (the class) was passed to `Future.error` instead of an instance

Closes #229

## Test plan

- [x] Search for a food in the Products (OFF) tab — results load normally
- [x] Search for a food in the Food (FDC) tab — results load normally
- [x] Scan a barcode for a known product — loads correctly
- [x] Scan an unknown barcode — shows not-found state immediately (no retry delay)
- [x] `flutter analyze` — no issues
- [x] `flutter test` — all 26 tests pass