### PR TITLE
Regression test pack + iOS localization & notification fixes

### DIFF
--- a/.github/workflows/default_workflow.yml
+++ b/.github/workflows/default_workflow.yml
@@ -12,18 +12,14 @@ on:
   workflow_dispatch:
 
 jobs:
-  build:
+  linux-checks:
     runs-on: ubuntu-latest
     timeout-minutes: 30
-
+    permissions:
+      contents: read
     steps:
       - name: Checkout code
-        uses: actions/checkout@v3
-      
-      - uses: actions/setup-java@v2
-        with:
-          distribution: 'zulu'
-          java-version: '11'
+        uses: actions/checkout@v4
 
       - name: Setup Flutter
         uses: subosito/flutter-action@v2
@@ -34,7 +30,7 @@ jobs:
 
       - name: Setup Just
         uses: taiki-e/install-action@just
-          
+
       - name: Cache Flutter packages
         uses: actions/cache@v4
         with:
@@ -43,6 +39,123 @@ jobs:
           restore-keys: |
             ${{ runner.os }}-pub-cache-
 
+      # The envied package obfuscates `.env` values into env.g.dart at compile
+      # time. CI doesn't have access to the real secrets and the test suite
+      # never hits Sentry / Supabase / FDC at runtime, so we stub them. Real
+      # values must come from a developer's local .env when building for
+      # release.
+      - name: Generate stub .env for CI
+        run: |
+          cat > .env <<'EOF'
+          FDC_API_KEY="ci-stub"
+          SENTRY_DNS="https://stub@sentry.io/0"
+          SUPABASE_PROJECT_URL="https://stub.supabase.co"
+          SUPABASE_PROJECT_ANON_KEY="ci-stub"
+          EOF
+
+      # `just ci` would also run `dart format --set-exit-if-changed`, but the
+      # codebase currently has accumulated pre-existing format drift from the
+      # period when CI was disabled. We run the rest of `just ci` (intl
+      # check, build_runner, analyze, test) and leave the format pass for a
+      # dedicated follow-up PR.
+      - name: Install Flutter packages
+        run: just install
+
+      - name: Verify generated intl files
+        run: just check_intl
+
+      - name: Generate code (env.g.dart, Hive adapters, JSON serializers)
+        run: just build
+
+      - name: Static analysis
+        run: flutter analyze
+
+      - name: Run tests
+        run: just test
+
+  ios-build:
+    runs-on: macos-latest
+    timeout-minutes: 45
+    needs: linux-checks
+    permissions:
+      contents: write
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+        with:
+          # Check out the PR head so auto-commit lands on the right branch.
+          # Falls back to github.ref for push and workflow_dispatch.
+          ref: ${{ github.event.pull_request.head.ref || github.ref }}
+          repository: ${{ github.event.pull_request.head.repo.full_name || github.repository }}
+
+      - name: Setup Flutter
+        uses: subosito/flutter-action@v2
+        with:
+          flutter-version: '3.41.7'
+          channel: 'stable'
+          cache: true
+
+      - name: Cache Flutter packages
+        uses: actions/cache@v4
+        with:
+          path: ~/.pub-cache
+          key: ${{ runner.os }}-pub-cache-${{ hashFiles('**/pubspec.lock') }}
+          restore-keys: |
+            ${{ runner.os }}-pub-cache-
+
+      - name: Cache CocoaPods
+        uses: actions/cache@v4
+        with:
+          path: ios/Pods
+          key: ${{ runner.os }}-pods-${{ hashFiles('ios/Podfile.lock') }}
+          restore-keys: |
+            ${{ runner.os }}-pods-
+
+      - name: Generate stub .env for CI
+        run: |
+          cat > .env <<'EOF'
+          FDC_API_KEY="ci-stub"
+          SENTRY_DNS="https://stub@sentry.io/0"
+          SUPABASE_PROJECT_URL="https://stub.supabase.co"
+          SUPABASE_PROJECT_ANON_KEY="ci-stub"
+          EOF
+
+      - name: Install Flutter packages
+        run: flutter pub get
+
+      - name: Generate code
+        run: dart run build_runner build --delete-conflicting-outputs
+
+      - name: Pod install
+        run: cd ios && pod install
+
+      # Same-repo PRs only — fork PRs run with a read-only token so this
+      # step would fail to push. Fork contributors get the lockfile via
+      # the artifact uploaded below.
+      - name: Auto-commit refreshed Podfile.lock
+        if: >-
+          github.event_name == 'pull_request' &&
+          github.event.pull_request.head.repo.full_name == github.repository
+        uses: stefanzweifel/git-auto-commit-action@v5
+        with:
+          file_pattern: 'ios/Podfile.lock'
+          commit_message: 'chore(ios): refresh Podfile.lock via CI'
+
+      - name: Upload Podfile.lock artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: ios-podfile-lock
+          path: ios/Podfile.lock
+
+      - name: Build iOS (no codesign)
+        run: flutter build ios --no-codesign --release
+
+# Historical reference — the original single-step `just ci` invocation that
+# was used before this workflow was split into linux-checks + ios-build.
+# Kept here so reviewers can see how the secrets-templated form would look
+# if/when real secrets are configured in repo Settings → Secrets and the
+# stub .env approach above is replaced.
+#
 #      - name: Run CI
 #        run: just ci
 #        env:

--- a/.github/workflows/default_workflow.yml
+++ b/.github/workflows/default_workflow.yml
@@ -126,14 +126,22 @@ jobs:
       - name: Generate code
         run: dart run build_runner build --delete-conflicting-outputs
 
-      # --repo-update so CocoaPods refreshes its spec repo cache and
-      # re-resolves dependencies. Without it, a stale Podfile.lock that
-      # pins an older subdep (e.g. Sentry/HybridSDK 8.46 when
-      # sentry_flutter 9.19 now requires 8.58) is treated as authoritative
-      # and the install fails. The auto-commit step below picks up the
-      # refreshed lockfile.
-      - name: Pod install
-        run: cd ios && pod install --repo-update
+      # `pod install` honours Podfile.lock as authoritative even with
+      # --repo-update — CocoaPods will only refresh the spec cache, not
+      # re-resolve. So if the lockfile pins a transitive subdep version
+      # that's been bumped in pubspec.yaml (e.g. sentry_flutter 9.19
+      # now wants Sentry/HybridSDK 8.58 but the lock still pins 8.46),
+      # `pod install` fails. The fallback `pod update` re-resolves and
+      # writes a fresh lockfile. The auto-commit step below pushes the
+      # refreshed lockfile back to the PR branch so future runs hit the
+      # deterministic `install` path.
+      - name: Pod install (regenerate lockfile if constraints have shifted)
+        run: |
+          cd ios
+          if ! pod install --repo-update; then
+            echo "::warning::Podfile.lock has stale constraints; regenerating via pod update"
+            pod update
+          fi
 
       # Same-repo PRs only — fork PRs run with a read-only token so this
       # step would fail to push. Fork contributors get the lockfile via

--- a/.github/workflows/default_workflow.yml
+++ b/.github/workflows/default_workflow.yml
@@ -126,8 +126,14 @@ jobs:
       - name: Generate code
         run: dart run build_runner build --delete-conflicting-outputs
 
+      # --repo-update so CocoaPods refreshes its spec repo cache and
+      # re-resolves dependencies. Without it, a stale Podfile.lock that
+      # pins an older subdep (e.g. Sentry/HybridSDK 8.46 when
+      # sentry_flutter 9.19 now requires 8.58) is treated as authoritative
+      # and the install fails. The auto-commit step below picks up the
+      # refreshed lockfile.
       - name: Pod install
-        run: cd ios && pod install
+        run: cd ios && pod install --repo-update
 
       # Same-repo PRs only — fork PRs run with a read-only token so this
       # step would fail to push. Fork contributors get the lockfile via

--- a/ios/Podfile.lock
+++ b/ios/Podfile.lock
@@ -36,72 +36,33 @@ PODS:
     - DKImagePickerController/PhotoGallery
     - Flutter
   - Flutter (1.0.0)
-  - flutter_keyboard_visibility (0.0.1):
+  - flutter_keyboard_visibility_temp_fork (0.0.1):
     - Flutter
-  - flutter_secure_storage (6.0.0):
+  - flutter_local_notifications (0.0.1):
     - Flutter
-  - GoogleDataTransport (10.1.0):
-    - nanopb (~> 3.30910.0)
-    - PromisesObjC (~> 2.4)
-  - GoogleMLKit/BarcodeScanning (7.0.0):
-    - GoogleMLKit/MLKitCore
-    - MLKitBarcodeScanning (~> 6.0.0)
-  - GoogleMLKit/MLKitCore (7.0.0):
-    - MLKitCommon (~> 12.0.0)
-  - GoogleToolboxForMac/Defines (4.2.1)
-  - GoogleToolboxForMac/Logger (4.2.1):
-    - GoogleToolboxForMac/Defines (= 4.2.1)
-  - "GoogleToolboxForMac/NSData+zlib (4.2.1)":
-    - GoogleToolboxForMac/Defines (= 4.2.1)
-  - GoogleUtilities/Environment (8.1.0):
-    - GoogleUtilities/Privacy
-  - GoogleUtilities/Logger (8.1.0):
-    - GoogleUtilities/Environment
-    - GoogleUtilities/Privacy
-  - GoogleUtilities/Privacy (8.1.0)
-  - GoogleUtilities/UserDefaults (8.1.0):
-    - GoogleUtilities/Logger
-    - GoogleUtilities/Privacy
-  - GTMSessionFetcher/Core (3.5.0)
-  - MLImage (1.0.0-beta6)
-  - MLKitBarcodeScanning (6.0.0):
-    - MLKitCommon (~> 12.0)
-    - MLKitVision (~> 8.0)
-  - MLKitCommon (12.0.0):
-    - GoogleDataTransport (~> 10.0)
-    - GoogleToolboxForMac/Logger (< 5.0, >= 4.2.1)
-    - "GoogleToolboxForMac/NSData+zlib (< 5.0, >= 4.2.1)"
-    - GoogleUtilities/Logger (~> 8.0)
-    - GoogleUtilities/UserDefaults (~> 8.0)
-    - GTMSessionFetcher/Core (< 4.0, >= 3.3.2)
-  - MLKitVision (8.0.0):
-    - GoogleToolboxForMac/Logger (< 5.0, >= 4.2.1)
-    - "GoogleToolboxForMac/NSData+zlib (< 5.0, >= 4.2.1)"
-    - GTMSessionFetcher/Core (< 4.0, >= 3.3.2)
-    - MLImage (= 1.0.0-beta6)
-    - MLKitCommon (~> 12.0)
-  - mobile_scanner (6.0.2):
+  - flutter_secure_storage_darwin (10.0.0):
     - Flutter
