### PR TITLE
fix(home): restore Share/Import options on the meal section popup menu

### DIFF
--- a/lib/features/home/presentation/widgets/intake_vertical_list.dart
+++ b/lib/features/home/presentation/widgets/intake_vertical_list.dart
@@ -13,6 +13,8 @@ import 'package:opennutritracker/features/add_meal/presentation/add_meal_type.da
 import 'package:opennutritracker/features/diary/presentation/bloc/calendar_day_bloc.dart';
 import 'package:opennutritracker/features/diary/presentation/bloc/diary_bloc.dart';
 import 'package:opennutritracker/features/home/presentation/bloc/home_bloc.dart';
+import 'package:opennutritracker/features/home/presentation/screens/import_meal_scanner_screen.dart';
+import 'package:opennutritracker/features/home/presentation/widgets/share_meal_qr_dialog.dart';
 import 'package:opennutritracker/features/meal_detail/presentation/bloc/meal_detail_bloc.dart';
 import 'package:opennutritracker/generated/l10n.dart';
 
@@ -105,7 +107,7 @@ class _IntakeVerticalListState extends State<IntakeVerticalList> {
                     ?.copyWith(color: Theme.of(context).colorScheme.onSurface),
               ),
               const Spacer(),
-              if (totalKcal > 0) ...[
+              if (totalKcal > 0)
                 Text(
                   widget.showMealMacros
                       ? '${totalKcal.toInt()} ${S.of(context).kcalLabel}\n'
@@ -118,7 +120,7 @@ class _IntakeVerticalListState extends State<IntakeVerticalList> {
                           .withValues(alpha: 0.7)),
                   textAlign: TextAlign.center,
                 ),
-                PopupMenuButton<VerticalListPopupMenuSelections>(
+              PopupMenuButton<VerticalListPopupMenuSelections>(
                     onSelected:
                         (VerticalListPopupMenuSelections selection) async {
                       switch (selection) {
@@ -147,21 +149,46 @@ class _IntakeVerticalListState extends State<IntakeVerticalList> {
                             break;
                           }
                         case VerticalListPopupMenuSelections.onShare:
+                          if (context.mounted) {
+                            await showDialog(
+                              context: context,
+                              builder: (_) => ShareMealQrDialog(
+                                intakeList: widget.intakeList,
+                              ),
+                            );
+                          }
                         case VerticalListPopupMenuSelections.onImport:
-                          break;
+                          if (context.mounted) {
+                            Navigator.of(context).pushNamed(
+                              NavigationOptions.importMealScannerRoute,
+                              arguments: ImportMealScannerArguments(
+                                widget.addMealType.getIntakeType(),
+                                widget.addMealType,
+                                widget.day,
+                              ),
+                            );
+                          }
                       }
                     },
                     itemBuilder: (BuildContext context) =>
                         <PopupMenuEntry<VerticalListPopupMenuSelections>>[
-                          if (widget.onCopyIntakeCallback != null)
+                          if (widget.onCopyIntakeCallback != null &&
+                              totalKcal > 0)
                             PopupMenuItem<VerticalListPopupMenuSelections>(
                                 value: VerticalListPopupMenuSelections.onCopy,
                                 child: Text(S.of(context).dialogCopyLabel)),
+                          if (totalKcal > 0)
+                            PopupMenuItem<VerticalListPopupMenuSelections>(
+                                value: VerticalListPopupMenuSelections.onDelete,
+                                child: Text(S.of(context).deleteAllLabel)),
+                          if (totalKcal > 0)
+                            PopupMenuItem<VerticalListPopupMenuSelections>(
+                                value: VerticalListPopupMenuSelections.onShare,
+                                child: Text(S.of(context).shareMealLabel)),
                           PopupMenuItem<VerticalListPopupMenuSelections>(
-                              value: VerticalListPopupMenuSelections.onDelete,
-                              child: Text(S.of(context).deleteAllLabel)),
+                              value: VerticalListPopupMenuSelections.onImport,
+                              child: Text(S.of(context).importMealLabel)),
                         ]),
-              ],
             ],
           ),
         ),

