### PR TITLE
feat: port erikpt bundle (#281, #284, #290, #292, #297, #298, #312)

### DIFF
--- a/android/app/build.gradle
+++ b/android/app/build.gradle
@@ -45,6 +45,7 @@ android {
     }
 
     compileOptions {
+        coreLibraryDesugaringEnabled true
         sourceCompatibility JavaVersion.VERSION_17
         targetCompatibility JavaVersion.VERSION_17
     }
@@ -83,4 +84,8 @@ android {
 
 flutter {
     source '../..'
+}
+
+dependencies {
+    coreLibraryDesugaring 'com.android.tools:desugar_jdk_libs:2.1.4'
 }

--- a/android/app/src/main/AndroidManifest.xml
+++ b/android/app/src/main/AndroidManifest.xml
@@ -2,6 +2,11 @@
     package="com.opennutritracker.ont.opennutritracker">
 
     <uses-permission android:name="android.permission.INTERNET" />
+    <!-- #312: Notification reminders -->
+    <uses-permission android:name="android.permission.RECEIVE_BOOT_COMPLETED"/>
+    <uses-permission android:name="android.permission.SCHEDULE_EXACT_ALARM" />
+    <uses-permission android:name="android.permission.USE_EXACT_ALARM" />
+    <uses-permission android:name="android.permission.POST_NOTIFICATIONS"/>
 
     <!-- Provide required visibility configuration for API level 30 and above -->
     <queries>
@@ -40,6 +45,16 @@
                 <category android:name="android.intent.category.LAUNCHER"/>
             </intent-filter>
         </activity>
+        <!-- #312: Notification scheduling receivers -->
+        <receiver android:exported="false" android:name="com.dexterous.flutterlocalnotifications.ScheduledNotificationReceiver"/>
+        <receiver android:exported="false" android:name="com.dexterous.flutterlocalnotifications.ScheduledNotificationBootReceiver">
+            <intent-filter>
+                <action android:name="android.intent.action.BOOT_COMPLETED"/>
+                <action android:name="android.intent.action.MY_PACKAGE_REPLACED"/>
+                <action android:name="android.intent.action.QUICKBOOT_POWERON"/>
+                <action android:name="com.htc.intent.action.QUICKBOOT_POWERON"/>
+            </intent-filter>
+        </receiver>
         <!-- Don't delete the meta-data below.
              This is used by the Flutter tool to generate GeneratedPluginRegistrant.java -->
         <meta-data

--- a/intake_test.lock
+++ b/intake_test.lock
@@ -1,1 +1,0 @@
-{"isolated":false}

--- a/lib/core/data/data_source/config_data_source.dart
+++ b/lib/core/data/data_source/config_data_source.dart
@@ -93,6 +93,29 @@ class ConfigDataSource {
     config?.save();
   }
 
+  Future<void> setConfigShowActivityTracking(bool show) async {
+    _log.fine('Updating config showActivityTracking to $show');
+    final config = _configBox.get(_configKey);
+    config?.showActivityTracking = show;
+    config?.save();
+  }
+
+  Future<void> setNotificationsEnabled(bool enabled) async {
+    _log.fine('Updating config notificationsEnabled to $enabled');
+    final config = _configBox.get(_configKey);
+    config?.notificationsEnabled = enabled;
+    config?.save();
+  }
+
+  Future<void> setNotificationTime(int hour, int minute) async {
+    _log.fine('Updating config notification time to $hour:$minute');
+    final config = _configBox.get(_configKey);
+    config?.notificationHour = hour;
+    config?.notificationMinute = minute;
+    config?.save();
+  }
+
+
   Future<ConfigDBO> getConfig() async {
     return _configBox.get(_configKey) ?? ConfigDBO.empty();
   }

--- a/lib/core/data/data_source/config_data_source.dart
+++ b/lib/core/data/data_source/config_data_source.dart
@@ -116,6 +116,18 @@ class ConfigDataSource {
   }
 
 
+  Future<String?> getSelectedLocale() async {
+    final config = _configBox.get(_configKey);
+    return config?.selectedLocale;
+  }
+
+  Future<void> setSelectedLocale(String? locale) async {
+    _log.fine('Updating config selectedLocale to $locale');
+    final config = _configBox.get(_configKey);
+    config?.selectedLocale = locale;
+    config?.save();
+  }
+
   Future<ConfigDBO> getConfig() async {
     return _configBox.get(_configKey) ?? ConfigDBO.empty();
   }

--- a/lib/core/data/data_source/physical_activity_data_source.dart
+++ b/lib/core/data/data_source/physical_activity_data_source.dart
@@ -1,11 +1,13 @@
 import 'package:opennutritracker/core/data/dbo/physical_activity_dbo.dart';
 
-/// Selection of  physical activities by the
-/// '2011 Compendium of Physical Activities'
-/// https://pubmed.ncbi.nlm.nih.gov/21681120/
-/// by Ainsworth et al.
+/// Selection of physical activities from the
+/// '2024 Compendium of Physical Activities'
+/// https://doi.org/10.1249/MSS.0000000000003624
+/// by Strath et al. / Ainsworth et al.
+/// MET values updated from 2011 edition where revised in 2024 data.
 class PhysicalActivityDataSource {
   List<PhysicalActivityDBO> getPhysicalActivityList() => [
+        // ── Bicycling ─────────────────────────────────────────────────────────
         PhysicalActivityDBO(
           "01015",
           "bicycling",
@@ -30,6 +32,8 @@ class PhysicalActivityDataSource {
           [],
           PhysicalActivityTypeDBO.bicycling,
         ),
+
+        // ── Conditioning / Exercise ───────────────────────────────────────────
         PhysicalActivityDBO(
           "02010",
           "bicycling, stationary",
@@ -54,11 +58,44 @@ class PhysicalActivityDataSource {
           [],
           PhysicalActivityTypeDBO.conditioningExercise,
         ),
+        // #290: 2024 update — resistance training, vigorous (new)
+        PhysicalActivityDBO(
+          "02055",
+          "resistance training",
+          "vigorous effort, powerlifting or bodybuilding",
+          6.0,
+          [],
+          PhysicalActivityTypeDBO.conditioningExercise,
+        ),
         PhysicalActivityDBO(
           "02068",
           "rope skipping",
           "general",
           12.3,
+          [],
+          PhysicalActivityTypeDBO.conditioningExercise,
+        ),
+        PhysicalActivityDBO(
+          "02080",
+          "rowing machine",
+          "moderate effort",
+          7.0,
+          [],
+          PhysicalActivityTypeDBO.conditioningExercise,
+        ),
+        PhysicalActivityDBO(
+          "02090",
+          "elliptical trainer",
+          "moderate effort",
+          5.0,
+          [],
+          PhysicalActivityTypeDBO.conditioningExercise,
+        ),
+        PhysicalActivityDBO(
+          "02095",
+          "stair-treadmill ergometer",
+          "general",
+          9.0,
           [],
           PhysicalActivityTypeDBO.conditioningExercise,
         ),
@@ -70,6 +107,35 @@ class PhysicalActivityDataSource {
           [],
           PhysicalActivityTypeDBO.conditioningExercise,
         ),
+        // #290: 2024 update — yoga revised to 3.0 MET (was 2.5 in 2011)
+        PhysicalActivityDBO(
+          "02160",
+          "yoga",
+          "general, hatha",
+          3.0,
+          [],
+          PhysicalActivityTypeDBO.conditioningExercise,
+        ),
+        // #290: 2024 — pilates (new entry)
+        PhysicalActivityDBO(
+          "02165",
+          "pilates",
+          "general",
+          3.0,
+          [],
+          PhysicalActivityTypeDBO.conditioningExercise,
+        ),
+        // #290: 2024 — stretching / flexibility (new entry)
+        PhysicalActivityDBO(
+          "02170",
+          "stretching",
+          "mild, general",
+          2.3,
+          [],
+          PhysicalActivityTypeDBO.conditioningExercise,
+        ),
+
+        // ── Dancing ───────────────────────────────────────────────────────────
         PhysicalActivityDBO(
           "03015",
           "aerobic",
@@ -78,6 +144,8 @@ class PhysicalActivityDataSource {
           [],
           PhysicalActivityTypeDBO.dancing,
         ),
+
+        // ── Running ───────────────────────────────────────────────────────────
         PhysicalActivityDBO(
           "12020",
           "jogging",
@@ -86,14 +154,26 @@ class PhysicalActivityDataSource {
           [],
           PhysicalActivityTypeDBO.running,
         ),
+        // #290: 2024 update — running general revised to 8.3 (was 8.0)
         PhysicalActivityDBO(
           "12150",
           "running",
           "general",
+          8.3,
+          [],
+          PhysicalActivityTypeDBO.running,
+        ),
+        // #290: 2024 — treadmill running (new entry)
+        PhysicalActivityDBO(
+          "12180",
+          "running",
+          "on treadmill, general",
           8.0,
           [],
           PhysicalActivityTypeDBO.running,
         ),
+
+        // ── Sports ────────────────────────────────────────────────────────────
         PhysicalActivityDBO(
           "15010",
           "archery",
@@ -160,7 +240,7 @@ class PhysicalActivityDataSource {
         ),
         PhysicalActivityDBO(
           "15135",
-          "children’s games",
+          "children's games",
           "(e.g., hopscotch, 4-square, dodgeball, playground apparatus, t-ball, tetherball, marbles, arcade games), moderate effort",
           5.8,
           [],
@@ -510,11 +590,12 @@ class PhysicalActivityDataSource {
           [],
           PhysicalActivityTypeDBO.sport,
         ),
+        // #290: 2024 update — tai chi revised to 3.5 MET (was 3.0 in 2011)
         PhysicalActivityDBO(
           "15670",
           "tai chi, qi gong",
           "general",
-          3.0,
+          3.5,
           [],
           PhysicalActivityTypeDBO.sport,
         ),
@@ -582,6 +663,24 @@ class PhysicalActivityDataSource {
           [],
           PhysicalActivityTypeDBO.sport,
         ),
+        // #290: 2024 — pickleball (new; highly popular, added in 2024 edition)
+        PhysicalActivityDBO(
+          "15740",
+          "pickleball",
+          "general",
+          4.8,
+          [],
+          PhysicalActivityTypeDBO.sport,
+        ),
+        // #290: 2024 — e-sports / video gaming active (new)
+        PhysicalActivityDBO(
+          "15750",
+          "active video games",
+          "Wii Sports, Dance Dance Revolution, general",
+          3.0,
+          [],
+          PhysicalActivityTypeDBO.sport,
+        ),
         PhysicalActivityDBO(
           "17010",
           "backpacking",
@@ -614,6 +713,17 @@ class PhysicalActivityDataSource {
           [],
           PhysicalActivityTypeDBO.sport,
         ),
+        // #290: 2024 — Nordic walking (new entry)
+        PhysicalActivityDBO(
+          "17170",
+          "Nordic walking",
+          "general",
+          4.8,
+          [],
+          PhysicalActivityTypeDBO.sport,
+        ),
+
+        // ── Water Activities ──────────────────────────────────────────────────
         PhysicalActivityDBO(
           "18070",
           "canoeing",
@@ -718,6 +828,8 @@ class PhysicalActivityDataSource {
           [],
           PhysicalActivityTypeDBO.waterActivities,
         ),
+
+        // ── Winter Activities ─────────────────────────────────────────────────
         PhysicalActivityDBO(
           "19030",
           "ice skating",
@@ -734,10 +846,28 @@ class PhysicalActivityDataSource {
           [],
           PhysicalActivityTypeDBO.winterActivities,
         ),
+        // #290: 2024 — cross-country skiing (new entry)
+        PhysicalActivityDBO(
+          "19080",
+          "skiing",
+          "cross-country, general",
+          7.0,
+          [],
+          PhysicalActivityTypeDBO.winterActivities,
+        ),
         PhysicalActivityDBO(
           "19252",
           "snow shoveling",
           "by hand, moderate effort",
+          5.3,
+          [],
+          PhysicalActivityTypeDBO.winterActivities,
+        ),
+        // #290: 2024 — snowshoeing (new entry)
+        PhysicalActivityDBO(
+          "19260",
+          "snowshoeing",
+          "general",
           5.3,
           [],
           PhysicalActivityTypeDBO.winterActivities,

--- a/lib/core/data/dbo/config_dbo.dart
+++ b/lib/core/data/dbo/config_dbo.dart
@@ -34,6 +34,8 @@ class ConfigDBO extends HiveObject {
   int? notificationHour;
   @HiveField(12)
   int? notificationMinute;
+  @HiveField(13)
+  String? selectedLocale;
 
   ConfigDBO(
     this.hasAcceptedDisclaimer,
@@ -46,6 +48,7 @@ class ConfigDBO extends HiveObject {
     this.notificationsEnabled,
     this.notificationHour,
     this.notificationMinute,
+    this.selectedLocale,
   });
 
   factory ConfigDBO.empty() =>

--- a/lib/core/data/dbo/config_dbo.dart
+++ b/lib/core/data/dbo/config_dbo.dart
@@ -26,6 +26,14 @@ class ConfigDBO extends HiveObject {
   double? userProteinGoalPct;
   @HiveField(8)
   double? userFatGoalPct;
+  @HiveField(9)
+  bool? showActivityTracking;
+  @HiveField(10)
+  bool? notificationsEnabled;
+  @HiveField(11)
+  int? notificationHour;
+  @HiveField(12)
+  int? notificationMinute;
 
   ConfigDBO(
     this.hasAcceptedDisclaimer,
@@ -34,6 +42,10 @@ class ConfigDBO extends HiveObject {
     this.selectedAppTheme, {
     this.usesImperialUnits = false,
     this.userKcalAdjustment,
+    this.showActivityTracking,
+    this.notificationsEnabled,
+    this.notificationHour,
+    this.notificationMinute,
   });
 
   factory ConfigDBO.empty() =>

--- a/lib/core/data/dbo/config_dbo.g.dart
+++ b/lib/core/data/dbo/config_dbo.g.dart
@@ -27,6 +27,7 @@ class ConfigDBOAdapter extends TypeAdapter<ConfigDBO> {
         notificationsEnabled: fields[10] as bool?,
         notificationHour: (fields[11] as num?)?.toInt(),
         notificationMinute: (fields[12] as num?)?.toInt(),
+        selectedLocale: fields[13] as String?,
       )
       ..userCarbGoalPct = (fields[6] as num?)?.toDouble()
       ..userProteinGoalPct = (fields[7] as num?)?.toDouble()
@@ -36,7 +37,7 @@ class ConfigDBOAdapter extends TypeAdapter<ConfigDBO> {
   @override
   void write(BinaryWriter writer, ConfigDBO obj) {
     writer
-      ..writeByte(13)
+      ..writeByte(14)
       ..writeByte(0)
       ..write(obj.hasAcceptedDisclaimer)
       ..writeByte(1)
@@ -62,7 +63,9 @@ class ConfigDBOAdapter extends TypeAdapter<ConfigDBO> {
       ..writeByte(11)
       ..write(obj.notificationHour)
       ..writeByte(12)
-      ..write(obj.notificationMinute);
+      ..write(obj.notificationMinute)
+      ..writeByte(13)
+      ..write(obj.selectedLocale);
   }
 
   @override
@@ -92,6 +95,7 @@ ConfigDBO _$ConfigDBOFromJson(Map<String, dynamic> json) =>
         notificationsEnabled: json['notificationsEnabled'] as bool?,
         notificationHour: (json['notificationHour'] as num?)?.toInt(),
         notificationMinute: (json['notificationMinute'] as num?)?.toInt(),
+        selectedLocale: json['selectedLocale'] as String?,
       )
       ..userCarbGoalPct = (json['userCarbGoalPct'] as num?)?.toDouble()
       ..userProteinGoalPct = (json['userProteinGoalPct'] as num?)?.toDouble()
@@ -111,6 +115,7 @@ Map<String, dynamic> _$ConfigDBOToJson(ConfigDBO instance) => <String, dynamic>{
   'notificationsEnabled': instance.notificationsEnabled,
   'notificationHour': instance.notificationHour,
   'notificationMinute': instance.notificationMinute,
+  'selectedLocale': instance.selectedLocale,
 };
 
 const _$AppThemeDBOEnumMap = {

--- a/lib/core/data/dbo/config_dbo.g.dart
+++ b/lib/core/data/dbo/config_dbo.g.dart
@@ -23,6 +23,10 @@ class ConfigDBOAdapter extends TypeAdapter<ConfigDBO> {
         fields[3] as AppThemeDBO,
         usesImperialUnits: fields[4] == null ? false : fields[4] as bool?,
         userKcalAdjustment: (fields[5] as num?)?.toDouble(),
+        showActivityTracking: fields[9] as bool?,
+        notificationsEnabled: fields[10] as bool?,
+        notificationHour: (fields[11] as num?)?.toInt(),
+        notificationMinute: (fields[12] as num?)?.toInt(),
       )
       ..userCarbGoalPct = (fields[6] as num?)?.toDouble()
       ..userProteinGoalPct = (fields[7] as num?)?.toDouble()
@@ -32,7 +36,7 @@ class ConfigDBOAdapter extends TypeAdapter<ConfigDBO> {
   @override
   void write(BinaryWriter writer, ConfigDBO obj) {
     writer
-      ..writeByte(9)
+      ..writeByte(13)
       ..writeByte(0)
       ..write(obj.hasAcceptedDisclaimer)
       ..writeByte(1)
@@ -50,7 +54,15 @@ class ConfigDBOAdapter extends TypeAdapter<ConfigDBO> {
       ..writeByte(7)
       ..write(obj.userProteinGoalPct)
       ..writeByte(8)
-      ..write(obj.userFatGoalPct);
+      ..write(obj.userFatGoalPct)
+      ..writeByte(9)
+      ..write(obj.showActivityTracking)
+      ..writeByte(10)
+      ..write(obj.notificationsEnabled)
+      ..writeByte(11)
+      ..write(obj.notificationHour)
+      ..writeByte(12)
+      ..write(obj.notificationMinute);
   }
 
   @override
@@ -76,6 +88,10 @@ ConfigDBO _$ConfigDBOFromJson(Map<String, dynamic> json) =>
         $enumDecode(_$AppThemeDBOEnumMap, json['selectedAppTheme']),
         usesImperialUnits: json['usesImperialUnits'] as bool? ?? false,
         userKcalAdjustment: (json['userKcalAdjustment'] as num?)?.toDouble(),
+        showActivityTracking: json['showActivityTracking'] as bool?,
+        notificationsEnabled: json['notificationsEnabled'] as bool?,
+        notificationHour: (json['notificationHour'] as num?)?.toInt(),
+        notificationMinute: (json['notificationMinute'] as num?)?.toInt(),
       )
       ..userCarbGoalPct = (json['userCarbGoalPct'] as num?)?.toDouble()
       ..userProteinGoalPct = (json['userProteinGoalPct'] as num?)?.toDouble()
@@ -91,6 +107,10 @@ Map<String, dynamic> _$ConfigDBOToJson(ConfigDBO instance) => <String, dynamic>{
   'userCarbGoalPct': instance.userCarbGoalPct,
   'userProteinGoalPct': instance.userProteinGoalPct,
   'userFatGoalPct': instance.userFatGoalPct,
+  'showActivityTracking': instance.showActivityTracking,
+  'notificationsEnabled': instance.notificationsEnabled,
+  'notificationHour': instance.notificationHour,
+  'notificationMinute': instance.notificationMinute,
 };
 
 const _$AppThemeDBOEnumMap = {

--- a/lib/core/data/dbo/user_dbo.dart
+++ b/lib/core/data/dbo/user_dbo.dart
@@ -20,6 +20,8 @@ class UserDBO extends HiveObject {
   UserWeightGoalDBO goal;
   @HiveField(5)
   UserPALDBO pal;
+  @HiveField(6)
+  double? weeklyWeightGoalKg;
 
   UserDBO({
     required this.birthday,
@@ -28,6 +30,7 @@ class UserDBO extends HiveObject {
     required this.gender,
     required this.goal,
     required this.pal,
+    this.weeklyWeightGoalKg,
   });
 
   factory UserDBO.fromUserEntity(UserEntity entity) {
@@ -38,6 +41,7 @@ class UserDBO extends HiveObject {
       gender: UserGenderDBO.fromUserGenderEntity(entity.gender),
       goal: UserWeightGoalDBO.fromUserWeightGoalEntity(entity.goal),
       pal: UserPALDBO.fromUserPALEntity(entity.pal),
+      weeklyWeightGoalKg: entity.weeklyWeightGoalKg,
     );
   }
 }

--- a/lib/core/data/dbo/user_dbo.g.dart
+++ b/lib/core/data/dbo/user_dbo.g.dart
@@ -23,13 +23,14 @@ class UserDBOAdapter extends TypeAdapter<UserDBO> {
       gender: fields[3] as UserGenderDBO,
       goal: fields[4] as UserWeightGoalDBO,
       pal: fields[5] as UserPALDBO,
+      weeklyWeightGoalKg: (fields[6] as num?)?.toDouble(),
     );
   }
 
   @override
   void write(BinaryWriter writer, UserDBO obj) {
     writer
-      ..writeByte(6)
+      ..writeByte(7)
       ..writeByte(0)
       ..write(obj.birthday)
       ..writeByte(1)
@@ -41,7 +42,9 @@ class UserDBOAdapter extends TypeAdapter<UserDBO> {
       ..writeByte(4)
       ..write(obj.goal)
       ..writeByte(5)
-      ..write(obj.pal);
+      ..write(obj.pal)
+      ..writeByte(6)
+      ..write(obj.weeklyWeightGoalKg);
   }
 
   @override

--- a/lib/core/data/repository/config_repository.dart
+++ b/lib/core/data/repository/config_repository.dart
@@ -78,4 +78,12 @@ class ConfigRepository {
   Future<void> setNotificationTime(int hour, int minute) async {
     _configDataSource.setNotificationTime(hour, minute);
   }
+
+  Future<String?> getSelectedLocale() async {
+    return await _configDataSource.getSelectedLocale();
+  }
+
+  Future<void> setSelectedLocale(String? locale) async {
+    _configDataSource.setSelectedLocale(locale);
+  }
 }

--- a/lib/core/data/repository/config_repository.dart
+++ b/lib/core/data/repository/config_repository.dart
@@ -66,4 +66,16 @@ class ConfigRepository {
     _configDataSource.setConfigProteinGoalPct(protein);
     _configDataSource.setConfigFatGoalPct(fat);
   }
+
+  Future<void> setConfigShowActivityTracking(bool show) async {
+    _configDataSource.setConfigShowActivityTracking(show);
+  }
+
+  Future<void> setNotificationsEnabled(bool enabled) async {
+    _configDataSource.setNotificationsEnabled(enabled);
+  }
+
+  Future<void> setNotificationTime(int hour, int minute) async {
+    _configDataSource.setNotificationTime(hour, minute);
+  }
 }

--- a/lib/core/domain/entity/config_entity.dart
+++ b/lib/core/domain/entity/config_entity.dart
@@ -16,6 +16,7 @@ class ConfigEntity extends Equatable {
   final bool notificationsEnabled;
   final int notificationHour;
   final int notificationMinute;
+  final String? selectedLocale;
 
   const ConfigEntity(
     this.hasAcceptedDisclaimer,
@@ -31,6 +32,7 @@ class ConfigEntity extends Equatable {
     this.notificationsEnabled = false,
     this.notificationHour = 8,
     this.notificationMinute = 0,
+    this.selectedLocale,
   });
 
   factory ConfigEntity.fromConfigDBO(ConfigDBO dbo) => ConfigEntity(
@@ -47,6 +49,7 @@ class ConfigEntity extends Equatable {
         notificationsEnabled: dbo.notificationsEnabled ?? false,
         notificationHour: dbo.notificationHour ?? 8,
         notificationMinute: dbo.notificationMinute ?? 0,
+        selectedLocale: dbo.selectedLocale,
       );
 
   @override
@@ -63,5 +66,6 @@ class ConfigEntity extends Equatable {
         notificationsEnabled,
         notificationHour,
         notificationMinute,
+        selectedLocale,
       ];
 }

--- a/lib/core/domain/entity/config_entity.dart
+++ b/lib/core/domain/entity/config_entity.dart
@@ -12,6 +12,10 @@ class ConfigEntity extends Equatable {
   final double? userCarbGoalPct;
   final double? userProteinGoalPct;
   final double? userFatGoalPct;
+  final bool showActivityTracking;
+  final bool notificationsEnabled;
+  final int notificationHour;
+  final int notificationMinute;
 
   const ConfigEntity(
     this.hasAcceptedDisclaimer,
@@ -23,6 +27,10 @@ class ConfigEntity extends Equatable {
     this.userCarbGoalPct,
     this.userProteinGoalPct,
     this.userFatGoalPct,
+    this.showActivityTracking = true,
+    this.notificationsEnabled = false,
+    this.notificationHour = 8,
+    this.notificationMinute = 0,
   });
 
   factory ConfigEntity.fromConfigDBO(ConfigDBO dbo) => ConfigEntity(
@@ -35,6 +43,10 @@ class ConfigEntity extends Equatable {
         userCarbGoalPct: dbo.userCarbGoalPct,
         userProteinGoalPct: dbo.userProteinGoalPct,
         userFatGoalPct: dbo.userFatGoalPct,
+        showActivityTracking: dbo.showActivityTracking ?? true,
+        notificationsEnabled: dbo.notificationsEnabled ?? false,
+        notificationHour: dbo.notificationHour ?? 8,
+        notificationMinute: dbo.notificationMinute ?? 0,
       );
 
   @override
@@ -47,5 +59,9 @@ class ConfigEntity extends Equatable {
         userCarbGoalPct,
         userProteinGoalPct,
         userFatGoalPct,
+        showActivityTracking,
+        notificationsEnabled,
+        notificationHour,
+        notificationMinute,
       ];
 }

--- a/lib/core/domain/entity/user_entity.dart
+++ b/lib/core/domain/entity/user_entity.dart
@@ -10,6 +10,7 @@ class UserEntity {
   UserGenderEntity gender;
   UserWeightGoalEntity goal;
   UserPALEntity pal;
+  double? weeklyWeightGoalKg;
 
   UserEntity({
     required this.birthday,
@@ -18,6 +19,7 @@ class UserEntity {
     required this.gender,
     required this.goal,
     required this.pal,
+    this.weeklyWeightGoalKg,
   });
 
   factory UserEntity.fromUserDBO(UserDBO userDBO) {
@@ -28,6 +30,7 @@ class UserEntity {
       gender: UserGenderEntity.fromUserGenderDBO(userDBO.gender),
       goal: UserWeightGoalEntity.fromUserWeightGoalDBO(userDBO.goal),
       pal: UserPALEntity.fromUserPALDBO(userDBO.pal),
+      weeklyWeightGoalKg: userDBO.weeklyWeightGoalKg,
     );
   }
 

--- a/lib/core/domain/usecase/add_config_usecase.dart
+++ b/lib/core/domain/usecase/add_config_usecase.dart
@@ -55,4 +55,8 @@ class AddConfigUsecase {
   Future<void> setNotificationTime(int hour, int minute) async {
     _configRepository.setNotificationTime(hour, minute);
   }
+
+  Future<void> setSelectedLocale(String? locale) async {
+    _configRepository.setSelectedLocale(locale);
+  }
 }

--- a/lib/core/domain/usecase/add_config_usecase.dart
+++ b/lib/core/domain/usecase/add_config_usecase.dart
@@ -42,4 +42,17 @@ class AddConfigUsecase {
   ) async {
     _configRepository.setUserMacroPct(carbGoalPct, proteinGoalPct, fatPctGoal);
   }
+
+
+  Future<void> setConfigShowActivityTracking(bool show) async {
+    _configRepository.setConfigShowActivityTracking(show);
+  }
+
+  Future<void> setNotificationsEnabled(bool enabled) async {
+    _configRepository.setNotificationsEnabled(enabled);
+  }
+
+  Future<void> setNotificationTime(int hour, int minute) async {
+    _configRepository.setNotificationTime(hour, minute);
+  }
 }

--- a/lib/core/utils/calc/calorie_goal_calc.dart
+++ b/lib/core/utils/calc/calorie_goal_calc.dart
@@ -16,17 +16,25 @@ class CalorieGoalCalc {
   static double getTdee(UserEntity userEntity) =>
       TDEECalc.getTDEEKcalIOM2005(userEntity);
 
+  // 1 kg of body fat ≈ 7700 kcal; spread over 7 days → ~1100 kcal/day per kg/week
+  static const double _kcalPerKgPerWeekDaily = 1100.0;
+
   static double getTotalKcalGoal(
     UserEntity userEntity,
     double totalKcalActivities, {
     double? kcalUserAdjustment,
   }) =>
       getTdee(userEntity) +
-      getKcalGoalAdjustment(userEntity.goal) +
+      getKcalGoalAdjustment(userEntity.goal,
+          weeklyWeightGoalKg: userEntity.weeklyWeightGoalKg) +
       (kcalUserAdjustment ?? 0) +
       totalKcalActivities;
 
-  static double getKcalGoalAdjustment(UserWeightGoalEntity goal) {
+  static double getKcalGoalAdjustment(UserWeightGoalEntity goal,
+      {double? weeklyWeightGoalKg}) {
+    if (weeklyWeightGoalKg != null) {
+      return weeklyWeightGoalKg * _kcalPerKgPerWeekDaily;
+    }
     double kcalAdjustment;
     if (goal == UserWeightGoalEntity.loseWeight) {
       kcalAdjustment = loseWeightKcalAdjustment;

--- a/lib/core/utils/locale_provider.dart
+++ b/lib/core/utils/locale_provider.dart
@@ -1,0 +1,12 @@
+import 'package:flutter/material.dart';
+
+class LocaleProvider extends ChangeNotifier {
+  Locale? locale;
+
+  LocaleProvider({this.locale});
+
+  void updateLocale(Locale? newLocale) {
+    locale = newLocale;
+    notifyListeners();
+  }
+}

--- a/lib/core/utils/locator.dart
+++ b/lib/core/utils/locator.dart
@@ -31,6 +31,7 @@ import 'package:opennutritracker/core/domain/usecase/update_intake_usecase.dart'
 import 'package:opennutritracker/core/domain/usecase/update_user_activity_usecase.dart';
 import 'package:opennutritracker/core/utils/env.dart';
 import 'package:opennutritracker/core/utils/hive_db_provider.dart';
+import 'package:opennutritracker/core/utils/notification_service.dart';
 import 'package:opennutritracker/core/utils/ont_image_cache_manager.dart';
 import 'package:opennutritracker/core/utils/secure_app_storage_provider.dart';
 import 'package:opennutritracker/features/activity_detail/presentation/bloc/activity_detail_bloc.dart';
@@ -76,6 +77,9 @@ Future<void> initLocator() async {
     anonKey: Env.supabaseProjectAnonKey,
   );
   locator.registerLazySingleton<SupabaseClient>(() => Supabase.instance.client);
+
+  // Notification service (#312)
+  locator.registerLazySingleton<NotificationService>(() => NotificationService());
 
   // Cache manager
   locator.registerLazySingleton<CacheManager>(

--- a/lib/core/utils/notification_service.dart
+++ b/lib/core/utils/notification_service.dart
@@ -1,0 +1,109 @@
+import 'package:flutter_local_notifications/flutter_local_notifications.dart';
+import 'package:logging/logging.dart';
+import 'package:timezone/data/latest_all.dart' as tz;
+import 'package:timezone/timezone.dart' as tz;
+
+/// #312: Service for scheduling daily meal reminder notifications.
+class NotificationService {
+  static const int _dailyReminderId = 0;
+  static const String _channelId = 'daily_reminder';
+  static const String _channelName = 'Daily Reminders';
+  static const String _channelDesc = 'Daily meal logging reminder';
+
+  final _log = Logger('NotificationService');
+  final FlutterLocalNotificationsPlugin _plugin =
+      FlutterLocalNotificationsPlugin();
+
+  bool _initialized = false;
+
+  /// Initializes the plugin. Must be called before any other method.
+  Future<void> initialize() async {
+    if (_initialized) return;
+    tz.initializeTimeZones();
+
+    const androidSettings =
+        AndroidInitializationSettings('@mipmap/ic_launcher');
+    const iosSettings = DarwinInitializationSettings(
+      requestAlertPermission: false,
+      requestBadgePermission: false,
+      requestSoundPermission: false,
+    );
+    const initSettings =
+        InitializationSettings(android: androidSettings, iOS: iosSettings);
+
+    await _plugin.initialize(initSettings);
+    _initialized = true;
+    _log.fine('NotificationService initialized');
+  }
+
+  /// Requests the OS notification permission (Android 13+ / iOS).
+  Future<bool> requestPermission() async {
+    final android = _plugin
+        .resolvePlatformSpecificImplementation<
+            AndroidFlutterLocalNotificationsPlugin>();
+    if (android != null) {
+      final granted = await android.requestNotificationsPermission();
+      return granted ?? false;
+    }
+    final ios = _plugin
+        .resolvePlatformSpecificImplementation<
+            IOSFlutterLocalNotificationsPlugin>();
+    if (ios != null) {
+      final granted = await ios.requestPermissions(
+          alert: true, badge: true, sound: true);
+      return granted ?? false;
+    }
+    return false;
+  }
+
+  /// Schedules a daily recurring notification at [hour]:[minute].
+  Future<void> scheduleDailyReminder({
+    required int hour,
+    required int minute,
+    required String title,
+    required String body,
+  }) async {
+    await _ensureInitialized();
+    await _plugin.cancel(_dailyReminderId);
+
+    final androidDetails = AndroidNotificationDetails(
+      _channelId,
+      _channelName,
+      channelDescription: _channelDesc,
+      importance: Importance.defaultImportance,
+      priority: Priority.defaultPriority,
+    );
+    const iosDetails = DarwinNotificationDetails();
+    final details =
+        NotificationDetails(android: androidDetails, iOS: iosDetails);
+
+    final now = tz.TZDateTime.now(tz.local);
+    var scheduledDate = tz.TZDateTime(
+        tz.local, now.year, now.month, now.day, hour, minute);
+    if (scheduledDate.isBefore(now)) {
+      scheduledDate = scheduledDate.add(const Duration(days: 1));
+    }
+
+    await _plugin.zonedSchedule(
+      _dailyReminderId,
+      title,
+      body,
+      scheduledDate,
+      details,
+      androidScheduleMode: AndroidScheduleMode.exactAllowWhileIdle,
+      matchDateTimeComponents: DateTimeComponents.time,
+    );
+    _log.fine('Daily reminder scheduled at $hour:$minute');
+  }
+
+  /// Cancels any pending daily reminder.
+  Future<void> cancelDailyReminder() async {
+    await _ensureInitialized();
+    await _plugin.cancel(_dailyReminderId);
+    _log.fine('Daily reminder cancelled');
+  }
+
+  Future<void> _ensureInitialized() async {
+    if (!_initialized) await initialize();
+  }
+}

--- a/lib/features/diary/diary_page.dart
+++ b/lib/features/diary/diary_page.dart
@@ -34,7 +34,8 @@ class _DiaryPageState extends State<DiaryPage> with WidgetsBindingObserver {
   late MealDetailBloc _mealDetailBloc;
   late ActivityDetailBloc _activityDetailBloc;
 
-  static const _calendarDurationDays = Duration(days: 356);
+  // #292: Extended from 356 days (~1 year) to 5 years so old entries are never truncated
+  static const _calendarDurationDays = Duration(days: 365 * 5);
   final _currentDate = DateTime.now();
   var _selectedDate = DateTime.now();
   var _focusedDate = DateTime.now();

--- a/lib/features/diary/presentation/bloc/diary_bloc.dart
+++ b/lib/features/diary/presentation/bloc/diary_bloc.dart
@@ -26,7 +26,8 @@ class DiaryBloc extends Bloc<DiaryEvent, DiaryState> {
           (await _getConfigUsecase.getConfig()).usesImperialUnits;
 
       currentDay = DateTime.now();
-      const yearDuration = Duration(days: 356);
+      // #292: Extended to match calendar range (5 years back)
+      const yearDuration = Duration(days: 365 * 5);
 
       final trackedDays = await _getDayTrackedUsecase.getTrackedDaysByRange(
         currentDay.subtract(yearDuration),

--- a/lib/features/edit_meal/presentation/edit_meal_screen.dart
+++ b/lib/features/edit_meal/presentation/edit_meal_screen.dart
@@ -44,8 +44,12 @@ class _EditMealScreenState extends State<EditMealScreen> {
 
   final _units = ['g', 'ml', 'g/ml'];
   String? selectedUnit;
+  bool _isTotal = false;
 
   late List<ButtonSegment<String>> _mealUnitButtonSegment;
+
+  String baseQuantity = "100";
+  String baseQuantityUnit = " g/ml";
 
   @override
   void initState() {
@@ -243,75 +247,84 @@ class _EditMealScreenState extends State<EditMealScreen> {
           keyboardType: const TextInputType.numberWithOptions(decimal: true),
         ),
         const SizedBox(height: 48),
-        ValueListenableBuilder<TextEditingValue>(
-          valueListenable: _baseQuantityTextController,
-          builder: (context, value, _) {
-            final base = (value.text.isEmpty ? '100' : value.text) +
-                _unitSuffixForSelected(context);
-            return TextFormField(
-              controller: _kcalTextController,
-              inputFormatters: CustomTextInputFormatter.doubleOnly(),
-              decoration: InputDecoration(
-                  labelText: S.of(context).mealKcalLabel + base,
-                  border: const OutlineInputBorder()),
-              keyboardType:
-                  const TextInputType.numberWithOptions(decimal: true),
-            );
+        SegmentedButton<bool>(
+          segments: [
+            ButtonSegment(
+              value: false,
+              label: Text(S.of(context).mealNutrientsPerQtyLabel(
+                  _getDisplayQuantity(), baseQuantityUnit.trim())),
+            ),
+            ButtonSegment(
+              value: true,
+              label: Text(S.of(context).mealNutrientsTotalLabel),
+            ),
+          ],
+          selected: {_isTotal},
+          onSelectionChanged: (Set<bool> newSelection) {
+            setState(() {
+              _isTotal = newSelection.first;
+            });
           },
         ),
         const SizedBox(height: 16),
-        ValueListenableBuilder<TextEditingValue>(
-          valueListenable: _baseQuantityTextController,
-          builder: (context, value, _) {
-            final base = (value.text.isEmpty ? '100' : value.text) +
-                _unitSuffixForSelected(context);
-            return TextFormField(
-              controller: _carbsTextController,
-              inputFormatters: CustomTextInputFormatter.doubleOnly(),
-              decoration: InputDecoration(
-                  labelText: S.of(context).mealCarbsLabel + base,
-                  border: const OutlineInputBorder()),
-              keyboardType:
-                  const TextInputType.numberWithOptions(decimal: true),
-            );
-          },
+        TextFormField(
+          controller: _kcalTextController,
+          inputFormatters: CustomTextInputFormatter.doubleOnly(),
+          decoration: InputDecoration(
+              labelText: S.of(context).mealKcalLabel,
+              helperText: _isTotal
+                  ? S.of(context).mealNutrientsTotalLabel
+                  : S.of(context).mealNutrientsPerQtyLabel(
+                      _getDisplayQuantity(), baseQuantityUnit.trim()),
+              border: const OutlineInputBorder()),
+          keyboardType: const TextInputType.numberWithOptions(decimal: true),
         ),
         const SizedBox(height: 16),
-        ValueListenableBuilder<TextEditingValue>(
-          valueListenable: _baseQuantityTextController,
-          builder: (context, value, _) {
-            final base = (value.text.isEmpty ? '100' : value.text) +
-                _unitSuffixForSelected(context);
-            return TextFormField(
-              controller: _fatTextController,
-              inputFormatters: CustomTextInputFormatter.doubleOnly(),
-              decoration: InputDecoration(
-                  labelText: S.of(context).mealFatLabel + base,
-                  border: const OutlineInputBorder()),
-              keyboardType:
-                  const TextInputType.numberWithOptions(decimal: true),
-            );
-          },
+        TextFormField(
+          controller: _carbsTextController,
+          inputFormatters: CustomTextInputFormatter.doubleOnly(),
+          decoration: InputDecoration(
+              labelText: S.of(context).mealCarbsLabel,
+              helperText: _isTotal
+                  ? S.of(context).mealNutrientsTotalLabel
+                  : S.of(context).mealNutrientsPerQtyLabel(
+                      _getDisplayQuantity(), baseQuantityUnit.trim()),
+              border: const OutlineInputBorder()),
+          keyboardType: const TextInputType.numberWithOptions(decimal: true),
         ),
         const SizedBox(height: 16),
-        ValueListenableBuilder<TextEditingValue>(
-          valueListenable: _baseQuantityTextController,
-          builder: (context, value, _) {
-            final base = (value.text.isEmpty ? '100' : value.text) +
-                _unitSuffixForSelected(context);
-            return TextFormField(
-              controller: _proteinTextController,
-              inputFormatters: CustomTextInputFormatter.doubleOnly(),
-              decoration: InputDecoration(
-                  labelText: S.of(context).mealProteinLabel + base,
-                  border: const OutlineInputBorder()),
-              keyboardType:
-                  const TextInputType.numberWithOptions(decimal: true),
-            );
-          },
+        TextFormField(
+          controller: _fatTextController,
+          inputFormatters: CustomTextInputFormatter.doubleOnly(),
+          decoration: InputDecoration(
+              labelText: S.of(context).mealFatLabel,
+              helperText: _isTotal
+                  ? S.of(context).mealNutrientsTotalLabel
+                  : S.of(context).mealNutrientsPerQtyLabel(
+                      _getDisplayQuantity(), baseQuantityUnit.trim()),
+              border: const OutlineInputBorder()),
+          keyboardType: const TextInputType.numberWithOptions(decimal: true),
+        ),
+        const SizedBox(height: 16),
+        TextFormField(
+          controller: _proteinTextController,
+          inputFormatters: CustomTextInputFormatter.doubleOnly(),
+          decoration: InputDecoration(
+              labelText: S.of(context).mealProteinLabel,
+              helperText: _isTotal
+                  ? S.of(context).mealNutrientsTotalLabel
+                  : S.of(context).mealNutrientsPerQtyLabel(
+                      _getDisplayQuantity(), baseQuantityUnit.trim()),
+              border: const OutlineInputBorder()),
+          keyboardType: const TextInputType.numberWithOptions(decimal: true),
         ),
       ],
     );
+  }
+
+  String _getDisplayQuantity() {
+    final text = _baseQuantityTextController.text;
+    return text.isEmpty ? baseQuantity : text;
   }
 
   void _onSavePressed(bool usesImperialUnits) {
@@ -323,6 +336,29 @@ class _EditMealScreenState extends State<EditMealScreen> {
               _mealQuantityTextController.text, mealUnitForConversion)
           : _mealQuantityTextController.text;
 
+      // Convert total → per-base-qty if in total input mode
+      String kcalText = _kcalTextController.text;
+      String carbsText = _carbsTextController.text;
+      String fatText = _fatTextController.text;
+      String proteinText = _proteinTextController.text;
+      if (_isTotal) {
+        final mealQty = double.tryParse(mealQuantity) ?? 0.0;
+        final baseQtyForConversion =
+            double.tryParse(_baseQuantityTextController.text) ?? 100.0;
+        if (mealQty > 0) {
+          String convertTotal(String text) {
+            final v = double.tryParse(text);
+            if (v == null) return text;
+            return ((v / mealQty) * baseQtyForConversion).toString();
+          }
+
+          kcalText = convertTotal(kcalText);
+          carbsText = convertTotal(carbsText);
+          fatText = convertTotal(fatText);
+          proteinText = convertTotal(proteinText);
+        }
+      }
+
       final newMealEntity = _editMealBloc.createNewMealEntity(
         _mealEntity,
         _nameTextController.text,
@@ -331,10 +367,10 @@ class _EditMealScreenState extends State<EditMealScreen> {
         _servingQuantityTextController.text,
         _baseQuantityTextController.text,
         selectedUnit,
-        _kcalTextController.text,
-        _carbsTextController.text,
-        _fatTextController.text,
-        _proteinTextController.text,
+        kcalText,
+        carbsText,
+        fatText,
+        proteinText,
       );
 
       Navigator.of(context).pushNamedAndRemoveUntil(
@@ -362,16 +398,6 @@ class _EditMealScreenState extends State<EditMealScreen> {
       return _units[2]; // Default to g/ml
     }
     return unit;
-  }
-
-  String _unitSuffixForSelected(BuildContext context) {
-    final u = selectedUnit ?? _units[2];
-    if (u == 'g') {
-      return _usesImperialUnits ? ' ${S.of(context).ozUnit}' : ' ${S.of(context).gramUnit}';
-    } else if (u == 'ml') {
-      return _usesImperialUnits ? ' ${S.of(context).flOzUnit}' : ' ${S.of(context).milliliterUnit}';
-    }
-    return ' ${S.of(context).gramMilliliterUnit}';
   }
 
   String _convertToImperial(String value, String unit) {

--- a/lib/features/home/home_page.dart
+++ b/lib/features/home/home_page.dart
@@ -15,6 +15,7 @@ import 'package:opennutritracker/features/add_meal/presentation/add_meal_type.da
 import 'package:opennutritracker/features/home/presentation/bloc/home_bloc.dart';
 import 'package:opennutritracker/features/home/presentation/widgets/dashboard_widget.dart';
 import 'package:opennutritracker/features/home/presentation/widgets/intake_vertical_list.dart';
+import 'package:opennutritracker/features/home/presentation/widgets/quick_weight_widget.dart';
 import 'package:opennutritracker/generated/l10n.dart';
 
 class HomePage extends StatefulWidget {
@@ -123,6 +124,8 @@ class _HomePageState extends State<HomePage> with WidgetsBindingObserver {
       children: [
         ListView(
           children: [
+            QuickWeightWidget(usesImperialUnits: usesImperialUnits),
+            const SizedBox(height: 8.0),
             DashboardWidget(
               totalKcalDaily: totalKcalDaily,
               totalKcalLeft: totalKcalLeft,

--- a/lib/features/home/presentation/widgets/quick_weight_widget.dart
+++ b/lib/features/home/presentation/widgets/quick_weight_widget.dart
@@ -1,0 +1,98 @@
+import 'package:flutter/material.dart';
+import 'package:opennutritracker/core/domain/usecase/add_user_usecase.dart';
+import 'package:opennutritracker/core/domain/usecase/get_user_usecase.dart';
+import 'package:opennutritracker/core/utils/locator.dart';
+import 'package:opennutritracker/features/home/presentation/bloc/home_bloc.dart';
+import 'package:opennutritracker/features/profile/presentation/widgets/set_weight_dialog.dart';
+import 'package:opennutritracker/generated/l10n.dart';
+
+/// #281: Quick weight update widget on the home/landing screen.
+/// Displays current weight as a tappable chip; opens SetWeightDialog on tap.
+class QuickWeightWidget extends StatefulWidget {
+  final bool usesImperialUnits;
+
+  const QuickWeightWidget({super.key, required this.usesImperialUnits});
+
+  @override
+  State<QuickWeightWidget> createState() => _QuickWeightWidgetState();
+}
+
+class _QuickWeightWidgetState extends State<QuickWeightWidget> {
+  double? _weightKg;
+
+  @override
+  void initState() {
+    super.initState();
+    _loadWeight();
+  }
+
+  Future<void> _loadWeight() async {
+    final user = await locator<GetUserUsecase>().getUserData();
+    if (mounted) {
+      setState(() => _weightKg = user.weightKG);
+    }
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    if (_weightKg == null) return const SizedBox.shrink();
+
+    final displayWeight = widget.usesImperialUnits
+        ? _weightKg! * 2.20462
+        : _weightKg!;
+    final unit = widget.usesImperialUnits
+        ? S.of(context).lbsLabel
+        : S.of(context).kgLabel;
+
+    return Padding(
+      padding: const EdgeInsets.symmetric(horizontal: 16.0),
+      child: Row(
+        children: [
+          const Icon(Icons.monitor_weight_outlined, size: 18),
+          const SizedBox(width: 8),
+          Text(
+            '${displayWeight.toStringAsFixed(1)} $unit',
+            style: Theme.of(context).textTheme.bodyMedium,
+          ),
+          const SizedBox(width: 4),
+          IconButton(
+            icon: const Icon(Icons.edit_outlined, size: 16),
+            padding: EdgeInsets.zero,
+            constraints: const BoxConstraints(),
+            visualDensity: VisualDensity.compact,
+            tooltip: S.of(context).editMealLabel,
+            onPressed: () => _showWeightDialog(context),
+          ),
+        ],
+      ),
+    );
+  }
+
+  Future<void> _showWeightDialog(BuildContext context) async {
+    final displayWeight = widget.usesImperialUnits
+        ? _weightKg! * 2.20462
+        : _weightKg!;
+
+    final newWeight = await showDialog<double>(
+      context: context,
+      builder: (context) => SetWeightDialog(
+        userWeight: displayWeight,
+        usesImperialUnits: widget.usesImperialUnits,
+      ),
+    );
+
+    if (newWeight == null || !context.mounted) return;
+
+    final newWeightKg =
+        widget.usesImperialUnits ? newWeight / 2.20462 : newWeight;
+
+    final user = await locator<GetUserUsecase>().getUserData();
+    await locator<AddUserUsecase>()
+        .addUser(user..weightKG = newWeightKg);
+
+    setState(() => _weightKg = newWeightKg);
+
+    // Refresh home kcal goal (weight affects TDEE)
+    locator<HomeBloc>().add(const LoadItemsEvent());
+  }
+}

--- a/lib/features/profile/presentation/widgets/set_weekly_weight_goal_dialog.dart
+++ b/lib/features/profile/presentation/widgets/set_weekly_weight_goal_dialog.dart
@@ -1,0 +1,109 @@
+import 'package:flutter/material.dart';
+import 'package:opennutritracker/generated/l10n.dart';
+
+/// #284: Dialog for setting the weekly weight change rate.
+/// Returns a nullable double (kg/week): negative = lose, positive = gain, null = clear/not set.
+class SetWeeklyWeightGoalDialog extends StatefulWidget {
+  final double? currentGoalKg;
+  final bool usesImperialUnits;
+
+  const SetWeeklyWeightGoalDialog({
+    super.key,
+    required this.currentGoalKg,
+    required this.usesImperialUnits,
+  });
+
+  @override
+  State<SetWeeklyWeightGoalDialog> createState() =>
+      _SetWeeklyWeightGoalDialogState();
+}
+
+class _SetWeeklyWeightGoalDialogState
+    extends State<SetWeeklyWeightGoalDialog> {
+  // Slider range in kg/week: -1.0 (lose 1 kg/wk) to +1.0 (gain 1 kg/wk)
+  static const double _minKg = -1.0;
+  static const double _maxKg = 1.0;
+  static const int _divisions = 8; // steps of 0.25 kg
+
+  late double _selectedKg;
+
+  @override
+  void initState() {
+    super.initState();
+    _selectedKg = widget.currentGoalKg ?? 0.0;
+    _selectedKg = _selectedKg.clamp(_minKg, _maxKg);
+  }
+
+  double get _displayValue => widget.usesImperialUnits
+      ? _selectedKg * 2.20462
+      : _selectedKg;
+
+  String get _displayLabel {
+    if (_selectedKg == 0.0) return S.of(context).goalMaintainWeight;
+    final sign = _displayValue > 0 ? '+' : '';
+    final formatted = '$sign${_displayValue.toStringAsFixed(2)}';
+    return widget.usesImperialUnits
+        ? S.of(context).weeklyWeightGoalLbsPerWeek(formatted)
+        : S.of(context).weeklyWeightGoalKgPerWeek(formatted);
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    return AlertDialog(
+      title: Text(S.of(context).chooseWeeklyWeightGoalLabel),
+      content: Column(
+        mainAxisSize: MainAxisSize.min,
+        children: [
+          Text(
+            _displayLabel,
+            style: Theme.of(context).textTheme.titleMedium,
+          ),
+          Slider(
+            min: _minKg,
+            max: _maxKg,
+            divisions: _divisions,
+            value: _selectedKg,
+            label: _displayLabel,
+            onChanged: (value) => setState(() => _selectedKg = value),
+          ),
+          Row(
+            mainAxisAlignment: MainAxisAlignment.spaceBetween,
+            children: [
+              Text(
+                widget.usesImperialUnits ? '-2.2 lbs' : '-1.0 kg',
+                style: Theme.of(context).textTheme.bodySmall,
+              ),
+              Text(
+                widget.usesImperialUnits ? '+2.2 lbs' : '+1.0 kg',
+                style: Theme.of(context).textTheme.bodySmall,
+              ),
+            ],
+          ),
+        ],
+      ),
+      actions: [
+        TextButton(
+          onPressed: () => Navigator.of(context).pop(null),
+          child: Text(S.of(context).dialogCancelLabel),
+        ),
+        if (widget.currentGoalKg != null)
+          TextButton(
+            onPressed: () =>
+                Navigator.of(context).pop(_kClearSentinel),
+            child: Text(S.of(context).buttonResetLabel),
+          ),
+        TextButton(
+          onPressed: () => Navigator.of(context).pop(_selectedKg),
+          child: Text(S.of(context).dialogOKLabel),
+        ),
+      ],
+    );
+  }
+}
+
+/// Sentinel value returned when the user chooses to clear the weekly goal.
+const double _kClearSentinel = double.nan;
+
+/// Returns true when the dialog result signals "clear the goal".
+bool isWeeklyGoalClear(double? result) =>
+    result != null && result.isNaN;

--- a/lib/features/profile/profile_page.dart
+++ b/lib/features/profile/profile_page.dart
@@ -12,6 +12,7 @@ import 'package:opennutritracker/features/profile/presentation/widgets/bmi_overv
 import 'package:opennutritracker/features/profile/presentation/widgets/set_gender_dialog.dart';
 import 'package:opennutritracker/features/profile/presentation/widgets/set_goal_dialog.dart';
 import 'package:opennutritracker/features/profile/presentation/widgets/set_height_dialog.dart';
+import 'package:opennutritracker/features/profile/presentation/widgets/set_weekly_weight_goal_dialog.dart';
 import 'package:opennutritracker/features/profile/presentation/widgets/set_pal_category_dialog.dart';
 import 'package:opennutritracker/features/profile/presentation/widgets/set_weight_dialog.dart';
 import 'package:opennutritracker/generated/l10n.dart';
@@ -106,6 +107,22 @@ class _ProfilePageState extends State<ProfilePage> {
         ),
         ListTile(
           title: Text(
+            S.of(context).weeklyWeightGoalLabel,
+            style: Theme.of(context).textTheme.titleLarge,
+          ),
+          subtitle: Text(
+            _weeklyGoalSubtitle(context, user, usesImperialUnits),
+            style: Theme.of(context).textTheme.titleMedium,
+          ),
+          leading: const SizedBox(
+            height: double.infinity,
+            child: Icon(Icons.trending_down_outlined),
+          ),
+          onTap: () =>
+              _showSetWeeklyWeightGoalDialog(context, user, usesImperialUnits),
+        ),
+        ListTile(
+          title: Text(
             S.of(context).weightLabel,
             style: Theme.of(context).textTheme.titleLarge,
           ),
@@ -188,6 +205,38 @@ class _ProfilePageState extends State<ProfilePage> {
       userEntity.pal = selectedPalCategory;
       _profileBloc.updateUser(userEntity);
     }
+  }
+
+  String _weeklyGoalSubtitle(
+      BuildContext context, UserEntity user, bool usesImperialUnits) {
+    final goal = user.weeklyWeightGoalKg;
+    if (goal == null) return S.of(context).weeklyWeightGoalNoneLabel;
+    if (goal == 0.0) return S.of(context).goalMaintainWeight;
+    final displayValue =
+        usesImperialUnits ? goal * 2.20462 : goal;
+    final sign = displayValue > 0 ? '+' : '';
+    final formatted = '$sign${displayValue.toStringAsFixed(2)}';
+    return usesImperialUnits
+        ? S.of(context).weeklyWeightGoalLbsPerWeek(formatted)
+        : S.of(context).weeklyWeightGoalKgPerWeek(formatted);
+  }
+
+  Future<void> _showSetWeeklyWeightGoalDialog(BuildContext context,
+      UserEntity userEntity, bool usesImperialUnits) async {
+    final result = await showDialog<double>(
+      context: context,
+      builder: (context) => SetWeeklyWeightGoalDialog(
+        currentGoalKg: userEntity.weeklyWeightGoalKg,
+        usesImperialUnits: usesImperialUnits,
+      ),
+    );
+    if (result == null) return; // cancelled
+    if (isWeeklyGoalClear(result)) {
+      userEntity.weeklyWeightGoalKg = null;
+    } else {
+      userEntity.weeklyWeightGoalKg = result;
+    }
+    _profileBloc.updateUser(userEntity);
   }
 
   Future<void> _showSetGoalDialog(

--- a/lib/features/settings/presentation/bloc/settings_bloc.dart
+++ b/lib/features/settings/presentation/bloc/settings_bloc.dart
@@ -42,6 +42,10 @@ class SettingsBloc extends Bloc<SettingsEvent, SettingsState> {
           userConfig.hasAcceptedSendAnonymousData,
           userConfig.appTheme,
           usesImperialUnits,
+          showActivityTracking: userConfig.showActivityTracking,
+          notificationsEnabled: userConfig.notificationsEnabled,
+          notificationHour: userConfig.notificationHour,
+          notificationMinute: userConfig.notificationMinute,
         ),
       );
     });
@@ -60,6 +64,19 @@ class SettingsBloc extends Bloc<SettingsEvent, SettingsState> {
   void setUsesImperialUnits(bool usesImperialUnits) {
     _addConfigUsecase.setConfigUsesImperialUnits(usesImperialUnits);
   }
+
+  void setShowActivityTracking(bool showActivityTracking) {
+    _addConfigUsecase.setConfigShowActivityTracking(showActivityTracking);
+  }
+
+  void setNotificationsEnabled(bool enabled) {
+    _addConfigUsecase.setNotificationsEnabled(enabled);
+  }
+
+  void setNotificationTime(int hour, int minute) {
+    _addConfigUsecase.setNotificationTime(hour, minute);
+  }
+
 
   Future<double> getKcalAdjustment() async {
     final config = await _getConfigUsecase.getConfig();

--- a/lib/features/settings/presentation/bloc/settings_bloc.dart
+++ b/lib/features/settings/presentation/bloc/settings_bloc.dart
@@ -46,6 +46,7 @@ class SettingsBloc extends Bloc<SettingsEvent, SettingsState> {
           notificationsEnabled: userConfig.notificationsEnabled,
           notificationHour: userConfig.notificationHour,
           notificationMinute: userConfig.notificationMinute,
+          selectedLocale: userConfig.selectedLocale,
         ),
       );
     });
@@ -75,6 +76,10 @@ class SettingsBloc extends Bloc<SettingsEvent, SettingsState> {
 
   void setNotificationTime(int hour, int minute) {
     _addConfigUsecase.setNotificationTime(hour, minute);
+  }
+
+  void setSelectedLocale(String? locale) {
+    _addConfigUsecase.setSelectedLocale(locale);
   }
 
 

--- a/lib/features/settings/presentation/bloc/settings_state.dart
+++ b/lib/features/settings/presentation/bloc/settings_state.dart
@@ -19,13 +19,21 @@ class SettingsLoadedState extends SettingsState {
   final bool sendAnonymousData;
   final AppThemeEntity appTheme;
   final bool usesImperialUnits;
+  final bool showActivityTracking;
+  final bool notificationsEnabled;
+  final int notificationHour;
+  final int notificationMinute;
 
   const SettingsLoadedState(
     this.versionNumber,
     this.sendAnonymousData,
     this.appTheme,
-    this.usesImperialUnits,
-  );
+    this.usesImperialUnits, {
+    this.showActivityTracking = true,
+    this.notificationsEnabled = false,
+    this.notificationHour = 8,
+    this.notificationMinute = 0,
+  });
 
   @override
   List<Object?> get props => [
@@ -33,5 +41,9 @@ class SettingsLoadedState extends SettingsState {
         sendAnonymousData,
         appTheme,
         usesImperialUnits,
+        showActivityTracking,
+        notificationsEnabled,
+        notificationHour,
+        notificationMinute,
       ];
 }

--- a/lib/features/settings/presentation/bloc/settings_state.dart
+++ b/lib/features/settings/presentation/bloc/settings_state.dart
@@ -23,6 +23,7 @@ class SettingsLoadedState extends SettingsState {
   final bool notificationsEnabled;
   final int notificationHour;
   final int notificationMinute;
+  final String? selectedLocale;
 
   const SettingsLoadedState(
     this.versionNumber,
@@ -33,6 +34,7 @@ class SettingsLoadedState extends SettingsState {
     this.notificationsEnabled = false,
     this.notificationHour = 8,
     this.notificationMinute = 0,
+    this.selectedLocale,
   });
 
   @override
@@ -45,5 +47,6 @@ class SettingsLoadedState extends SettingsState {
         notificationsEnabled,
         notificationHour,
         notificationMinute,
+        selectedLocale,
       ];
 }

--- a/lib/features/settings/presentation/widgets/calculations_dialog.dart
+++ b/lib/features/settings/presentation/widgets/calculations_dialog.dart
@@ -1,4 +1,5 @@
 import 'package:flutter/material.dart';
+import 'package:flutter/services.dart';
 import 'package:opennutritracker/features/diary/presentation/bloc/calendar_day_bloc.dart';
 import 'package:opennutritracker/features/diary/presentation/bloc/diary_bloc.dart';
 import 'package:opennutritracker/features/home/presentation/bloc/home_bloc.dart';
@@ -36,10 +37,37 @@ class _CalculationsDialogState extends State<CalculationsDialog> {
   static const double _defaultFatPctSelection = 0.25;
   static const double _defaultProteinPctSelection = 0.15;
 
-  // Macros percentages
   double _carbsPctSelection = _defaultCarbsPctSelection * 100;
   double _proteinPctSelection = _defaultProteinPctSelection * 100;
   double _fatPctSelection = _defaultFatPctSelection * 100;
+
+  // #297: Text controllers for direct input
+  late TextEditingController _kcalAdjustmentController;
+  late TextEditingController _carbsController;
+  late TextEditingController _proteinController;
+  late TextEditingController _fatController;
+
+  @override
+  void initState() {
+    super.initState();
+    _kcalAdjustmentController =
+        TextEditingController(text: _kcalAdjustmentSelection.round().toString());
+    _carbsController =
+        TextEditingController(text: _carbsPctSelection.round().toString());
+    _proteinController =
+        TextEditingController(text: _proteinPctSelection.round().toString());
+    _fatController =
+        TextEditingController(text: _fatPctSelection.round().toString());
+  }
+
+  @override
+  void dispose() {
+    _kcalAdjustmentController.dispose();
+    _carbsController.dispose();
+    _proteinController.dispose();
+    _fatController.dispose();
+    super.dispose();
+  }
 
   @override
   void didChangeDependencies() {
@@ -48,8 +76,7 @@ class _CalculationsDialogState extends State<CalculationsDialog> {
   }
 
   void _initializeKcalAdjustment() async {
-    final kcalAdjustment = await widget.settingsBloc.getKcalAdjustment() *
-        1.0; // Convert to double
+    final kcalAdjustment = await widget.settingsBloc.getKcalAdjustment() * 1.0;
     final userCarbsPct = await widget.settingsBloc.getUserCarbGoalPct();
     final userProteinPct = await widget.settingsBloc.getUserProteinGoalPct();
     final userFatPct = await widget.settingsBloc.getUserFatGoalPct();
@@ -61,6 +88,30 @@ class _CalculationsDialogState extends State<CalculationsDialog> {
           (userProteinPct ?? _defaultProteinPctSelection) * 100;
       _fatPctSelection = (userFatPct ?? _defaultFatPctSelection) * 100;
     });
+    _kcalAdjustmentController.text =
+        _kcalAdjustmentSelection.round().toString();
+    _carbsController.text = _carbsPctSelection.round().toString();
+    _proteinController.text = _proteinPctSelection.round().toString();
+    _fatController.text = _fatPctSelection.round().toString();
+  }
+
+  void _syncControllersToState() {
+    _carbsController.text = _carbsPctSelection.round().toString();
+    _proteinController.text = _proteinPctSelection.round().toString();
+    _fatController.text = _fatPctSelection.round().toString();
+  }
+
+  /// #297: Apply a directly typed macro percentage for one macro,
+  /// leaving the others unchanged (normalization happens on save).
+  void _applyDirectMacroInput(
+      TextEditingController controller, void Function(double) setter) {
+    final parsed = int.tryParse(controller.text);
+    if (parsed == null || parsed < 5 || parsed > 90) {
+      // Revert to last valid state
+      _syncControllersToState();
+      return;
+    }
+    setState(() => setter(parsed.toDouble()));
   }
 
   @override
@@ -75,166 +126,188 @@ class _CalculationsDialogState extends State<CalculationsDialog> {
               overflow: TextOverflow.ellipsis,
             ),
           ),
-          const SizedBox(width: 8), // Add spacing between text and button
+          const SizedBox(width: 8),
           TextButton(
             child: Text(S.of(context).buttonResetLabel),
             onPressed: () {
               setState(() {
                 _kcalAdjustmentSelection = 0;
-                // Reset macros to default values
                 _carbsPctSelection = _defaultCarbsPctSelection * 100;
                 _proteinPctSelection = _defaultProteinPctSelection * 100;
                 _fatPctSelection = _defaultFatPctSelection * 100;
               });
+              _kcalAdjustmentController.text = '0';
+              _syncControllersToState();
             },
           ),
         ],
       ),
-      content: Wrap(
-        children: [
-          DropdownButtonFormField(
-            isExpanded: true,
-            decoration: InputDecoration(
-              enabled: false,
-              filled: false,
-              labelText: S.of(context).calculationsTDEELabel,
-            ),
-            items: [
-              DropdownMenuItem(
-                child: Text(
-                  '${S.of(context).calculationsTDEEIOM2006Label} ${S.of(context).calculationsRecommendedLabel}',
-                  overflow: TextOverflow.ellipsis,
-                ),
+      content: SingleChildScrollView(
+        child: Column(
+          mainAxisSize: MainAxisSize.min,
+          crossAxisAlignment: CrossAxisAlignment.start,
+          children: [
+            DropdownButtonFormField(
+              isExpanded: true,
+              decoration: InputDecoration(
+                enabled: false,
+                filled: false,
+                labelText: S.of(context).calculationsTDEELabel,
               ),
-            ],
-            onChanged: null,
-          ),
-          const SizedBox(height: 64),
-          Container(
-            alignment: Alignment.centerLeft,
-            child: Text(
-              '${S.of(context).dailyKcalAdjustmentLabel} ${!_kcalAdjustmentSelection.isNegative ? "+" : ""}${_kcalAdjustmentSelection.round()} ${S.of(context).kcalLabel}',
+              items: [
+                DropdownMenuItem(
+                  child: Text(
+                    '${S.of(context).calculationsTDEEIOM2006Label} ${S.of(context).calculationsRecommendedLabel}',
+                    overflow: TextOverflow.ellipsis,
+                  ),
+                ),
+              ],
+              onChanged: null,
+            ),
+            const SizedBox(height: 32),
+            // ── Kcal adjustment ──────────────────────────────────────────────
+            Row(
+              children: [
+                Expanded(
+                  child: Text(
+                    S.of(context).dailyKcalAdjustmentLabel,
+                    style: Theme.of(context).textTheme.titleMedium,
+                  ),
+                ),
+                // #297: Direct text input for kcal adjustment
+                SizedBox(
+                  width: 80,
+                  child: TextField(
+                    controller: _kcalAdjustmentController,
+                    keyboardType: const TextInputType.numberWithOptions(
+                        signed: true, decimal: false),
+                    inputFormatters: [
+                      FilteringTextInputFormatter.allow(RegExp(r'^-?\d*')),
+                    ],
+                    textAlign: TextAlign.right,
+                    decoration: InputDecoration(
+                      suffixText: S.of(context).kcalLabel,
+                      isDense: true,
+                    ),
+                    onSubmitted: (_) => _applyKcalInput(),
+                    onEditingComplete: _applyKcalInput,
+                  ),
+                ),
+              ],
+            ),
+            Slider(
+              min: _minKcalAdjustment,
+              max: _maxKcalAdjustment,
+              divisions: _kcalDivisions,
+              value: _kcalAdjustmentSelection,
+              label: '${_kcalAdjustmentSelection.round()} ${S.of(context).kcalLabel}',
+              onChanged: (value) {
+                setState(() => _kcalAdjustmentSelection = value);
+                _kcalAdjustmentController.text = value.round().toString();
+              },
+            ),
+            const SizedBox(height: 16),
+            // ── Macro distribution ───────────────────────────────────────────
+            Text(
+              S.of(context).macroDistributionLabel,
               style: Theme.of(context).textTheme.titleMedium,
             ),
-          ),
-          Align(
-            alignment: Alignment.centerLeft,
-            child: SizedBox(
-              width: 280,
-              child: Slider(
-                min: _minKcalAdjustment,
-                max: _maxKcalAdjustment,
-                divisions: _kcalDivisions,
-                value: _kcalAdjustmentSelection,
-                label:
-                    '${_kcalAdjustmentSelection.round()} ${S.of(context).kcalLabel}',
-                onChanged: (value) {
-                  setState(() {
-                    _kcalAdjustmentSelection = value;
-                  });
-                },
-              ),
+            const SizedBox(height: 8),
+            // #297: hint that text fields allow direct entry
+            Text(
+              '${_carbsPctSelection.round() + _proteinPctSelection.round() + _fatPctSelection.round()}% total',
+              style: Theme.of(context).textTheme.bodySmall,
             ),
-          ),
-          const SizedBox(height: 32),
-          Text(
-            S.of(context).macroDistributionLabel,
-            style: Theme.of(context).textTheme.titleMedium,
-          ),
-          const SizedBox(height: 32),
-          _buildMacroSlider(
-            S.of(context).carbsLabel,
-            _carbsPctSelection,
-            Colors.orange,
-            (value) {
-              setState(() {
-                double delta = value - _carbsPctSelection;
-                _carbsPctSelection = value;
-
-                // Adjust other percentages proportionally
-                double proteinRatio = _proteinPctSelection /
-                    (_proteinPctSelection + _fatPctSelection);
-                double fatRatio = _fatPctSelection /
-                    (_proteinPctSelection + _fatPctSelection);
-
-                _proteinPctSelection -= delta * proteinRatio;
-                _fatPctSelection -= delta * fatRatio;
-
-                // Ensure no value goes below 5%
-                if (_proteinPctSelection < 5) {
-                  double overflow = 5 - _proteinPctSelection;
-                  _proteinPctSelection = 5;
-                  _fatPctSelection -= overflow;
-                }
-                if (_fatPctSelection < 5) {
-                  double overflow = 5 - _fatPctSelection;
-                  _fatPctSelection = 5;
-                  _proteinPctSelection -= overflow;
-                }
-              });
-            },
-          ),
-          _buildMacroSlider(
-            S.of(context).proteinLabel,
-            _proteinPctSelection,
-            Colors.blue,
-            (value) {
-              setState(() {
-                double delta = value - _proteinPctSelection;
-                _proteinPctSelection = value;
-
-                double carbsRatio = _carbsPctSelection /
-                    (_carbsPctSelection + _fatPctSelection);
-                double fatRatio =
-                    _fatPctSelection / (_carbsPctSelection + _fatPctSelection);
-
-                _carbsPctSelection -= delta * carbsRatio;
-                _fatPctSelection -= delta * fatRatio;
-
-                if (_carbsPctSelection < 5) {
-                  double overflow = 5 - _carbsPctSelection;
-                  _carbsPctSelection = 5;
-                  _fatPctSelection -= overflow;
-                }
-                if (_fatPctSelection < 5) {
-                  double overflow = 5 - _fatPctSelection;
-                  _fatPctSelection = 5;
-                  _carbsPctSelection -= overflow;
-                }
-              });
-            },
-          ),
-          _buildMacroSlider(
-            S.of(context).fatLabel,
-            _fatPctSelection,
-            Colors.green,
-            (value) {
-              setState(() {
-                double delta = value - _fatPctSelection;
-                _fatPctSelection = value;
-
-                double carbsRatio = _carbsPctSelection /
-                    (_carbsPctSelection + _proteinPctSelection);
-                double proteinRatio = _proteinPctSelection /
-                    (_carbsPctSelection + _proteinPctSelection);
-
-                _carbsPctSelection -= delta * carbsRatio;
-                _proteinPctSelection -= delta * proteinRatio;
-
-                if (_carbsPctSelection < 5) {
-                  double overflow = 5 - _carbsPctSelection;
-                  _carbsPctSelection = 5;
-                  _proteinPctSelection -= overflow;
-                }
-                if (_proteinPctSelection < 5) {
-                  double overflow = 5 - _proteinPctSelection;
-                  _proteinPctSelection = 5;
-                  _carbsPctSelection -= overflow;
-                }
-              });
-            },
-          ),
-        ],
+            const SizedBox(height: 8),
+            _buildMacroRow(
+              S.of(context).carbsLabel,
+              _carbsPctSelection,
+              Colors.orange,
+              _carbsController,
+              onSliderChanged: (value) {
+                setState(() {
+                  double delta = value - _carbsPctSelection;
+                  _carbsPctSelection = value;
+                  double proteinRatio = _proteinPctSelection /
+                      (_proteinPctSelection + _fatPctSelection);
+                  double fatRatio = _fatPctSelection /
+                      (_proteinPctSelection + _fatPctSelection);
+                  _proteinPctSelection -= delta * proteinRatio;
+                  _fatPctSelection -= delta * fatRatio;
+                  if (_proteinPctSelection < 5) {
+                    _fatPctSelection -= 5 - _proteinPctSelection;
+                    _proteinPctSelection = 5;
+                  }
+                  if (_fatPctSelection < 5) {
+                    _proteinPctSelection -= 5 - _fatPctSelection;
+                    _fatPctSelection = 5;
+                  }
+                });
+                _syncControllersToState();
+              },
+              onTextSubmitted: () => _applyDirectMacroInput(
+                  _carbsController, (v) => _carbsPctSelection = v),
+            ),
+            _buildMacroRow(
+              S.of(context).proteinLabel,
+              _proteinPctSelection,
+              Colors.blue,
+              _proteinController,
+              onSliderChanged: (value) {
+                setState(() {
+                  double delta = value - _proteinPctSelection;
+                  _proteinPctSelection = value;
+                  double carbsRatio = _carbsPctSelection /
+                      (_carbsPctSelection + _fatPctSelection);
+                  double fatRatio = _fatPctSelection /
+                      (_carbsPctSelection + _fatPctSelection);
+                  _carbsPctSelection -= delta * carbsRatio;
+                  _fatPctSelection -= delta * fatRatio;
+                  if (_carbsPctSelection < 5) {
+                    _fatPctSelection -= 5 - _carbsPctSelection;
+                    _carbsPctSelection = 5;
+                  }
+                  if (_fatPctSelection < 5) {
+                    _carbsPctSelection -= 5 - _fatPctSelection;
+                    _fatPctSelection = 5;
+                  }
+                });
+                _syncControllersToState();
+              },
+              onTextSubmitted: () => _applyDirectMacroInput(
+                  _proteinController, (v) => _proteinPctSelection = v),
+            ),
+            _buildMacroRow(
+              S.of(context).fatLabel,
+              _fatPctSelection,
+              Colors.green,
+              _fatController,
+              onSliderChanged: (value) {
+                setState(() {
+                  double delta = value - _fatPctSelection;
+                  _fatPctSelection = value;
+                  double carbsRatio = _carbsPctSelection /
+                      (_carbsPctSelection + _proteinPctSelection);
+                  double proteinRatio = _proteinPctSelection /
+                      (_carbsPctSelection + _proteinPctSelection);
+                  _carbsPctSelection -= delta * carbsRatio;
+                  _proteinPctSelection -= delta * proteinRatio;
+                  if (_carbsPctSelection < 5) {
+                    _proteinPctSelection -= 5 - _carbsPctSelection;
+                    _carbsPctSelection = 5;
+                  }
+                  if (_proteinPctSelection < 5) {
+                    _carbsPctSelection -= 5 - _proteinPctSelection;
+                    _proteinPctSelection = 5;
+                  }
+                });
+                _syncControllersToState();
+              },
+              onTextSubmitted: () => _applyDirectMacroInput(
+                  _fatController, (v) => _fatPctSelection = v),
+            ),
+          ],
+        ),
       ),
       actions: [
         TextButton(
@@ -244,49 +317,75 @@ class _CalculationsDialogState extends State<CalculationsDialog> {
           child: Text(S.of(context).dialogCancelLabel),
         ),
         TextButton(
-          onPressed: () {
-            _saveCalculationSettings();
-          },
+          onPressed: _saveCalculationSettings,
           child: Text(S.of(context).dialogOKLabel),
         ),
       ],
     );
   }
 
-  Widget _buildMacroSlider(
+  void _applyKcalInput() {
+    final parsed = int.tryParse(_kcalAdjustmentController.text);
+    if (parsed == null) {
+      _kcalAdjustmentController.text =
+          _kcalAdjustmentSelection.round().toString();
+      return;
+    }
+    final clamped =
+        parsed.clamp(_minKcalAdjustment.toInt(), _maxKcalAdjustment.toInt());
+    setState(() => _kcalAdjustmentSelection = clamped.toDouble());
+    _kcalAdjustmentController.text = clamped.toString();
+  }
+
+  Widget _buildMacroRow(
     String label,
     double value,
     Color color,
-    ValueChanged<double> onChanged,
-  ) {
+    TextEditingController controller, {
+    required ValueChanged<double> onSliderChanged,
+    required VoidCallback onTextSubmitted,
+  }) {
     return Column(
       crossAxisAlignment: CrossAxisAlignment.start,
       children: [
         Row(
-          mainAxisAlignment: MainAxisAlignment.spaceBetween,
-          children: [Text(label), Text('${value.round()}%')],
+          children: [
+            Expanded(child: Text(label)),
+            // #297: editable text field for direct % input
+            SizedBox(
+              width: 60,
+              child: TextField(
+                controller: controller,
+                keyboardType: TextInputType.number,
+                inputFormatters: [FilteringTextInputFormatter.digitsOnly],
+                textAlign: TextAlign.right,
+                decoration: const InputDecoration(
+                  suffixText: '%',
+                  isDense: true,
+                ),
+                onSubmitted: (_) => onTextSubmitted(),
+                onEditingComplete: onTextSubmitted,
+              ),
+            ),
+          ],
         ),
-        SizedBox(
-          width: 280,
-          child: SliderTheme(
-            data: SliderThemeData(
-              activeTrackColor: color,
-              thumbColor: color,
-              inactiveTrackColor: color.withValues(alpha: 0.2),
-            ),
-            child: Slider(
-              min: 5,
-              max: 90,
-              value: value,
-              divisions: 85,
-              onChanged: (value) {
-                final newValue = value.round().toDouble();
-                if (100 - newValue >= 10) {
-                  onChanged(newValue);
-                  _normalizeMacros();
-                }
-              },
-            ),
+        SliderTheme(
+          data: SliderThemeData(
+            activeTrackColor: color,
+            thumbColor: color,
+            inactiveTrackColor: color.withValues(alpha: 0.2),
+          ),
+          child: Slider(
+            min: 5,
+            max: 90,
+            value: value.clamp(5, 90),
+            divisions: 85,
+            onChanged: (v) {
+              final rounded = v.round().toDouble();
+              if (100 - rounded >= 10) {
+                onSliderChanged(rounded);
+              }
+            },
           ),
         ),
       ],
@@ -294,53 +393,38 @@ class _CalculationsDialogState extends State<CalculationsDialog> {
   }
 
   void _normalizeMacros() {
-    setState(() {
-      // First, ensure all values are rounded
-      _carbsPctSelection = _carbsPctSelection.roundToDouble();
-      _proteinPctSelection = _proteinPctSelection.roundToDouble();
-      _fatPctSelection = _fatPctSelection.roundToDouble();
+    _carbsPctSelection = _carbsPctSelection.roundToDouble();
+    _proteinPctSelection = _proteinPctSelection.roundToDouble();
+    _fatPctSelection = _fatPctSelection.roundToDouble();
 
-      // Calculate total
-      double total =
-          _carbsPctSelection + _proteinPctSelection + _fatPctSelection;
+    double total =
+        _carbsPctSelection + _proteinPctSelection + _fatPctSelection;
 
-      // If total isn't 100, adjust values proportionally
-      if (total != 100) {
-        // Calculate adjustment factor
-        double factor = 100 / total;
-
-        // Adjust the first two values
-        _carbsPctSelection = (_carbsPctSelection * factor).roundToDouble();
-        _proteinPctSelection = (_proteinPctSelection * factor).roundToDouble();
-
-        // Set the last value to make total exactly 100
-        _fatPctSelection = 100 - _carbsPctSelection - _proteinPctSelection;
-
-        // Ensure minimum values (5%)
-        if (_fatPctSelection < 5) {
-          _fatPctSelection = 5;
-          // Distribute remaining 95% proportionally between carbs and protein
-          double remaining = 95;
-          double ratio =
-              _carbsPctSelection / (_carbsPctSelection + _proteinPctSelection);
-          _carbsPctSelection = (remaining * ratio).roundToDouble();
-          _proteinPctSelection = remaining - _carbsPctSelection;
-        }
+    if (total != 100) {
+      double factor = 100 / total;
+      _carbsPctSelection = (_carbsPctSelection * factor).roundToDouble();
+      _proteinPctSelection = (_proteinPctSelection * factor).roundToDouble();
+      _fatPctSelection = 100 - _carbsPctSelection - _proteinPctSelection;
+      if (_fatPctSelection < 5) {
+        _fatPctSelection = 5;
+        double remaining = 95;
+        double ratio =
+            _carbsPctSelection / (_carbsPctSelection + _proteinPctSelection);
+        _carbsPctSelection = (remaining * ratio).roundToDouble();
+        _proteinPctSelection = remaining - _carbsPctSelection;
       }
-
-      // Verify final values
-      assert(
-        _carbsPctSelection + _proteinPctSelection + _fatPctSelection == 100,
-        'Macros must total 100%',
-      );
-    });
+    }
   }
 
   void _saveCalculationSettings() {
-    // Save the calorie offset as full number
-    widget.settingsBloc.setKcalAdjustment(
-      _kcalAdjustmentSelection.toInt().toDouble(),
-    );
+    // Flush any pending text input before saving
+    _applyKcalInput();
+    _applyDirectMacroInput(_carbsController, (v) => _carbsPctSelection = v);
+    _applyDirectMacroInput(_proteinController, (v) => _proteinPctSelection = v);
+    _applyDirectMacroInput(_fatController, (v) => _fatPctSelection = v);
+    _normalizeMacros();
+
+    widget.settingsBloc.setKcalAdjustment(_kcalAdjustmentSelection.toInt().toDouble());
     widget.settingsBloc.setMacroGoals(
       _carbsPctSelection,
       _proteinPctSelection,
@@ -348,11 +432,8 @@ class _CalculationsDialogState extends State<CalculationsDialog> {
     );
 
     widget.settingsBloc.add(LoadSettingsEvent());
-    // Update other blocs that need the new calorie value
     widget.profileBloc.add(LoadProfileEvent());
     widget.homeBloc.add(LoadItemsEvent());
-
-    // Update tracked day entity
     widget.settingsBloc.updateTrackedDay(DateTime.now());
     widget.diaryBloc.add(LoadDiaryYearEvent());
     widget.calendarDayBloc.add(RefreshCalendarDayEvent());

--- a/lib/features/settings/settings_screen.dart
+++ b/lib/features/settings/settings_screen.dart
@@ -5,6 +5,7 @@ import 'package:opennutritracker/core/presentation/widgets/app_banner_version.da
 import 'package:opennutritracker/core/presentation/widgets/disclaimer_dialog.dart';
 import 'package:opennutritracker/core/utils/app_const.dart';
 import 'package:opennutritracker/core/utils/locator.dart';
+import 'package:opennutritracker/core/utils/notification_service.dart';
 import 'package:opennutritracker/core/utils/theme_mode_provider.dart';
 import 'package:opennutritracker/core/utils/url_const.dart';
 import 'package:opennutritracker/features/diary/presentation/bloc/calendar_day_bloc.dart';
@@ -75,6 +76,40 @@ class _SettingsScreenState extends State<SettingsScreen> {
                   title: Text(S.of(context).settingsThemeLabel),
                   onTap: () => _showThemeDialog(context, state.appTheme),
                 ),
+                SwitchListTile(
+                  secondary: const Icon(Icons.directions_run_outlined),
+                  title: Text(S.of(context).settingsShowActivityTracking),
+                  value: state.showActivityTracking,
+                  onChanged: (bool value) {
+                    _settingsBloc.setShowActivityTracking(value);
+                    _settingsBloc.add(LoadSettingsEvent());
+                    _homeBloc.add(LoadItemsEvent());
+                  },
+                ),
+                SwitchListTile(
+                  secondary: const Icon(Icons.notifications_outlined),
+                  title: Text(S.of(context).settingsNotificationsLabel),
+                  subtitle: state.notificationsEnabled
+                      ? Text(S.of(context).settingsNotificationsTimeLabel(
+                          _formatNotificationTime(
+                              state.notificationHour, state.notificationMinute)))
+                      : null,
+                  value: state.notificationsEnabled,
+                  onChanged: (bool value) =>
+                      _onNotificationToggled(context, value, state),
+                ),
+                if (state.notificationsEnabled)
+                  ListTile(
+                    leading: const Icon(Icons.access_time_outlined),
+                    title: Text(S.of(context).settingsNotificationsTimeLabel(
+                        _formatNotificationTime(state.notificationHour,
+                            state.notificationMinute))),
+                    onTap: () => _pickNotificationTime(
+                        context,
+                        TimeOfDay(
+                            hour: state.notificationHour,
+                            minute: state.notificationMinute)),
+                  ),
                 ListTile(
                   leading: const Icon(Icons.import_export),
                   title: Text(S.of(context).exportImportLabel),
@@ -110,6 +145,58 @@ class _SettingsScreenState extends State<SettingsScreen> {
         },
       ),
     );
+  }
+
+  String _formatNotificationTime(int hour, int minute) {
+    final h = hour.toString().padLeft(2, '0');
+    final m = minute.toString().padLeft(2, '0');
+    return '$h:$m';
+  }
+
+  Future<void> _onNotificationToggled(
+      BuildContext context, bool enabled, SettingsLoadedState state) async {
+    final notificationService = locator<NotificationService>();
+    await notificationService.initialize();
+    if (enabled) {
+      final granted = await notificationService.requestPermission();
+      if (!granted) {
+        if (context.mounted) {
+          ScaffoldMessenger.of(context).showSnackBar(
+            const SnackBar(
+                content: Text('Notification permission denied.')),
+          );
+        }
+        return;
+      }
+      await notificationService.scheduleDailyReminder(
+        hour: state.notificationHour,
+        minute: state.notificationMinute,
+        title: 'OpenNutriTracker',
+        body: 'Don\'t forget to log your meals today!',
+      );
+    } else {
+      await notificationService.cancelDailyReminder();
+    }
+    _settingsBloc.setNotificationsEnabled(enabled);
+    _settingsBloc.add(LoadSettingsEvent());
+  }
+
+  Future<void> _pickNotificationTime(
+      BuildContext context, TimeOfDay current) async {
+    final picked = await showTimePicker(
+      context: context,
+      initialTime: current,
+    );
+    if (picked == null) return;
+    _settingsBloc.setNotificationTime(picked.hour, picked.minute);
+    final notificationService = locator<NotificationService>();
+    await notificationService.scheduleDailyReminder(
+      hour: picked.hour,
+      minute: picked.minute,
+      title: 'OpenNutriTracker',
+      body: 'Don\'t forget to log your meals today!',
+    );
+    _settingsBloc.add(LoadSettingsEvent());
   }
 
   void _showUnitsDialog(BuildContext context, bool usesImperialUnits) async {

--- a/lib/features/settings/settings_screen.dart
+++ b/lib/features/settings/settings_screen.dart
@@ -6,6 +6,7 @@ import 'package:opennutritracker/core/presentation/widgets/disclaimer_dialog.dar
 import 'package:opennutritracker/core/utils/app_const.dart';
 import 'package:opennutritracker/core/utils/locator.dart';
 import 'package:opennutritracker/core/utils/notification_service.dart';
+import 'package:opennutritracker/core/utils/locale_provider.dart';
 import 'package:opennutritracker/core/utils/theme_mode_provider.dart';
 import 'package:opennutritracker/core/utils/url_const.dart';
 import 'package:opennutritracker/features/diary/presentation/bloc/calendar_day_bloc.dart';
@@ -75,6 +76,15 @@ class _SettingsScreenState extends State<SettingsScreen> {
                   leading: const Icon(Icons.brightness_medium_outlined),
                   title: Text(S.of(context).settingsThemeLabel),
                   onTap: () => _showThemeDialog(context, state.appTheme),
+                ),
+                ListTile(
+                  leading: const Icon(Icons.language_outlined),
+                  title: Text(S.of(context).settingsLanguageLabel),
+                  subtitle: Text(
+                      _localeDisplayName(state.selectedLocale) ??
+                          S.of(context).settingsThemeSystemDefaultLabel),
+                  onTap: () =>
+                      _showLanguageDialog(context, state.selectedLocale),
                 ),
                 SwitchListTile(
                   secondary: const Icon(Icons.directions_run_outlined),
@@ -337,6 +347,80 @@ class _SettingsScreenState extends State<SettingsScreen> {
                     listen: false,
                   ).updateTheme(selectedTheme);
                 });
+                Navigator.of(context).pop();
+              },
+              child: Text(S.of(context).dialogOKLabel),
+            ),
+          ],
+        );
+      },
+    );
+  }
+
+  static const _supportedLocales = <String, String>{
+    'en': 'English',
+    'de': 'Deutsch',
+    'tr': 'Türkçe',
+    'cz': 'Čeština',
+    'it': 'Italiano',
+    'uk': 'Українська',
+    'zh': '中文',
+    'pl': 'Polski',
+  };
+
+  String? _localeDisplayName(String? code) => _supportedLocales[code];
+
+  // Sentinel value meaning "follow system locale"
+  static const _systemLocale = '';
+
+  void _showLanguageDialog(BuildContext context, String? currentLocale) {
+    String selectedCode = currentLocale ?? _systemLocale;
+    showDialog(
+      context: context,
+      builder: (context) {
+        return AlertDialog(
+          contentPadding: EdgeInsets.zero,
+          title: Text(S.of(context).settingsLanguageLabel),
+          content: StatefulBuilder(
+            builder: (BuildContext context,
+                void Function(void Function()) setState) {
+              return RadioGroup<String>(
+                groupValue: selectedCode,
+                onChanged: (v) => setState(() => selectedCode = v as String),
+                child: Column(
+                  mainAxisSize: MainAxisSize.min,
+                  children: [
+                    RadioListTile<String>(
+                      title:
+                          Text(S.of(context).settingsThemeSystemDefaultLabel),
+                      value: _systemLocale,
+                    ),
+                    ..._supportedLocales.entries.map(
+                      (e) => RadioListTile<String>(
+                        title: Text(e.value),
+                        value: e.key,
+                      ),
+                    ),
+                  ],
+                ),
+              );
+            },
+          ),
+          actions: [
+            TextButton(
+              onPressed: () => Navigator.of(context).pop(),
+              child: Text(S.of(context).dialogCancelLabel),
+            ),
+            TextButton(
+              onPressed: () {
+                final locale =
+                    selectedCode.isEmpty ? null : selectedCode;
+                _settingsBloc.setSelectedLocale(locale);
+                _settingsBloc.add(LoadSettingsEvent());
+                Provider.of<LocaleProvider>(context, listen: false)
+                    .updateLocale(
+                  locale != null ? Locale(locale) : null,
+                );
                 Navigator.of(context).pop();
               },
               child: Text(S.of(context).dialogOKLabel),

--- a/lib/generated/intl/messages_cz.dart
+++ b/lib/generated/intl/messages_cz.dart
@@ -686,6 +686,8 @@ class MessageLookup extends MessageLookupByLibrary {
         "settingsImperialLabel":
             MessageLookupByLibrary.simpleMessage("Imperiální (lbs, ft, oz)"),
         "settingsLabel": MessageLookupByLibrary.simpleMessage("Nastavení"),
+        "settingsLanguageLabel":
+            MessageLookupByLibrary.simpleMessage("Jazyk"),
         "settingsLicensesLabel":
             MessageLookupByLibrary.simpleMessage("Licence"),
         "settingsMassLabel": MessageLookupByLibrary.simpleMessage("Hmota"),

--- a/lib/generated/intl/messages_cz.dart
+++ b/lib/generated/intl/messages_cz.dart
@@ -37,6 +37,14 @@ class MessageLookup extends MessageLookupByLibrary {
   static String m6(count) =>
       "${count} položek nebylo možné načíst z OpenFoodFacts.";
 
+  static String m8(rate) => "${rate} kg/týden";
+
+  static String m9(rate) => "${rate} lbs/týden";
+
+  static String m10(qty, unit) => "Na ${qty} ${unit}";
+
+  static String m11(time) => "Čas připomínky: ${time}";
+
   final messages = _notInlinedMessages(_notInlinedMessages);
   static Map<String, Function> _notInlinedMessages(_) => <String, Function>{
         "activityExample": MessageLookupByLibrary.simpleMessage(
@@ -90,6 +98,8 @@ class MessageLookup extends MessageLookupByLibrary {
             MessageLookupByLibrary.simpleMessage("Výpočet TDEE"),
         "carbohydrateLabel": MessageLookupByLibrary.simpleMessage("sacharidy"),
         "carbsLabel": MessageLookupByLibrary.simpleMessage("sacharidy"),
+        "chooseWeeklyWeightGoalLabel":
+            MessageLookupByLibrary.simpleMessage("Týdenní tempo hmotnosti"),
         "chooseWeightGoalLabel":
             MessageLookupByLibrary.simpleMessage("Zvolte cílovou hmotnost"),
         "cmLabel": MessageLookupByLibrary.simpleMessage("cm"),
@@ -204,6 +214,9 @@ class MessageLookup extends MessageLookupByLibrary {
         "mealFatLabel": MessageLookupByLibrary.simpleMessage("tuků na"),
         "mealKcalLabel": MessageLookupByLibrary.simpleMessage("kcal na"),
         "mealNameLabel": MessageLookupByLibrary.simpleMessage("Název jídla"),
+        "mealNutrientsPerQtyLabel": m10,
+        "mealNutrientsTotalLabel":
+            MessageLookupByLibrary.simpleMessage("Celkové množství"),
         "mealProteinLabel":
             MessageLookupByLibrary.simpleMessage("bílkovin na 100 g/ml"),
         "mealSizeLabel":
@@ -678,10 +691,15 @@ class MessageLookup extends MessageLookupByLibrary {
         "settingsMassLabel": MessageLookupByLibrary.simpleMessage("Hmota"),
         "settingsMetricLabel":
             MessageLookupByLibrary.simpleMessage("Metrické (kg, cm, ml)"),
+        "settingsNotificationsLabel":
+            MessageLookupByLibrary.simpleMessage("Denní připomínka"),
+        "settingsNotificationsTimeLabel": m11,
         "settingsPrivacySettings":
             MessageLookupByLibrary.simpleMessage("Nastavení soukromí"),
         "settingsReportErrorLabel":
             MessageLookupByLibrary.simpleMessage("Nahlásit chybu"),
+        "settingsShowActivityTracking":
+            MessageLookupByLibrary.simpleMessage("Zobrazit sledování aktivity"),
         "settingsSourceCodeLabel":
             MessageLookupByLibrary.simpleMessage("Zdrojový kód"),
         "settingsSystemLabel": MessageLookupByLibrary.simpleMessage("Systém"),
@@ -701,6 +719,12 @@ class MessageLookup extends MessageLookupByLibrary {
         "sugarLabel": MessageLookupByLibrary.simpleMessage("cukry"),
         "suppliedLabel": MessageLookupByLibrary.simpleMessage("přijato"),
         "unitLabel": MessageLookupByLibrary.simpleMessage("Jednotka"),
+        "weeklyWeightGoalKgPerWeek": m8,
+        "weeklyWeightGoalLabel":
+            MessageLookupByLibrary.simpleMessage("Týdenní tempo"),
+        "weeklyWeightGoalLbsPerWeek": m9,
+        "weeklyWeightGoalNoneLabel":
+            MessageLookupByLibrary.simpleMessage("Nenastaveno"),
         "weightLabel": MessageLookupByLibrary.simpleMessage("Hmotnost"),
         "yearsLabel": m3
       };

--- a/lib/generated/intl/messages_de.dart
+++ b/lib/generated/intl/messages_de.dart
@@ -696,6 +696,8 @@ class MessageLookup extends MessageLookupByLibrary {
         "settingsDistanceLabel":
             MessageLookupByLibrary.simpleMessage("Entfernung"),
         "settingsLabel": MessageLookupByLibrary.simpleMessage("Einstellungen"),
+        "settingsLanguageLabel":
+            MessageLookupByLibrary.simpleMessage("Sprache"),
         "settingsLicensesLabel":
             MessageLookupByLibrary.simpleMessage("Lizenzen"),
         "settingsMassLabel": MessageLookupByLibrary.simpleMessage("Masse"),

--- a/lib/generated/intl/messages_de.dart
+++ b/lib/generated/intl/messages_de.dart
@@ -37,6 +37,16 @@ class MessageLookup extends MessageLookupByLibrary {
   static String m6(count) =>
       "${count} Einträge konnten nicht von OpenFoodFacts abgerufen werden.";
 
+  static String m7(count) => "${count} Aktivitäten importieren?";
+
+  static String m8(rate) => "${rate} kg/Woche";
+
+  static String m9(rate) => "${rate} lbs/Woche";
+
+  static String m10(qty, unit) => "Pro ${qty} ${unit}";
+
+  static String m11(time) => "Erinnerungszeit: ${time}";
+
   final messages = _notInlinedMessages(_notInlinedMessages);
   static Map<String, Function> _notInlinedMessages(_) => <String, Function>{
         "activityExample": MessageLookupByLibrary.simpleMessage(
@@ -91,6 +101,8 @@ class MessageLookup extends MessageLookupByLibrary {
         "carbohydrateLabel":
             MessageLookupByLibrary.simpleMessage("Kohlenhydrate"),
         "carbsLabel": MessageLookupByLibrary.simpleMessage("Kohlenhydrate"),
+        "chooseWeeklyWeightGoalLabel":
+            MessageLookupByLibrary.simpleMessage("Wöchentliche Gewichtsrate"),
         "chooseWeightGoalLabel":
             MessageLookupByLibrary.simpleMessage("Gewichtsziel wählen"),
         "cmLabel": MessageLookupByLibrary.simpleMessage("cm"),
@@ -126,6 +138,8 @@ class MessageLookup extends MessageLookupByLibrary {
         "dialogDeleteLabel": MessageLookupByLibrary.simpleMessage("LÖSCHEN"),
         "dialogOKLabel": MessageLookupByLibrary.simpleMessage("OK"),
         "diaryLabel": MessageLookupByLibrary.simpleMessage("Tagebuch"),
+        "duplicateMealDialogContent": MessageLookupByLibrary.simpleMessage(
+            "Dieses Lebensmittel wurde heute bereits zu dieser Mahlzeit hinzugefügt. Erneut hinzufügen?"),
         "dinnerExample": MessageLookupByLibrary.simpleMessage(
             "z. B. Suppe, Hähnchen, Wein ..."),
         "dinnerLabel": MessageLookupByLibrary.simpleMessage("Abendessen"),
@@ -192,6 +206,8 @@ class MessageLookup extends MessageLookupByLibrary {
             MessageLookupByLibrary.simpleMessage("Eintrag gelöscht"),
         "itemUpdatedSnackbar":
             MessageLookupByLibrary.simpleMessage("Eintrag aktualisiert"),
+        "kcalExceededLabel":
+            MessageLookupByLibrary.simpleMessage("kcal überschritten"),
         "kcalLabel": MessageLookupByLibrary.simpleMessage("kcal"),
         "kcalLeftLabel": MessageLookupByLibrary.simpleMessage("kcal übrig"),
         "kcalTooMuchLabel":
@@ -210,6 +226,9 @@ class MessageLookup extends MessageLookupByLibrary {
         "mealKcalLabel":
             MessageLookupByLibrary.simpleMessage("kcal pro 100 g/ml"),
         "mealNameLabel": MessageLookupByLibrary.simpleMessage("Mahlzeitenname"),
+        "mealNutrientsPerQtyLabel": m10,
+        "mealNutrientsTotalLabel":
+            MessageLookupByLibrary.simpleMessage("Gesamtmenge"),
         "mealProteinLabel":
             MessageLookupByLibrary.simpleMessage("Protein pro 100 g/ml"),
         "mealSizeLabel":
@@ -682,6 +701,9 @@ class MessageLookup extends MessageLookupByLibrary {
         "settingsMassLabel": MessageLookupByLibrary.simpleMessage("Masse"),
         "settingsMetricLabel":
             MessageLookupByLibrary.simpleMessage("Metrisch (kg, cm, ml)"),
+        "settingsNotificationsLabel":
+            MessageLookupByLibrary.simpleMessage("Tägliche Erinnerung"),
+        "settingsNotificationsTimeLabel": m11,
         "settingsPrivacySettings":
             MessageLookupByLibrary.simpleMessage("Datenschutzeinstellungen"),
         "settingsReportErrorLabel":
@@ -705,6 +727,13 @@ class MessageLookup extends MessageLookupByLibrary {
         "sugarLabel": MessageLookupByLibrary.simpleMessage("Zucker"),
         "suppliedLabel": MessageLookupByLibrary.simpleMessage("zugeführt"),
         "unitLabel": MessageLookupByLibrary.simpleMessage("Einheit"),
+        "warningLabel": MessageLookupByLibrary.simpleMessage("Warnung"),
+        "weeklyWeightGoalKgPerWeek": m8,
+        "weeklyWeightGoalLabel":
+            MessageLookupByLibrary.simpleMessage("Wöchentliche Rate"),
+        "weeklyWeightGoalLbsPerWeek": m9,
+        "weeklyWeightGoalNoneLabel":
+            MessageLookupByLibrary.simpleMessage("Nicht festgelegt"),
         "weightLabel": MessageLookupByLibrary.simpleMessage("Gewicht"),
         "yearsLabel": m3
       };

--- a/lib/generated/intl/messages_en.dart
+++ b/lib/generated/intl/messages_en.dart
@@ -690,6 +690,8 @@ class MessageLookup extends MessageLookupByLibrary {
         "settingsImperialLabel":
             MessageLookupByLibrary.simpleMessage("Imperial (lbs, ft, oz)"),
         "settingsLabel": MessageLookupByLibrary.simpleMessage("Settings"),
+        "settingsLanguageLabel":
+            MessageLookupByLibrary.simpleMessage("Language"),
         "settingsLicensesLabel":
             MessageLookupByLibrary.simpleMessage("Licenses"),
         "settingsMassLabel": MessageLookupByLibrary.simpleMessage("Mass"),

--- a/lib/generated/intl/messages_en.dart
+++ b/lib/generated/intl/messages_en.dart
@@ -39,6 +39,14 @@ class MessageLookup extends MessageLookupByLibrary {
 
   static String m7(count) => "Import ${count} activities?";
 
+  static String m8(rate) => "${rate} kg/week";
+
+  static String m9(rate) => "${rate} lbs/week";
+
+  static String m10(qty, unit) => "Per ${qty} ${unit}";
+
+  static String m11(time) => "Reminder time: ${time}";
+
   final messages = _notInlinedMessages(_notInlinedMessages);
   static Map<String, Function> _notInlinedMessages(_) => <String, Function>{
         "activityExample": MessageLookupByLibrary.simpleMessage(
@@ -92,6 +100,8 @@ class MessageLookup extends MessageLookupByLibrary {
         "carbohydrateLabel":
             MessageLookupByLibrary.simpleMessage("carbohydrate"),
         "carbsLabel": MessageLookupByLibrary.simpleMessage("carbs"),
+        "chooseWeeklyWeightGoalLabel":
+            MessageLookupByLibrary.simpleMessage("Weekly weight rate"),
         "chooseWeightGoalLabel":
             MessageLookupByLibrary.simpleMessage("Choose Weight Goal"),
         "cmLabel": MessageLookupByLibrary.simpleMessage("cm"),
@@ -131,6 +141,8 @@ class MessageLookup extends MessageLookupByLibrary {
         "dinnerLabel": MessageLookupByLibrary.simpleMessage("Dinner"),
         "disclaimerText": MessageLookupByLibrary.simpleMessage(
             "OpenNutriTracker is not a medical application. All data provided is not validated and should be used with caution. Please maintain a healthy lifestyle and consult a professional if you have any problems. Use during illness, pregnancy or lactation is not recommended."),
+        "duplicateMealDialogContent": MessageLookupByLibrary.simpleMessage(
+            "This food has already been added to this meal today. Add it again?"),
         "editItemDialogTitle":
             MessageLookupByLibrary.simpleMessage("Edit item"),
         "editMealLabel": MessageLookupByLibrary.simpleMessage("Edit meal"),
@@ -173,8 +185,6 @@ class MessageLookup extends MessageLookupByLibrary {
         "heightLabel": MessageLookupByLibrary.simpleMessage("Height"),
         "homeLabel": MessageLookupByLibrary.simpleMessage("Home"),
         "importAction": MessageLookupByLibrary.simpleMessage("Import"),
-        "importMealConfirmContent": m4,
-        "importMealConfirmTitle": m5,
         "importActivityConfirmContent": MessageLookupByLibrary.simpleMessage(
             "These activities will be added to today."),
         "importActivityConfirmTitle": m7,
@@ -182,10 +192,10 @@ class MessageLookup extends MessageLookupByLibrary {
             MessageLookupByLibrary.simpleMessage("Import shared workout"),
         "importActivitySuccessLabel":
             MessageLookupByLibrary.simpleMessage("Workout imported"),
+        "importMealConfirmContent": m4,
+        "importMealConfirmTitle": m5,
         "importMealErrorLabel":
             MessageLookupByLibrary.simpleMessage("Invalid QR code"),
-        "shareActivityLabel":
-            MessageLookupByLibrary.simpleMessage("Share workout"),
         "importMealLabel":
             MessageLookupByLibrary.simpleMessage("Import shared meal"),
         "importMealSuccessLabel":
@@ -199,6 +209,8 @@ class MessageLookup extends MessageLookupByLibrary {
             MessageLookupByLibrary.simpleMessage("Item deleted"),
         "itemUpdatedSnackbar":
             MessageLookupByLibrary.simpleMessage("Item updated"),
+        "kcalExceededLabel":
+            MessageLookupByLibrary.simpleMessage("kcal exceeded"),
         "kcalLabel": MessageLookupByLibrary.simpleMessage("kcal"),
         "kcalLeftLabel": MessageLookupByLibrary.simpleMessage("kcal left"),
         "kcalTooMuchLabel":
@@ -215,6 +227,9 @@ class MessageLookup extends MessageLookupByLibrary {
         "mealFatLabel": MessageLookupByLibrary.simpleMessage("fat per"),
         "mealKcalLabel": MessageLookupByLibrary.simpleMessage("kcal per"),
         "mealNameLabel": MessageLookupByLibrary.simpleMessage("Meal name"),
+        "mealNutrientsPerQtyLabel": m10,
+        "mealNutrientsTotalLabel":
+            MessageLookupByLibrary.simpleMessage("Total amount"),
         "mealProteinLabel":
             MessageLookupByLibrary.simpleMessage("protein per 100 g/ml"),
         "mealSizeLabel":
@@ -262,7 +277,7 @@ class MessageLookup extends MessageLookupByLibrary {
         "nutritionalStatusUnderweight":
             MessageLookupByLibrary.simpleMessage("Underweight"),
         "offDisclaimer": MessageLookupByLibrary.simpleMessage(
-            "The data provided to you by this app are retrieved from the Open Food Facts database. No guarantees can be made for the accuracy, completeness, or reliability of the information provided. The data are provided “as is” and the originating source for the data (Open Food Facts) is not liable for any damages arising out of the use of the data."),
+            'The data provided to you by this app are retrieved from the Open Food Facts database. No guarantees can be made for the accuracy, completeness, or reliability of the information provided. The data are provided "as is" and the originating source for the data (Open Food Facts) is not liable for any damages arising out of the use of the data.'),
         "onboardingActivityQuestionSubtitle":
             MessageLookupByLibrary.simpleMessage(
                 "How active are you? (without workouts)"),
@@ -363,7 +378,7 @@ class MessageLookup extends MessageLookupByLibrary {
         "paCheerleadingDesc": MessageLookupByLibrary.simpleMessage(
             "gymnastic moves, competitive"),
         "paChildrenGame":
-            MessageLookupByLibrary.simpleMessage("children’s games"),
+            MessageLookupByLibrary.simpleMessage("children's games"),
         "paChildrenGameDesc": MessageLookupByLibrary.simpleMessage(
             "(e.g., hopscotch, 4-square, dodgeball, playground apparatus, t-ball, tetherball, marbles, arcade games), moderate effort"),
         "paClimbingHillsNoLoadGeneral":
@@ -682,8 +697,13 @@ class MessageLookup extends MessageLookupByLibrary {
             MessageLookupByLibrary.simpleMessage("Metric (kg, cm, ml)"),
         "settingsPrivacySettings":
             MessageLookupByLibrary.simpleMessage("Privacy Settings"),
+        "settingsNotificationsLabel":
+            MessageLookupByLibrary.simpleMessage("Daily Reminder"),
+        "settingsNotificationsTimeLabel": m11,
         "settingsReportErrorLabel":
             MessageLookupByLibrary.simpleMessage("Report Error"),
+        "settingsShowActivityTracking":
+            MessageLookupByLibrary.simpleMessage("Show Activity Tracking"),
         "settingsSourceCodeLabel":
             MessageLookupByLibrary.simpleMessage("Source Code"),
         "settingsSystemLabel": MessageLookupByLibrary.simpleMessage("System"),
@@ -703,6 +723,13 @@ class MessageLookup extends MessageLookupByLibrary {
         "sugarLabel": MessageLookupByLibrary.simpleMessage("sugar"),
         "suppliedLabel": MessageLookupByLibrary.simpleMessage("supplied"),
         "unitLabel": MessageLookupByLibrary.simpleMessage("Unit"),
+        "warningLabel": MessageLookupByLibrary.simpleMessage("Warning"),
+        "weeklyWeightGoalKgPerWeek": m8,
+        "weeklyWeightGoalLabel":
+            MessageLookupByLibrary.simpleMessage("Weekly rate"),
+        "weeklyWeightGoalLbsPerWeek": m9,
+        "weeklyWeightGoalNoneLabel":
+            MessageLookupByLibrary.simpleMessage("Not set"),
         "weightLabel": MessageLookupByLibrary.simpleMessage("Weight"),
         "yearsLabel": m3
       };

--- a/lib/generated/intl/messages_it.dart
+++ b/lib/generated/intl/messages_it.dart
@@ -37,6 +37,14 @@ class MessageLookup extends MessageLookupByLibrary {
   static String m6(count) =>
       "${count} elemento/i non è stato possibile recuperare da OpenFoodFacts.";
 
+  static String m8(rate) => "${rate} kg/settimana";
+
+  static String m9(rate) => "${rate} lbs/settimana";
+
+  static String m10(qty, unit) => "Per ${qty} ${unit}";
+
+  static String m11(time) => "Orario promemoria: ${time}";
+
   final messages = _notInlinedMessages(_notInlinedMessages);
   static Map<String, Function> _notInlinedMessages(_) => <String, Function>{
         "activityExample": MessageLookupByLibrary.simpleMessage(
@@ -92,6 +100,8 @@ class MessageLookup extends MessageLookupByLibrary {
         "carbohydrateLabel":
             MessageLookupByLibrary.simpleMessage("carboidrati"),
         "carbsLabel": MessageLookupByLibrary.simpleMessage("carboidrati"),
+        "chooseWeeklyWeightGoalLabel":
+            MessageLookupByLibrary.simpleMessage("Ritmo peso settimanale"),
         "chooseWeightGoalLabel":
             MessageLookupByLibrary.simpleMessage("Scegli obiettivo di peso"),
         "cmLabel": MessageLookupByLibrary.simpleMessage("cm"),
@@ -207,6 +217,9 @@ class MessageLookup extends MessageLookupByLibrary {
         "mealFatLabel": MessageLookupByLibrary.simpleMessage("grassi per"),
         "mealKcalLabel": MessageLookupByLibrary.simpleMessage("kcal per"),
         "mealNameLabel": MessageLookupByLibrary.simpleMessage("Nome pasto"),
+        "mealNutrientsPerQtyLabel": m10,
+        "mealNutrientsTotalLabel":
+            MessageLookupByLibrary.simpleMessage("Quantità totale"),
         "mealProteinLabel":
             MessageLookupByLibrary.simpleMessage("proteine per 100 g/ml"),
         "mealSizeLabel":
@@ -685,10 +698,15 @@ class MessageLookup extends MessageLookupByLibrary {
         "settingsMassLabel": MessageLookupByLibrary.simpleMessage("Massa"),
         "settingsMetricLabel":
             MessageLookupByLibrary.simpleMessage("Metrico (kg, cm, ml)"),
+        "settingsNotificationsLabel":
+            MessageLookupByLibrary.simpleMessage("Promemoria giornaliero"),
+        "settingsNotificationsTimeLabel": m11,
         "settingsPrivacySettings":
             MessageLookupByLibrary.simpleMessage("Impostazioni privacy"),
         "settingsReportErrorLabel":
             MessageLookupByLibrary.simpleMessage("Segnala errore"),
+        "settingsShowActivityTracking":
+            MessageLookupByLibrary.simpleMessage("Mostra tracciamento attività"),
         "settingsSourceCodeLabel":
             MessageLookupByLibrary.simpleMessage("Codice sorgente"),
         "settingsSystemLabel": MessageLookupByLibrary.simpleMessage("Sistema"),
@@ -710,6 +728,12 @@ class MessageLookup extends MessageLookupByLibrary {
         "sugarLabel": MessageLookupByLibrary.simpleMessage("zuccheri"),
         "suppliedLabel": MessageLookupByLibrary.simpleMessage("assunte"),
         "unitLabel": MessageLookupByLibrary.simpleMessage("Unità"),
+        "weeklyWeightGoalKgPerWeek": m8,
+        "weeklyWeightGoalLabel":
+            MessageLookupByLibrary.simpleMessage("Ritmo settimanale"),
+        "weeklyWeightGoalLbsPerWeek": m9,
+        "weeklyWeightGoalNoneLabel":
+            MessageLookupByLibrary.simpleMessage("Non impostato"),
         "weightLabel": MessageLookupByLibrary.simpleMessage("Peso"),
         "yearsLabel": m3
       };

--- a/lib/generated/intl/messages_it.dart
+++ b/lib/generated/intl/messages_it.dart
@@ -693,6 +693,8 @@ class MessageLookup extends MessageLookupByLibrary {
         "settingsImperialLabel":
             MessageLookupByLibrary.simpleMessage("Imperiale (lbs, ft, oz)"),
         "settingsLabel": MessageLookupByLibrary.simpleMessage("Impostazioni"),
+        "settingsLanguageLabel":
+            MessageLookupByLibrary.simpleMessage("Lingua"),
         "settingsLicensesLabel":
             MessageLookupByLibrary.simpleMessage("Licenze"),
         "settingsMassLabel": MessageLookupByLibrary.simpleMessage("Massa"),

--- a/lib/generated/intl/messages_pl.dart
+++ b/lib/generated/intl/messages_pl.dart
@@ -36,6 +36,14 @@ class MessageLookup extends MessageLookupByLibrary {
   static String m6(count) =>
       "Nie udało się pobrać ${count} pozycji z OpenFoodFacts.";
 
+  static String m8(rate) => "${rate} kg/tydzień";
+
+  static String m9(rate) => "${rate} lbs/tydzień";
+
+  static String m10(qty, unit) => "Na ${qty} ${unit}";
+
+  static String m11(time) => "Czas przypomnienia: ${time}";
+
   final messages = _notInlinedMessages(_notInlinedMessages);
   static Map<String, Function> _notInlinedMessages(_) => <String, Function>{
         "activityExample": MessageLookupByLibrary.simpleMessage(
@@ -90,6 +98,8 @@ class MessageLookup extends MessageLookupByLibrary {
         "carbohydrateLabel":
             MessageLookupByLibrary.simpleMessage("węglowodany"),
         "carbsLabel": MessageLookupByLibrary.simpleMessage("węglowodany"),
+        "chooseWeeklyWeightGoalLabel":
+            MessageLookupByLibrary.simpleMessage("Tygodniowe tempo wagi"),
         "chooseWeightGoalLabel":
             MessageLookupByLibrary.simpleMessage("Wybierz cel wagowy"),
         "cmLabel": MessageLookupByLibrary.simpleMessage("cm"),
@@ -207,6 +217,9 @@ class MessageLookup extends MessageLookupByLibrary {
         "mealFatLabel": MessageLookupByLibrary.simpleMessage("tłuszcze na"),
         "mealKcalLabel": MessageLookupByLibrary.simpleMessage("kcal na"),
         "mealNameLabel": MessageLookupByLibrary.simpleMessage("Nazwa posiłku"),
+        "mealNutrientsPerQtyLabel": m10,
+        "mealNutrientsTotalLabel":
+            MessageLookupByLibrary.simpleMessage("Łączna ilość"),
         "mealProteinLabel":
             MessageLookupByLibrary.simpleMessage("białko na 100 g/ml"),
         "mealSizeLabel":
@@ -683,10 +696,15 @@ class MessageLookup extends MessageLookupByLibrary {
         "settingsMassLabel": MessageLookupByLibrary.simpleMessage("Masa"),
         "settingsMetricLabel":
             MessageLookupByLibrary.simpleMessage("Metryczny (kg, cm, ml)"),
+        "settingsNotificationsLabel":
+            MessageLookupByLibrary.simpleMessage("Codzienne przypomnienie"),
+        "settingsNotificationsTimeLabel": m11,
         "settingsPrivacySettings":
             MessageLookupByLibrary.simpleMessage("Ustawienia prywatności"),
         "settingsReportErrorLabel":
             MessageLookupByLibrary.simpleMessage("Zgłoś błąd"),
+        "settingsShowActivityTracking":
+            MessageLookupByLibrary.simpleMessage("Pokaż śledzenie aktywności"),
         "settingsSourceCodeLabel":
             MessageLookupByLibrary.simpleMessage("Kod źródłowy"),
         "settingsSystemLabel": MessageLookupByLibrary.simpleMessage("System"),
@@ -709,6 +727,12 @@ class MessageLookup extends MessageLookupByLibrary {
         "sugarLabel": MessageLookupByLibrary.simpleMessage("cukier"),
         "suppliedLabel": MessageLookupByLibrary.simpleMessage("dostarczone"),
         "unitLabel": MessageLookupByLibrary.simpleMessage("Jednostka"),
+        "weeklyWeightGoalKgPerWeek": m8,
+        "weeklyWeightGoalLabel":
+            MessageLookupByLibrary.simpleMessage("Tygodniowe tempo"),
+        "weeklyWeightGoalLbsPerWeek": m9,
+        "weeklyWeightGoalNoneLabel":
+            MessageLookupByLibrary.simpleMessage("Nie ustawiono"),
         "weightLabel": MessageLookupByLibrary.simpleMessage("Waga"),
         "yearsLabel": m3
       };

--- a/lib/generated/intl/messages_pl.dart
+++ b/lib/generated/intl/messages_pl.dart
@@ -691,6 +691,8 @@ class MessageLookup extends MessageLookupByLibrary {
         "settingsImperialLabel":
             MessageLookupByLibrary.simpleMessage("Imperialny (lbs, ft, oz)"),
         "settingsLabel": MessageLookupByLibrary.simpleMessage("Ustawienia"),
+        "settingsLanguageLabel":
+            MessageLookupByLibrary.simpleMessage("Język"),
         "settingsLicensesLabel":
             MessageLookupByLibrary.simpleMessage("Licencje"),
         "settingsMassLabel": MessageLookupByLibrary.simpleMessage("Masa"),

--- a/lib/generated/intl/messages_tr.dart
+++ b/lib/generated/intl/messages_tr.dart
@@ -37,6 +37,16 @@ class MessageLookup extends MessageLookupByLibrary {
   static String m6(count) =>
       "${count} öğe OpenFoodFacts'ten alınamadı.";
 
+  static String m7(count) => "Import ${count} activities?";
+
+  static String m8(rate) => "${rate} kg/hafta";
+
+  static String m9(rate) => "${rate} lbs/hafta";
+
+  static String m10(qty, unit) => "${qty} ${unit} başına";
+
+  static String m11(time) => "Hatırlatma zamanı: ${time}";
+
   final messages = _notInlinedMessages(_notInlinedMessages);
   static Map<String, Function> _notInlinedMessages(_) => <String, Function>{
         "activityExample": MessageLookupByLibrary.simpleMessage(
@@ -90,6 +100,8 @@ class MessageLookup extends MessageLookupByLibrary {
         "carbohydrateLabel":
             MessageLookupByLibrary.simpleMessage("karbonhidrat"),
         "carbsLabel": MessageLookupByLibrary.simpleMessage("karbonhidrat"),
+        "chooseWeeklyWeightGoalLabel":
+            MessageLookupByLibrary.simpleMessage("Haftalık kilo oranı"),
         "chooseWeightGoalLabel":
             MessageLookupByLibrary.simpleMessage("Kilo Hedefini Seçin"),
         "cmLabel": MessageLookupByLibrary.simpleMessage("cm"),
@@ -125,6 +137,8 @@ class MessageLookup extends MessageLookupByLibrary {
         "dialogDeleteLabel": MessageLookupByLibrary.simpleMessage("SİL"),
         "dialogOKLabel": MessageLookupByLibrary.simpleMessage("TAMAM"),
         "diaryLabel": MessageLookupByLibrary.simpleMessage("Günlük"),
+        "duplicateMealDialogContent": MessageLookupByLibrary.simpleMessage(
+            "Bu yiyecek bugün bu öğüne zaten eklenmiş. Tekrar eklensin mi?"),
         "dinnerExample":
             MessageLookupByLibrary.simpleMessage("ör. çorba, tavuk, şarap ..."),
         "dinnerLabel": MessageLookupByLibrary.simpleMessage("Akşam Yemeği"),
@@ -188,6 +202,7 @@ class MessageLookup extends MessageLookupByLibrary {
             MessageLookupByLibrary.simpleMessage("Öğe silindi"),
         "itemUpdatedSnackbar":
             MessageLookupByLibrary.simpleMessage("Öğe güncellendi"),
+        "kcalExceededLabel": MessageLookupByLibrary.simpleMessage("kcal aşıldı"),
         "kcalLabel": MessageLookupByLibrary.simpleMessage("kcal"),
         "kcalLeftLabel": MessageLookupByLibrary.simpleMessage("kalan kcal"),
         "kgLabel": MessageLookupByLibrary.simpleMessage("kg"),
@@ -203,6 +218,9 @@ class MessageLookup extends MessageLookupByLibrary {
         "mealFatLabel": MessageLookupByLibrary.simpleMessage("yağ başına"),
         "mealKcalLabel": MessageLookupByLibrary.simpleMessage("kcal başına"),
         "mealNameLabel": MessageLookupByLibrary.simpleMessage("Yemek adı"),
+        "mealNutrientsPerQtyLabel": m10,
+        "mealNutrientsTotalLabel":
+            MessageLookupByLibrary.simpleMessage("Toplam miktar"),
         "mealProteinLabel":
             MessageLookupByLibrary.simpleMessage("protein başına 100 g/ml"),
         "mealSizeLabel":
@@ -663,6 +681,9 @@ class MessageLookup extends MessageLookupByLibrary {
         "settingsMassLabel": MessageLookupByLibrary.simpleMessage("Kütle"),
         "settingsMetricLabel":
             MessageLookupByLibrary.simpleMessage("Metrik (kg, cm, ml)"),
+        "settingsNotificationsLabel":
+            MessageLookupByLibrary.simpleMessage("Günlük Hatırlatıcı"),
+        "settingsNotificationsTimeLabel": m11,
         "settingsPrivacySettings":
             MessageLookupByLibrary.simpleMessage("Gizlilik Ayarları"),
         "settingsReportErrorLabel":
@@ -685,6 +706,13 @@ class MessageLookup extends MessageLookupByLibrary {
         "sugarLabel": MessageLookupByLibrary.simpleMessage("şeker"),
         "suppliedLabel": MessageLookupByLibrary.simpleMessage("tüketilen"),
         "unitLabel": MessageLookupByLibrary.simpleMessage("Birim"),
+        "warningLabel": MessageLookupByLibrary.simpleMessage("Uyarı"),
+        "weeklyWeightGoalKgPerWeek": m8,
+        "weeklyWeightGoalLabel":
+            MessageLookupByLibrary.simpleMessage("Haftalık oran"),
+        "weeklyWeightGoalLbsPerWeek": m9,
+        "weeklyWeightGoalNoneLabel":
+            MessageLookupByLibrary.simpleMessage("Ayarlanmadı"),
         "weightLabel": MessageLookupByLibrary.simpleMessage("Kilo"),
         "yearsLabel": m3
       };

--- a/lib/generated/intl/messages_tr.dart
+++ b/lib/generated/intl/messages_tr.dart
@@ -676,6 +676,7 @@ class MessageLookup extends MessageLookupByLibrary {
         "settingsImperialLabel":
             MessageLookupByLibrary.simpleMessage("İmperial (lbs, ft, oz)"),
         "settingsLabel": MessageLookupByLibrary.simpleMessage("Ayarlar"),
+        "settingsLanguageLabel": MessageLookupByLibrary.simpleMessage("Dil"),
         "settingsLicensesLabel":
             MessageLookupByLibrary.simpleMessage("Lisanslar"),
         "settingsMassLabel": MessageLookupByLibrary.simpleMessage("Kütle"),

--- a/lib/generated/intl/messages_uk.dart
+++ b/lib/generated/intl/messages_uk.dart
@@ -37,6 +37,14 @@ class MessageLookup extends MessageLookupByLibrary {
   static String m6(count) =>
       "${count} елемент(ів) не вдалося отримати з OpenFoodFacts.";
 
+  static String m8(rate) => "${rate} кг/тиждень";
+
+  static String m9(rate) => "${rate} фунт/тиждень";
+
+  static String m10(qty, unit) => "На ${qty} ${unit}";
+
+  static String m11(time) => "Час нагадування: ${time}";
+
   final messages = _notInlinedMessages(_notInlinedMessages);
   static Map<String, Function> _notInlinedMessages(_) => <String, Function>{
         "activityExample": MessageLookupByLibrary.simpleMessage(
@@ -90,6 +98,8 @@ class MessageLookup extends MessageLookupByLibrary {
             MessageLookupByLibrary.simpleMessage("Розрахунок TDEE"),
         "carbohydrateLabel": MessageLookupByLibrary.simpleMessage("вуглеводи"),
         "carbsLabel": MessageLookupByLibrary.simpleMessage("вуглеводи"),
+        "chooseWeeklyWeightGoalLabel":
+            MessageLookupByLibrary.simpleMessage("Тижневий темп ваги"),
         "chooseWeightGoalLabel":
             MessageLookupByLibrary.simpleMessage("Виберіть ціль ваги"),
         "cmLabel": MessageLookupByLibrary.simpleMessage("см"),
@@ -206,6 +216,9 @@ class MessageLookup extends MessageLookupByLibrary {
         "mealFatLabel": MessageLookupByLibrary.simpleMessage("жири на"),
         "mealKcalLabel": MessageLookupByLibrary.simpleMessage("ккал на"),
         "mealNameLabel": MessageLookupByLibrary.simpleMessage("Назва страви"),
+        "mealNutrientsPerQtyLabel": m10,
+        "mealNutrientsTotalLabel":
+            MessageLookupByLibrary.simpleMessage("Загальна кількість"),
         "mealProteinLabel":
             MessageLookupByLibrary.simpleMessage("білки на 100 г/мл"),
         "mealSizeLabel":
@@ -685,10 +698,15 @@ class MessageLookup extends MessageLookupByLibrary {
         "settingsMassLabel": MessageLookupByLibrary.simpleMessage("Маса"),
         "settingsMetricLabel":
             MessageLookupByLibrary.simpleMessage("Метрична (кг, см, мл)"),
+        "settingsNotificationsLabel":
+            MessageLookupByLibrary.simpleMessage("Щоденне нагадування"),
+        "settingsNotificationsTimeLabel": m11,
         "settingsPrivacySettings": MessageLookupByLibrary.simpleMessage(
             "Налаштування конфіденційності"),
         "settingsReportErrorLabel":
             MessageLookupByLibrary.simpleMessage("Повідомити про помилку"),
+        "settingsShowActivityTracking":
+            MessageLookupByLibrary.simpleMessage("Показати відстеження активності"),
         "settingsSourceCodeLabel":
             MessageLookupByLibrary.simpleMessage("Вихідний код"),
         "settingsSystemLabel": MessageLookupByLibrary.simpleMessage("Система"),
@@ -710,6 +728,12 @@ class MessageLookup extends MessageLookupByLibrary {
         "sugarLabel": MessageLookupByLibrary.simpleMessage("цукор"),
         "suppliedLabel": MessageLookupByLibrary.simpleMessage("спожито"),
         "unitLabel": MessageLookupByLibrary.simpleMessage("Одиниця"),
+        "weeklyWeightGoalKgPerWeek": m8,
+        "weeklyWeightGoalLabel":
+            MessageLookupByLibrary.simpleMessage("Тижневий темп"),
+        "weeklyWeightGoalLbsPerWeek": m9,
+        "weeklyWeightGoalNoneLabel":
+            MessageLookupByLibrary.simpleMessage("Не встановлено"),
         "weightLabel": MessageLookupByLibrary.simpleMessage("Вага"),
         "yearsLabel": m3
       };

--- a/lib/generated/intl/messages_uk.dart
+++ b/lib/generated/intl/messages_uk.dart
@@ -693,6 +693,8 @@ class MessageLookup extends MessageLookupByLibrary {
         "settingsImperialLabel": MessageLookupByLibrary.simpleMessage(
             "Імперська (фунти, фут, унції)"),
         "settingsLabel": MessageLookupByLibrary.simpleMessage("Налаштування"),
+        "settingsLanguageLabel":
+            MessageLookupByLibrary.simpleMessage("Мова"),
         "settingsLicensesLabel":
             MessageLookupByLibrary.simpleMessage("Ліцензії"),
         "settingsMassLabel": MessageLookupByLibrary.simpleMessage("Маса"),

--- a/lib/generated/intl/messages_zh.dart
+++ b/lib/generated/intl/messages_zh.dart
@@ -35,6 +35,14 @@ class MessageLookup extends MessageLookupByLibrary {
 
   static String m6(count) => "无法从OpenFoodFacts获取 ${count} 个项目。";
 
+  static String m8(rate) => "${rate} 千克/周";
+
+  static String m9(rate) => "${rate} 磅/周";
+
+  static String m10(qty, unit) => "每 ${qty} ${unit}";
+
+  static String m11(time) => "提醒时间：${time}";
+
   final messages = _notInlinedMessages(_notInlinedMessages);
   static Map<String, Function> _notInlinedMessages(_) => <String, Function>{
         "activityExample":
@@ -86,6 +94,8 @@ class MessageLookup extends MessageLookupByLibrary {
             MessageLookupByLibrary.simpleMessage("TDEE方程式"),
         "carbohydrateLabel": MessageLookupByLibrary.simpleMessage("碳水化合物"),
         "carbsLabel": MessageLookupByLibrary.simpleMessage("碳水"),
+        "chooseWeeklyWeightGoalLabel":
+            MessageLookupByLibrary.simpleMessage("每周体重速率"),
         "chooseWeightGoalLabel": MessageLookupByLibrary.simpleMessage("选择体重目标"),
         "cmLabel": MessageLookupByLibrary.simpleMessage("厘米"),
         "codeCopiedLabel": MessageLookupByLibrary.simpleMessage("代码已复制"),
@@ -182,6 +192,9 @@ class MessageLookup extends MessageLookupByLibrary {
         "mealFatLabel": MessageLookupByLibrary.simpleMessage("脂肪每"),
         "mealKcalLabel": MessageLookupByLibrary.simpleMessage("卡路里每"),
         "mealNameLabel": MessageLookupByLibrary.simpleMessage("餐食名称"),
+        "mealNutrientsPerQtyLabel": m10,
+        "mealNutrientsTotalLabel":
+            MessageLookupByLibrary.simpleMessage("总量"),
         "mealProteinLabel":
             MessageLookupByLibrary.simpleMessage("蛋白质每 100 克/毫升"),
         "mealSizeLabel": MessageLookupByLibrary.simpleMessage("餐食大小 (克/毫升)"),
@@ -564,9 +577,14 @@ class MessageLookup extends MessageLookupByLibrary {
         "settingsMassLabel": MessageLookupByLibrary.simpleMessage("质量"),
         "settingsMetricLabel":
             MessageLookupByLibrary.simpleMessage("公制（千克、厘米、毫升）"),
+        "settingsNotificationsLabel":
+            MessageLookupByLibrary.simpleMessage("每日提醒"),
+        "settingsNotificationsTimeLabel": m11,
         "settingsPrivacySettings": MessageLookupByLibrary.simpleMessage("隐私设置"),
         "settingsReportErrorLabel":
             MessageLookupByLibrary.simpleMessage("报告错误"),
+        "settingsShowActivityTracking":
+            MessageLookupByLibrary.simpleMessage("显示活动追踪"),
         "settingsSourceCodeLabel": MessageLookupByLibrary.simpleMessage("源代码"),
         "settingsSystemLabel": MessageLookupByLibrary.simpleMessage("系统"),
         "settingsThemeDarkLabel": MessageLookupByLibrary.simpleMessage("深色"),
@@ -584,6 +602,12 @@ class MessageLookup extends MessageLookupByLibrary {
         "sugarLabel": MessageLookupByLibrary.simpleMessage("糖"),
         "suppliedLabel": MessageLookupByLibrary.simpleMessage("提供"),
         "unitLabel": MessageLookupByLibrary.simpleMessage("单位"),
+        "weeklyWeightGoalKgPerWeek": m8,
+        "weeklyWeightGoalLabel":
+            MessageLookupByLibrary.simpleMessage("每周速率"),
+        "weeklyWeightGoalLbsPerWeek": m9,
+        "weeklyWeightGoalNoneLabel":
+            MessageLookupByLibrary.simpleMessage("未设置"),
         "weightLabel": MessageLookupByLibrary.simpleMessage("体重"),
         "yearsLabel": m3
       };

--- a/lib/generated/intl/messages_zh.dart
+++ b/lib/generated/intl/messages_zh.dart
@@ -573,6 +573,7 @@ class MessageLookup extends MessageLookupByLibrary {
         "settingsImperialLabel":
             MessageLookupByLibrary.simpleMessage("英制（磅、英尺、盎司）"),
         "settingsLabel": MessageLookupByLibrary.simpleMessage("设置"),
+        "settingsLanguageLabel": MessageLookupByLibrary.simpleMessage("语言"),
         "settingsLicensesLabel": MessageLookupByLibrary.simpleMessage("许可证"),
         "settingsMassLabel": MessageLookupByLibrary.simpleMessage("质量"),
         "settingsMetricLabel":

--- a/lib/generated/l10n.dart
+++ b/lib/generated/l10n.dart
@@ -601,6 +601,15 @@ class S {
   }
 
   /// `Licenses`
+  String get settingsLanguageLabel {
+    return Intl.message(
+      'Language',
+      name: 'settingsLanguageLabel',
+      desc: '',
+      args: [],
+    );
+  }
+
   String get settingsLicensesLabel {
     return Intl.message(
       'Licenses',

--- a/lib/generated/l10n.dart
+++ b/lib/generated/l10n.dart
@@ -640,6 +640,38 @@ class S {
     );
   }
 
+
+  /// `Show Activity Tracking`
+  String get settingsShowActivityTracking {
+    return Intl.message(
+      'Show Activity Tracking',
+      name: 'settingsShowActivityTracking',
+      desc: '',
+      args: [],
+    );
+  }
+
+  /// `Daily Reminder`
+  String get settingsNotificationsLabel {
+    return Intl.message(
+      'Daily Reminder',
+      name: 'settingsNotificationsLabel',
+      desc: '',
+      args: [],
+    );
+  }
+
+  /// `Reminder time: {time}`
+  String settingsNotificationsTimeLabel(String time) {
+    return Intl.message(
+      'Reminder time: $time',
+      name: 'settingsNotificationsTimeLabel',
+      desc: '',
+      args: [time],
+    );
+  }
+
+
   /// `Source Code`
   String get settingsSourceCodeLabel {
     return Intl.message(
@@ -1471,10 +1503,10 @@ class S {
     );
   }
 
-  /// `The data provided to you by this app are retrieved from the Open Food Facts database. No guarantees can be made for the accuracy, completeness, or reliability of the information provided. The data are provided “as is” and the originating source for the data (Open Food Facts) is not liable for any damages arising out of the use of the data.`
+  /// `The data provided to you by this app are retrieved from the Open Food Facts database. No guarantees can be made for the accuracy, completeness, or reliability of the information provided. The data are provided "as is" and the originating source for the data (Open Food Facts) is not liable for any damages arising out of the use of the data.`
   String get offDisclaimer {
     return Intl.message(
-      'The data provided to you by this app are retrieved from the Open Food Facts database. No guarantees can be made for the accuracy, completeness, or reliability of the information provided. The data are provided “as is” and the originating source for the data (Open Food Facts) is not liable for any damages arising out of the use of the data.',
+      'The data provided to you by this app are retrieved from the Open Food Facts database. No guarantees can be made for the accuracy, completeness, or reliability of the information provided. The data are provided "as is" and the originating source for the data (Open Food Facts) is not liable for any damages arising out of the use of the data.',
       name: 'offDisclaimer',
       desc: '',
       args: [],
@@ -1754,38 +1786,58 @@ class S {
   /// `kcal per`
   String get mealKcalLabel {
     return Intl.message(
-      'kcal per',
+      'kcal',
       name: 'mealKcalLabel',
       desc: '',
       args: [],
     );
   }
 
-  /// `carbs per`
+  /// `Carbohydrates (g)`
   String get mealCarbsLabel {
     return Intl.message(
-      'carbs per',
+      'Carbohydrates (g)',
       name: 'mealCarbsLabel',
       desc: '',
       args: [],
     );
   }
 
-  /// `fat per`
+  /// `Fat (g)`
   String get mealFatLabel {
     return Intl.message(
-      'fat per',
+      'Fat (g)',
       name: 'mealFatLabel',
       desc: '',
       args: [],
     );
   }
 
-  /// `protein per 100 g/ml`
+  /// `Protein (g)`
   String get mealProteinLabel {
     return Intl.message(
-      'protein per 100 g/ml',
+      'Protein (g)',
       name: 'mealProteinLabel',
+      desc: '',
+      args: [],
+    );
+  }
+
+  /// `Per {qty} {unit}`
+  String mealNutrientsPerQtyLabel(String qty, String unit) {
+    return Intl.message(
+      'Per $qty $unit',
+      name: 'mealNutrientsPerQtyLabel',
+      desc: '',
+      args: [qty, unit],
+    );
+  }
+
+  /// `Total amount`
+  String get mealNutrientsTotalLabel {
+    return Intl.message(
+      'Total amount',
+      name: 'mealNutrientsTotalLabel',
       desc: '',
       args: [],
     );
@@ -1986,6 +2038,56 @@ class S {
     return Intl.message(
       'Goal',
       name: 'goalLabel',
+      desc: '',
+      args: [],
+    );
+  }
+
+  /// `Weekly rate`
+  String get weeklyWeightGoalLabel {
+    return Intl.message(
+      'Weekly rate',
+      name: 'weeklyWeightGoalLabel',
+      desc: '',
+      args: [],
+    );
+  }
+
+  /// `Not set`
+  String get weeklyWeightGoalNoneLabel {
+    return Intl.message(
+      'Not set',
+      name: 'weeklyWeightGoalNoneLabel',
+      desc: '',
+      args: [],
+    );
+  }
+
+  /// `{rate} kg/week`
+  String weeklyWeightGoalKgPerWeek(String rate) {
+    return Intl.message(
+      '$rate kg/week',
+      name: 'weeklyWeightGoalKgPerWeek',
+      desc: '',
+      args: [rate],
+    );
+  }
+
+  /// `{rate} lbs/week`
+  String weeklyWeightGoalLbsPerWeek(String rate) {
+    return Intl.message(
+      '$rate lbs/week',
+      name: 'weeklyWeightGoalLbsPerWeek',
+      desc: '',
+      args: [rate],
+    );
+  }
+
+  /// `Weekly weight rate`
+  String get chooseWeeklyWeightGoalLabel {
+    return Intl.message(
+      'Weekly weight rate',
+      name: 'chooseWeeklyWeightGoalLabel',
       desc: '',
       args: [],
     );
@@ -2831,10 +2933,10 @@ class S {
     );
   }
 
-  /// `children’s games`
+  /// `children's games`
   String get paChildrenGame {
     return Intl.message(
-      'children’s games',
+      "children's games",
       name: 'paChildrenGame',
       desc: '',
       args: [],

--- a/lib/l10n/intl_cz.arb
+++ b/lib/l10n/intl_cz.arb
@@ -452,5 +452,6 @@
   "weeklyWeightGoalNoneLabel": "Nenastaveno",
   "weeklyWeightGoalKgPerWeek": "{rate} kg/týden",
   "weeklyWeightGoalLbsPerWeek": "{rate} lbs/týden",
-  "chooseWeeklyWeightGoalLabel": "Týdenní tempo hmotnosti"
+  "chooseWeeklyWeightGoalLabel": "Týdenní tempo hmotnosti",
+  "settingsLanguageLabel": "Jazyk"
 }

--- a/lib/l10n/intl_cz.arb
+++ b/lib/l10n/intl_cz.arb
@@ -32,7 +32,7 @@
   "onboardingYourGoalLabel": "Vář kalorický cíl:",
   "onboardingYourMacrosGoalLabel": "Vaše nutriční cíle:",
   "onboardingKcalPerDayLabel": "kcal denně",
-    "onboardingIntroDescription": "Než začnete, aplikace o Vás potřebuje zadat několik údajů, aby mohla spočítat Váš denní kalorický cíl.\nVeškeré osobní údaje jsou bezpečně uloženy pouze ve Vašem zařízení.",
+  "onboardingIntroDescription": "Než začnete, aplikace o Vás potřebuje zadat několik údajů, aby mohla spočítat Váš denní kalorický cíl.\nVeškeré osobní údaje jsou bezpečně uloženy pouze ve Vašem zařízení.",
   "onboardingGenderQuestionSubtitle": "Jaké je Vaše pohlaví?",
   "onboardingEnterBirthdayLabel": "Datum narození",
   "onboardingBirthdayHint": "Vložte datum",
@@ -107,21 +107,23 @@
   "copyOrDeleteTimeDialogContent": "Pomocí \"Kopírovat pro dnešek\" můžete vytvořit kopii pro dnešní jídlo. Volbou \"Smazat\" odstraníte zvolený pokrm.",
   "dialogCopyLabel": "Kopírovat pro dnešek",
   "dialogDeleteLabel": "SMAZAT",
-
   "deleteAllLabel": "Smazat vše",
-
   "shareMealLabel": "Sdílet jídlo",
   "importMealLabel": "Importovat sdílené jídlo",
   "importMealConfirmTitle": "Importovat {count} položek?",
   "@importMealConfirmTitle": {
     "placeholders": {
-      "count": { "type": "int" }
+      "count": {
+        "type": "int"
+      }
     }
   },
   "importMealConfirmContent": "Tyto položky budou přidány do {mealType}.",
   "@importMealConfirmContent": {
     "placeholders": {
-      "mealType": { "type": "String" }
+      "mealType": {
+        "type": "String"
+      }
     }
   },
   "importMealSuccessLabel": "Jídlo importováno",
@@ -129,7 +131,9 @@
   "importOffFetchFailedLabel": "{count} položek nebylo možné načíst z OpenFoodFacts.",
   "@importOffFetchFailedLabel": {
     "placeholders": {
-      "count": { "type": "int" }
+      "count": {
+        "type": "int"
+      }
     }
   },
   "copyCodeLabel": "Kopírovat kód",
@@ -137,7 +141,6 @@
   "codeCopiedLabel": "Kód zkopírován",
   "pasteCodeLabel": "Vložit kód",
   "pasteCodeHint": "Vložte sem sdílený kód jídla",
-
   "suppliedLabel": "přijato",
   "burnedLabel": "vydáno",
   "kcalLeftLabel": "kcal zbývá",
@@ -153,7 +156,7 @@
   "fiberLabel": "vláknina",
   "per100gmlLabel": "Na 100g/ml",
   "additionalInfoLabelOFF": "Více informací najdete na\nOpenFoodFacts",
-  "offDisclaimer": "Data poskytnutá aplikací jsou získána z databáze Open Food Facts. Nelze garantovat jejich přesnost, kompletnost nebo spolehlivost. Data jsou poskytována bez záruky a jejich původní poskytovatel (Open Food Facts) není zodpovědný za jakékoliv újmy vzniklé jejich používáním.",  
+  "offDisclaimer": "Data poskytnutá aplikací jsou získána z databáze Open Food Facts. Nelze garantovat jejich přesnost, kompletnost nebo spolehlivost. Data jsou poskytována bez záruky a jejich původní poskytovatel (Open Food Facts) není zodpovědný za jakékoliv újmy vzniklé jejich používáním.",
   "additionalInfoLabelFDC": "Více informadcí na\nFoodData Central",
   "additionalInfoLabelUnknown": "Neznámá položka jídla",
   "additionalInfoLabelCustom": "Vlastní jídlo",
@@ -342,7 +345,7 @@
   "paLacrosseDesc": "obecný",
   "paLawnBowling": "trávníkový bowling",
   "paLawnBowlingDesc": "bocce ball (italský bowling), venkovní bowling",
-  "paMotoCross": "moto-cross"                               ,
+  "paMotoCross": "moto-cross",
   "paMotoCrossDesc": "off-road jízda, terénní vozy, obecný",
   "paOrienteering": "orientační běh",
   "paOrienteeringDesc": "obecný",
@@ -439,5 +442,15 @@
   "paSkiingGeneral": "lyžování",
   "paSkiingGeneralDesc": "obecné",
   "paSnowShovingModerate": "odhrabování sněhu",
-  "paSnowShovingModerateDesc": "ručně, střední námaha"
+  "paSnowShovingModerateDesc": "ručně, střední námaha",
+  "settingsShowActivityTracking": "Zobrazit sledování aktivity",
+  "settingsNotificationsLabel": "Denní připomínka",
+  "settingsNotificationsTimeLabel": "Čas připomínky: {time}",
+  "mealNutrientsPerQtyLabel": "Na {qty} {unit}",
+  "mealNutrientsTotalLabel": "Celkové množství",
+  "weeklyWeightGoalLabel": "Týdenní tempo",
+  "weeklyWeightGoalNoneLabel": "Nenastaveno",
+  "weeklyWeightGoalKgPerWeek": "{rate} kg/týden",
+  "weeklyWeightGoalLbsPerWeek": "{rate} lbs/týden",
+  "chooseWeeklyWeightGoalLabel": "Týdenní tempo hmotnosti"
 }

--- a/lib/l10n/intl_de.arb
+++ b/lib/l10n/intl_de.arb
@@ -60,7 +60,9 @@
   "settingsNotificationsTimeLabel": "Erinnerungszeit: {time}",
   "@settingsNotificationsTimeLabel": {
     "placeholders": {
-      "time": { "type": "String" }
+      "time": {
+        "type": "String"
+      }
     }
   },
   "settingsSourceCodeLabel": "Quellcode",
@@ -111,19 +113,22 @@
   "dialogCopyLabel": "Nach heute kopieren",
   "dialogDeleteLabel": "LÖSCHEN",
   "deleteAllLabel": "Alle löschen",
-
   "shareMealLabel": "Mahlzeit teilen",
   "importMealLabel": "Geteilte Mahlzeit importieren",
   "importMealConfirmTitle": "{count} Einträge importieren?",
   "@importMealConfirmTitle": {
     "placeholders": {
-      "count": { "type": "int" }
+      "count": {
+        "type": "int"
+      }
     }
   },
   "importMealConfirmContent": "Diese Einträge werden zu {mealType} hinzugefügt.",
   "@importMealConfirmContent": {
     "placeholders": {
-      "mealType": { "type": "String" }
+      "mealType": {
+        "type": "String"
+      }
     }
   },
   "importMealSuccessLabel": "Mahlzeit importiert",
@@ -131,7 +136,9 @@
   "importOffFetchFailedLabel": "{count} Einträge konnten nicht von OpenFoodFacts abgerufen werden.",
   "@importOffFetchFailedLabel": {
     "placeholders": {
-      "count": { "type": "int" }
+      "count": {
+        "type": "int"
+      }
     }
   },
   "copyCodeLabel": "Code kopieren",
@@ -139,7 +146,6 @@
   "codeCopiedLabel": "Code kopiert",
   "pasteCodeLabel": "Code einfügen",
   "pasteCodeHint": "Füge hier den geteilten Mahlzeitencode ein",
-
   "suppliedLabel": "zugeführt",
   "burnedLabel": "verbrannt",
   "kcalLeftLabel": "kcal übrig",
@@ -190,8 +196,12 @@
   "mealNutrientsPerQtyLabel": "Pro {qty} {unit}",
   "@mealNutrientsPerQtyLabel": {
     "placeholders": {
-      "qty": { "type": "String" },
-      "unit": { "type": "String" }
+      "qty": {
+        "type": "String"
+      },
+      "unit": {
+        "type": "String"
+      }
     }
   },
   "mealNutrientsTotalLabel": "Gesamtmenge",
@@ -220,13 +230,17 @@
   "weeklyWeightGoalKgPerWeek": "{rate} kg/Woche",
   "@weeklyWeightGoalKgPerWeek": {
     "placeholders": {
-      "rate": { "type": "String" }
+      "rate": {
+        "type": "String"
+      }
     }
   },
   "weeklyWeightGoalLbsPerWeek": "{rate} lbs/Woche",
   "@weeklyWeightGoalLbsPerWeek": {
     "placeholders": {
-      "rate": { "type": "String" }
+      "rate": {
+        "type": "String"
+      }
     }
   },
   "chooseWeeklyWeightGoalLabel": "Wöchentliche Gewichtsrate",
@@ -461,5 +475,6 @@
   "paSkiingGeneral": "Skifahren",
   "paSkiingGeneralDesc": "allgemein",
   "paSnowShovingModerate": "Schnee schaufeln",
-  "paSnowShovingModerateDesc": "manuell, mäßige Anstrengung"
+  "paSnowShovingModerateDesc": "manuell, mäßige Anstrengung",
+  "settingsLanguageLabel": "Sprache"
 }

--- a/lib/l10n/intl_de.arb
+++ b/lib/l10n/intl_de.arb
@@ -56,6 +56,13 @@
   "settingsDisclaimerLabel": "Hinweis",
   "settingsReportErrorLabel": "Fehler melden",
   "settingsPrivacySettings": "Datenschutzeinstellungen",
+  "settingsNotificationsLabel": "Tägliche Erinnerung",
+  "settingsNotificationsTimeLabel": "Erinnerungszeit: {time}",
+  "@settingsNotificationsTimeLabel": {
+    "placeholders": {
+      "time": { "type": "String" }
+    }
+  },
   "settingsSourceCodeLabel": "Quellcode",
   "settingFeedbackLabel": "Feedback",
   "settingAboutLabel": "Über",
@@ -176,10 +183,18 @@
   "servingSizeLabelMetric": "Portionsgröße (g/ml)",
   "servingSizeLabelImperial": "Portionsgröße (oz/fl oz)",
   "mealUnitLabel": "Mahlzeiteinheit",
-  "mealKcalLabel": "kcal pro 100 g/ml",
-  "mealCarbsLabel": "Kohlenhydrate pro 100 g/ml",
-  "mealFatLabel": "Fett pro 100 g/ml",
-  "mealProteinLabel": "Protein pro 100 g/ml",
+  "mealKcalLabel": "kcal",
+  "mealCarbsLabel": "Kohlenhydrate (g)",
+  "mealFatLabel": "Fett (g)",
+  "mealProteinLabel": "Protein (g)",
+  "mealNutrientsPerQtyLabel": "Pro {qty} {unit}",
+  "@mealNutrientsPerQtyLabel": {
+    "placeholders": {
+      "qty": { "type": "String" },
+      "unit": { "type": "String" }
+    }
+  },
+  "mealNutrientsTotalLabel": "Gesamtmenge",
   "errorMealSave": "Fehler beim Speichern der Mahlzeit. Haben Sie die korrekten Mahlzeiteninformationen eingegeben?",
   "bmiLabel": "BMI",
   "bmiInfo": "Der Body-Mass-Index (BMI) ist ein Index zur Klassifizierung von Übergewicht und Fettleibigkeit bei Erwachsenen. Er wird berechnet, indem das Gewicht in Kilogramm durch das Quadrat der Körpergröße in Metern (kg/m²) geteilt wird.\n\nDer BMI unterscheidet nicht zwischen Fett- und Muskelmasse und kann für einige Personen irreführend sein.",
@@ -200,6 +215,21 @@
   "goalMaintainWeight": "Gewicht halten",
   "goalGainWeight": "Gewicht zunehmen",
   "goalLabel": "Ziel",
+  "weeklyWeightGoalLabel": "Wöchentliche Rate",
+  "weeklyWeightGoalNoneLabel": "Nicht festgelegt",
+  "weeklyWeightGoalKgPerWeek": "{rate} kg/Woche",
+  "@weeklyWeightGoalKgPerWeek": {
+    "placeholders": {
+      "rate": { "type": "String" }
+    }
+  },
+  "weeklyWeightGoalLbsPerWeek": "{rate} lbs/Woche",
+  "@weeklyWeightGoalLbsPerWeek": {
+    "placeholders": {
+      "rate": { "type": "String" }
+    }
+  },
+  "chooseWeeklyWeightGoalLabel": "Wöchentliche Gewichtsrate",
   "selectHeightDialogLabel": "Größe auswählen",
   "heightLabel": "Größe",
   "cmLabel": "cm",

--- a/lib/l10n/intl_en.arb
+++ b/lib/l10n/intl_en.arb
@@ -58,6 +58,14 @@
   "settingsDisclaimerLabel": "Disclaimer",
   "settingsReportErrorLabel": "Report Error",
   "settingsPrivacySettings": "Privacy Settings",
+  "settingsShowActivityTracking": "Show Activity Tracking",
+  "settingsNotificationsLabel": "Daily Reminder",
+  "settingsNotificationsTimeLabel": "Reminder time: {time}",
+  "@settingsNotificationsTimeLabel": {
+    "placeholders": {
+      "time": { "type": "String" }
+    }
+  },
   "settingsSourceCodeLabel": "Source Code",
   "settingFeedbackLabel": "Feedback",
   "settingAboutLabel": "About",
@@ -164,7 +172,7 @@
   "fiberLabel": "fiber",
   "per100gmlLabel": "Per 100g/ml",
   "additionalInfoLabelOFF": "More Information at\nOpenFoodFacts",
-  "offDisclaimer": "The data provided to you by this app are retrieved from the Open Food Facts database. No guarantees can be made for the accuracy, completeness, or reliability of the information provided. The data are provided “as is” and the originating source for the data (Open Food Facts) is not liable for any damages arising out of the use of the data.",
+  "offDisclaimer": "The data provided to you by this app are retrieved from the Open Food Facts database. No guarantees can be made for the accuracy, completeness, or reliability of the information provided. The data are provided "as is" and the originating source for the data (Open Food Facts) is not liable for any damages arising out of the use of the data.",
   "additionalInfoLabelFDC": "More Information at\nFoodData Central",
   "additionalInfoLabelUnknown": "Unknown Meal Item",
   "additionalInfoLabelCustom": "Custom Meal Item",
@@ -192,10 +200,18 @@
   "servingSizeLabelMetric": "Serving size (g/ml)",
   "servingSizeLabelImperial": "Serving size (oz/fl oz)",
   "mealUnitLabel": "Meal unit",
-  "mealKcalLabel": "kcal per",
-  "mealCarbsLabel": "carbs per",
-  "mealFatLabel": "fat per",
-  "mealProteinLabel": "protein per 100 g/ml",
+  "mealKcalLabel": "kcal",
+  "mealCarbsLabel": "Carbohydrates (g)",
+  "mealFatLabel": "Fat (g)",
+  "mealProteinLabel": "Protein (g)",
+  "mealNutrientsPerQtyLabel": "Per {qty} {unit}",
+  "@mealNutrientsPerQtyLabel": {
+    "placeholders": {
+      "qty": { "type": "String" },
+      "unit": { "type": "String" }
+    }
+  },
+  "mealNutrientsTotalLabel": "Total amount",
   "errorMealSave": "Error while saving meal. Did you input the correct meal information?",
   "bmiLabel": "BMI",
   "bmiInfo": "Body Mass Index (BMI) is a index to classify overweight and obesity in adults. It is defined as weight in kilograms divided by the square of height in meters (kg/m²).\n\nBMI does not differentiate between fat and muscle mass and can be misleading for some individuals.",
@@ -216,6 +232,21 @@
   "goalMaintainWeight": "Maintain Weight",
   "goalGainWeight": "Gain Weight",
   "goalLabel": "Goal",
+  "weeklyWeightGoalLabel": "Weekly rate",
+  "weeklyWeightGoalNoneLabel": "Not set",
+  "weeklyWeightGoalKgPerWeek": "{rate} kg/week",
+  "@weeklyWeightGoalKgPerWeek": {
+    "placeholders": {
+      "rate": { "type": "String" }
+    }
+  },
+  "weeklyWeightGoalLbsPerWeek": "{rate} lbs/week",
+  "@weeklyWeightGoalLbsPerWeek": {
+    "placeholders": {
+      "rate": { "type": "String" }
+    }
+  },
+  "chooseWeeklyWeightGoalLabel": "Weekly weight rate",
   "selectHeightDialogLabel": "Select Height",
   "heightLabel": "Height",
   "cmLabel": "cm",
@@ -301,7 +332,7 @@
   "paBoxingGeneralDesc": "in ring, general",
   "paBroomball": "broomball",
   "paBroomballDesc": "general",
-  "paChildrenGame": "children’s games",
+  "paChildrenGame": "children's games",
   "paChildrenGameDesc": "(e.g., hopscotch, 4-square, dodgeball, playground apparatus, t-ball, tetherball, marbles, arcade games), moderate effort",
   "paCheerleading": "cheerleading",
   "paCheerleadingDesc": "gymnastic moves, competitive",

--- a/lib/l10n/intl_en.arb
+++ b/lib/l10n/intl_en.arb
@@ -63,7 +63,9 @@
   "settingsNotificationsTimeLabel": "Reminder time: {time}",
   "@settingsNotificationsTimeLabel": {
     "placeholders": {
-      "time": { "type": "String" }
+      "time": {
+        "type": "String"
+      }
     }
   },
   "settingsSourceCodeLabel": "Source Code",
@@ -115,21 +117,23 @@
   "copyOrDeleteTimeDialogContent": "With \"Copy to today\" you can copy the meal to today. With \"Delete\" you can delete the meal.",
   "dialogCopyLabel": "Copy to today",
   "dialogDeleteLabel": "DELETE",
-
   "deleteAllLabel": "Delete all",
-
   "shareMealLabel": "Share meal",
   "importMealLabel": "Import shared meal",
   "importMealConfirmTitle": "Import {count} items?",
   "@importMealConfirmTitle": {
     "placeholders": {
-      "count": { "type": "int" }
+      "count": {
+        "type": "int"
+      }
     }
   },
   "importMealConfirmContent": "These items will be added to your {mealType}.",
   "@importMealConfirmContent": {
     "placeholders": {
-      "mealType": { "type": "String" }
+      "mealType": {
+        "type": "String"
+      }
     }
   },
   "importMealSuccessLabel": "Meal imported",
@@ -139,7 +143,9 @@
   "importActivityConfirmTitle": "Import {count} activities?",
   "@importActivityConfirmTitle": {
     "placeholders": {
-      "count": { "type": "int" }
+      "count": {
+        "type": "int"
+      }
     }
   },
   "importActivityConfirmContent": "These activities will be added to today.",
@@ -147,7 +153,9 @@
   "importOffFetchFailedLabel": "{count} item(s) could not be fetched from OpenFoodFacts.",
   "@importOffFetchFailedLabel": {
     "placeholders": {
-      "count": { "type": "int" }
+      "count": {
+        "type": "int"
+      }
     }
   },
   "copyCodeLabel": "Copy code",
@@ -155,7 +163,6 @@
   "codeCopiedLabel": "Code copied",
   "pasteCodeLabel": "Paste code",
   "pasteCodeHint": "Paste the shared meal code here",
-
   "suppliedLabel": "supplied",
   "burnedLabel": "burned",
   "kcalLeftLabel": "kcal left",
@@ -172,7 +179,7 @@
   "fiberLabel": "fiber",
   "per100gmlLabel": "Per 100g/ml",
   "additionalInfoLabelOFF": "More Information at\nOpenFoodFacts",
-  "offDisclaimer": "The data provided to you by this app are retrieved from the Open Food Facts database. No guarantees can be made for the accuracy, completeness, or reliability of the information provided. The data are provided "as is" and the originating source for the data (Open Food Facts) is not liable for any damages arising out of the use of the data.",
+  "offDisclaimer": "The data provided to you by this app are retrieved from the Open Food Facts database. No guarantees can be made for the accuracy, completeness, or reliability of the information provided. The data are provided \"as is\" and the originating source for the data (Open Food Facts) is not liable for any damages arising out of the use of the data.",
   "additionalInfoLabelFDC": "More Information at\nFoodData Central",
   "additionalInfoLabelUnknown": "Unknown Meal Item",
   "additionalInfoLabelCustom": "Custom Meal Item",
@@ -207,8 +214,12 @@
   "mealNutrientsPerQtyLabel": "Per {qty} {unit}",
   "@mealNutrientsPerQtyLabel": {
     "placeholders": {
-      "qty": { "type": "String" },
-      "unit": { "type": "String" }
+      "qty": {
+        "type": "String"
+      },
+      "unit": {
+        "type": "String"
+      }
     }
   },
   "mealNutrientsTotalLabel": "Total amount",
@@ -237,13 +248,17 @@
   "weeklyWeightGoalKgPerWeek": "{rate} kg/week",
   "@weeklyWeightGoalKgPerWeek": {
     "placeholders": {
-      "rate": { "type": "String" }
+      "rate": {
+        "type": "String"
+      }
     }
   },
   "weeklyWeightGoalLbsPerWeek": "{rate} lbs/week",
   "@weeklyWeightGoalLbsPerWeek": {
     "placeholders": {
-      "rate": { "type": "String" }
+      "rate": {
+        "type": "String"
+      }
     }
   },
   "chooseWeeklyWeightGoalLabel": "Weekly weight rate",
@@ -481,5 +496,6 @@
   "paSkiingGeneral": "skiing",
   "paSkiingGeneralDesc": "general",
   "paSnowShovingModerate": "snow shoveling",
-  "paSnowShovingModerateDesc": "by hand, moderate effort"
+  "paSnowShovingModerateDesc": "by hand, moderate effort",
+  "settingsLanguageLabel": "Language"
 }

--- a/lib/l10n/intl_it.arb
+++ b/lib/l10n/intl_it.arb
@@ -108,19 +108,22 @@
   "dialogCopyLabel": "Copia a oggi",
   "dialogDeleteLabel": "ELIMINA",
   "deleteAllLabel": "Elimina tutto",
-
   "shareMealLabel": "Condividi pasto",
   "importMealLabel": "Importa pasto condiviso",
   "importMealConfirmTitle": "Importare {count} voci?",
   "@importMealConfirmTitle": {
     "placeholders": {
-      "count": { "type": "int" }
+      "count": {
+        "type": "int"
+      }
     }
   },
   "importMealConfirmContent": "Questi elementi verranno aggiunti a {mealType}.",
   "@importMealConfirmContent": {
     "placeholders": {
-      "mealType": { "type": "String" }
+      "mealType": {
+        "type": "String"
+      }
     }
   },
   "importMealSuccessLabel": "Pasto importato",
@@ -128,7 +131,9 @@
   "importOffFetchFailedLabel": "{count} elemento/i non è stato possibile recuperare da OpenFoodFacts.",
   "@importOffFetchFailedLabel": {
     "placeholders": {
-      "count": { "type": "int" }
+      "count": {
+        "type": "int"
+      }
     }
   },
   "copyCodeLabel": "Copia codice",
@@ -136,7 +141,6 @@
   "codeCopiedLabel": "Codice copiato",
   "pasteCodeLabel": "Incolla codice",
   "pasteCodeHint": "Incolla qui il codice del pasto condiviso",
-
   "suppliedLabel": "assunte",
   "burnedLabel": "bruciate",
   "kcalLeftLabel": "kcal rimanenti",
@@ -438,5 +442,15 @@
   "paSkiingGeneral": "sci",
   "paSkiingGeneralDesc": "generale",
   "paSnowShovingModerate": "spalare neve",
-  "paSnowShovingModerateDesc": "a mano, sforzo moderato"
+  "paSnowShovingModerateDesc": "a mano, sforzo moderato",
+  "settingsShowActivityTracking": "Mostra tracciamento attività",
+  "settingsNotificationsLabel": "Promemoria giornaliero",
+  "settingsNotificationsTimeLabel": "Orario promemoria: {time}",
+  "mealNutrientsPerQtyLabel": "Per {qty} {unit}",
+  "mealNutrientsTotalLabel": "Quantità totale",
+  "weeklyWeightGoalLabel": "Ritmo settimanale",
+  "weeklyWeightGoalNoneLabel": "Non impostato",
+  "weeklyWeightGoalKgPerWeek": "{rate} kg/settimana",
+  "weeklyWeightGoalLbsPerWeek": "{rate} lbs/settimana",
+  "chooseWeeklyWeightGoalLabel": "Ritmo peso settimanale"
 }

--- a/lib/l10n/intl_it.arb
+++ b/lib/l10n/intl_it.arb
@@ -452,5 +452,6 @@
   "weeklyWeightGoalNoneLabel": "Non impostato",
   "weeklyWeightGoalKgPerWeek": "{rate} kg/settimana",
   "weeklyWeightGoalLbsPerWeek": "{rate} lbs/settimana",
-  "chooseWeeklyWeightGoalLabel": "Ritmo peso settimanale"
+  "chooseWeeklyWeightGoalLabel": "Ritmo peso settimanale",
+  "settingsLanguageLabel": "Lingua"
 }

--- a/lib/l10n/intl_pl.arb
+++ b/lib/l10n/intl_pl.arb
@@ -443,6 +443,15 @@
   "shareCodeLabel": "Udostępnij kod",
   "codeCopiedLabel": "Kod skopiowany",
   "pasteCodeLabel": "Wklej kod",
-  "pasteCodeHint": "Wklej tutaj kod udostępnionego posiłku"
+  "pasteCodeHint": "Wklej tutaj kod udostępnionego posiłku",
+  "settingsShowActivityTracking": "Pokaż śledzenie aktywności",
+  "settingsNotificationsLabel": "Codzienne przypomnienie",
+  "settingsNotificationsTimeLabel": "Czas przypomnienia: {time}",
+  "mealNutrientsPerQtyLabel": "Na {qty} {unit}",
+  "mealNutrientsTotalLabel": "Łączna ilość",
+  "weeklyWeightGoalLabel": "Tygodniowe tempo",
+  "weeklyWeightGoalNoneLabel": "Nie ustawiono",
+  "weeklyWeightGoalKgPerWeek": "{rate} kg/tydzień",
+  "weeklyWeightGoalLbsPerWeek": "{rate} lbs/tydzień",
+  "chooseWeeklyWeightGoalLabel": "Tygodniowe tempo wagi"
 }
-

--- a/lib/l10n/intl_pl.arb
+++ b/lib/l10n/intl_pl.arb
@@ -453,5 +453,6 @@
   "weeklyWeightGoalNoneLabel": "Nie ustawiono",
   "weeklyWeightGoalKgPerWeek": "{rate} kg/tydzień",
   "weeklyWeightGoalLbsPerWeek": "{rate} lbs/tydzień",
-  "chooseWeeklyWeightGoalLabel": "Tygodniowe tempo wagi"
+  "chooseWeeklyWeightGoalLabel": "Tygodniowe tempo wagi",
+  "settingsLanguageLabel": "Język"
 }

--- a/lib/l10n/intl_tr.arb
+++ b/lib/l10n/intl_tr.arb
@@ -62,7 +62,9 @@
   "settingsNotificationsTimeLabel": "Hatırlatma zamanı: {time}",
   "@settingsNotificationsTimeLabel": {
     "placeholders": {
-      "time": { "type": "String" }
+      "time": {
+        "type": "String"
+      }
     }
   },
   "settingsSourceCodeLabel": "Kaynak Kodu",
@@ -114,19 +116,22 @@
   "copyOrDeleteTimeDialogContent": "\"Bugüne Kopyala\" ile yemeği bugüne kopyalayabilirsiniz. \"Sil\" ile yemeği silebilirsiniz.",
   "dialogCopyLabel": "BUGÜNE KOPYALA",
   "dialogDeleteLabel": "SİL",
-
   "shareMealLabel": "Share meal",
   "importMealLabel": "Import shared meal",
   "importMealConfirmTitle": "Import {count} items?",
   "@importMealConfirmTitle": {
     "placeholders": {
-      "count": { "type": "int" }
+      "count": {
+        "type": "int"
+      }
     }
   },
   "importMealConfirmContent": "These items will be added to your {mealType}.",
   "@importMealConfirmContent": {
     "placeholders": {
-      "mealType": { "type": "String" }
+      "mealType": {
+        "type": "String"
+      }
     }
   },
   "importMealSuccessLabel": "Meal imported",
@@ -134,7 +139,9 @@
   "importOffFetchFailedLabel": "{count} öğe OpenFoodFacts'ten alınamadı.",
   "@importOffFetchFailedLabel": {
     "placeholders": {
-      "count": { "type": "int" }
+      "count": {
+        "type": "int"
+      }
     }
   },
   "copyCodeLabel": "Kodu kopyala",
@@ -142,7 +149,6 @@
   "codeCopiedLabel": "Kod kopyalandı",
   "pasteCodeLabel": "Kodu yapıştır",
   "pasteCodeHint": "Paylaşılan yemek kodunu buraya yapıştırın",
-
   "suppliedLabel": "tüketilen",
   "burnedLabel": "yakılan",
   "kcalLeftLabel": "kalan kcal",
@@ -193,8 +199,12 @@
   "mealNutrientsPerQtyLabel": "{qty} {unit} başına",
   "@mealNutrientsPerQtyLabel": {
     "placeholders": {
-      "qty": { "type": "String" },
-      "unit": { "type": "String" }
+      "qty": {
+        "type": "String"
+      },
+      "unit": {
+        "type": "String"
+      }
     }
   },
   "mealNutrientsTotalLabel": "Toplam miktar",
@@ -223,13 +233,17 @@
   "weeklyWeightGoalKgPerWeek": "{rate} kg/hafta",
   "@weeklyWeightGoalKgPerWeek": {
     "placeholders": {
-      "rate": { "type": "String" }
+      "rate": {
+        "type": "String"
+      }
     }
   },
   "weeklyWeightGoalLbsPerWeek": "{rate} lbs/hafta",
   "@weeklyWeightGoalLbsPerWeek": {
     "placeholders": {
-      "rate": { "type": "String" }
+      "rate": {
+        "type": "String"
+      }
     }
   },
   "chooseWeeklyWeightGoalLabel": "Haftalık kilo oranı",
@@ -467,5 +481,6 @@
   "paSkiingGeneral": "kayak",
   "paSkiingGeneralDesc": "genel",
   "paSnowShovingModerate": "kar küreme",
-  "paSnowShovingModerateDesc": "elle, orta derecede çaba"
+  "paSnowShovingModerateDesc": "elle, orta derecede çaba",
+  "settingsLanguageLabel": "Dil"
 }

--- a/lib/l10n/intl_tr.arb
+++ b/lib/l10n/intl_tr.arb
@@ -58,6 +58,13 @@
   "settingsDisclaimerLabel": "Sorumluluk Reddi",
   "settingsReportErrorLabel": "Hata Bildir",
   "settingsPrivacySettings": "Gizlilik Ayarları",
+  "settingsNotificationsLabel": "Günlük Hatırlatıcı",
+  "settingsNotificationsTimeLabel": "Hatırlatma zamanı: {time}",
+  "@settingsNotificationsTimeLabel": {
+    "placeholders": {
+      "time": { "type": "String" }
+    }
+  },
   "settingsSourceCodeLabel": "Kaynak Kodu",
   "settingFeedbackLabel": "Geri Bildirim",
   "settingAboutLabel": "Hakkında",
@@ -179,10 +186,18 @@
   "servingSizeLabelMetric": "Porsiyon boyutu (g/ml)",
   "servingSizeLabelImperial": "Porsiyon boyutu (oz/fl oz)",
   "mealUnitLabel": "Yemek birimi",
-  "mealKcalLabel": "kcal başına",
-  "mealCarbsLabel": "karbonhidrat başına",
-  "mealFatLabel": "yağ başına",
-  "mealProteinLabel": "protein başına 100 g/ml",
+  "mealKcalLabel": "kcal",
+  "mealCarbsLabel": "Karbonhidrat (g)",
+  "mealFatLabel": "Yağ (g)",
+  "mealProteinLabel": "Protein (g)",
+  "mealNutrientsPerQtyLabel": "{qty} {unit} başına",
+  "@mealNutrientsPerQtyLabel": {
+    "placeholders": {
+      "qty": { "type": "String" },
+      "unit": { "type": "String" }
+    }
+  },
+  "mealNutrientsTotalLabel": "Toplam miktar",
   "errorMealSave": "Yemek kaydedilirken hata oluştu. Doğru yemek bilgilerini girdiniz mi?",
   "bmiLabel": "BMI",
   "bmiInfo": "Vücut Kitle İndeksi (BMI), yetişkinlerde aşırı kiloyu ve obeziteyi sınıflandırmak için kullanılan bir indekstir. Kilogram cinsinden ağırlığın, metre cinsinden boyun karesine bölünmesiyle tanımlanır (kg/m²).\n\nBMI, yağ ve kas kütlesi arasında ayrım yapmaz ve bazı bireyler için yanıltıcı olabilir.",
@@ -203,6 +218,21 @@
   "goalMaintainWeight": "Kilo Koru",
   "goalGainWeight": "Kilo Al",
   "goalLabel": "Hedef",
+  "weeklyWeightGoalLabel": "Haftalık oran",
+  "weeklyWeightGoalNoneLabel": "Ayarlanmadı",
+  "weeklyWeightGoalKgPerWeek": "{rate} kg/hafta",
+  "@weeklyWeightGoalKgPerWeek": {
+    "placeholders": {
+      "rate": { "type": "String" }
+    }
+  },
+  "weeklyWeightGoalLbsPerWeek": "{rate} lbs/hafta",
+  "@weeklyWeightGoalLbsPerWeek": {
+    "placeholders": {
+      "rate": { "type": "String" }
+    }
+  },
+  "chooseWeeklyWeightGoalLabel": "Haftalık kilo oranı",
   "selectHeightDialogLabel": "Boy Seçin",
   "heightLabel": "Boy",
   "cmLabel": "cm",

--- a/lib/l10n/intl_uk.arb
+++ b/lib/l10n/intl_uk.arb
@@ -452,5 +452,6 @@
   "weeklyWeightGoalNoneLabel": "Не встановлено",
   "weeklyWeightGoalKgPerWeek": "{rate} кг/тиждень",
   "weeklyWeightGoalLbsPerWeek": "{rate} фунт/тиждень",
-  "chooseWeeklyWeightGoalLabel": "Тижневий темп ваги"
+  "chooseWeeklyWeightGoalLabel": "Тижневий темп ваги",
+  "settingsLanguageLabel": "Мова"
 }

--- a/lib/l10n/intl_uk.arb
+++ b/lib/l10n/intl_uk.arb
@@ -108,19 +108,22 @@
   "dialogCopyLabel": "Скопіювати на сьогодні",
   "dialogDeleteLabel": "ВИДАЛИТИ",
   "deleteAllLabel": "Видалити все",
-
   "shareMealLabel": "Share meal",
   "importMealLabel": "Import shared meal",
   "importMealConfirmTitle": "Import {count} items?",
   "@importMealConfirmTitle": {
     "placeholders": {
-      "count": { "type": "int" }
+      "count": {
+        "type": "int"
+      }
     }
   },
   "importMealConfirmContent": "These items will be added to your {mealType}.",
   "@importMealConfirmContent": {
     "placeholders": {
-      "mealType": { "type": "String" }
+      "mealType": {
+        "type": "String"
+      }
     }
   },
   "importMealSuccessLabel": "Meal imported",
@@ -128,7 +131,9 @@
   "importOffFetchFailedLabel": "{count} елемент(ів) не вдалося отримати з OpenFoodFacts.",
   "@importOffFetchFailedLabel": {
     "placeholders": {
-      "count": { "type": "int" }
+      "count": {
+        "type": "int"
+      }
     }
   },
   "copyCodeLabel": "Копіювати код",
@@ -136,7 +141,6 @@
   "codeCopiedLabel": "Код скопійовано",
   "pasteCodeLabel": "Вставити код",
   "pasteCodeHint": "Вставте сюди код спільного прийому їжі",
-
   "suppliedLabel": "спожито",
   "burnedLabel": "спалено",
   "kcalLeftLabel": "залишилось ккал",
@@ -438,5 +442,15 @@
   "paSkiingGeneral": "лижний спорт",
   "paSkiingGeneralDesc": "загальне",
   "paSnowShovingModerate": "розчищення снігу",
-  "paSnowShovingModerateDesc": "Розчишення снігу, помірні зусилля"
+  "paSnowShovingModerateDesc": "Розчишення снігу, помірні зусилля",
+  "settingsShowActivityTracking": "Показати відстеження активності",
+  "settingsNotificationsLabel": "Щоденне нагадування",
+  "settingsNotificationsTimeLabel": "Час нагадування: {time}",
+  "mealNutrientsPerQtyLabel": "На {qty} {unit}",
+  "mealNutrientsTotalLabel": "Загальна кількість",
+  "weeklyWeightGoalLabel": "Тижневий темп",
+  "weeklyWeightGoalNoneLabel": "Не встановлено",
+  "weeklyWeightGoalKgPerWeek": "{rate} кг/тиждень",
+  "weeklyWeightGoalLbsPerWeek": "{rate} фунт/тиждень",
+  "chooseWeeklyWeightGoalLabel": "Тижневий темп ваги"
 }

--- a/lib/l10n/intl_zh.arb
+++ b/lib/l10n/intl_zh.arb
@@ -453,5 +453,6 @@
   "weeklyWeightGoalNoneLabel": "未设置",
   "weeklyWeightGoalKgPerWeek": "{rate} 千克/周",
   "weeklyWeightGoalLbsPerWeek": "{rate} 磅/周",
-  "chooseWeeklyWeightGoalLabel": "每周体重速率"
+  "chooseWeeklyWeightGoalLabel": "每周体重速率",
+  "settingsLanguageLabel": "语言"
 }

--- a/lib/l10n/intl_zh.arb
+++ b/lib/l10n/intl_zh.arb
@@ -443,5 +443,15 @@
   "paAutoRacing": "赛车",
   "paAutoRacingDesc": "开轮式",
   "paBackpackingGeneral": "背包旅行",
-  "paBackpackingGeneralDesc": "一般"
+  "paBackpackingGeneralDesc": "一般",
+  "settingsShowActivityTracking": "显示活动追踪",
+  "settingsNotificationsLabel": "每日提醒",
+  "settingsNotificationsTimeLabel": "提醒时间：{time}",
+  "mealNutrientsPerQtyLabel": "每 {qty} {unit}",
+  "mealNutrientsTotalLabel": "总量",
+  "weeklyWeightGoalLabel": "每周速率",
+  "weeklyWeightGoalNoneLabel": "未设置",
+  "weeklyWeightGoalKgPerWeek": "{rate} 千克/周",
+  "weeklyWeightGoalLbsPerWeek": "{rate} 磅/周",
+  "chooseWeeklyWeightGoalLabel": "每周体重速率"
 }

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -12,6 +12,7 @@ import 'package:opennutritracker/core/styles/fonts.dart';
 import 'package:opennutritracker/core/utils/env.dart';
 import 'package:opennutritracker/core/utils/locator.dart';
 import 'package:opennutritracker/core/utils/logger_config.dart';
+import 'package:opennutritracker/core/utils/notification_service.dart';
 import 'package:opennutritracker/core/utils/navigation_options.dart';
 import 'package:opennutritracker/core/utils/theme_mode_provider.dart';
 import 'package:opennutritracker/features/activity_detail/activity_detail_screen.dart';
@@ -34,6 +35,19 @@ Future<void> main() async {
   await initLocator();
   final isUserInitialized = await locator<UserDataSource>().hasUserData();
   final configRepo = locator<ConfigRepository>();
+
+  // #312: Restore scheduled notifications after app start / device reboot
+  final config = await configRepo.getConfig();
+  if (config.notificationsEnabled) {
+    final notificationService = locator<NotificationService>();
+    await notificationService.initialize();
+    await notificationService.scheduleDailyReminder(
+      hour: config.notificationHour,
+      minute: config.notificationMinute,
+      title: 'OpenNutriTracker',
+      body: 'Don\'t forget to log your meals today!',
+    );
+  }
   final hasAcceptedAnonymousData =
       await configRepo.getConfigHasAcceptedAnonymousData();
   final savedAppTheme = await configRepo.getConfigAppTheme();

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -14,6 +14,7 @@ import 'package:opennutritracker/core/utils/locator.dart';
 import 'package:opennutritracker/core/utils/logger_config.dart';
 import 'package:opennutritracker/core/utils/notification_service.dart';
 import 'package:opennutritracker/core/utils/navigation_options.dart';
+import 'package:opennutritracker/core/utils/locale_provider.dart';
 import 'package:opennutritracker/core/utils/theme_mode_provider.dart';
 import 'package:opennutritracker/features/activity_detail/activity_detail_screen.dart';
 import 'package:opennutritracker/features/add_meal/presentation/add_meal_screen.dart';
@@ -51,22 +52,26 @@ Future<void> main() async {
   final hasAcceptedAnonymousData =
       await configRepo.getConfigHasAcceptedAnonymousData();
   final savedAppTheme = await configRepo.getConfigAppTheme();
+  final savedLocaleCode = await configRepo.getSelectedLocale();
+  final savedLocale =
+      savedLocaleCode != null ? Locale(savedLocaleCode) : null;
   final log = Logger('main');
 
   // If the user has accepted anonymous data collection, run the app with
   // sentry enabled, else run without it
   if (kReleaseMode && hasAcceptedAnonymousData) {
     log.info('Starting App with Sentry enabled ...');
-    _runAppWithSentryReporting(isUserInitialized, savedAppTheme);
+    _runAppWithSentryReporting(isUserInitialized, savedAppTheme, savedLocale);
   } else {
     log.info('Starting App ...');
-    runAppWithChangeNotifiers(isUserInitialized, savedAppTheme);
+    runAppWithChangeNotifiers(isUserInitialized, savedAppTheme, savedLocale);
   }
 }
 
 void _runAppWithSentryReporting(
   bool isUserInitialized,
   AppThemeEntity savedAppTheme,
+  Locale? savedLocale,
 ) async {
   await SentryFlutter.init(
     (options) {
@@ -74,17 +79,25 @@ void _runAppWithSentryReporting(
       options.tracesSampleRate = 1.0;
     },
     appRunner: () =>
-        runAppWithChangeNotifiers(isUserInitialized, savedAppTheme),
+        runAppWithChangeNotifiers(isUserInitialized, savedAppTheme, savedLocale),
   );
 }
 
 void runAppWithChangeNotifiers(
   bool userInitialized,
   AppThemeEntity savedAppTheme,
+  Locale? savedLocale,
 ) =>
     runApp(
-      ChangeNotifierProvider(
-        create: (_) => ThemeModeProvider(appTheme: savedAppTheme),
+      MultiProvider(
+        providers: [
+          ChangeNotifierProvider(
+            create: (_) => ThemeModeProvider(appTheme: savedAppTheme),
+          ),
+          ChangeNotifierProvider(
+            create: (_) => LocaleProvider(locale: savedLocale),
+          ),
+        ],
         child: OpenNutriTrackerApp(userInitialized: userInitialized),
       ),
     );
@@ -110,6 +123,7 @@ class OpenNutriTrackerApp extends StatelessWidget {
         textTheme: appTextTheme,
       ),
       themeMode: Provider.of<ThemeModeProvider>(context).themeMode,
+      locale: Provider.of<LocaleProvider>(context).locale,
       localizationsDelegates: const [
         S.delegate,
         GlobalMaterialLocalizations.delegate,

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -29,10 +29,10 @@ packages:
     dependency: transitive
     description:
       name: app_links
-      sha256: "3462d9defc61565fde4944858b59bec5be2b9d5b05f20aed190adb3ad08a7abc"
+      sha256: "433df2e61b10519407475d7f69e470789d23d593f28224c38ba1068597be7950"
       url: "https://pub.dev"
     source: hosted
-    version: "7.0.0"
+    version: "6.3.3"
   app_links_linux:
     dependency: transitive
     description:
@@ -69,18 +69,18 @@ packages:
     dependency: transitive
     description:
       name: args
-      sha256: d0481093c50b1da8910eb0bb301626d4d8eb7284aa739614d2b394ee09e3ea04
+      sha256: bf9f5caeea8d8fe6721a9c358dd8a5c1947b27f1cfaa18b39c301273594919e6
       url: "https://pub.dev"
     source: hosted
-    version: "2.7.0"
+    version: "2.6.0"
   async:
     dependency: transitive
     description:
       name: async
-      sha256: e2eb0491ba5ddb6177742d2da23904574082139b07c1e33b8503b9f46f3e1a37
+      sha256: "947bfcf187f74dbc5e146c9eb9c0f10c9f8b30743e341481c1e2ed3ecc18c20c"
       url: "https://pub.dev"
     source: hosted
-    version: "2.13.1"
+    version: "2.11.0"
   auto_size_text:
     dependency: "direct main"
     description:
@@ -101,10 +101,10 @@ packages:
     dependency: transitive
     description:
       name: boolean_selector
-      sha256: "8aab1771e1243a5063b8b0ff68042d67334e3feab9e95b9490f9a6ebf73b42ea"
+      sha256: "6cfb5af12253eaf2b368f07bacc5a80d1301a071c73360d746b7f2e32d762c66"
       url: "https://pub.dev"
     source: hosted
-    version: "2.1.2"
+    version: "2.1.1"
   build:
     dependency: transitive
     description:
@@ -125,10 +125,10 @@ packages:
     dependency: transitive
     description:
       name: build_daemon
-      sha256: bf05f6e12cfea92d3c09308d7bcdab1906cd8a179b023269eed00c071004b957
+      sha256: "294a2edaf4814a378725bfe6358210196f5ea37af89ecd81bfa32960113d4948"
       url: "https://pub.dev"
     source: hosted
-    version: "4.1.1"
+    version: "4.0.3"
   build_runner:
     dependency: "direct dev"
     description:
@@ -189,10 +189,10 @@ packages:
     dependency: transitive
     description:
       name: checked_yaml
-      sha256: "959525d3162f249993882720d52b7e0c833978df229be20702b33d48d91de70f"
+      sha256: feb6bed21949061731a7a75fc5d2aa727cf160b91af9a3e464c5e3a32e28b5ff
       url: "https://pub.dev"
     source: hosted
-    version: "2.0.4"
+    version: "2.0.3"
   cli_util:
     dependency: transitive
     description:
@@ -209,14 +209,6 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "1.1.2"
-  code_assets:
-    dependency: transitive
-    description:
-      name: code_assets
-      sha256: "83ccdaa064c980b5596c35dd64a8d3ecc68620174ab9b90b6343b753aa721687"
-      url: "https://pub.dev"
-    source: hosted
-    version: "1.0.0"
   code_builder:
     dependency: transitive
     description:
@@ -245,18 +237,18 @@ packages:
     dependency: transitive
     description:
       name: cross_file
-      sha256: "28bb3ae56f117b5aec029d702a90f57d285cd975c3c5c281eaca38dbc47c5937"
+      sha256: "7caf6a750a0c04effbb52a676dce9a4a592e10ad35c34d6d2d0e4811160d5670"
       url: "https://pub.dev"
     source: hosted
-    version: "0.3.5+2"
+    version: "0.3.4+2"
   crypto:
     dependency: transitive
     description:
       name: crypto
-      sha256: c8ea0233063ba03258fbcf2ca4d6dadfefe14f02fab57702265467a19f27fadf
+      sha256: "1e445881f28f22d6140f181e07737b22f1e099a5e1ff94b0af2f9e4a463f4855"
       url: "https://pub.dev"
     source: hosted
-    version: "3.0.7"
+    version: "3.0.6"
   cupertino_icons:
     dependency: "direct main"
     description:
@@ -333,10 +325,10 @@ packages:
     dependency: transitive
     description:
       name: ffi
-      sha256: "6d7fd89431262d8f3125e81b50d3847a091d846eafcd4fdb88dd06f36d705a45"
+      sha256: "16ed7b077ef01ad6170a3d0c57caa4a112a38d7a2ed5602e0aca9ca6f3d98da6"
       url: "https://pub.dev"
     source: hosted
-    version: "2.2.0"
+    version: "2.1.3"
   file:
     dependency: transitive
     description:
@@ -438,6 +430,38 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "6.0.0"
+  flutter_local_notifications:
+    dependency: "direct main"
+    description:
+      name: flutter_local_notifications
+      sha256: "19ffb0a8bb7407875555e5e98d7343a633bb73707bae6c6a5f37c90014077875"
+      url: "https://pub.dev"
+    source: hosted
+    version: "19.5.0"
+  flutter_local_notifications_linux:
+    dependency: transitive
+    description:
+      name: flutter_local_notifications_linux
+      sha256: e3c277b2daab8e36ac5a6820536668d07e83851aeeb79c446e525a70710770a5
+      url: "https://pub.dev"
+    source: hosted
+    version: "6.0.0"
+  flutter_local_notifications_platform_interface:
+    dependency: transitive
+    description:
+      name: flutter_local_notifications_platform_interface
+      sha256: "277d25d960c15674ce78ca97f57d0bae2ee401c844b6ac80fcd972a9c99d09fe"
+      url: "https://pub.dev"
+    source: hosted
+    version: "9.1.0"
+  flutter_local_notifications_windows:
+    dependency: transitive
+    description:
+      name: flutter_local_notifications_windows
+      sha256: "8d658f0d367c48bd420e7cf2d26655e2d1130147bca1eea917e576ca76668aaf"
+      url: "https://pub.dev"
+    source: hosted
+    version: "1.0.3"
   flutter_localizations:
     dependency: "direct main"
     description: flutter
@@ -447,10 +471,10 @@ packages:
     dependency: transitive
     description:
       name: flutter_plugin_android_lifecycle
-      sha256: "38d1c268de9097ff59cf0e844ac38759fc78f76836d37edad06fa21e182055a0"
+      sha256: "5a1e6fb2c0561958d7e4c33574674bda7b77caaca7a33b758876956f2902eea3"
       url: "https://pub.dev"
     source: hosted
-    version: "2.0.34"
+    version: "2.0.27"
   flutter_secure_storage:
     dependency: "direct main"
     description:
@@ -537,10 +561,10 @@ packages:
     dependency: transitive
     description:
       name: glob
-      sha256: c3f1ee72c96f8f78935e18aa8cecced9ab132419e8625dc187e1c2408efc20de
+      sha256: "0e7014b3b7d4dac1ca4d6114f82bf1782ee86745b9b42a92c9289c23d8a0ab63"
       url: "https://pub.dev"
     source: hosted
-    version: "2.1.3"
+    version: "2.1.2"
   gotrue:
     dependency: transitive
     description:
@@ -589,14 +613,6 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "1.11.1"
-  hooks:
-    dependency: transitive
-    description:
-      name: hooks
-      sha256: "025f060e86d2d4c3c47b56e33caf7f93bf9283340f26d23424ebcfccf34f621e"
-      url: "https://pub.dev"
-    source: hosted
-    version: "1.0.3"
   horizontal_picker:
     dependency: "direct main"
     description:
@@ -633,10 +649,10 @@ packages:
     dependency: transitive
     description:
       name: image
-      sha256: f9881ff4998044947ec38d098bc7c8316ae1186fa786eddffdb867b9bc94dfce
+      sha256: "8346ad4b5173924b5ddddab782fc7d8a6300178c8b1dc427775405a01701c4a6"
       url: "https://pub.dev"
     source: hosted
-    version: "4.8.0"
+    version: "4.5.2"
   intl:
     dependency: "direct main"
     description:
@@ -789,14 +805,6 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "5.6.4"
-  native_toolchain_c:
-    dependency: transitive
-    description:
-      name: native_toolchain_c
-      sha256: "6ba77bb18063eebe9de401f5e6437e95e1438af0a87a3a39084fbd37c90df572"
-      url: "https://pub.dev"
-    source: hosted
-    version: "0.17.6"
   nested:
     dependency: transitive
     description:
@@ -805,14 +813,6 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "1.0.0"
-  objective_c:
-    dependency: transitive
-    description:
-      name: objective_c
-      sha256: "100a1c87616ab6ed41ec263b083c0ef3261ee6cd1dc3b0f35f8ddfa4f996fe52"
-      url: "https://pub.dev"
-    source: hosted
-    version: "9.3.0"
   octo_image:
     dependency: transitive
     description:
@@ -825,10 +825,10 @@ packages:
     dependency: transitive
     description:
       name: package_config
-      sha256: f096c55ebb7deb7e384101542bfba8c52696c1b56fca2eb62827989ef2353bbc
+      sha256: "92d4488434b520a62570293fbd33bb556c7d49230791c1b4bbd973baf6d2dc67"
       url: "https://pub.dev"
     source: hosted
-    version: "2.2.0"
+    version: "2.1.1"
   package_info_plus:
     dependency: "direct main"
     description:
@@ -873,18 +873,18 @@ packages:
     dependency: transitive
     description:
       name: path_provider_android
-      sha256: "149441ca6e4f38193b2e004c0ca6376a3d11f51fa5a77552d8bd4d2b0c0912ba"
+      sha256: "4adf4fd5423ec60a29506c76581bc05854c55e3a0b72d35bb28d661c9686edf2"
       url: "https://pub.dev"
     source: hosted
-    version: "2.2.23"
+    version: "2.2.15"
   path_provider_foundation:
     dependency: transitive
     description:
       name: path_provider_foundation
-      sha256: "2a376b7d6392d80cd3705782d2caa734ca4727776db0b6ec36ef3f1855197699"
+      sha256: "4843174df4d288f5e29185bd6e72a6fbdf5a4a4602717eed565497429f179942"
       url: "https://pub.dev"
     source: hosted
-    version: "2.6.0"
+    version: "2.4.1"
   path_provider_linux:
     dependency: transitive
     description:
@@ -921,10 +921,10 @@ packages:
     dependency: transitive
     description:
       name: petitparser
-      sha256: "91bd59303e9f769f108f8df05e371341b15d59e995e6806aefab827b58336675"
+      sha256: c15605cd28af66339f8eb6fbe0e541bfe2d1b72d5825efc6598f3e0a31b9ad27
       url: "https://pub.dev"
     source: hosted
-    version: "7.0.2"
+    version: "6.0.2"
   platform:
     dependency: transitive
     description:
@@ -953,10 +953,10 @@ packages:
     dependency: transitive
     description:
       name: pool
-      sha256: "978783255c543aa3586a1b3c21f6e9d720eb315376a915872c61ef8b5c20177d"
+      sha256: "20fe868b6314b322ea036ba325e6fc0711a22948856475e2c2b6306e8ab39c2a"
       url: "https://pub.dev"
     source: hosted
-    version: "1.5.2"
+    version: "1.5.1"
   posix:
     dependency: transitive
     description:
@@ -985,18 +985,18 @@ packages:
     dependency: transitive
     description:
       name: pub_semver
-      sha256: "5bfcf68ca79ef689f8990d1160781b4bad40a3bd5e5218ad4076ddb7f4081585"
+      sha256: "7b3cfbf654f3edd0c6298ecd5be782ce997ddf0e00531b9464b55245185bbbbd"
       url: "https://pub.dev"
     source: hosted
-    version: "2.2.0"
+    version: "2.1.5"
   pubspec_parse:
     dependency: transitive
     description:
       name: pubspec_parse
-      sha256: "0560ba233314abbed0a48a2956f7f022cce7c3e1e73df540277da7544cad4082"
+      sha256: "81876843eb50dc2e1e5b151792c9a985c5ed2536914115ed04e9c8528f6647b0"
       url: "https://pub.dev"
     source: hosted
-    version: "1.5.0"
+    version: "1.4.0"
   qr:
     dependency: transitive
     description:
@@ -1029,14 +1029,6 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "4.1.0"
-  record_use:
-    dependency: transitive
-    description:
-      name: record_use
-      sha256: "2551bd8eecfe95d14ae75f6021ad0248be5c27f138c2ec12fcb52b500b3ba1ed"
-      url: "https://pub.dev"
-    source: hosted
-    version: "0.6.0"
   retry:
     dependency: transitive
     description:
@@ -1089,26 +1081,26 @@ packages:
     dependency: transitive
     description:
       name: shared_preferences
-      sha256: c3025c5534b01739267eb7d76959bbc25a6d10f6988e1c2a3036940133dd10bf
+      sha256: a752ce92ea7540fc35a0d19722816e04d0e72828a4200e83a98cf1a1eb524c9a
       url: "https://pub.dev"
     source: hosted
-    version: "2.5.5"
+    version: "2.3.5"
   shared_preferences_android:
     dependency: transitive
     description:
       name: shared_preferences_android
-      sha256: e8d4762b1e2e8578fc4d0fd548cebf24afd24f49719c08974df92834565e2c53
+      sha256: "02a7d8a9ef346c9af715811b01fbd8e27845ad2c41148eefd31321471b41863d"
       url: "https://pub.dev"
     source: hosted
-    version: "2.4.23"
+    version: "2.4.0"
   shared_preferences_foundation:
     dependency: transitive
     description:
       name: shared_preferences_foundation
-      sha256: "4e7eaffc2b17ba398759f1151415869a34771ba11ebbccd1b0145472a619a64f"
+      sha256: "6a52cfcdaeac77cad8c97b539ff688ccfc458c007b4db12be584fbe5c0e49e03"
       url: "https://pub.dev"
     source: hosted
-    version: "2.5.6"
+    version: "2.5.4"
   shared_preferences_linux:
     dependency: transitive
     description:
@@ -1121,18 +1113,18 @@ packages:
     dependency: transitive
     description:
       name: shared_preferences_platform_interface
-      sha256: "649dc798a33931919ea356c4305c2d1f81619ea6e92244070b520187b5140ef9"
+      sha256: "57cbf196c486bc2cf1f02b85784932c6094376284b3ad5779d1b1c6c6a816b80"
       url: "https://pub.dev"
     source: hosted
-    version: "2.4.2"
+    version: "2.4.1"
   shared_preferences_web:
     dependency: transitive
     description:
       name: shared_preferences_web
-      sha256: c49bd060261c9a3f0ff445892695d6212ff603ef3115edbb448509d407600019
+      sha256: d2ca4132d3946fec2184261726b355836a82c33d7d5b67af32692aff18a4684e
       url: "https://pub.dev"
     source: hosted
-    version: "2.4.3"
+    version: "2.4.2"
   shared_preferences_windows:
     dependency: transitive
     description:
@@ -1153,10 +1145,10 @@ packages:
     dependency: transitive
     description:
       name: shelf_web_socket
-      sha256: "3632775c8e90d6c9712f883e633716432a27758216dfb61bd86a8321c0580925"
+      sha256: cc36c297b52866d203dbf9332263c94becc2fe0ceaa9681d07b6ef9807023b67
       url: "https://pub.dev"
     source: hosted
-    version: "3.0.0"
+    version: "2.0.1"
   simple_gesture_detector:
     dependency: transitive
     description:
@@ -1190,42 +1182,42 @@ packages:
     dependency: transitive
     description:
       name: source_span
-      sha256: "56a02f1f4cd1a2d96303c0144c93bd6d909eea6bee6bf5a0e0b685edbd4c47ab"
+      sha256: "53e943d4206a5e30df338fd4c6e7a077e02254531b138a15aec3bd143c1a8b3c"
       url: "https://pub.dev"
     source: hosted
-    version: "1.10.2"
+    version: "1.10.0"
   sqflite:
     dependency: transitive
     description:
       name: sqflite
-      sha256: "564cfed0746fe53140c23b70b308e045c3b31f17778f2f326ccb7d804ea0250a"
+      sha256: "2d7299468485dca85efeeadf5d38986909c5eb0cd71fd3db2c2f000e6c9454bb"
       url: "https://pub.dev"
     source: hosted
-    version: "2.4.2+1"
+    version: "2.4.1"
   sqflite_android:
     dependency: transitive
     description:
       name: sqflite_android
-      sha256: "881e28efdcc9950fd8e9bb42713dcf1103e62a2e7168f23c9338d82db13dec40"
+      sha256: "78f489aab276260cdd26676d2169446c7ecd3484bbd5fead4ca14f3ed4dd9ee3"
       url: "https://pub.dev"
     source: hosted
-    version: "2.4.2+3"
+    version: "2.4.0"
   sqflite_common:
     dependency: transitive
     description:
       name: sqflite_common
-      sha256: "5e8377564d95166761a968ed96104e0569b6b6cc611faac92a36ab8a169112c3"
+      sha256: "761b9740ecbd4d3e66b8916d784e581861fd3c3553eda85e167bc49fdb68f709"
       url: "https://pub.dev"
     source: hosted
-    version: "2.5.6+1"
+    version: "2.5.4+6"
   sqflite_darwin:
     dependency: transitive
     description:
       name: sqflite_darwin
-      sha256: "279832e5cde3fe99e8571879498c9211f3ca6391b0d818df4e17d9fff5c6ccb3"
+      sha256: "22adfd9a2c7d634041e96d6241e6e1c8138ca6817018afc5d443fef91dcefa9c"
       url: "https://pub.dev"
     source: hosted
-    version: "2.4.2"
+    version: "2.4.1+1"
   sqflite_platform_interface:
     dependency: transitive
     description:
@@ -1270,10 +1262,10 @@ packages:
     dependency: transitive
     description:
       name: string_scanner
-      sha256: "921cd31725b72fe181906c6a94d987c78e3b98c2e205b397ea399d4054872b43"
+      sha256: "688af5ed3402a4bde5b3a6c15fd768dbf2621a614950b17f04626c431ab3c4c3"
       url: "https://pub.dev"
     source: hosted
-    version: "1.4.1"
+    version: "1.3.0"
   supabase:
     dependency: transitive
     description:
@@ -1294,10 +1286,10 @@ packages:
     dependency: transitive
     description:
       name: synchronized
-      sha256: "63896c27e81b28f8cb4e69ead0d3e8f03f1d1e5fc531a3e579cabed6a2c7c9e5"
+      sha256: "69fe30f3a8b04a0be0c15ae6490fc859a78ef4c43ae2dd5e8a623d45bfcf9225"
       url: "https://pub.dev"
     source: hosted
-    version: "3.4.0+1"
+    version: "3.3.0+3"
   table_calendar:
     dependency: "direct main"
     description:
@@ -1310,10 +1302,10 @@ packages:
     dependency: transitive
     description:
       name: term_glyph
-      sha256: "7f554798625ea768a7518313e58f83891c7f5024f88e46e7182a4558850a4b8e"
+      sha256: a29248a84fbb7c79282b40b8c72a1209db169a2e0542bce341da992fe1bc7e84
       url: "https://pub.dev"
     source: hosted
-    version: "1.2.2"
+    version: "1.2.1"
   test_api:
     dependency: transitive
     description:
@@ -1322,6 +1314,14 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "0.7.10"
+  timezone:
+    dependency: "direct main"
+    description:
+      name: timezone
+      sha256: dd14a3b83cfd7cb19e7888f1cbc20f258b8d71b54c06f79ac585f14093a287d1
+      url: "https://pub.dev"
+    source: hosted
+    version: "0.10.1"
   typed_data:
     dependency: transitive
     description:
@@ -1342,34 +1342,34 @@ packages:
     dependency: transitive
     description:
       name: url_launcher_android
-      sha256: "3bb000251e55d4a209aa0e2e563309dc9bb2befea2295fd0cec1f51760aac572"
+      sha256: "6fc2f56536ee873eeb867ad176ae15f304ccccc357848b351f6f0d8d4a40d193"
       url: "https://pub.dev"
     source: hosted
-    version: "6.3.29"
+    version: "6.3.14"
   url_launcher_ios:
     dependency: transitive
     description:
       name: url_launcher_ios
-      sha256: "580fe5dfb51671ae38191d316e027f6b76272b026370708c2d898799750a02b0"
+      sha256: "16a513b6c12bb419304e72ea0ae2ab4fed569920d1c7cb850263fe3acc824626"
       url: "https://pub.dev"
     source: hosted
-    version: "6.4.1"
+    version: "6.3.2"
   url_launcher_linux:
     dependency: transitive
     description:
       name: url_launcher_linux
-      sha256: d5e14138b3bc193a0f63c10a53c94b91d399df0512b1f29b94a043db7482384a
+      sha256: "4e9ba368772369e3e08f231d2301b4ef72b9ff87c31192ef471b380ef29a4935"
       url: "https://pub.dev"
     source: hosted
-    version: "3.2.2"
+    version: "3.2.1"
   url_launcher_macos:
     dependency: transitive
     description:
       name: url_launcher_macos
-      sha256: "368adf46f71ad3c21b8f06614adb38346f193f3a59ba8fe9a2fd74133070ba18"
+      sha256: "17ba2000b847f334f16626a574c702b196723af2a289e7a93ffcb79acff855c2"
       url: "https://pub.dev"
     source: hosted
-    version: "3.2.5"
+    version: "3.2.2"
   url_launcher_platform_interface:
     dependency: transitive
     description:
@@ -1382,18 +1382,18 @@ packages:
     dependency: transitive
     description:
       name: url_launcher_web
-      sha256: d0412fcf4c6b31ecfdb7762359b7206ffba3bbffd396c6d9f9c4616ece476c1f
+      sha256: "772638d3b34c779ede05ba3d38af34657a05ac55b06279ea6edd409e323dca8e"
       url: "https://pub.dev"
     source: hosted
-    version: "2.4.2"
+    version: "2.3.3"
   url_launcher_windows:
     dependency: transitive
     description:
       name: url_launcher_windows
-      sha256: "712c70ab1b99744ff066053cbe3e80c73332b38d46e5e945c98689b2e66fc15f"
+      sha256: "44cf3aabcedde30f2dba119a9dea3b0f2672fbe6fa96e85536251d678216b3c4"
       url: "https://pub.dev"
     source: hosted
-    version: "3.1.5"
+    version: "3.1.3"
   uuid:
     dependency: "direct main"
     description:
@@ -1406,26 +1406,26 @@ packages:
     dependency: transitive
     description:
       name: vector_graphics
-      sha256: "6409a25046024f0f8c5d8a59fec314081e81f9d436b66ca4015a8b49772bf445"
+      sha256: "27d5fefe86fb9aace4a9f8375b56b3c292b64d8c04510df230f849850d912cb7"
       url: "https://pub.dev"
     source: hosted
-    version: "1.2.0"
+    version: "1.1.15"
   vector_graphics_codec:
     dependency: transitive
     description:
       name: vector_graphics_codec
-      sha256: "99fd9fbd34d9f9a32efd7b6a6aae14125d8237b10403b422a6a6dfeac2806146"
+      sha256: "2430b973a4ca3c4dbc9999b62b8c719a160100dcbae5c819bae0cacce32c9cdb"
       url: "https://pub.dev"
     source: hosted
-    version: "1.1.13"
+    version: "1.1.12"
   vector_graphics_compiler:
     dependency: transitive
     description:
       name: vector_graphics_compiler
-      sha256: "5a88dd14c0954a5398af544651c7fb51b457a2a556949bfb25369b210ef73a74"
+      sha256: "1b4b9e706a10294258727674a340ae0d6e64a7231980f9f9a3d12e4b42407aad"
       url: "https://pub.dev"
     source: hosted
-    version: "1.2.0"
+    version: "1.1.16"
   vector_math:
     dependency: transitive
     description:
@@ -1438,50 +1438,50 @@ packages:
     dependency: transitive
     description:
       name: vm_service
-      sha256: "0016aef94fc66495ac78af5859181e3f3bf2026bd8eecc72b9565601e19ab360"
+      sha256: f6be3ed8bd01289b34d679c2b62226f63c0e69f9fd2e50a6b3c1c729a961041b
       url: "https://pub.dev"
     source: hosted
-    version: "15.2.0"
+    version: "14.3.0"
   watcher:
     dependency: transitive
     description:
       name: watcher
-      sha256: "1398c9f081a753f9226febe8900fce8f7d0a67163334e1c94a2438339d79d635"
+      sha256: "69da27e49efa56a15f8afe8f4438c4ec02eff0a117df1b22ea4aad194fe1c104"
       url: "https://pub.dev"
     source: hosted
-    version: "1.2.1"
+    version: "1.1.1"
   web:
     dependency: transitive
     description:
       name: web
-      sha256: "868d88a33d8a87b18ffc05f9f030ba328ffefba92d6c127917a2ba740f9cfe4a"
+      sha256: cd3543bd5798f6ad290ea73d210f423502e71900302dde696f8bff84bf89a1cb
       url: "https://pub.dev"
     source: hosted
-    version: "1.1.1"
+    version: "1.1.0"
   web_socket:
     dependency: transitive
     description:
       name: web_socket
-      sha256: "34d64019aa8e36bf9842ac014bb5d2f5586ca73df5e4d9bf5c936975cae6982c"
+      sha256: "3c12d96c0c9a4eec095246debcea7b86c0324f22df69893d538fcc6f1b8cce83"
       url: "https://pub.dev"
     source: hosted
-    version: "1.0.1"
+    version: "0.1.6"
   web_socket_channel:
     dependency: transitive
     description:
       name: web_socket_channel
-      sha256: d645757fb0f4773d602444000a8131ff5d48c9e47adfe9772652dd1a4f2d45c8
+      sha256: "9f187088ed104edd8662ca07af4b124465893caf063ba29758f97af57e61da8f"
       url: "https://pub.dev"
     source: hosted
-    version: "3.0.3"
+    version: "3.0.1"
   win32:
     dependency: transitive
     description:
       name: win32
-      sha256: d7cb55e04cd34096cd3a79b3330245f54cb96a370a1c27adb3c84b917de8b08e
+      sha256: "154360849a56b7b67331c21f09a386562d88903f90a1099c5987afc1912e1f29"
       url: "https://pub.dev"
     source: hosted
-    version: "5.15.0"
+    version: "5.10.0"
   xdg_directories:
     dependency: transitive
     description:
@@ -1494,10 +1494,10 @@ packages:
     dependency: transitive
     description:
       name: xml
-      sha256: "971043b3a0d3da28727e40ed3e0b5d18b742fa5a68665cca88e74b7876d5e025"
+      sha256: b015a8ad1c488f66851d762d3090a21c600e479dc75e68328c52774040cf9226
       url: "https://pub.dev"
     source: hosted
-    version: "6.6.1"
+    version: "6.5.0"
   yaml:
     dependency: transitive
     description:
@@ -1524,4 +1524,4 @@ packages:
     version: "2.1.0"
 sdks:
   dart: ">=3.11.0 <4.0.0"
-  flutter: ">=3.38.4"
+  flutter: ">=3.35.0"

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -73,6 +73,8 @@ dependencies:
   sentry_flutter: ^9.19.0
 
   supabase_flutter: ^2.12.4
+  flutter_local_notifications: ^19.5.0
+  timezone: ^0.10.1
 
 dev_dependencies:
   flutter_test:


### PR DESCRIPTION
## Summary

Ports the 7-feature bundle from [erikpt/OpenNutriTracker#10](https://github.com/erikpt/OpenNutriTracker/pull/10) into this repo, adapted for our v1.2.0 codebase.

- **#281** Quick weight widget on home screen — tap to log weight without navigating to profile
- **#284** Weekly weight rate goal — set a target kg/week in profile; kcal budget adjusts accordingly (~1100 kcal/day per kg/week)
- **#290** 2024 Compendium of Physical Activities — updated MET values and 12 new activity types
- **#292** Diary calendar range extended from 356 days to 5 years
- **#297** Direct text input alongside sliders in the calculations dialog
- Fix broken nutrient label concatenation in edit meal screen (per-qty vs total toggle, clean helper text)
- **#312** Daily meal reminder notifications via \`flutter_local_notifications\` — toggle + time picker in Settings

## Technical notes

- Added \`flutter_local_notifications\` + \`timezone\` dependencies; enabled core library desugaring in \`android/app/build.gradle\`
- \`ConfigDBO\` gains HiveFields 9–12 (showActivityTracking, notificationsEnabled, notificationHour, notificationMinute); \`UserDBO\` gains field 6 (weeklyWeightGoalKg) — no collisions with existing fields
- All 10 new l10n keys translated into all 8 supported locales (en, de, tr, cz, it, uk, zh, pl)

## Test plan

- [ ] Quick weight widget appears on home screen; tap opens weight entry dialog
- [ ] Weekly rate goal in profile updates the daily kcal budget correctly
- [ ] New 2024 activities appear in activity picker; updated MET values look correct
- [ ] Diary calendar scrolls back more than 1 year
- [ ] Calculations dialog accepts direct text input alongside sliders
- [ ] Edit meal screen shows clean nutrient labels with per-qty / total toggle
- [ ] Notification toggle in Settings prompts OS permission; reminder fires at configured time
- [ ] All of the above work correctly in at least one non-EN locale