-    - GoogleMLKit/BarcodeScanning (~> 7.0.0)
-  - nanopb (3.30910.0):
-    - nanopb/decode (= 3.30910.0)
-    - nanopb/encode (= 3.30910.0)
-  - nanopb/decode (3.30910.0)
-  - nanopb/encode (3.30910.0)
+    - FlutterMacOS
+  - flutter_timezone (0.0.1):
+    - Flutter
+  - mobile_scanner (7.0.0):
+    - Flutter
+    - FlutterMacOS
   - package_info_plus (0.4.5):
     - Flutter
   - path_provider_foundation (0.0.1):
     - Flutter
     - FlutterMacOS
-  - PromisesObjC (2.4.0)
-  - SDWebImage (5.21.0):
-    - SDWebImage/Core (= 5.21.0)
-  - SDWebImage/Core (5.21.0)
-  - Sentry/HybridSDK (8.46.0)
-  - sentry_flutter (8.14.2):
+  - SDWebImage (5.21.7):
+    - SDWebImage/Core (= 5.21.7)
+  - SDWebImage/Core (5.21.7)
+  - Sentry/HybridSDK (8.58.1)
+  - sentry_flutter (9.19.0):
     - Flutter
     - FlutterMacOS
-    - Sentry/HybridSDK (= 8.46.0)
+    - Sentry/HybridSDK (= 8.58.1)
+  - share_plus (0.0.1):
+    - Flutter
   - shared_preferences_foundation (0.0.1):
     - Flutter
     - FlutterMacOS
@@ -116,12 +77,15 @@ DEPENDENCIES:
   - app_links (from `.symlinks/plugins/app_links/ios`)
   - file_picker (from `.symlinks/plugins/file_picker/ios`)
   - Flutter (from `Flutter`)
-  - flutter_keyboard_visibility (from `.symlinks/plugins/flutter_keyboard_visibility/ios`)
-  - flutter_secure_storage (from `.symlinks/plugins/flutter_secure_storage/ios`)
-  - mobile_scanner (from `.symlinks/plugins/mobile_scanner/ios`)
+  - flutter_keyboard_visibility_temp_fork (from `.symlinks/plugins/flutter_keyboard_visibility_temp_fork/ios`)
+  - flutter_local_notifications (from `.symlinks/plugins/flutter_local_notifications/ios`)
+  - flutter_secure_storage_darwin (from `.symlinks/plugins/flutter_secure_storage_darwin/darwin`)
+  - flutter_timezone (from `.symlinks/plugins/flutter_timezone/ios`)
+  - mobile_scanner (from `.symlinks/plugins/mobile_scanner/darwin`)
   - package_info_plus (from `.symlinks/plugins/package_info_plus/ios`)
   - path_provider_foundation (from `.symlinks/plugins/path_provider_foundation/darwin`)
   - sentry_flutter (from `.symlinks/plugins/sentry_flutter/ios`)
+  - share_plus (from `.symlinks/plugins/share_plus/ios`)
   - shared_preferences_foundation (from `.symlinks/plugins/shared_preferences_foundation/darwin`)
   - sqflite_darwin (from `.symlinks/plugins/sqflite_darwin/darwin`)
   - url_launcher_ios (from `.symlinks/plugins/url_launcher_ios/ios`)
@@ -130,17 +94,6 @@ SPEC REPOS:
   trunk:
     - DKImagePickerController
     - DKPhotoGallery
-    - GoogleDataTransport
-    - GoogleMLKit
-    - GoogleToolboxForMac
-    - GoogleUtilities
-    - GTMSessionFetcher
-    - MLImage
-    - MLKitBarcodeScanning
-    - MLKitCommon
-    - MLKitVision
-    - nanopb
-    - PromisesObjC
     - SDWebImage
     - Sentry
     - SwiftyGif
@@ -152,18 +105,24 @@ EXTERNAL SOURCES:
     :path: ".symlinks/plugins/file_picker/ios"
   Flutter:
     :path: Flutter
-  flutter_keyboard_visibility:
-    :path: ".symlinks/plugins/flutter_keyboard_visibility/ios"
-  flutter_secure_storage:
-    :path: ".symlinks/plugins/flutter_secure_storage/ios"
+  flutter_keyboard_visibility_temp_fork:
+    :path: ".symlinks/plugins/flutter_keyboard_visibility_temp_fork/ios"
+  flutter_local_notifications:
+    :path: ".symlinks/plugins/flutter_local_notifications/ios"
+  flutter_secure_storage_darwin:
+    :path: ".symlinks/plugins/flutter_secure_storage_darwin/darwin"
+  flutter_timezone:
+    :path: ".symlinks/plugins/flutter_timezone/ios"
   mobile_scanner:
-    :path: ".symlinks/plugins/mobile_scanner/ios"
+    :path: ".symlinks/plugins/mobile_scanner/darwin"
   package_info_plus:
     :path: ".symlinks/plugins/package_info_plus/ios"
   path_provider_foundation:
     :path: ".symlinks/plugins/path_provider_foundation/darwin"
   sentry_flutter:
     :path: ".symlinks/plugins/sentry_flutter/ios"
+  share_plus:
+    :path: ".symlinks/plugins/share_plus/ios"
   shared_preferences_foundation:
     :path: ".symlinks/plugins/shared_preferences_foundation/darwin"
   sqflite_darwin:
@@ -176,26 +135,18 @@ SPEC CHECKSUMS:
   DKImagePickerController: 946cec48c7873164274ecc4624d19e3da4c1ef3c
   DKPhotoGallery: b3834fecb755ee09a593d7c9e389d8b5d6deed60
   file_picker: b159e0c068aef54932bb15dc9fd1571818edaf49
-  Flutter: e0871f40cf51350855a761d2e70bf5af5b9b5de7
-  flutter_keyboard_visibility: 0339d06371254c3eb25eeb90ba8d17dca8f9c069
-  flutter_secure_storage: d33dac7ae2ea08509be337e775f6b59f1ff45f12
-  GoogleDataTransport: aae35b7ea0c09004c3797d53c8c41f66f219d6a7
-  GoogleMLKit: eff9e23ec1d90ea4157a1ee2e32a4f610c5b3318
-  GoogleToolboxForMac: d1a2cbf009c453f4d6ded37c105e2f67a32206d8
-  GoogleUtilities: 00c88b9a86066ef77f0da2fab05f65d7768ed8e1
-  GTMSessionFetcher: 5aea5ba6bd522a239e236100971f10cb71b96ab6
-  MLImage: 0ad1c5f50edd027672d8b26b0fee78a8b4a0fc56
-  MLKitBarcodeScanning: 0a3064da0a7f49ac24ceb3cb46a5bc67496facd2
-  MLKitCommon: 07c2c33ae5640e5380beaaa6e4b9c249a205542d
-  MLKitVision: 45e79d68845a2de77e2dd4d7f07947f0ed157b0e
-  mobile_scanner: fd0054c52ede661e80bf5a4dea477a2467356bee
-  nanopb: fad817b59e0457d11a5dfbde799381cd727c1275
+  Flutter: cabc95a1d2626b1b06e7179b784ebcf0c0cde467
+  flutter_keyboard_visibility_temp_fork: 8a8809c4129e31d25fca77446e0f3fd548122ced
+  flutter_local_notifications: ff50f8405aaa0ccdc7dcfb9022ca192e8ad9688f
+  flutter_secure_storage_darwin: 557817588b80e60213cbecb573c45c76b788018d
+  flutter_timezone: ffb07bdad3c6276af8dada0f11978d8a1f8a20bb
+  mobile_scanner: 77265f3dc8d580810e91849d4a0811a90467ed5e
   package_info_plus: c0502532a26c7662a62a356cebe2692ec5fe4ec4
   path_provider_foundation: 2b6b4c569c0fb62ec74538f866245ac84301af46
-  PromisesObjC: f5707f49cb48b9636751c5b2e7d227e43fba9f47
-  SDWebImage: f84b0feeb08d2d11e6a9b843cb06d75ebf5b8868
-  Sentry: da60d980b197a46db0b35ea12cb8f39af48d8854
-  sentry_flutter: 2df8b0aab7e4aba81261c230cbea31c82a62dd1b
+  SDWebImage: e9fc87c1aab89a8ab1bbd74eba378c6f53be8abf
+  Sentry: 958d9619ceccf6abb8c4736003fa336dac1a80a7
+  sentry_flutter: 9bde8d71f013f0e807c424017de923f0ee489e9a
+  share_plus: 8b6f8b3447e494cca5317c8c3073de39b3600d1f
   shared_preferences_foundation: fcdcbc04712aee1108ac7fda236f363274528f78
   sqflite_darwin: 5a7236e3b501866c1c9befc6771dfd73ffb8702d
   SwiftyGif: 706c60cf65fa2bc5ee0313beece843c8eb8194d4
@@ -203,4 +154,4 @@ SPEC CHECKSUMS:
 
 PODFILE CHECKSUM: ea1096d657c31e2d1110caeae903d5267e26d5a8
 
-COCOAPODS: 1.15.2
+COCOAPODS: 1.16.2

--- a/ios/Runner/AppDelegate.swift
+++ b/ios/Runner/AppDelegate.swift
@@ -1,5 +1,6 @@
 import UIKit
 import Flutter
