### PR TITLE
More progress feedback during integration test runs

### DIFF
--- a/.github/workflows/default_workflow.yml
+++ b/.github/workflows/default_workflow.yml
@@ -237,7 +237,10 @@ jobs:
           echo "DEVICE_UDID=$DEVICE_UDID" >> $GITHUB_ENV
 
       - name: Run integration tests
-        run: flutter test integration_test/ -d "$DEVICE_UDID" --reporter expanded
+        # --verbose surfaces flutter_tools' install / launch / VM-service-attach
+        # phases. Without it, there's a long silent gap between "Xcode build
+        # done" and the first test result that makes CI runs hard to follow.
+        run: flutter test integration_test/ -d "$DEVICE_UDID" --reporter expanded --verbose
 
   android-build:
     runs-on: ubuntu-latest
@@ -396,7 +399,8 @@ jobs:
           force-avd-creation: false
           emulator-options: -no-snapshot-save -no-window -gpu swiftshader_indirect -noaudio -no-boot-anim -camera-back none
           disable-animations: true
-          script: flutter test integration_test/ --reporter expanded
+          # --verbose: see comment on the iOS counterpart above
+          script: flutter test integration_test/ --reporter expanded --verbose
 
 # Historical reference — the original single-step `just ci` invocation that
 # was used before this workflow was split into linux-checks + ios-build.

--- a/integration_test/app_smoke_test.dart
+++ b/integration_test/app_smoke_test.dart
@@ -13,12 +13,21 @@ import 'package:opennutritracker/main.dart' as app;
 /// to navigate past onboarding here — driving inputs requires platform-
 /// specific keyboard / picker handling that is out of scope for a basic
 /// boot-smoke.
+///
+/// `[smoke]`-prefixed prints below are intentional progress markers — there
+/// is otherwise a long silent gap between "Xcode build done" and the first
+/// assertion result, which makes CI runs hard to follow.
 void main() {
   IntegrationTestWidgetsFlutterBinding.ensureInitialized();
 
   testWidgets(
     'app boots, reaches a MaterialApp screen, no uncaught exceptions',
     (WidgetTester tester) async {
+      final stopwatch = Stopwatch()..start();
+      void mark(String step) =>
+          debugPrint('[smoke] +${stopwatch.elapsed.inMilliseconds}ms $step');
+
+      mark('test entered, installing FlutterError.onError sink');
       final caughtErrors = <FlutterErrorDetails>[];
       final originalOnError = FlutterError.onError;
       FlutterError.onError = (details) {
@@ -26,15 +35,28 @@ void main() {
         originalOnError?.call(details);
       };
 
+      mark('calling app.main() — runs initLocator, Hive, Supabase init, etc.');
       await app.main();
+
+      mark('app.main() returned, calling pumpAndSettle (≤30s)');
       await tester.pumpAndSettle(const Duration(seconds: 30));
 
-      expect(find.byType(MaterialApp), findsOneWidget,
-          reason: 'app should reach a MaterialApp');
-      expect(caughtErrors, isEmpty,
-          reason: 'no Flutter errors should fire during boot, got: '
-              '${caughtErrors.map((e) => e.exception).toList()}');
+      mark('pumpAndSettle complete, asserting MaterialApp on screen');
+      expect(
+        find.byType(MaterialApp),
+        findsOneWidget,
+        reason: 'app should reach a MaterialApp',
+      );
 
+      mark('MaterialApp found, asserting no Flutter errors fired');
+      expect(
+        caughtErrors,
+        isEmpty,
+        reason: 'no Flutter errors should fire during boot, got: '
+            '${caughtErrors.map((e) => e.exception).toList()}',
+      );
+
+      mark('all assertions passed, teardown');
       FlutterError.onError = originalOnError;
     },
   );


### PR DESCRIPTION
## Why

The integration test had a long silent gap between flutter_tools' \`Xcode build done\` line and the first assertion result. Anyone watching a CI run couldn't tell whether install / launch / VM-attach was progressing or hung.

## What changed

1. **Test body**: timestamped \`[smoke]\` progress markers via \`debugPrint\` at each phase. Output looks like:
   ```
   [smoke] +0ms test entered, installing FlutterError.onError sink
   [smoke] +2ms calling app.main() — runs initLocator, Hive, Supabase init, etc.
   [smoke] +1843ms app.main() returned, calling pumpAndSettle (≤30s)
   [smoke] +12005ms pumpAndSettle complete, asserting MaterialApp on screen
   ```

2. **CI**: \`flutter test integration_test/ ... --verbose\` on both the iOS and Android jobs. Surfaces flutter_tools' install / launch / VM-service-attach steps that were previously silent.

No behaviour change in the test itself — same assertions, same expected pass/fail.