### PR TITLE
feat(search): preserve custom-meal results when remote source fails

### DIFF
--- a/lib/features/add_meal/domain/usecase/search_products_usecase.dart
+++ b/lib/features/add_meal/domain/usecase/search_products_usecase.dart
@@ -1,36 +1,82 @@
+import 'package:logging/logging.dart';
 import 'package:opennutritracker/core/domain/usecase/get_intake_usecase.dart';
 import 'package:opennutritracker/features/add_meal/data/repository/products_repository.dart';
 import 'package:opennutritracker/features/add_meal/domain/entity/meal_entity.dart';
 
+/// Output of a product/food search. [meals] is the deduplicated list shown
+/// to the user (custom-meal matches first, then remote results).
+/// [remoteSourceEmpty] is true when the remote source returned zero rows
+/// or failed (rate limit, timeout, network error). The UI uses this to
+/// decide whether to render a "no remote results" hint below the custom-meal
+/// matches.
+class SearchProductsResult {
+  final List<MealEntity> meals;
+  final bool remoteSourceEmpty;
+
+  const SearchProductsResult({
+    required this.meals,
+    required this.remoteSourceEmpty,
+  });
+}
+
 class SearchProductsUseCase {
+  final _log = Logger('SearchProductsUseCase');
+
   final ProductsRepository _productsRepository;
   final GetIntakeUsecase _getIntakeUsecase;
 
   SearchProductsUseCase(this._productsRepository, this._getIntakeUsecase);
 
-  Future<List<MealEntity>> searchOFFProductsByString(
+  Future<SearchProductsResult> searchOFFProductsByString(
     String searchString,
   ) async {
-    final products = await _productsRepository.getOFFProductsByString(
-      searchString,
+    final remote = await _safeRemoteCall(
+      'OFF',
+      () => _productsRepository.getOFFProductsByString(searchString),
     );
-    return _prependMatchingCustomMeals(searchString, products);
+    return _buildResult(searchString, remote);
   }
 
-  Future<List<MealEntity>> searchFDCFoodByString(String searchString) async {
-    final foods = await _productsRepository.getSupabaseFDCFoodsByString(
-      searchString,
+  Future<SearchProductsResult> searchFDCFoodByString(String searchString) async {
+    final remote = await _safeRemoteCall(
+      'FDC',
+      () => _productsRepository.getSupabaseFDCFoodsByString(searchString),
     );
-    return _prependMatchingCustomMeals(searchString, foods);
+    return _buildResult(searchString, remote);
   }
 
-  Future<List<MealEntity>> _prependMatchingCustomMeals(
+  /// Run a remote search and fall back to an empty list when the source
+  /// throws (rate limit, timeout, network failure, etc). The caller still
+  /// receives matching custom meals from local intake history even when the
+  /// remote API is unavailable.
+  Future<List<MealEntity>> _safeRemoteCall(
+    String sourceLabel,
+    Future<List<MealEntity>> Function() call,
+  ) async {
+    try {
+      return await call();
+    } catch (exception, stack) {
+      _log.warning(
+        '$sourceLabel search failed; falling back to custom-meal results only',
+        exception,
+        stack,
+      );
+      return const [];
+    }
+  }
+
+  Future<SearchProductsResult> _buildResult(
     String searchString,
     List<MealEntity> remoteResults,
   ) async {
+    final remoteSourceEmpty = remoteResults.isEmpty;
+
     final normalizedSearchString = searchString.trim().toLowerCase();
     if (normalizedSearchString.isEmpty) {
-      return remoteResults;
+      return SearchProductsResult(
+        meals: remoteResults,
+        remoteSourceEmpty: remoteSourceEmpty,
+      );
     }
 
     final recentIntake = await _getIntakeUsecase.getRecentIntake();
@@ -40,7 +86,10 @@ class SearchProductsUseCase {
         .where((meal) => _mealMatchesSearch(meal, normalizedSearchString))
         .toList();
 
-    return _deduplicateMeals([...customMeals, ...remoteResults]);
+    return SearchProductsResult(
+      meals: _deduplicateMeals([...customMeals, ...remoteResults]),
+      remoteSourceEmpty: remoteSourceEmpty,
+    );
   }
 
   bool _mealMatchesSearch(MealEntity meal, String normalizedSearchString) {

--- a/lib/features/add_meal/presentation/add_meal_screen.dart
+++ b/lib/features/add_meal/presentation/add_meal_screen.dart
@@ -131,22 +131,27 @@ class _AddMealScreenState extends State<AddMealScreen>
                               child: CircularProgressIndicator(),
                             );
                           } else if (state is ProductsLoadedState) {
-                            return state.products.isNotEmpty
-                                ? Flexible(
-                                    child: ListView.builder(
-                                      itemCount: state.products.length,
-                                      itemBuilder: (context, index) {
-                                        return MealItemCard(
-                                          day: _day,
-                                          mealEntity: state.products[index],
-                                          addMealType: _mealType,
-                                          usesImperialUnits:
-                                              state.usesImperialUnits,
-                                        );
-                                      },
-                                    ),
-                                  )
-                                : const NoResultsWidget();
+                            if (state.products.isEmpty) {
+                              return const NoResultsWidget();
+                            }
+                            return Flexible(
+                              child: ListView.builder(
+                                itemCount: state.products.length +
+                                    (state.remoteSourceEmpty ? 1 : 0),
+                                itemBuilder: (context, index) {
+                                  if (index == state.products.length) {
+                                    return const NoResultsWidget();
+                                  }
+                                  return MealItemCard(
+                                    day: _day,
+                                    mealEntity: state.products[index],
+                                    addMealType: _mealType,
+                                    usesImperialUnits:
+                                        state.usesImperialUnits,
+                                  );
+                                },
+                              ),
+                            );
                           } else if (state is ProductsFailedState) {
                             return ErrorDialog(
                               errorText: S.of(context).errorFetchingProductData,
@@ -180,22 +185,27 @@ class _AddMealScreenState extends State<AddMealScreen>
                               child: CircularProgressIndicator(),
                             );
                           } else if (state is FoodLoadedState) {
-                            return state.food.isNotEmpty
-                                ? Flexible(
-                                    child: ListView.builder(
-                                      itemCount: state.food.length,
-                                      itemBuilder: (context, index) {
-                                        return MealItemCard(
-                                          day: _day,
-                                          mealEntity: state.food[index],
-                                          addMealType: _mealType,
-                                          usesImperialUnits:
-                                              state.usesImperialUnits,
-                                        );
-                                      },
-                                    ),
-                                  )
-                                : const NoResultsWidget();
+                            if (state.food.isEmpty) {
+                              return const NoResultsWidget();
+                            }
+                            return Flexible(
+                              child: ListView.builder(
+                                itemCount: state.food.length +
+                                    (state.remoteSourceEmpty ? 1 : 0),
+                                itemBuilder: (context, index) {
+                                  if (index == state.food.length) {
+                                    return const NoResultsWidget();
+                                  }
+                                  return MealItemCard(
+                                    day: _day,
+                                    mealEntity: state.food[index],
+                                    addMealType: _mealType,
+                                    usesImperialUnits:
+                                        state.usesImperialUnits,
+                                  );
+                                },
+                              ),
+                            );
                           } else if (state is FoodFailedState) {
                             return ErrorDialog(
                               errorText: S.of(context).errorFetchingProductData,

--- a/lib/features/add_meal/presentation/add_meal_screen.dart
+++ b/lib/features/add_meal/presentation/add_meal_screen.dart
@@ -328,7 +328,6 @@ class _AddMealScreenState extends State<AddMealScreen>
   }
 
   void _openEditMealScreen(bool usesImperialUnits) {
-    // TODO
     Navigator.of(context).pushNamed(
       NavigationOptions.editMealRoute,
       arguments: EditMealScreenArguments(

--- a/lib/features/add_meal/presentation/bloc/food_bloc.dart
+++ b/lib/features/add_meal/presentation/bloc/food_bloc.dart
@@ -31,8 +31,9 @@ class FoodBloc extends Bloc<FoodEvent, FoodState> {
 
           emit(
             FoodLoadedState(
-              food: result,
+              food: result.meals,
               usesImperialUnits: config.usesImperialUnits,
+              remoteSourceEmpty: result.remoteSourceEmpty,
             ),
           );
         } catch (error) {
@@ -47,7 +48,10 @@ class FoodBloc extends Bloc<FoodEvent, FoodState> {
         final result = await _searchProductUseCase.searchFDCFoodByString(
           _searchString,
         );
-        emit(FoodLoadedState(food: result));
+        emit(FoodLoadedState(
+          food: result.meals,
+          remoteSourceEmpty: result.remoteSourceEmpty,
+        ));
       } catch (error) {
         log.severe(error);
         emit(FoodFailedState());

--- a/lib/features/add_meal/presentation/bloc/food_state.dart
+++ b/lib/features/add_meal/presentation/bloc/food_state.dart
@@ -18,10 +18,19 @@ class FoodLoadedState extends FoodState {
   final List<MealEntity> food;
   final bool usesImperialUnits;
 
-  const FoodLoadedState({required this.food, this.usesImperialUnits = false});
+  /// True when the remote FDC source returned zero results (or failed
+  /// silently — e.g. rate limit). The UI uses this to show a "no results"
+  /// hint below any custom-meal matches.
+  final bool remoteSourceEmpty;
+
+  const FoodLoadedState({
+    required this.food,
+    this.usesImperialUnits = false,
+    this.remoteSourceEmpty = false,
+  });
 
   @override
-  List<Object?> get props => [food, usesImperialUnits];
+  List<Object?> get props => [food, usesImperialUnits, remoteSourceEmpty];
 }
 
 class FoodFailedState extends FoodState {

--- a/lib/features/add_meal/presentation/bloc/products_bloc.dart
+++ b/lib/features/add_meal/presentation/bloc/products_bloc.dart
@@ -31,8 +31,9 @@ class ProductsBloc extends Bloc<ProductsEvent, ProductsState> {
 
           emit(
             ProductsLoadedState(
-              products: result,
+              products: result.meals,
               usesImperialUnits: config.usesImperialUnits,
+              remoteSourceEmpty: result.remoteSourceEmpty,
             ),
           );
         } catch (error) {
@@ -47,7 +48,10 @@ class ProductsBloc extends Bloc<ProductsEvent, ProductsState> {
         final result = await _searchProductUseCase.searchOFFProductsByString(
           _searchString,
         );
-        emit(ProductsLoadedState(products: result));
+        emit(ProductsLoadedState(
+          products: result.meals,
+          remoteSourceEmpty: result.remoteSourceEmpty,
+        ));
       } catch (error) {
         log.severe(error);
         emit(ProductsFailedState());

--- a/lib/features/add_meal/presentation/bloc/products_state.dart
+++ b/lib/features/add_meal/presentation/bloc/products_state.dart
@@ -18,13 +18,19 @@ class ProductsLoadedState extends ProductsState {
   final List<MealEntity> products;
   final bool usesImperialUnits;
 
+  /// True when the remote OFF source returned zero results (or failed
+  /// silently — e.g. rate limit). The UI uses this to show a "no results"
+  /// hint below any custom-meal matches.
+  final bool remoteSourceEmpty;
+
   const ProductsLoadedState({
     required this.products,
     this.usesImperialUnits = false,
+    this.remoteSourceEmpty = false,
   });
 
   @override
-  List<Object?> get props => [products];
+  List<Object?> get props => [products, remoteSourceEmpty];
 }
 
 class ProductsFailedState extends ProductsState {

--- a/test/features/onboarding/presentation/widgets/onboarding_second_page_body_test.dart
+++ b/test/features/onboarding/presentation/widgets/onboarding_second_page_body_test.dart
@@ -11,7 +11,7 @@ void main() {
       ],
       home: Scaffold(
         body: OnboardingSecondPageBody(
-          setButtonContent: (_, __, ___, ____) {},
+          setButtonContent: (_, _, _, _) {},
         ),
       ),
     ));
@@ -31,7 +31,7 @@ void main() {
       ],
       home: Scaffold(
         body: OnboardingSecondPageBody(
-          setButtonContent: (_, __, ___, ____) {},
+          setButtonContent: (_, _, _, _) {},
         ),
       ),
     ));
@@ -62,7 +62,7 @@ void main() {
       ],
       home: Scaffold(
         body: OnboardingSecondPageBody(
-          setButtonContent: (_, __, ___, ____) {},
+          setButtonContent: (_, _, _, _) {},
         ),
       ),
     ));
@@ -93,7 +93,7 @@ void main() {
       ],
       home: Scaffold(
         body: OnboardingSecondPageBody(
-          setButtonContent: (_, __, ___, ____) {},
+          setButtonContent: (_, _, _, _) {},
         ),
       ),
     ));
@@ -127,7 +127,7 @@ void main() {
       ],
       home: Scaffold(
         body: OnboardingSecondPageBody(
-          setButtonContent: (_, __, ___, ____) {},
+          setButtonContent: (_, _, _, _) {},
         ),
       ),
     ));
@@ -158,7 +158,7 @@ void main() {
       ],
       home: Scaffold(
         body: OnboardingSecondPageBody(
-          setButtonContent: (_, __, ___, ____) {},
+          setButtonContent: (_, _, _, _) {},
         ),
       ),
     ));
@@ -194,7 +194,7 @@ void main() {
       ],
       home: Scaffold(
         body: OnboardingSecondPageBody(
-          setButtonContent: (_, __, ___, ____) {},
+          setButtonContent: (_, _, _, _) {},
         ),
       ),
     ));

--- a/test/unit_test/search_products_usecase_test.dart
+++ b/test/unit_test/search_products_usecase_test.dart
@@ -11,15 +11,28 @@ class _FakeProductsRepository implements ProductsRepository {
   final Map<String, List<MealEntity>> offResults = {};
   final Map<String, List<MealEntity>> fdcResults = {};
 
+  /// Search strings whose remote call should throw (simulates rate-limit /
+  /// network failure / 5xx).
+  final Set<String> offThrowOn = {};
+  final Set<String> fdcThrowOn = {};
+
   @override
-  Future<List<MealEntity>> getOFFProductsByString(String searchString) async =>
-      offResults[searchString] ?? const [];
+  Future<List<MealEntity>> getOFFProductsByString(String searchString) async {
+    if (offThrowOn.contains(searchString)) {
+      throw Exception('OFF HTTP 429');
+    }
+    return offResults[searchString] ?? const [];
+  }
 
   @override
   Future<List<MealEntity>> getSupabaseFDCFoodsByString(
     String searchString,
-  ) async =>
-      fdcResults[searchString] ?? const [];
+  ) async {
+    if (fdcThrowOn.contains(searchString)) {
+      throw Exception('FDC HTTP 429');
+    }
+    return fdcResults[searchString] ?? const [];
+  }
 
   // Other ProductsRepository methods aren't exercised here — throw via
   // noSuchMethod if anything unexpectedly hits them.
@@ -85,7 +98,8 @@ void main() {
 
       final result = await useCase.searchOFFProductsByString('tofu');
 
-      expect(result, [customMatch, offApiResult]);
+      expect(result.meals, [customMatch, offApiResult]);
+      expect(result.remoteSourceEmpty, isFalse);
     });
 
     test('deduplicates repeated custom meals for FDC search', () async {
@@ -106,7 +120,8 @@ void main() {
 
       final result = await useCase.searchFDCFoodByString('apple');
 
-      expect(result, [customMatch, fdcApiResult]);
+      expect(result.meals, [customMatch, fdcApiResult]);
+      expect(result.remoteSourceEmpty, isFalse);
     });
 
     test('does not query recent intake for blank search strings', () async {
@@ -117,7 +132,7 @@ void main() {
 
       final result = await useCase.searchOFFProductsByString('   ');
 
-      expect(result, [offApiResult]);
+      expect(result.meals, [offApiResult]);
       expect(getIntakeUsecase.recentIntakeCallCount, 0);
     });
 
@@ -146,7 +161,8 @@ void main() {
 
       final result = await useCase.searchFDCFoodByString('ALMOND');
 
-      expect(result, [customBrandMatch, fdcApiResult]);
+      expect(result.meals, [customBrandMatch, fdcApiResult]);
+      expect(result.remoteSourceEmpty, isFalse);
     });
 
     test('deduplicates custom meals when code is missing by fallback name key',
@@ -178,8 +194,78 @@ void main() {
 
       final result = await useCase.searchOFFProductsByString('peanut');
 
-      expect(result, [customNoCode, offApiResult]);
+      expect(result.meals, [customNoCode, offApiResult]);
+      expect(result.remoteSourceEmpty, isFalse);
     });
+
+    test(
+      'returns custom meals + remoteSourceEmpty=true when OFF rate-limits',
+      () async {
+        final customMatch = _meal(
+            code: 'custom-tofu',
+            name: 'Tofu Bowl',
+            source: MealSourceEntity.custom);
+
+        productsRepository.offThrowOn.add('tofu');
+        getIntakeUsecase.recentIntake = [_intake('i1', customMatch)];
+
+        final result = await useCase.searchOFFProductsByString('tofu');
+
+        expect(result.meals, [customMatch]);
+        expect(result.remoteSourceEmpty, isTrue);
+      },
+    );
+
+    test(
+      'returns custom meals + remoteSourceEmpty=true when FDC rate-limits',
+      () async {
+        final customMatch = _meal(
+            code: 'custom-apple',
+            name: 'Apple Mix',
+            source: MealSourceEntity.custom);
+
+        productsRepository.fdcThrowOn.add('apple');
+        getIntakeUsecase.recentIntake = [_intake('i1', customMatch)];
+
+        final result = await useCase.searchFDCFoodByString('apple');
+
+        expect(result.meals, [customMatch]);
+        expect(result.remoteSourceEmpty, isTrue);
+      },
+    );
+
+    test(
+      'returns empty meals + remoteSourceEmpty=true when remote fails and no '
+      'custom meals match',
+      () async {
+        productsRepository.offThrowOn.add('xyzzy');
+        getIntakeUsecase.recentIntake = const [];
+
+        final result = await useCase.searchOFFProductsByString('xyzzy');
+
+        expect(result.meals, isEmpty);
+        expect(result.remoteSourceEmpty, isTrue);
+      },
+    );
+
+    test(
+      'remoteSourceEmpty=true when remote returns an empty list (not just on '
+      'failure)',
+      () async {
+        final customMatch = _meal(
+            code: 'custom-tofu',
+            name: 'Tofu Bowl',
+            source: MealSourceEntity.custom);
+
+        // No offResults entry for 'tofu' → fake returns []
+        getIntakeUsecase.recentIntake = [_intake('i1', customMatch)];
+
+        final result = await useCase.searchOFFProductsByString('tofu');
+
+        expect(result.meals, [customMatch]);
+        expect(result.remoteSourceEmpty, isTrue);
+      },
+    );
   });
 }
 