+import UserNotifications
 
 @main
 @objc class AppDelegate: FlutterAppDelegate {
@@ -8,6 +9,9 @@ import Flutter
     didFinishLaunchingWithOptions launchOptions: [UIApplication.LaunchOptionsKey: Any]?
   ) -> Bool {
     GeneratedPluginRegistrant.register(with: self)
+    // Required by flutter_local_notifications so foreground notifications are
+    // displayed instead of being silently dropped (#312).
+    UNUserNotificationCenter.current().delegate = self as? UNUserNotificationCenterDelegate
         // Exclude the documents folder from iCloud backup.
         try! setExcludeFromiCloudBackup(isExcluded: true)
     return super.application(application, didFinishLaunchingWithOptions: launchOptions)

--- a/ios/Runner/Info.plist
+++ b/ios/Runner/Info.plist
@@ -28,6 +28,12 @@
 	<array>
 		<string>en</string>
 		<string>de</string>
+		<string>cz</string>
+		<string>it</string>
+		<string>pl</string>
+		<string>tr</string>
+		<string>uk</string>
+		<string>zh</string>
 	</array>
 	<key>LSRequiresIPhoneOS</key>
 	<true/>

--- a/lib/core/utils/notification_service.dart
+++ b/lib/core/utils/notification_service.dart
@@ -80,12 +80,11 @@ class NotificationService {
     final details =
         NotificationDetails(android: androidDetails, iOS: iosDetails);
 
-    final now = tz.TZDateTime.now(tz.local);
-    var scheduledDate = tz.TZDateTime(
-        tz.local, now.year, now.month, now.day, hour, minute);
-    if (scheduledDate.isBefore(now)) {
-      scheduledDate = scheduledDate.add(const Duration(days: 1));
-    }
+    final scheduledDate = computeNextOccurrence(
+      tz.TZDateTime.now(tz.local),
+      hour,
+      minute,
+    );
 
     await _plugin.zonedSchedule(
       _dailyReminderId,
@@ -108,5 +107,23 @@ class NotificationService {
 
   Future<void> _ensureInitialized() async {
     if (!_initialized) await initialize();
+  }
+
+  /// Returns the next [tz.TZDateTime] at [hour]:[minute] in the same location
+  /// as [now]. If today's slot has already passed (or matches `now` exactly),
+  /// rolls forward to the next day. Pure function — extracted from
+  /// [scheduleDailyReminder] so it can be unit-tested across timezones / DST
+  /// transitions without touching the notification plugin.
+  static tz.TZDateTime computeNextOccurrence(
+    tz.TZDateTime now,
+    int hour,
+    int minute,
+  ) {
+    var scheduled = tz.TZDateTime(
+        now.location, now.year, now.month, now.day, hour, minute);
+    if (!scheduled.isAfter(now)) {
+      scheduled = scheduled.add(const Duration(days: 1));
+    }
+    return scheduled;
   }
 }

--- a/test/unit_test/calorie_goal_calc_test.dart
+++ b/test/unit_test/calorie_goal_calc_test.dart
@@ -1,5 +1,6 @@
 import 'package:flutter_test/flutter_test.dart';
 import 'package:opennutritracker/core/domain/entity/user_entity.dart';
+import 'package:opennutritracker/core/domain/entity/user_weight_goal_entity.dart';
 import 'package:opennutritracker/core/utils/calc/calorie_goal_calc.dart';
 
 import '../fixture/user_entity_fixtures.dart';
@@ -51,5 +52,82 @@ void main() {
         expect(resultCalorieGoal.toInt(), expectedKcal);
       },
     );
+
+    test('user kcal adjustment is added on top of goal adjustment', () {
+      final user = youngSedentaryMaleWantingToMaintainWeight;
+
+      final result = CalorieGoalCalc.getTotalKcalGoal(
+        user,
+        0,
+        kcalUserAdjustment: 250,
+      );
+      final baseline = CalorieGoalCalc.getTotalKcalGoal(user, 0);
+
+      expect(result, equals(baseline + 250));
+    });
+
+    test('negative user kcal adjustment subtracts from total', () {
+      final user = youngSedentaryMaleWantingToMaintainWeight;
+
+      final result = CalorieGoalCalc.getTotalKcalGoal(
+        user,
+        0,
+        kcalUserAdjustment: -300,
+      );
+      final baseline = CalorieGoalCalc.getTotalKcalGoal(user, 0);
+
+      expect(result, equals(baseline - 300));
+    });
+
+    test(
+        'weekly weight goal in kg overrides the lose/gain default adjustment',
+        () {
+      // -0.5 kg/week → -550 kcal/day (vs -500 default for loseWeight)
+      final base = UserEntityFixtures.middleAgedActiveFemaleWantingToLoseWeight;
+      final user = UserEntity(
+        birthday: base.birthday,
+        heightCM: base.heightCM,
+        weightKG: base.weightKG,
+        gender: base.gender,
+        goal: base.goal,
+        pal: base.pal,
+        weeklyWeightGoalKg: -0.5,
+      );
+
+      final adjustment = CalorieGoalCalc.getKcalGoalAdjustment(
+        user.goal,
+        weeklyWeightGoalKg: user.weeklyWeightGoalKg,
+      );
+      expect(adjustment, equals(-550));
+    });
+
+    test('positive weekly weight goal yields a positive adjustment', () {
+      final adjustment = CalorieGoalCalc.getKcalGoalAdjustment(
+        UserWeightGoalEntity.gainWeight,
+        weeklyWeightGoalKg: 0.5,
+      );
+      expect(adjustment, equals(550));
+    });
+
+    test('default lose/maintain/gain adjustments are -500/0/+500', () {
+      expect(
+        CalorieGoalCalc.getKcalGoalAdjustment(UserWeightGoalEntity.loseWeight),
+        equals(-500),
+      );
+      expect(
+        CalorieGoalCalc.getKcalGoalAdjustment(
+            UserWeightGoalEntity.maintainWeight),
+        equals(0),
+      );
+      expect(
+        CalorieGoalCalc.getKcalGoalAdjustment(UserWeightGoalEntity.gainWeight),
+        equals(500),
+      );
+    });
+
+    test('getDailyKcalLeft is goal minus intake', () {
+      expect(CalorieGoalCalc.getDailyKcalLeft(2000, 800), equals(1200));
+      expect(CalorieGoalCalc.getDailyKcalLeft(2000, 2200), equals(-200));
+    });
   });
 }

--- a/test/unit_test/custom_meal_data_source_test.dart
+++ b/test/unit_test/custom_meal_data_source_test.dart
@@ -1,0 +1,148 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:hive_ce/hive.dart';
+import 'package:opennutritracker/core/data/data_source/custom_meal_data_source.dart';
+import 'package:opennutritracker/core/data/dbo/meal_dbo.dart';
+import 'package:opennutritracker/core/data/dbo/meal_nutriments_dbo.dart';
+
+MealNutrimentsDBO _emptyNutriments({double? kcal}) => MealNutrimentsDBO(
+      energyKcal100: kcal,
+      carbohydrates100: null,
+      fat100: null,
+      proteins100: null,
+      sugars100: null,
+      saturatedFat100: null,
+      fiber100: null,
+    );
+
+MealDBO _meal({
+  String? code,
+  String? name,
+  double? kcal,
+  String? brands,
+}) =>
+    MealDBO(
+      code: code,
+      name: name,
+      brands: brands,
+      thumbnailImageUrl: null,
+      mainImageUrl: null,
+      url: null,
+      mealQuantity: '100',
+      mealUnit: 'g',
+      servingQuantity: null,
+      servingUnit: 'g',
+      servingSize: null,
+      nutriments: _emptyNutriments(kcal: kcal),
+      source: MealSourceDBO.custom,
+    );
+
+void main() {
+  group('CustomMealDataSource', () {
+    late Box<MealDBO> box;
+    late CustomMealDataSource ds;
+
+    setUpAll(() {
+      TestWidgetsFlutterBinding.ensureInitialized();
+      Hive.init('.');
+      Hive.registerAdapter(MealDBOAdapter());
+      Hive.registerAdapter(MealSourceDBOAdapter());
+      Hive.registerAdapter(MealNutrimentsDBOAdapter());
+    });
+
+    setUp(() async {
+      box = await Hive.openBox<MealDBO>(
+          'custom_meal_test_${DateTime.now().microsecondsSinceEpoch}');
+      ds = CustomMealDataSource(box);
+    });
+
+    tearDown(() async {
+      await box.deleteFromDisk();
+    });
+
+    test('saveCustomMeal adds a new meal', () async {
+      await ds.saveCustomMeal(_meal(code: '1', name: 'Apple', kcal: 52));
+      expect(ds.getAllCustomMeals(), hasLength(1));
+      expect(ds.getAllCustomMeals().single.name, equals('Apple'));
+    });
+
+    test('saveCustomMeal dedups by barcode (regression for re-import)',
+        () async {
+      await ds.saveCustomMeal(_meal(code: '1234', name: 'Apple v1', kcal: 52));
+      await ds.saveCustomMeal(_meal(code: '1234', name: 'Apple v2', kcal: 60));
+
+      expect(ds.getAllCustomMeals(), hasLength(1));
+      final saved = ds.getAllCustomMeals().single;
+      expect(saved.name, equals('Apple v2'));
+      expect(saved.nutriments.energyKcal100, equals(60));
+    });
+
+    test('saveCustomMeal dedups by name when barcode is null', () async {
+      await ds.saveCustomMeal(_meal(code: null, name: 'Banana', kcal: 89));
+      await ds.saveCustomMeal(_meal(code: null, name: 'Banana', kcal: 95));
+      await ds.saveCustomMeal(_meal(code: null, name: 'Apple', kcal: 52));
+
+      expect(ds.getAllCustomMeals(), hasLength(2));
+      final names = ds.getAllCustomMeals().map((m) => m.name).toSet();
+      expect(names, equals({'Banana', 'Apple'}));
+      final banana = ds.getAllCustomMeals().firstWhere((m) => m.name == 'Banana');
+      expect(banana.nutriments.energyKcal100, equals(95),
+          reason: 'most-recent save should win on dedup');
+    });
+
+    test(
+        'when a new no-barcode meal shares a name with a barcoded meal, '
+        'dedup matches by name and overwrites (documented quirk)', () async {
+      await ds.saveCustomMeal(_meal(code: '1', name: 'Apple', kcal: 52));
+      await ds.saveCustomMeal(_meal(code: null, name: 'Apple', kcal: 60));
+
+      expect(ds.getAllCustomMeals(), hasLength(1));
+      final stored = ds.getAllCustomMeals().single;
+      expect(stored.code, isNull);
+      expect(stored.nutriments.energyKcal100, equals(60));
+    });
+
+    test(
+        'a new barcoded meal does NOT match an existing name-only meal: '
+        'dedup is keyed on barcode when present', () async {
+      await ds.saveCustomMeal(_meal(code: null, name: 'Apple', kcal: 52));
+      await ds.saveCustomMeal(_meal(code: '1', name: 'Apple', kcal: 60));
+
+      expect(ds.getAllCustomMeals(), hasLength(2),
+          reason: 'incoming meal has a barcode, so it does not match the '
+              'name-only entry; both are kept');
+    });
+
+    test('deleteCustomMeal removes a meal by its barcode', () async {
+      await ds.saveCustomMeal(_meal(code: '1', name: 'Apple'));
+      await ds.saveCustomMeal(_meal(code: '2', name: 'Banana'));
+
+      await ds.deleteCustomMeal('1');
+
+      expect(ds.getAllCustomMeals(), hasLength(1));
+      expect(ds.getAllCustomMeals().single.code, equals('2'));
+    });
+
+    test('deleteCustomMeal removes a name-keyed meal when barcode is null',
+        () async {
+      await ds.saveCustomMeal(_meal(code: null, name: 'Apple'));
+      await ds.saveCustomMeal(_meal(code: null, name: 'Banana'));
+
+      await ds.deleteCustomMeal('Apple');
+
+      expect(ds.getAllCustomMeals(), hasLength(1));
+      expect(ds.getAllCustomMeals().single.name, equals('Banana'));
+    });
+
+    test('deleteCustomMeal is a no-op for unknown keys', () async {
+      await ds.saveCustomMeal(_meal(code: '1', name: 'Apple'));
+
+      await ds.deleteCustomMeal('does-not-exist');
+
+      expect(ds.getAllCustomMeals(), hasLength(1));
+    });
+
+    test('getAllCustomMeals returns an empty list initially', () {
+      expect(ds.getAllCustomMeals(), isEmpty);
+    });
+  });
+}

