### PR TITLE
fix(deps): upgrade flutter_timezone to 3.x (fixes Android build)

### DIFF
--- a/pubspec.lock
+++ b/pubspec.lock
@@ -540,10 +540,10 @@ packages:
     dependency: "direct main"
     description:
       name: flutter_timezone
-      sha256: "06b35132c98fa188db3c4b654b7e1af7ccd01dfe12a004d58be423357605fb24"
+      sha256: ea53c61c9152f271a5e30624a624184804947b6a733ff2b64186bb2579446892
       url: "https://pub.dev"
     source: hosted
-    version: "1.0.8"
+    version: "3.0.1"
   flutter_web_plugins:
     dependency: transitive
     description: flutter
@@ -701,14 +701,6 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "0.14.2"
-  js:
-    dependency: transitive
-    description:
-      name: js
-      sha256: "53385261521cc4a0c4658fd0ad07a7d14591cf8fc33abbceae306ddb974888dc"
-      url: "https://pub.dev"
-    source: hosted
-    version: "0.7.2"
   json_annotation:
     dependency: "direct main"
     description:

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -75,7 +75,7 @@ dependencies:
   supabase_flutter: ^2.12.4
   flutter_local_notifications: ^19.5.0
   timezone: ^0.10.1
-  flutter_timezone: ^1.0.8
+  flutter_timezone: ^3.0.0
 
 dev_dependencies:
   flutter_test:


### PR DESCRIPTION
## Summary

- `flutter_timezone ^1.0.8` fails to compile on Android: its Kotlin source uses the deprecated V1 embedding `Registrar` API which current Gradle no longer supports
- Upgraded to `^3.0.0` (resolves to 3.0.1) which uses V2 embedding
- `FlutterTimezone.getLocalTimezone()` call in `notification_service.dart` is unchanged — the public API is identical

## Test plan

- [x] `flutter build apk --debug` succeeds
- [x] Scheduled notifications still fire at the correct local time