--- a/test/features/home/presentation/widgets/intake_vertical_list_test.dart
+++ b/test/features/home/presentation/widgets/intake_vertical_list_test.dart
@@ -5,6 +5,7 @@ import 'package:opennutritracker/core/domain/entity/intake_entity.dart';
 import 'package:opennutritracker/core/domain/entity/intake_type_entity.dart';
 import 'package:opennutritracker/features/add_meal/domain/entity/meal_entity.dart';
 import 'package:opennutritracker/features/add_meal/domain/entity/meal_nutriments_entity.dart';
+import 'package:opennutritracker/core/utils/vertical_list_popup_menu_selections.dart';
 import 'package:opennutritracker/features/add_meal/presentation/add_meal_type.dart';
 import 'package:opennutritracker/features/home/presentation/bloc/home_bloc.dart';
 import 'package:opennutritracker/features/home/presentation/widgets/intake_vertical_list.dart';
@@ -163,6 +164,62 @@ void main() {
 
       expect(find.text(headerWithMacros()), findsNothing);
       expect(find.text(headerKcalOnly()), findsNothing);
+    },
+  );
+
+  // Regression: the QR-share/import options were dropped from the popup
+  // menu when the macros toggle PR landed on a stale base. Lock in the
+  // expected items so it can't happen again silently.
+  testWidgets(
+    'popup menu shows Copy/Delete/Share/Import for non-empty section',
+    (WidgetTester tester) async {
+      await tester.pumpWidget(_wrapWithMaterial(IntakeVerticalList(
+        day: DateTime(2026, 1, 1),
+        title: 'Breakfast',
+        listIcon: Icons.bakery_dining_outlined,
+        addMealType: AddMealType.breakfastType,
+        intakeList: intakes,
+        usesImperialUnits: false,
+        showMealMacros: true,
+        onCopyIntakeCallback: (_, _, _) {},
+        onDeleteIntakeCallback: (_, _) {},
+      )));
+      await tester.pump();
+
+      await tester.tap(find.byType(PopupMenuButton<VerticalListPopupMenuSelections>));
+      await tester.pumpAndSettle();
+
+      expect(find.text(S.current.dialogCopyLabel), findsOneWidget);
+      expect(find.text(S.current.deleteAllLabel), findsOneWidget);
+      expect(find.text(S.current.shareMealLabel), findsOneWidget);
+      expect(find.text(S.current.importMealLabel), findsOneWidget);
+    },
+  );
+
+  testWidgets(
+    'popup menu shows only Import when section is empty',
+    (WidgetTester tester) async {
+      await tester.pumpWidget(_wrapWithMaterial(IntakeVerticalList(
+        day: DateTime(2026, 1, 1),
+        title: 'Breakfast',
+        listIcon: Icons.bakery_dining_outlined,
+        addMealType: AddMealType.breakfastType,
+        intakeList: const [],
+        usesImperialUnits: false,
+        showMealMacros: true,
+        onDeleteIntakeCallback: (_, _) {},
+      )));
+      await tester.pump();
+
+      await tester.tap(find.byType(PopupMenuButton<VerticalListPopupMenuSelections>));
+      await tester.pumpAndSettle();
+
+      // Empty section: no Copy/Delete/Share — nothing to act on. Import is
+      // always available so the user can scan a QR to populate the section.
+      expect(find.text(S.current.dialogCopyLabel), findsNothing);
+      expect(find.text(S.current.deleteAllLabel), findsNothing);
+      expect(find.text(S.current.shareMealLabel), findsNothing);
+      expect(find.text(S.current.importMealLabel), findsOneWidget);
     },
   );
 }


### PR DESCRIPTION
The macros toggle PR (#231 / 221b07f8) was based on a branch that pre-dated the QR-share/import feature. When it landed, it accidentally stripped:

- the imports for share_meal_qr_dialog.dart and import_meal_scanner_screen.dart
- the PopupMenuItem entries for shareMealLabel and importMealLabel
- the case arms for VerticalListPopupMenuSelections.onShare and onImport (replaced with no-op breaks)
- the wrapping that kept the PopupMenuButton itself visible on empty meal sections (so users couldn't import a shared meal into an empty section)

Restore the missing menu items and their handlers, and pull the PopupMenuButton back out of the 'if (totalKcal > 0)' branch so it shows on empty sections too. Items inside the menu remain conditional on totalKcal > 0 (no point offering Copy / Delete / Share when there's nothing to act on).

Adds two regression tests:
- popup menu shows Copy/Delete/Share/Import for non-empty section
- popup menu shows only Import when section is empty