--- a/test/unit_test/ios_localizations_drift_test.dart
+++ b/test/unit_test/ios_localizations_drift_test.dart
@@ -1,0 +1,53 @@
+import 'dart:io';
+
+import 'package:flutter_test/flutter_test.dart';
+
+/// Guards against `ios/Runner/Info.plist`'s `CFBundleLocalizations` falling
+/// out of sync with `lib/l10n/intl_*.arb`. iOS uses that array to decide
+/// which languages to surface in Settings → app language picker; if a locale
+/// is missing here, iOS users can't pick it even though Flutter ships the
+/// strings. (The pre-existing miss caused 6 locales to be invisible on iOS.)
+void main() {
+  test('Info.plist CFBundleLocalizations contains every intl_*.arb locale',
+      () async {
+    final l10nDir = Directory('lib/l10n');
+    expect(l10nDir.existsSync(), isTrue,
+        reason: 'expected to find lib/l10n directory');
+
+    final arbLocales = l10nDir
+        .listSync()
+        .whereType<File>()
+        .map((f) => f.uri.pathSegments.last)
+        .where((name) => name.startsWith('intl_') && name.endsWith('.arb'))
+        .map((name) => name.substring('intl_'.length, name.length - '.arb'.length))
+        .toSet();
+
+    expect(arbLocales, isNotEmpty,
+        reason: 'sanity check: at least one ARB file should exist');
+    expect(arbLocales, contains('en'),
+        reason: 'the source ARB intl_en.arb must always exist');
+
+    final infoPlist = File('ios/Runner/Info.plist').readAsStringSync();
+    final localizationsBlock = RegExp(
+      r'<key>CFBundleLocalizations</key>\s*<array>(.*?)</array>',
+      dotAll: true,
+    ).firstMatch(infoPlist);
+    expect(localizationsBlock, isNotNull,
+        reason: 'Info.plist must declare CFBundleLocalizations');
+
+    final declaredLocales = RegExp(r'<string>([a-zA-Z-]+)</string>')
+        .allMatches(localizationsBlock!.group(1)!)
+        .map((m) => m.group(1)!)
+        .toSet();
+
+    final missing = arbLocales.difference(declaredLocales);
+    expect(
+      missing,
+      isEmpty,
+      reason: 'CFBundleLocalizations is missing the following locales that '
+          'are shipped via intl_*.arb files: ${missing.join(', ')}. '
+          'Add each missing <string>code</string> entry to '
+          'ios/Runner/Info.plist.',
+    );
+  });
+}

--- a/test/unit_test/notification_service_test.dart
+++ b/test/unit_test/notification_service_test.dart
@@ -1,0 +1,132 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:opennutritracker/core/utils/notification_service.dart';
+import 'package:timezone/data/latest_all.dart' as tzdata;
+import 'package:timezone/timezone.dart' as tz;
+
+void main() {
+  setUpAll(tzdata.initializeTimeZones);
+
+  group('NotificationService.computeNextOccurrence', () {
+    test('returns today when the slot is later today', () {
+      final ny = tz.getLocation('America/New_York');
+      final now = tz.TZDateTime(ny, 2026, 6, 15, 8, 0); // 08:00
+      final next = NotificationService.computeNextOccurrence(now, 20, 30);
+
+      expect(next.year, equals(2026));
+      expect(next.month, equals(6));
+      expect(next.day, equals(15));
+      expect(next.hour, equals(20));
+      expect(next.minute, equals(30));
+      expect(next.location.name, equals('America/New_York'));
+    });
+
+    test('rolls forward to tomorrow when the slot has already passed', () {
+      final ny = tz.getLocation('America/New_York');
+      final now = tz.TZDateTime(ny, 2026, 6, 15, 21, 0); // 21:00
+      final next = NotificationService.computeNextOccurrence(now, 20, 30);
+
+      expect(next.day, equals(16),
+          reason: 'past slot should roll to next day');
+      expect(next.hour, equals(20));
+      expect(next.minute, equals(30));
+    });
+
+    test('rolls forward when the slot matches now exactly', () {
+      // Equality counts as past — we never want to schedule "now" because
+      // the OS scheduler treats that as fire-immediately.
+      final ny = tz.getLocation('America/New_York');
+      final now = tz.TZDateTime(ny, 2026, 6, 15, 20, 30);
+      final next = NotificationService.computeNextOccurrence(now, 20, 30);
+
+      expect(next.day, equals(16));
+    });
+
+    test('handles month boundary correctly (last day → next month)', () {
+      final ny = tz.getLocation('America/New_York');
+      final now = tz.TZDateTime(ny, 2026, 6, 30, 21, 0);
+      final next = NotificationService.computeNextOccurrence(now, 8, 0);
+
+      expect(next.year, equals(2026));
+      expect(next.month, equals(7));
+      expect(next.day, equals(1));
+      expect(next.hour, equals(8));
+    });
+
+    test('handles year boundary correctly', () {
+      final ny = tz.getLocation('America/New_York');
+      final now = tz.TZDateTime(ny, 2026, 12, 31, 23, 0);
+      final next = NotificationService.computeNextOccurrence(now, 8, 0);
+
+      expect(next.year, equals(2027));
+      expect(next.month, equals(1));
+      expect(next.day, equals(1));
+    });
+
+    test('preserves the supplied timezone (London)', () {
+      final london = tz.getLocation('Europe/London');
+      final now = tz.TZDateTime(london, 2026, 6, 15, 8, 0);
+      final next = NotificationService.computeNextOccurrence(now, 20, 30);
+
+      expect(next.location.name, equals('Europe/London'));
+    });
+
+    test('preserves the supplied timezone (Tokyo)', () {
+      final tokyo = tz.getLocation('Asia/Tokyo');
+      final now = tz.TZDateTime(tokyo, 2026, 6, 15, 8, 0);
+      final next = NotificationService.computeNextOccurrence(now, 20, 30);
+
+      expect(next.location.name, equals('Asia/Tokyo'));
+    });
+
+    test('DST spring-forward: 02:30 in US/Eastern does not exist on '
+        '2026-03-08, slot rolls to next day', () {
+      // 2026-03-08 in America/New_York: clocks jump 02:00 → 03:00, so 02:30
+      // is a non-existent local time. The TZDateTime constructor canonicalises
+      // it to 03:30 EDT. Verify the next-occurrence helper still produces a
+      // valid future TZDateTime in this case.
+      final ny = tz.getLocation('America/New_York');
+      final beforeJump =
+          tz.TZDateTime(ny, 2026, 3, 8, 1, 0); // 01:00, well before the gap
+      final next = NotificationService.computeNextOccurrence(beforeJump, 2, 30);
+
+      // The helper should return *some* later TZDateTime (it canonicalises
+      // 02:30 → 03:30 but that's still after 01:00, so it stays on the same
+      // day). The crucial property is that it doesn't crash and the return
+      // value is strictly after `beforeJump`.
+      expect(next.isAfter(beforeJump), isTrue);
+      expect(next.day, equals(8));
+    });
+
+    test('DST fall-back: 01:30 occurs twice on 2026-11-01 in US/Eastern; '
+        'helper still produces a strictly future occurrence', () {
+      final ny = tz.getLocation('America/New_York');
+      final after = tz.TZDateTime(ny, 2026, 11, 1, 3, 0);
+      final next = NotificationService.computeNextOccurrence(after, 1, 30);
+
+      expect(next.isAfter(after), isTrue,
+          reason: 'must always return a future timestamp even across DST');
+      expect(next.day, equals(2),
+          reason: 'past slot should roll to next day across DST boundary');
+    });
+
+    test('handles midnight (00:00) slot', () {
+      final ny = tz.getLocation('America/New_York');
+      final now = tz.TZDateTime(ny, 2026, 6, 15, 23, 0);
+      final next = NotificationService.computeNextOccurrence(now, 0, 0);
+
+      expect(next.day, equals(16));
+      expect(next.hour, equals(0));
+      expect(next.minute, equals(0));
+    });
+
+    test('handles end-of-day (23:59) slot earlier in the day', () {
+      final ny = tz.getLocation('America/New_York');
+      final now = tz.TZDateTime(ny, 2026, 6, 15, 8, 0);
+      final next = NotificationService.computeNextOccurrence(now, 23, 59);
+
+      expect(next.day, equals(15));
+      expect(next.hour, equals(23));
+      expect(next.minute, equals(59));
+    });
+  });
+}

