### PR TITLE
fix(meal-detail): fix keyboard dismissal in quantity field

### DIFF
--- a/lib/features/activity_detail/activity_detail_screen.dart
+++ b/lib/features/activity_detail/activity_detail_screen.dart
@@ -41,6 +41,7 @@ class _ActivityDetailScreenState extends State<ActivityDetailScreen> {
     _activityDetailBloc = locator<ActivityDetailBloc>();
     quantityTextController = TextEditingController();
     quantityTextController.text = "0";
+    quantityTextController.addListener(_onQuantityChanged);
     totalQuantity = 0; // TODO change to 60
     totalKcal = 0;
     super.initState();
@@ -52,8 +53,14 @@ class _ActivityDetailScreenState extends State<ActivityDetailScreen> {
         as ActivityDetailScreenArguments;
     activityEntity = args.activityEntity;
     _day = args.day;
-    quantityTextController.addListener(() {});
     super.didChangeDependencies();
+  }
+
+  @override
+  void dispose() {
+    quantityTextController.removeListener(_onQuantityChanged);
+    quantityTextController.dispose();
+    super.dispose();
   }
 
   @override
@@ -70,9 +77,6 @@ class _ActivityDetailScreenState extends State<ActivityDetailScreen> {
           } else if (state is ActivityDetailLoadingState) {
             return getLoadingContent();
           } else if (state is ActivityDetailLoadedState) {
-            quantityTextController.addListener(() {
-              _onQuantityChanged(quantityTextController.text, state.userEntity);
-            });
             return getLoadedContent(state.totalKcalBurned, state.userEntity);
           } else {
             return const SizedBox();
@@ -173,11 +177,13 @@ class _ActivityDetailScreenState extends State<ActivityDetailScreen> {
     );
   }
 
-  void _onQuantityChanged(String quantityString, UserEntity userEntity) async {
+  void _onQuantityChanged() {
+    final state = _activityDetailBloc.state;
+    if (state is! ActivityDetailLoadedState) return;
     try {
-      final newQuantity = double.parse(quantityString);
+      final newQuantity = double.parse(quantityTextController.text);
       final newTotalKcal = _activityDetailBloc.getTotalKcalBurned(
-        userEntity,
+        state.userEntity,
         activityEntity,
         newQuantity,
       );
@@ -187,7 +193,7 @@ class _ActivityDetailScreenState extends State<ActivityDetailScreen> {
         scrollToCalorieText();
       });
     } on FormatException catch (_) {
-      log.warning("Error while parsing: \"$quantityString\"");
+      log.warning("Error while parsing: \"${quantityTextController.text}\"");
     }
   }
 

--- a/lib/features/meal_detail/meal_detail_screen.dart
+++ b/lib/features/meal_detail/meal_detail_screen.dart
@@ -107,12 +107,12 @@ class _MealDetailScreenState extends State<MealDetailScreen> {
   @override
   Widget build(BuildContext context) {
     return SafeArea(
-      child: BlocBuilder<MealDetailBloc, MealDetailState>(
-        bloc: _mealDetailBloc,
-        builder: (context, state) {
-          if (state is MealDetailInitial) {
-            return Scaffold(
-              body: _getLoadedContent(
+      child: Scaffold(
+        body: BlocBuilder<MealDetailBloc, MealDetailState>(
+          bloc: _mealDetailBloc,
+          builder: (context, state) {
+            if (state is MealDetailInitial) {
+              return _getLoadedContent(
                 context,
                 state.totalQuantityConverted,
                 state.totalKcal,
@@ -120,21 +120,26 @@ class _MealDetailScreenState extends State<MealDetailScreen> {
                 state.totalFat,
                 state.totalProtein,
                 state.selectedUnit,
-              ),
-              bottomSheet: MealDetailBottomSheet(
-                product: meal,
-                day: _day,
-                intakeTypeEntity: intakeTypeEntity,
-                selectedUnit: state.selectedUnit,
-                mealDetailBloc: _mealDetailBloc,
-                quantityTextController: quantityTextController,
-                onQuantityOrUnitChanged: onQuantityOrUnitChanged,
-              ),
+              );
+            }
+            return const Center(child: CircularProgressIndicator());
+          },
+        ),
+        bottomSheet: BlocSelector<MealDetailBloc, MealDetailState, String>(
+          bloc: _mealDetailBloc,
+          selector: (state) => state.selectedUnit,
+          builder: (context, selectedUnit) {
+            return MealDetailBottomSheet(
+              product: meal,
+              day: _day,
+              intakeTypeEntity: intakeTypeEntity,
+              selectedUnit: selectedUnit,
+              mealDetailBloc: _mealDetailBloc,
+              quantityTextController: quantityTextController,
+              onQuantityOrUnitChanged: onQuantityOrUnitChanged,
             );
-          } else {
-            return Scaffold(body: Center(child: CircularProgressIndicator()));
-          }
-        },
+          },
+        ),
       ),
     );
   }

--- a/lib/features/meal_detail/presentation/widgets/meal_detail_bottom_sheet.dart
+++ b/lib/features/meal_detail/presentation/widgets/meal_detail_bottom_sheet.dart
@@ -10,7 +10,7 @@ import 'package:opennutritracker/features/home/presentation/bloc/home_bloc.dart'
 import 'package:opennutritracker/features/meal_detail/presentation/bloc/meal_detail_bloc.dart';
 import 'package:opennutritracker/generated/l10n.dart';
 
-class MealDetailBottomSheet extends StatelessWidget {
+class MealDetailBottomSheet extends StatefulWidget {
   final MealEntity product;
   final DateTime day;
   final IntakeTypeEntity intakeTypeEntity;
@@ -31,6 +31,30 @@ class MealDetailBottomSheet extends StatelessWidget {
     required this.mealDetailBloc,
     required this.selectedUnit,
   });
+
+  @override
+  State<MealDetailBottomSheet> createState() => _MealDetailBottomSheetState();
+}
+
+class _MealDetailBottomSheetState extends State<MealDetailBottomSheet> {
+  @override
+  void initState() {
+    super.initState();
+    widget.quantityTextController.addListener(_onQuantityChanged);
+  }
+
+  @override
+  void dispose() {
+    widget.quantityTextController.removeListener(_onQuantityChanged);
+    super.dispose();
+  }
+
+  void _onQuantityChanged() {
+    widget.onQuantityOrUnitChanged(
+      widget.quantityTextController.text,
+      widget.selectedUnit,
+    );
+  }
 
   @override
   Widget build(BuildContext context) {
@@ -63,13 +87,7 @@ class MealDetailBottomSheet extends StatelessWidget {
                         Expanded(
                           child: TextFormField(
                             enabled: !productMissingRequiredInfo,
-                            controller: quantityTextController
-                              ..addListener(() {
-                                onQuantityOrUnitChanged(
-                                  quantityTextController.text,
-                                  selectedUnit,
-                                );
-                              }),
+                            controller: widget.quantityTextController,
                             keyboardType: TextInputType.numberWithOptions(
                               decimal: true,
                             ),
@@ -88,26 +106,26 @@ class MealDetailBottomSheet extends StatelessWidget {
                         Expanded(
                           child: DropdownButtonFormField(
                             isExpanded: true,
-                            initialValue: selectedUnit,
-                            key: ValueKey(selectedUnit),
+                            initialValue: widget.selectedUnit,
+                            key: ValueKey(widget.selectedUnit),
                             decoration: InputDecoration(
                               border: const OutlineInputBorder(),
                               labelText: S.of(context).unitLabel,
                             ),
                             items: <DropdownMenuItem<String>>[
-                              if (product.hasServingValues)
+                              if (widget.product.hasServingValues)
                                 _getServingDropdownItem(context),
-                              if (product.isSolid ||
-                                  !product.isLiquid && !product.isSolid)
+                              if (widget.product.isSolid ||
+                                  !widget.product.isLiquid && !widget.product.isSolid)
                                 ..._getSolidUnitDropdownItems(context),
-                              if (product.isLiquid ||
-                                  !product.isLiquid && !product.isSolid)
+                              if (widget.product.isLiquid ||
+                                  !widget.product.isLiquid && !widget.product.isSolid)
                                 ..._getLiquidUnitDropdownItems(context),
                               ..._getOtherDropdownItems(context),
                             ],
                             onChanged: (value) {
-                              onQuantityOrUnitChanged(
-                                quantityTextController.text,
+                              widget.onQuantityOrUnitChanged(
+                                widget.quantityTextController.text,
                                 value,
                               );
                             },
@@ -154,7 +172,7 @@ class MealDetailBottomSheet extends StatelessWidget {
   }
 
   bool _hasRequiredProductInfoMissing() {
-    final productNutriments = product.nutriments;
+    final productNutriments = widget.product.nutriments;
     if (productNutriments.energyKcal100 == null ||
         productNutriments.carbohydrates100 == null ||
         productNutriments.fat100 == null ||
@@ -166,13 +184,13 @@ class MealDetailBottomSheet extends StatelessWidget {
   }
 
   void onAddButtonPressed(BuildContext context) {
-    mealDetailBloc.addIntake(
+    widget.mealDetailBloc.addIntake(
       context,
-      mealDetailBloc.state.selectedUnit,
-      mealDetailBloc.state.totalQuantityConverted,
-      intakeTypeEntity,
-      product,
-      day,
+      widget.mealDetailBloc.state.selectedUnit,
+      widget.mealDetailBloc.state.totalQuantityConverted,
+      widget.intakeTypeEntity,
+      widget.product,
+      widget.day,
     );
 
     // Refresh Home Page
@@ -195,8 +213,8 @@ class MealDetailBottomSheet extends StatelessWidget {
     return DropdownMenuItem(
       value: UnitDropdownItem.serving.toString(),
       child: Text(
-        product.servingSize ??
-            '${S.of(context).servingLabel} (${product.servingQuantity} ${product.servingUnit})',
+        widget.product.servingSize ??
+            '${S.of(context).servingLabel} (${widget.product.servingQuantity} ${widget.product.servingUnit})',
         overflow: TextOverflow.ellipsis,
         maxLines: 1,
       ),


### PR DESCRIPTION
## Summary

- Converts `MealDetailBottomSheet` from `StatelessWidget` to `StatefulWidget`, moving the `TextEditingController` listener into `initState`/`dispose` — eliminates the listener accumulation that caused an exponential rebuild storm on every keystroke
- Moves `Scaffold` outside the `BlocBuilder` in `MealDetailScreen`; the bottom sheet now uses `BlocSelector` scoped to `selectedUnit` only, so it no longer rebuilds on every keystroke

Closes #169, #220, #239, #262

## Test plan

- [x] Navigate to any food item → MealDetailScreen
- [x] Tap quantity field — keyboard appears
- [x] Type several digits — keyboard stays visible throughout
- [x] Change the unit dropdown — kcal updates, keyboard behaviour is unaffected
- [x] Tap Add — intake is logged and screen returns to main
- [x] `flutter analyze` passes
- [x] All tests pass