### PR TITLE
fix(units): imperial weight round-trip rounding

### DIFF
--- a/lib/core/utils/calc/unit_calc.dart
+++ b/lib/core/utils/calc/unit_calc.dart
@@ -21,14 +21,13 @@ class UnitCalc {
     return (feet * 30.48).roundToDouble();
   }
 
-  /// Converts feet to inches and rounds the result
   static double kgToLbs(double kg) {
     return (kg * 2.20462).roundToDouble();
   }
 
-  /// Converts pounds to kilograms and rounds the result
+  /// Preserves two decimal places so round-tripping lbs→kg→lbs stays exact.
   static double lbsToKg(double lbs) {
-    return (lbs / 2.20462).roundToDouble();
+    return double.parse((lbs / 2.20462).toStringAsFixed(2));
   }
 
   static double gToOz(double g) {


### PR DESCRIPTION
## Summary

- `lbsToKg` was rounding to the nearest whole kilogram, causing lbs→kg→lbs round-trips to be off by 1–2 lbs (e.g. 233 lbs → 106 kg → 234 lbs)
- Fixed by preserving two decimal places of kg precision in `lbsToKg`, so the stored value faithfully represents the user's lbs input
- `kgToLbs` (display only) is unchanged — whole-number lbs in the UI remain correct

Fixes #253

## Test plan

- [x] Set weight to 232, 233, 234 lbs in profile — each value should display back exactly as entered
- [x] Set weight to 233 lbs in onboarding — should save and display as 233 lbs
- [x] Verify metric kg entry is unaffected