--- a/test/unit_test/remote_search_cache_data_source_test.dart
+++ b/test/unit_test/remote_search_cache_data_source_test.dart
@@ -1,0 +1,267 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:hive_ce/hive.dart';
+import 'package:opennutritracker/core/data/data_source/remote_search_cache_data_source.dart';
+import 'package:opennutritracker/core/data/dbo/meal_dbo.dart';
+import 'package:opennutritracker/core/data/dbo/meal_nutriments_dbo.dart';
+
+MealNutrimentsDBO _emptyNutriments() => MealNutrimentsDBO(
+      energyKcal100: null,
+      carbohydrates100: null,
+      fat100: null,
+      proteins100: null,
+      sugars100: null,
+      saturatedFat100: null,
+      fiber100: null,
+    );
+
+MealDBO _meal({
+  String? code,
+  String? name,
+  MealSourceDBO source = MealSourceDBO.off,
+}) {
+  return MealDBO(
+    code: code,
+    name: name,
+    brands: null,
+    thumbnailImageUrl: null,
+    mainImageUrl: null,
+    url: null,
+    mealQuantity: null,
+    mealUnit: 'g',
+    servingQuantity: null,
+    servingUnit: 'g',
+    servingSize: null,
+    nutriments: _emptyNutriments(),
+    source: source,
+  );
+}
+
+void main() {
+  group('RemoteSearchCacheDataSource', () {
+    late Box<MealDBO> cacheBox;
+    late Box<int> tsBox;
+    late RemoteSearchCacheDataSource ds;
+
+    setUpAll(() {
+      TestWidgetsFlutterBinding.ensureInitialized();
+      Hive.init('.');
+      Hive.registerAdapter(MealDBOAdapter());
+      Hive.registerAdapter(MealSourceDBOAdapter());
+      Hive.registerAdapter(MealNutrimentsDBOAdapter());
+    });
+
+    setUp(() async {
+      cacheBox = await Hive.openBox<MealDBO>(
+          'remote_cache_test_${DateTime.now().microsecondsSinceEpoch}');
+      tsBox = await Hive.openBox<int>(
+          'remote_cache_ts_test_${DateTime.now().microsecondsSinceEpoch}');
+      ds = RemoteSearchCacheDataSource(cacheBox, tsBox);
+    });
+
+    tearDown(() async {
+      await cacheBox.deleteFromDisk();
+      await tsBox.deleteFromDisk();
+    });
+
+    test('cache adds a new meal and stamps a timestamp', () async {
+      final before = DateTime.now().millisecondsSinceEpoch;
+      await ds.cache(_meal(code: 'A', name: 'Apple'));
+      final after = DateTime.now().millisecondsSinceEpoch;
+
+      expect(ds.count, equals(1));
+      final ts = tsBox.get('A');
+      expect(ts, isNotNull);
+      expect(ts!, greaterThanOrEqualTo(before));
+      expect(ts, lessThanOrEqualTo(after));
+    });
+
+    test('cache overwrites an existing entry by code (refresh)', () async {
+      await ds.cache(_meal(code: 'A', name: 'Apple v1'));
+      await ds.cache(_meal(code: 'A', name: 'Apple v2'));
+
+      expect(ds.count, equals(1));
+      expect(ds.getAll().single.name, equals('Apple v2'));
+    });
+
+    test('cache treats null-code entries as distinct by name', () async {
+      await ds.cache(_meal(code: null, name: 'Apple'));
+      await ds.cache(_meal(code: null, name: 'Banana'));
+      await ds.cache(_meal(code: null, name: 'Apple')); // dedup
+
+      expect(ds.count, equals(2));
+    });
+
+    test('cache uses code as timestamp key when present, else name',
+        () async {
+      await ds.cache(_meal(code: 'A', name: 'Apple'));
+      expect(tsBox.get('A'), isNotNull);
+      expect(tsBox.get('Apple'), isNull);
+
+      await ds.cache(_meal(code: null, name: 'Banana'));
+      expect(tsBox.get('Banana'), isNotNull);
+    });
+
+    test('cache silently skips timestamping when both code and name are null',
+        () async {
+      await ds.cache(_meal(code: null, name: null));
+      expect(ds.count, equals(1));
+      expect(tsBox.length, equals(0));
+    });
+
+    test('cacheAll touches every entry', () async {
+      await ds.cacheAll([
+        _meal(code: 'A', name: 'Apple'),
+        _meal(code: 'B', name: 'Banana'),
+        _meal(code: 'C', name: 'Cherry'),
+      ]);
+
+      expect(ds.count, equals(3));
+      expect(tsBox.get('A'), isNotNull);
+      expect(tsBox.get('B'), isNotNull);
+      expect(tsBox.get('C'), isNotNull);
+    });
+
+    test(
+        'cacheFromSearch preserves existing timestamps but refreshes meal data '
+        '(regression: bulk-caching must not wipe touch signal)', () async {
+      await ds.cache(_meal(code: 'A', name: 'Apple v1'));
+      final originalTs = tsBox.get('A');
+      expect(originalTs, isNotNull);
+
+      // Wait long enough that the millisecond clock would change.
+      await Future<void>.delayed(const Duration(milliseconds: 5));
+
+      await ds.cacheFromSearch([
+        _meal(code: 'A', name: 'Apple v2'), // existing → keep ts, refresh data
+        _meal(code: 'B', name: 'Banana'),   // new → fresh ts
+      ]);
+
+      expect(tsBox.get('A'), equals(originalTs),
+          reason: 'existing entry timestamp must be preserved on re-search');
+      expect(ds.getAll().firstWhere((m) => m.code == 'A').name,
+          equals('Apple v2'),
+          reason: 'meal data should still be refreshed even though ts is kept');
+      expect(tsBox.get('B'), isNotNull);
+    });
+
+    test('getByBarcode returns the matching cached entry or null', () async {
+      await ds.cache(_meal(code: 'X', name: 'Item X'));
+      await ds.cache(_meal(code: 'Y', name: 'Item Y'));
+
+      expect(ds.getByBarcode('X')?.name, equals('Item X'));
+      expect(ds.getByBarcode('Y')?.name, equals('Item Y'));
+      expect(ds.getByBarcode('Z'), isNull);
+    });
+
+    test('touch refreshes the timestamp without changing meal data', () async {
+      await ds.cache(_meal(code: 'A', name: 'Apple v1'));
+      final original = tsBox.get('A')!;
+
+      await Future<void>.delayed(const Duration(milliseconds: 5));
+      await ds.touch('A');
+
+      final touched = tsBox.get('A')!;
+      expect(touched, greaterThan(original));
+      expect(ds.getAll().single.name, equals('Apple v1'),
+          reason: 'touch must not modify the cached meal');
+    });
+
+    test('touch is a no-op for empty code', () async {
+      await ds.touch('');
+      expect(tsBox.length, equals(0));
+    });
+
+    test('getAllByMostRecentlyTouched orders newest-touched first', () async {
+      await ds.cache(_meal(code: 'A', name: 'Apple'));
+      await Future<void>.delayed(const Duration(milliseconds: 5));
+      await ds.cache(_meal(code: 'B', name: 'Banana'));
+      await Future<void>.delayed(const Duration(milliseconds: 5));
+      await ds.cache(_meal(code: 'C', name: 'Cherry'));
+      await Future<void>.delayed(const Duration(milliseconds: 5));
+
+      // Touch A so it jumps to the top.
+      await ds.touch('A');
+
+      final ordered = ds.getAllByMostRecentlyTouched()
+          .map((m) => m.code)
+          .toList();
+      expect(ordered.first, equals('A'));
+      expect(ordered, equals(const ['A', 'C', 'B']));
+    });
+
+    test('getAllByMostRecentlyTouched sorts entries with no timestamp last',
+        () async {
+      await ds.cache(_meal(code: 'A', name: 'Apple'));
+      await ds.cache(_meal(code: 'B', name: 'Banana'));
+      // Manually add an entry without a timestamp record (pre-TTL data).
+      await cacheBox.add(_meal(code: 'OLD', name: 'Legacy'));
+
+      final ordered = ds.getAllByMostRecentlyTouched()
+          .map((m) => m.code)
+          .toList();
+      expect(ordered.last, equals('OLD'));
+    });
+
+    test('pruneStale removes entries older than maxAge', () async {
+      await ds.cache(_meal(code: 'OLD', name: 'Old'));
+      // Backdate the OLD entry's timestamp by 100 days.
+      await tsBox.put(
+          'OLD',
+          DateTime.now()
+              .subtract(const Duration(days: 100))
+              .millisecondsSinceEpoch);
+
+      await ds.cache(_meal(code: 'FRESH', name: 'Fresh'));
+
+      final removed = await ds.pruneStale(const Duration(days: 90));
+      expect(removed, equals(1));
+      expect(ds.count, equals(1));
+      expect(ds.getAll().single.code, equals('FRESH'));
+      expect(tsBox.get('OLD'), isNull);
+      expect(tsBox.get('FRESH'), isNotNull);
+    });
+
+    test('pruneStale drops entries with no timestamp record', () async {
+      // Manually insert without a ts entry.
+      await cacheBox.add(_meal(code: 'NO_TS', name: 'Legacy'));
+      await ds.cache(_meal(code: 'FRESH', name: 'Fresh'));
+
+      final removed = await ds.pruneStale(const Duration(days: 90));
+      expect(removed, equals(1));
+      expect(ds.count, equals(1));
+      expect(ds.getAll().single.code, equals('FRESH'));
+    });
+
+    test('pruneStale drops entries that have neither code nor name', () async {
+      await cacheBox.add(_meal(code: null, name: null));
+      final removed = await ds.pruneStale(const Duration(days: 90));
+      expect(removed, equals(1));
+      expect(ds.count, equals(0));
+    });
+
+    test('pruneStale returns 0 when nothing is stale', () async {
+      await ds.cache(_meal(code: 'A', name: 'Apple'));
+      await ds.cache(_meal(code: 'B', name: 'Banana'));
+
+      final removed = await ds.pruneStale(const Duration(days: 90));
+      expect(removed, equals(0));
+      expect(ds.count, equals(2));
+    });
+
+    test('clear empties both the cache and the timestamps box', () async {
+      await ds.cache(_meal(code: 'A', name: 'Apple'));
+      await ds.cache(_meal(code: 'B', name: 'Banana'));
+
+      await ds.clear();
+
+      expect(ds.count, equals(0));
+      expect(tsBox.length, equals(0));
+    });
+
+    test('getStorageSizeBytes returns a non-negative number', () async {
+      await ds.cache(_meal(code: 'A', name: 'Apple'));
+      final size = await ds.getStorageSizeBytes();
+      expect(size, greaterThanOrEqualTo(0));
+    });
+  });
+}