### PR DESCRIPTION
## Summary

Follow-up to #304 (just merged). Two issues that affected custom-meal search even after #304:

1. **Custom meals were lost when the remote source threw.** OFF/FDC rate-limit responses (HTTP 429) bubble up as exceptions from `fetchSearchWordResults`. The previous `SearchProductsUseCase` propagated those exceptions, so the bloc emitted `*FailedState` and the user saw zero results — even when their own custom-meal history matched the query.

2. **No "no results" indicator when only custom meals matched.** With #304's fallback path returning just the custom matches, the existing `if (state.products.isEmpty)` UI guard treated the screen as "results found" and silently hid the no-remote-results message — user couldn't tell if remote was empty or unavailable.

## Changes

**Use case** (`search_products_usecase.dart`):
- Wrap remote calls in `_safeRemoteCall` that swallows the exception, logs it, and falls back to `[]` so custom matches are still surfaced.
- Return new `SearchProductsResult { meals, remoteSourceEmpty }` instead of a flat `List<MealEntity>`. `remoteSourceEmpty=true` when remote returned `[]` *or* threw.

**Blocs** (`products_bloc.dart`, `food_bloc.dart`, `*_state.dart`):
- Thread `remoteSourceEmpty` through `*LoadedState`.

**UI** (`add_meal_screen.dart`):
- If `meals.isEmpty` → render `NoResultsWidget` centered (existing behavior).
- If `meals.isNotEmpty` && `remoteSourceEmpty` → render the meal list followed by a `NoResultsWidget` underneath, so the user knows their custom matches are surfaced but no remote results were available.

**Cleanup** (separate commit):
- Replace `(_, __, ___, ____)` lint-flagged callback signatures with `(_, _, _, _)` in the second-page onboarding test (21 `unnecessary_underscores` warnings → 0).
- Drop a bare `// TODO` comment in `add_meal_screen.dart` with no associated work item.

Brings `flutter analyze lib/ test/` from 21 issues to 0.

## Test plan

- [x] `flutter test` — 102 tests pass (4 new use-case tests for the fallback / remote-empty cases)
- [x] `flutter analyze lib/ test/` — no issues
- [x] Manually verify on device: search for a recent custom-meal name while OFFLINE → custom meal appears, "no results" indicator below
- [x] Search a string the custom doesn't match while OFFLINE → centered "no results" widget
- [x] Online with remote returning matches → no extra "no results" indicator