### PR TITLE
fix(notifications): wire up flutter_timezone for local timezone scheduling

### DIFF
--- a/lib/core/utils/notification_service.dart
+++ b/lib/core/utils/notification_service.dart
@@ -1,4 +1,5 @@
 import 'package:flutter_local_notifications/flutter_local_notifications.dart';
+import 'package:flutter_timezone/flutter_timezone.dart';
 import 'package:logging/logging.dart';
 import 'package:timezone/data/latest_all.dart' as tz;
 import 'package:timezone/timezone.dart' as tz;
@@ -20,6 +21,8 @@ class NotificationService {
   Future<void> initialize() async {
     if (_initialized) return;
     tz.initializeTimeZones();
+    final String timeZoneName = await FlutterTimezone.getLocalTimezone();
+    tz.setLocalLocation(tz.getLocation(timeZoneName));
 
     const androidSettings =
         AndroidInitializationSettings('@mipmap/ic_launcher');

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -536,6 +536,14 @@ packages:
     description: flutter
     source: sdk
     version: "0.0.0"
+  flutter_timezone:
+    dependency: "direct main"
+    description:
+      name: flutter_timezone
+      sha256: "06b35132c98fa188db3c4b654b7e1af7ccd01dfe12a004d58be423357605fb24"
+      url: "https://pub.dev"
+    source: hosted
+    version: "1.0.8"
   flutter_web_plugins:
     dependency: transitive
     description: flutter
@@ -693,6 +701,14 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "0.14.2"
+  js:
+    dependency: transitive
+    description:
+      name: js
+      sha256: "53385261521cc4a0c4658fd0ad07a7d14591cf8fc33abbceae306ddb974888dc"
+      url: "https://pub.dev"
+    source: hosted
+    version: "0.7.2"
   json_annotation:
     dependency: "direct main"
     description:

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -75,6 +75,7 @@ dependencies:
   supabase_flutter: ^2.12.4
   flutter_local_notifications: ^19.5.0
   timezone: ^0.10.1
+  flutter_timezone: ^1.0.8
 
 dev_dependencies:
   flutter_test:


### PR DESCRIPTION
## Summary
- Adds `flutter_timezone: ^1.0.8` dependency (was in pubspec but uncommitted)
- Wires up `FlutterTimezone.getLocalTimezone()` in `NotificationService.initialize()` so daily reminders fire at the user's local time rather than UTC on both iOS and Android

## Test plan
- [ ] All existing tests pass (`fvm flutter test`)
- [ ] `flutter analyze` clean
- [ ] Manually schedule a reminder and verify it fires at the correct local time on device