--- a/test/unit_test/retry_util_test.dart
+++ b/test/unit_test/retry_util_test.dart
@@ -1,0 +1,127 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:opennutritracker/core/utils/retry_util.dart';
+
+class _BoomError implements Exception {
+  final String message;
+  _BoomError(this.message);
+  @override
+  String toString() => 'BoomError($message)';
+}
+
+void main() {
+  group('withRetry', () {
+    test('returns the result on first success without retrying', () async {
+      var calls = 0;
+      final result = await withRetry(() async {
+        calls++;
+        return 42;
+      });
+
+      expect(result, equals(42));
+      expect(calls, equals(1));
+    });
+
+    test('rethrows immediately when shouldRetry returns false', () async {
+      var calls = 0;
+      Object? caught;
+
+      try {
+        await withRetry<int>(
+          () async {
+            calls++;
+            throw _BoomError('non-retriable');
+          },
+          attempts: 5,
+          shouldRetry: (_) => false,
+        );
+      } catch (e) {
+        caught = e;
+      }
+
+      expect(calls, equals(1),
+          reason: 'must not retry when shouldRetry returns false');
+      expect(caught, isA<_BoomError>());
+    });
+
+    test('rethrows immediately on attempts=1', () async {
+      var calls = 0;
+      Object? caught;
+      try {
+        await withRetry<int>(
+          () async {
+            calls++;
+            throw _BoomError('first try');
+          },
+          attempts: 1,
+        );
+      } catch (e) {
+        caught = e;
+      }
+
+      expect(calls, equals(1));
+      expect(caught, isA<_BoomError>());
+    });
+
+    test('shouldRetry can inspect error type to decide', () async {
+      var calls = 0;
+      Object? caught;
+
+      try {
+        await withRetry<int>(
+          () async {
+            calls++;
+            throw StateError('always non-retriable');
+          },
+          attempts: 5,
+          shouldRetry: (e) => e is _BoomError,
+        );
+      } catch (e) {
+        caught = e;
+      }
+
+      expect(calls, equals(1));
+      expect(caught, isA<StateError>());
+    });
+
+    test('retries on exception and succeeds when attempts allow', () async {
+      var calls = 0;
+      final stopwatch = Stopwatch()..start();
+      final result = await withRetry<int>(
+        () async {
+          calls++;
+          if (calls < 2) throw _BoomError('once');
+          return 7;
+        },
+        attempts: 3,
+      );
+      stopwatch.stop();
+
+      expect(result, equals(7));
+      expect(calls, equals(2));
+      // Backoff after the first failed attempt is 1<<0 = 1 second.
+      expect(stopwatch.elapsed,
+          greaterThan(const Duration(milliseconds: 800)));
+    }, timeout: const Timeout(Duration(seconds: 5)));
+
+    test('rethrows the original error after all attempts exhausted', () async {
+      var calls = 0;
+      Object? caught;
+
+      try {
+        await withRetry<int>(
+          () async {
+            calls++;
+            throw _BoomError('try $calls');
+          },
+          attempts: 2, // 1 failure + 1s wait + 1 retry = ~1s
+        );
+      } catch (e) {
+        caught = e;
+      }
+
+      expect(calls, equals(2));
+      expect(caught, isA<_BoomError>());
+      expect((caught as _BoomError).message, equals('try 2'));
+    }, timeout: const Timeout(Duration(seconds: 5)));
+  });
+}

--- a/test/unit_test/shared_meal_payload_compression_test.dart
+++ b/test/unit_test/shared_meal_payload_compression_test.dart
@@ -173,5 +173,148 @@ void main() {
         throwsA(isA<SharedMealParseException>()),
       );
     });
+
+    test('plain JSON (uncompressed) input is also accepted', () {
+      // The encoder always gzips, but the decoder should fall back to
+      // treating the input as a plain JSON string when gzip/base64 fails.
+      const raw = '[1,[],[]]';
+      final decoded = SharedMealPayload.fromJsonString(raw);
+      expect(decoded.version, equals(1));
+      expect(decoded.offRefs, isEmpty);
+      expect(decoded.items, isEmpty);
+    });
+
+    test('malformed top-level shape throws SharedMealParseException', () {
+      final raw = base64Url.encode(gzip.encode(utf8.encode('{"bad":true}')));
+      expect(
+        () => SharedMealPayload.fromJsonString(raw),
+        throwsA(isA<SharedMealParseException>()),
+      );
+    });
+
+    test('completely garbage input throws SharedMealParseException', () {
+      expect(
+        () => SharedMealPayload.fromJsonString('not-base64-or-json'),
+        throwsA(isA<SharedMealParseException>()),
+      );
+    });
+
+    test('totalCount sums OFF refs and custom items', () {
+      final intakes = [
+        makeIntake(createMeal(
+            code: '4001', name: 'A', source: MealSourceEntity.off)),
+        makeIntake(createMeal(
+            code: '4002', name: 'B', source: MealSourceEntity.off)),
+        makeIntake(
+            createMeal(
+                code: 'cust-1',
+                name: 'Custom',
+                source: MealSourceEntity.custom)),
+      ];
+      final payload = SharedMealPayload.fromIntakeList(intakes);
+      expect(payload.totalCount, equals(3));
+      expect(payload.offRefs.length, equals(2));
+      expect(payload.items.length, equals(1));
+    });
+
+    test('OFF intake without a barcode falls back to a custom item', () {
+      // A meal flagged source=off but missing its code shouldn't be lost —
+      // it must be encoded as a full custom item so the recipient can still
+      // see its data.
+      final orphan = createMeal(
+          code: '', name: 'Lost Product', source: MealSourceEntity.off);
+      // Override code to null via a fresh entity — our helper requires a code,
+      // so build a minimal stand-in.
+      final intake = IntakeEntity(
+        id: 'orphan',
+        meal: MealEntity(
+          code: null,
+          name: orphan.name,
+          brands: null,
+          thumbnailImageUrl: null,
+          mainImageUrl: null,
+          url: null,
+          mealQuantity: null,
+          mealUnit: null,
+          servingQuantity: null,
+          servingUnit: null,
+          servingSize: null,
+          nutriments: MealNutrimentsEntity.empty(),
+          source: MealSourceEntity.off,
+        ),
+        amount: 100,
+        unit: 'g',
+        dateTime: DateTime(2026, 4, 27),
+        type: IntakeTypeEntity.breakfast,
+      );
+
+      final payload = SharedMealPayload.fromIntakeList([intake]);
+      expect(payload.offRefs, isEmpty);
+      expect(payload.items.length, equals(1));
+      expect(payload.items.single.name, equals('Lost Product'));
+    });
+
+    test('toMealEntities assigns a fresh unique code to each rebuilt item',
+        () {
+      final intakes = [
+        makeIntake(createMeal(
+            code: 'c1', name: 'A', source: MealSourceEntity.custom)),
+        makeIntake(createMeal(
+            code: 'c2', name: 'B', source: MealSourceEntity.custom)),
+      ];
+      final payload = SharedMealPayload.fromIntakeList(intakes);
+      final rebuilt = payload.toMealEntities();
+      expect(rebuilt.length, equals(2));
+      expect(rebuilt[0].code, isNot(equals(rebuilt[1].code)));
+      expect(rebuilt[0].code, isNotNull);
+    });
+
+    test('whole-number nutrient values round-trip as ints in the JSON', () {
+      // The _compact() optimisation emits ints for whole numbers. Verify the
+      // round-trip restores the original value as a double.
+      final meal = createMeal(
+        code: 'whole',
+        name: 'Round',
+        source: MealSourceEntity.custom,
+      );
+      final intake = IntakeEntity(
+        id: 'r',
+        meal: MealEntity(
+          code: meal.code,
+          name: meal.name,
+          brands: null,
+          thumbnailImageUrl: null,
+          mainImageUrl: null,
+          url: null,
+          mealQuantity: null,
+          mealUnit: null,
+          servingQuantity: null,
+          servingUnit: null,
+          servingSize: null,
+          nutriments: MealNutrimentsEntity(
+            energyKcal100: 100, // whole
+            carbohydrates100: 22.5, // 1dp
+            fat100: 0,
+            proteins100: 7,
+            sugars100: null,
+            saturatedFat100: null,
+            fiber100: null,
+          ),
+          source: MealSourceEntity.custom,
+        ),
+        amount: 100,
+        unit: 'g',
+        dateTime: DateTime(2026, 4, 27),
+        type: IntakeTypeEntity.breakfast,
+      );
+      final encoded =
+          SharedMealPayload.fromIntakeList([intake]).toJsonString();
+      final decoded = SharedMealPayload.fromJsonString(encoded);
+
+      expect(decoded.items.single.energyKcal100, equals(100));
+      expect(decoded.items.single.carbohydrates100, equals(22.5));
+      expect(decoded.items.single.fat100, equals(0));
+      expect(decoded.items.single.proteins100, equals(7));
+    });
   });
 }

--- a/test/unit_test/tracked_day_data_source_test.dart
+++ b/test/unit_test/tracked_day_data_source_test.dart
@@ -141,4 +141,165 @@ void main() {
       expect(result.length, 0);
     });
   });
+
+  group('TrackedDayDataSource mutations', () {
+    late Box<TrackedDayDBO> box;
+    late TrackedDayDataSource ds;
+
+    setUpAll(() {
+      TestWidgetsFlutterBinding.ensureInitialized();
+      if (!Hive.isAdapterRegistered(9)) {
+        Hive.registerAdapter(TrackedDayDBOAdapter());
+      }
+    });
+
+    setUp(() async {
+      Hive.init('.');
+      box = await Hive.openBox<TrackedDayDBO>(
+          'tracked_day_mut_test_${DateTime.now().microsecondsSinceEpoch}');
+      ds = TrackedDayDataSource(box);
+    });
+
+    tearDown(() async {
+      await box.deleteFromDisk();
+    });
+
+    final day = DateTime.utc(2024, 6, 15);
+    TrackedDayDBO seed() => TrackedDayDBO(
+          day: day,
+          calorieGoal: 2000,
+          caloriesTracked: 0,
+          carbsGoal: 250,
+          carbsTracked: 0,
+          fatGoal: 65,
+          fatTracked: 0,
+          proteinGoal: 150,
+          proteinTracked: 0,
+        );
+
+    test('hasTrackedDay reports false when day is missing, true after save',
+        () async {
+      expect(await ds.hasTrackedDay(day), isFalse);
+      await ds.saveTrackedDay(seed());
+      expect(await ds.hasTrackedDay(day), isTrue);
+    });
+
+    test('addDayCaloriesTracked accumulates additively', () async {
+      await ds.saveTrackedDay(seed());
+      await ds.addDayCaloriesTracked(day, 500);
+      await ds.addDayCaloriesTracked(day, 250);
+
+      final result = await ds.getTrackedDay(day);
+      expect(result!.caloriesTracked, equals(750));
+    });
+
+    test('decreaseDayCaloriesTracked subtracts', () async {
+      await ds.saveTrackedDay(seed());
+      await ds.addDayCaloriesTracked(day, 500);
+      await ds.decreaseDayCaloriesTracked(day, 200);
+
+      final result = await ds.getTrackedDay(day);
+      expect(result!.caloriesTracked, equals(300));
+    });
+
+    test('increase / reduceDayCalorieGoal adjust the goal', () async {
+      await ds.saveTrackedDay(seed());
+      await ds.increaseDayCalorieGoal(day, 100);
+      var result = await ds.getTrackedDay(day);
+      expect(result!.calorieGoal, equals(2100));
+
+      await ds.reduceDayCalorieGoal(day, 50);
+      result = await ds.getTrackedDay(day);
+      expect(result!.calorieGoal, equals(2050));
+    });
+
+    test('updateDayMacroGoals updates only the named macros', () async {
+      await ds.saveTrackedDay(seed());
+      await ds.updateDayMacroGoals(day, carbsGoal: 300, proteinGoal: 200);
+
+      final result = await ds.getTrackedDay(day);
+      expect(result!.carbsGoal, equals(300));
+      expect(result.fatGoal, equals(65), reason: 'fat goal not touched');
+      expect(result.proteinGoal, equals(200));
+    });
+
+    test('addDayMacroTracked accumulates and removeDayMacroTracked subtracts',
+        () async {
+      await ds.saveTrackedDay(seed());
+
+      await ds.addDayMacroTracked(day,
+          carbsAmount: 30, fatAmount: 10, proteinAmount: 20);
+      await ds.addDayMacroTracked(day, carbsAmount: 20);
+      await ds.removeDayMacroTracked(day, fatAmount: 4);
+
+      final result = await ds.getTrackedDay(day);
+      expect(result!.carbsTracked, equals(50));
+      expect(result.fatTracked, equals(6));
+      expect(result.proteinTracked, equals(20));
+    });
+
+    test('reconcileCaloriesAndMacrosTracked sets the totals exactly',
+        () async {
+      await ds.saveTrackedDay(seed());
+      await ds.addDayCaloriesTracked(day, 999);
+      await ds.addDayMacroTracked(day,
+          carbsAmount: 999, fatAmount: 999, proteinAmount: 999);
+
+      await ds.reconcileCaloriesAndMacrosTracked(day, 1500, 200, 50, 100);
+
+      final result = await ds.getTrackedDay(day);
+      expect(result!.caloriesTracked, equals(1500));
+      expect(result.carbsTracked, equals(200));
+      expect(result.fatTracked, equals(50));
+      expect(result.proteinTracked, equals(100));
+    });
+
+    test('all mutations are no-ops when the day has no tracked record',
+        () async {
+      await ds.addDayCaloriesTracked(day, 100);
+      await ds.decreaseDayCaloriesTracked(day, 50);
+      await ds.increaseDayCalorieGoal(day, 10);
+      await ds.updateDayMacroGoals(day, carbsGoal: 1);
+      await ds.addDayMacroTracked(day, carbsAmount: 5);
+      await ds.removeDayMacroTracked(day, carbsAmount: 1);
+      await ds.reconcileCaloriesAndMacrosTracked(day, 1, 1, 1, 1);
+
+      expect(await ds.getTrackedDay(day), isNull);
+      expect(await ds.hasTrackedDay(day), isFalse);
+    });
+
+    test('saveAllTrackedDays inserts every entry, keyed by day', () async {
+      await ds.saveAllTrackedDays([
+        TrackedDayDBO(
+          day: DateTime.utc(2024, 6, 1),
+          calorieGoal: 2000,
+          caloriesTracked: 1000,
+        ),
+        TrackedDayDBO(
+          day: DateTime.utc(2024, 6, 2),
+          calorieGoal: 2000,
+          caloriesTracked: 1100,
+        ),
+      ]);
+
+      expect((await ds.getAllTrackedDays()).length, equals(2));
+      expect(
+          (await ds.getTrackedDay(DateTime.utc(2024, 6, 1)))!.caloriesTracked,
+          equals(1000));
+    });
+
+    test('saveTrackedDay overwrites prior entry for the same day', () async {
+      await ds.saveTrackedDay(seed());
+      await ds.saveTrackedDay(TrackedDayDBO(
+        day: day,
+        calorieGoal: 2500,
+        caloriesTracked: 800,
+      ));
+
+      final result = await ds.getTrackedDay(day);
+      expect(result!.calorieGoal, equals(2500));
+      expect(result.caloriesTracked, equals(800));
+      expect((await ds.getAllTrackedDays()).length, equals(1));
+    });
+  });
 }

--- a/test/unit_test/unit_calc_imperial_round_trip_test.dart
+++ b/test/unit_test/unit_calc_imperial_round_trip_test.dart
@@ -1,0 +1,131 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:opennutritracker/core/utils/calc/unit_calc.dart';
+
+void main() {
+  group('UnitCalc.lbsToKg', () {
+    test('preserves two decimal places (regression for PR #348)', () {
+      expect(UnitCalc.lbsToKg(150), closeTo(68.04, 0.0001));
+      expect(UnitCalc.lbsToKg(200), closeTo(90.72, 0.0001));
+      expect(UnitCalc.lbsToKg(176), closeTo(79.83, 0.0001));
+    });
+
+    test('round-trip lbs → kg → lbs is exact for whole-pound weights', () {
+      for (final lbs in const [100.0, 120.0, 150.0, 165.0, 180.0, 200.0, 250.0]) {
+        final kg = UnitCalc.lbsToKg(lbs);
+        final roundTrip = UnitCalc.kgToLbs(kg);
+        expect(roundTrip, equals(lbs),
+            reason: '$lbs lbs -> $kg kg -> $roundTrip lbs lost precision');
+      }
+    });
+
+    test('handles zero and small weights', () {
+      expect(UnitCalc.lbsToKg(0), equals(0));
+      expect(UnitCalc.lbsToKg(1), closeTo(0.45, 0.005));
+    });
+
+    test('handles large weights', () {
+      expect(UnitCalc.lbsToKg(1000), closeTo(453.59, 0.005));
+    });
+  });
+
+  group('UnitCalc.kgToLbs', () {
+    test('rounds to whole pounds', () {
+      expect(UnitCalc.kgToLbs(50), equals(110));
+      expect(UnitCalc.kgToLbs(70), equals(154));
+      expect(UnitCalc.kgToLbs(100), equals(220));
+    });
+
+    test('handles zero weight', () {
+      expect(UnitCalc.kgToLbs(0), equals(0));
+    });
+  });
+
+  group('UnitCalc.cmToInches / inchesToCm', () {
+    test('inches → cm → inches preserves whole inches', () {
+      for (final inches in const [60.0, 65.0, 70.0, 72.0, 75.0]) {
+        final cm = UnitCalc.inchesToCm(inches);
+        final back = UnitCalc.cmToInches(cm);
+        expect(back, closeTo(inches, 0.0001));
+      }
+    });
+
+    test('1 inch is 2.54 cm exactly', () {
+      expect(UnitCalc.inchesToCm(1), equals(2.54));
+    });
+  });
+
+  group('UnitCalc.cmToFeet / feetToCm', () {
+    test('cmToFeet rounds to two decimal places', () {
+      expect(UnitCalc.cmToFeet(180), closeTo(5.91, 0.001));
+      expect(UnitCalc.cmToFeet(170), closeTo(5.58, 0.001));
+    });
+
+    test('feetToCm rounds to whole cm', () {
+      expect(UnitCalc.feetToCm(6), equals(183));
+      expect(UnitCalc.feetToCm(5.5), equals(168));
+    });
+  });
+
+  group('UnitCalc.gToOz / ozToG', () {
+    test('round-trip is approximately exact', () {
+      for (final g in const [100.0, 250.0, 500.0]) {
+        final oz = UnitCalc.gToOz(g);
+        final back = UnitCalc.ozToG(oz);
+        expect(back, closeTo(g, 0.0001));
+      }
+    });
+
+    test('1 oz is 28.3495 g', () {
+      expect(UnitCalc.ozToG(1), equals(28.3495));
+    });
+  });
+
+  group('UnitCalc.mlToFlOz / flOzToMl', () {
+    test('round-trip is approximately exact', () {
+      for (final ml in const [100.0, 250.0, 500.0]) {
+        final flOz = UnitCalc.mlToFlOz(ml);
+        final back = UnitCalc.flOzToMl(flOz);
+        expect(back, closeTo(ml, 0.0001));
+      }
+    });
+
+    test('1 fl oz is 29.5735 ml', () {
+      expect(UnitCalc.flOzToMl(1), equals(29.5735));
+    });
+  });
+
+  group('UnitCalc.metricToImperialValue', () {
+    test('converts grams to ounces', () {
+      expect(UnitCalc.metricToImperialValue(100, 'g'),
+          closeTo(UnitCalc.gToOz(100), 0.0001));
+    });
+
+    test('converts ml to fl oz', () {
+      expect(UnitCalc.metricToImperialValue(250, 'ml'),
+          closeTo(UnitCalc.mlToFlOz(250), 0.0001));
+    });
+
+    test('passes through unknown units unchanged', () {
+      expect(UnitCalc.metricToImperialValue(42, 'kcal'), equals(42));
+      expect(UnitCalc.metricToImperialValue(42, ''), equals(42));
+    });
+  });
+
+  group('UnitCalc.imperialToMetricValue', () {
+    test('converts ounces to grams', () {
+      expect(UnitCalc.imperialToMetricValue(2, 'oz'),
+          closeTo(UnitCalc.ozToG(2), 0.0001));
+    });
+
+    test('converts fl oz (both spelling variants) to ml', () {
+      expect(UnitCalc.imperialToMetricValue(8, 'fl oz'),
+          closeTo(UnitCalc.flOzToMl(8), 0.0001));
+      expect(UnitCalc.imperialToMetricValue(8, 'fl.oz'),
+          closeTo(UnitCalc.flOzToMl(8), 0.0001));
+    });
+
+    test('passes through unknown units unchanged', () {
+      expect(UnitCalc.imperialToMetricValue(42, 'kcal'), equals(42));
+    });
+  });
+}

--- a/test/unit_test/user_activity_repository_test.dart
+++ b/test/unit_test/user_activity_repository_test.dart
@@ -4,6 +4,7 @@ import 'package:opennutritracker/core/data/data_source/user_activity_data_source
 import 'package:opennutritracker/core/data/data_source/user_activity_dbo.dart';
 import 'package:opennutritracker/core/data/dbo/physical_activity_dbo.dart';
 import 'package:opennutritracker/core/data/repository/user_activity_repository.dart';
+import 'package:opennutritracker/core/domain/entity/user_activity_entity.dart';
 
 void main() {
   group('UserActivityRepository', () {
@@ -62,6 +63,216 @@ void main() {
       final result =
           await repo.updateUserActivity('nonexistent', 60.0, 100.0);
       expect(result, isNull);
+    });
+
+    test('updateUserActivity preserves the original date', () async {
+      final box = await Hive.openBox<UserActivityDBO>('activity_test');
+      final repo = UserActivityRepository(UserActivityDataSource(box));
+
+      final originalDate = DateTime.utc(2026, 3, 14, 9, 26, 53);
+      final physicalActivity = PhysicalActivityDBO(
+        'cycling_general',
+        'cycling, general',
+        'cycling, general',
+        7.5,
+        [],
+        PhysicalActivityTypeDBO.bicycling,
+      );
+      await box.add(UserActivityDBO(
+        'date-test',
+        45.0,
+        300.0,
+        originalDate,
+        physicalActivity,
+      ));
+
+      final updated = await repo.updateUserActivity('date-test', 30.0, 200.0);
+      expect(updated, isNotNull);
+      expect(updated!.date, equals(originalDate));
+    });
+
+    test('updateUserActivity preserves the underlying physical activity',
+        () async {
+      final box = await Hive.openBox<UserActivityDBO>('activity_test');
+      final repo = UserActivityRepository(UserActivityDataSource(box));
+
+      final physicalActivity = PhysicalActivityDBO(
+        'walking_brisk',
+        'walking, brisk',
+        'walking, brisk',
+        4.3,
+        ['walking'],
+        PhysicalActivityTypeDBO.sport,
+      );
+      await box.add(UserActivityDBO(
+        'phys-test',
+        20.0,
+        100.0,
+        DateTime.utc(2026, 1, 1),
+        physicalActivity,
+      ));
+
+      final updated = await repo.updateUserActivity('phys-test', 25.0, 130.0);
+      expect(updated!.physicalActivityEntity.code, equals('walking_brisk'));
+      expect(updated.physicalActivityEntity.mets, equals(4.3));
+    });
+
+    test('updateUserActivity accepts a zero duration without crashing',
+        () async {
+      final box = await Hive.openBox<UserActivityDBO>('activity_test');
+      final repo = UserActivityRepository(UserActivityDataSource(box));
+
+      final physicalActivity = PhysicalActivityDBO(
+        'running_general',
+        'running, general',
+        'running, general',
+        8.0,
+        [],
+        PhysicalActivityTypeDBO.running,
+      );
+      await box.add(UserActivityDBO(
+        'zero-test',
+        30.0,
+        50.0,
+        DateTime.utc(2024, 6, 1),
+        physicalActivity,
+      ));
+
+      final updated = await repo.updateUserActivity('zero-test', 0.0, 0.0);
+      expect(updated, isNotNull);
+      expect(updated!.duration, equals(0.0));
+      expect(updated.burnedKcal, equals(0.0));
+    });
+
+    test('two consecutive updates both work and the last one wins', () async {
+      final box = await Hive.openBox<UserActivityDBO>('activity_test');
+      await box.clear();
+      final repo = UserActivityRepository(UserActivityDataSource(box));
+
+      final physicalActivity = PhysicalActivityDBO(
+        'running_general',
+        'running, general',
+        'running, general',
+        8.0,
+        [],
+        PhysicalActivityTypeDBO.running,
+      );
+      await box.add(UserActivityDBO(
+        'multi-test',
+        30.0,
+        50.0,
+        DateTime.utc(2024, 6, 1),
+        physicalActivity,
+      ));
+
+      await repo.updateUserActivity('multi-test', 45.0, 75.0);
+      final second = await repo.updateUserActivity('multi-test', 60.0, 100.0);
+
+      expect(second, isNotNull);
+      expect(second!.duration, equals(60.0));
+      expect(second.burnedKcal, equals(100.0));
+
+      // The store should still hold exactly one row for that id.
+      final all = await repo.getAllUserActivityDBO();
+      final matches = all.where((a) => a.id == 'multi-test').toList();
+      expect(matches, hasLength(1));
+    });
+
+    test('deleteUserActivity removes the activity by id', () async {
+      final box = await Hive.openBox<UserActivityDBO>('activity_test');
+      final repo = UserActivityRepository(UserActivityDataSource(box));
+
+      final physicalActivity = PhysicalActivityDBO(
+        'running_general',
+        'running, general',
+        'running, general',
+        8.0,
+        [],
+        PhysicalActivityTypeDBO.running,
+      );
+      final activity = UserActivityDBO(
+        'delete-test',
+        30.0,
+        50.0,
+        DateTime.utc(2024, 6, 1),
+        physicalActivity,
+      );
+      await box.add(activity);
+
+      await repo.deleteUserActivity(
+        UserActivityEntity.fromUserActivityDBO(activity),
+      );
+
+      final all = await repo.getAllUserActivityDBO();
+      expect(all.where((a) => a.id == 'delete-test'), isEmpty);
+    });
+
+    test('getAllUserActivityByDate returns only same-day activities',
+        () async {
+      final box = await Hive.openBox<UserActivityDBO>('activity_test');
+      await box.clear();
+      final repo = UserActivityRepository(UserActivityDataSource(box));
+
+      final physicalActivity = PhysicalActivityDBO(
+        'walking_brisk',
+        'walking, brisk',
+        'walking, brisk',
+        4.3,
+        [],
+        PhysicalActivityTypeDBO.sport,
+      );
+
+      await box.addAll([
+        UserActivityDBO('a', 30, 50, DateTime.utc(2024, 6, 1, 8, 0),
+            physicalActivity),
+        UserActivityDBO('b', 30, 50, DateTime.utc(2024, 6, 1, 18, 0),
+            physicalActivity),
+        UserActivityDBO('c', 30, 50, DateTime.utc(2024, 6, 2, 8, 0),
+            physicalActivity),
+      ]);
+
+      final june1 =
+          await repo.getAllUserActivityByDate(DateTime.utc(2024, 6, 1, 12));
+      expect(june1.map((a) => a.id).toSet(), equals({'a', 'b'}));
+
+      final june2 =
+          await repo.getAllUserActivityByDate(DateTime.utc(2024, 6, 2));
+      expect(june2.map((a) => a.id).toList(), equals(['c']));
+    });
+
+    test('getRecentUserActivity dedups by physical activity code, '
+        'most recent first', () async {
+      final box = await Hive.openBox<UserActivityDBO>('activity_test');
+      await box.clear();
+      final repo = UserActivityRepository(UserActivityDataSource(box));
+
+      final running = PhysicalActivityDBO(
+        'running_general',
+        'running, general',
+        'running, general',
+        8.0,
+        [],
+        PhysicalActivityTypeDBO.running,
+      );
+      final cycling = PhysicalActivityDBO(
+        'cycling_general',
+        'cycling, general',
+        'cycling, general',
+        7.5,
+        [],
+        PhysicalActivityTypeDBO.bicycling,
+      );
+
+      await box.addAll([
+        UserActivityDBO('r1', 30, 50, DateTime.utc(2024, 6, 1), running),
+        UserActivityDBO('r2', 30, 50, DateTime.utc(2024, 6, 5), running),
+        UserActivityDBO('c1', 30, 50, DateTime.utc(2024, 6, 3), cycling),
+      ]);
+
+      final recent = await repo.getRecentUserActivity();
+      // r1 deduped because r2 is newer with same code.
+      expect(recent.map((a) => a.physicalActivityEntity.code).toList(),
+          equals(['running_general', 'cycling_general']));
     });
   });
 }


### PR DESCRIPTION
## Summary

- **+119 unit tests** locking down behaviour across the ~25 PRs merged into `develop` since the 2026-05-03 release. Test count goes from 135 → 254 (all passing, analyzer clean).
- **2 iOS bug fixes** caught during the audit:
  - `Info.plist` `CFBundleLocalizations` only listed `en` and `de` — iOS users couldn't pick `cz`, `it`, `pl`, `tr`, `uk`, or `zh` from system settings even though the strings ship with the app.
  - `AppDelegate.swift` was missing the `UNUserNotificationCenter` delegate setup that `flutter_local_notifications` requires on iOS 10+ for foreground notifications. Without it, the daily reminder would only display when the app was backgrounded.
- **1 small refactor** to extract the next-occurrence date arithmetic out of `NotificationService.scheduleDailyReminder` so it's pure-Dart and unit-testable across timezones / DST.

No production behaviour change in any other file.

## Coverage by area

| Area | Test file | New tests |
|---|---|---|
| Imperial unit round-trip (PR #348) | `unit_calc_imperial_round_trip_test.dart` | 20 |
| OFF/FDC search cache (PR #352) | `remote_search_cache_data_source_test.dart` | 18 |
| Custom meal dedup (PRs #347, #351) | `custom_meal_data_source_test.dart` | 9 |
| `withRetry` helper (PR #338) | `retry_util_test.dart` | 6 |
| Activity edit symmetry (PR #337) | `user_activity_repository_test.dart` (extended) | +7 |
| Tracked-day kcal/macro mutations | `tracked_day_data_source_test.dart` (extended) | +10 |
| Shared meal QR payload edge cases | `shared_meal_payload_compression_test.dart` (extended) | +7 |
| Calorie goal weekly-kg override | `calorie_goal_calc_test.dart` (extended) | +6 |
| Notification next-occurrence (DST-aware) | `notification_service_test.dart` | 11 |
| iOS locale drift prevention | `ios_localizations_drift_test.dart` | 1 |

## iOS-specific changes

- `ios/Runner/Info.plist`: 6 missing locales added.
- `ios/Runner/AppDelegate.swift`: 1 line + 1 import to wire up `UNUserNotificationCenter.current().delegate`.
- `test/unit_test/ios_localizations_drift_test.dart`: parses ARB filenames and Info.plist; fails fast if a future locale is added without updating Info.plist.

## Out of scope

A few iOS gaps need a Mac to verify — see the follow-up comment.

## Test plan

- [x] `just test` — 254 tests pass
- [x] `flutter analyze` — clean
- [x] `just check_intl` — clean