### PR TITLE
fix(home,onboarding,profile): correct kcal budget after onboarding and on hormone-profile changes

### DIFF
--- a/lib/core/data/data_source/config_data_source.dart
+++ b/lib/core/data/data_source/config_data_source.dart
@@ -38,7 +38,7 @@ class ConfigDataSource {
     );
     final config = _configBox.get(_configKey);
     config?.hasAcceptedSendAnonymousData = hasAcceptedAnonymousData;
-    config?.save();
+    await config?.save();
   }
 
   Future<AppThemeDBO> getAppTheme() async {
@@ -57,7 +57,7 @@ class ConfigDataSource {
     _log.fine('Updating config usesImperialUnits to $usesImperialUnits');
     final config = _configBox.get(_configKey);
     config?.usesImperialUnits = usesImperialUnits;
-    config?.save();
+    await config?.save();
   }
 
   Future<double> getKcalAdjustment() async {

--- a/lib/core/data/data_source/config_data_source.dart
+++ b/lib/core/data/data_source/config_data_source.dart
@@ -18,7 +18,7 @@ class ConfigDataSource {
 
   Future<void> addConfig(ConfigDBO configDBO) async {
     _log.fine('Adding new config item to db');
-    _configBox.put(_configKey, configDBO);
+    await _configBox.put(_configKey, configDBO);
   }
 
   Future<void> setConfigDisclaimer(bool hasAcceptedDisclaimer) async {
@@ -27,7 +27,7 @@ class ConfigDataSource {
     );
     final config = _configBox.get(_configKey);
     config?.hasAcceptedDisclaimer = hasAcceptedDisclaimer;
-    config?.save();
+    await config?.save();
   }
 
   Future<void> setConfigAcceptedAnonymousData(
@@ -50,7 +50,7 @@ class ConfigDataSource {
     _log.fine('Updating config appTheme to $appTheme');
     final config = _configBox.get(_configKey);
     config?.selectedAppTheme = appTheme;
-    config?.save();
+    await config?.save();
   }
 
   Future<void> setConfigUsesImperialUnits(bool usesImperialUnits) async {
@@ -69,49 +69,49 @@ class ConfigDataSource {
     _log.fine('Updating config kcalAdjustment to $kcalAdjustment');
     final config = _configBox.get(_configKey);
     config?.userKcalAdjustment = kcalAdjustment;
-    config?.save();
+    await config?.save();
   }
 
   Future<void> setConfigCarbGoalPct(double carbGoalPct) async {
     _log.fine('Updating config carbGoalPct to $carbGoalPct');
     final config = _configBox.get(_configKey);
     config?.userCarbGoalPct = carbGoalPct;
-    config?.save();
+    await config?.save();
   }
 
   Future<void> setConfigProteinGoalPct(double proteinGoalPct) async {
     _log.fine('Updating config proteinGoalPct to $proteinGoalPct');
     final config = _configBox.get(_configKey);
     config?.userProteinGoalPct = proteinGoalPct;
-    config?.save();
+    await config?.save();
   }
 
   Future<void> setConfigFatGoalPct(double fatGoalPct) async {
     _log.fine('Updating config fatGoalPct to $fatGoalPct');
     final config = _configBox.get(_configKey);
     config?.userFatGoalPct = fatGoalPct;
-    config?.save();
+    await config?.save();
   }
 
   Future<void> setConfigShowActivityTracking(bool show) async {
     _log.fine('Updating config showActivityTracking to $show');
     final config = _configBox.get(_configKey);
     config?.showActivityTracking = show;
-    config?.save();
+    await config?.save();
   }
 
   Future<void> setConfigShowMealMacros(bool show) async {
     _log.fine('Updating config showMealMacros to $show');
     final config = _configBox.get(_configKey);
     config?.showMealMacros = show;
-    config?.save();
+    await config?.save();
   }
 
   Future<void> setNotificationsEnabled(bool enabled) async {
     _log.fine('Updating config notificationsEnabled to $enabled');
     final config = _configBox.get(_configKey);
     config?.notificationsEnabled = enabled;
-    config?.save();
+    await config?.save();
   }
 
   Future<void> setNotificationTime(int hour, int minute) async {
@@ -119,7 +119,7 @@ class ConfigDataSource {
     final config = _configBox.get(_configKey);
     config?.notificationHour = hour;
     config?.notificationMinute = minute;
-    config?.save();
+    await config?.save();
   }
 
   Future<String?> getSelectedLocale() async {
@@ -137,14 +137,14 @@ class ConfigDataSource {
     _log.fine('Updating config selectedLocale to $locale');
     final config = _configBox.get(_configKey);
     config?.selectedLocale = locale;
-    config?.save();
+    await config?.save();
   }
 
   Future<void> setConfigShowMicronutrients(bool show) async {
     _log.fine('Updating config showMicronutrients to $show');
     final config = _configBox.get(_configKey);
     config?.showMicronutrients = show;
-    config?.save();
+    await config?.save();
   }
 
 

--- a/lib/core/data/data_source/intake_data_source.dart
+++ b/lib/core/data/data_source/intake_data_source.dart
@@ -14,21 +14,21 @@ class IntakeDataSource {
 
   Future<void> addIntake(IntakeDBO intakeDBO) async {
     log.fine('Adding new intake item to db');
-    _intakeBox.add(intakeDBO);
+    await _intakeBox.add(intakeDBO);
   }
 
   Future<void> addAllIntakes(List<IntakeDBO> intakeDBOList) async {
     log.fine('Adding new intake items to db');
-    _intakeBox.addAll(intakeDBOList);
+    await _intakeBox.addAll(intakeDBOList);
   }
 
   Future<void> deleteIntakeFromId(String intakeId) async {
     log.fine('Deleting intake item from db');
-    _intakeBox.values.where((dbo) => dbo.id == intakeId).toList().forEach((
-      element,
-    ) {
-      element.delete();
-    });
+    final toDelete =
+        _intakeBox.values.where((dbo) => dbo.id == intakeId).toList();
+    for (final element in toDelete) {
+      await element.delete();
+    }
   }
 
   Future<IntakeDBO?> updateIntake(
@@ -46,7 +46,7 @@ class IntakeDataSource {
       return null;
     }
     intakeObject.$2.amount = fields['amount'] ?? intakeObject.$2.amount;
-    _intakeBox.putAt(intakeObject.$1, intakeObject.$2);
+    await _intakeBox.putAt(intakeObject.$1, intakeObject.$2);
     return _intakeBox.getAt(intakeObject.$1);
   }
 

--- a/lib/core/data/data_source/tracked_day_data_source.dart
+++ b/lib/core/data/data_source/tracked_day_data_source.dart
@@ -11,12 +11,12 @@ class TrackedDayDataSource {
 
   Future<void> saveTrackedDay(TrackedDayDBO trackedDayDBO) async {
     log.fine('Updating tracked day in db');
-    _trackedDayBox.put(trackedDayDBO.day.toParsedDay(), trackedDayDBO);
+    await _trackedDayBox.put(trackedDayDBO.day.toParsedDay(), trackedDayDBO);
   }
 
   Future<void> saveAllTrackedDays(List<TrackedDayDBO> trackedDayDBOList) async {
     log.fine('Updating tracked days in db');
-    _trackedDayBox.putAll({
+    await _trackedDayBox.putAll({
       for (var trackedDayDBO in trackedDayDBOList)
         trackedDayDBO.day.toParsedDay(): trackedDayDBO,
     });
@@ -52,7 +52,7 @@ class TrackedDayDataSource {
 
     if (updateDay != null) {
       updateDay.calorieGoal = calorieGoal;
-      updateDay.save();
+      await updateDay.save();
     }
   }
 
@@ -62,7 +62,7 @@ class TrackedDayDataSource {
 
     if (updateDay != null) {
       updateDay.calorieGoal += amount;
-      updateDay.save();
+      await updateDay.save();
     }
   }
 
@@ -72,7 +72,7 @@ class TrackedDayDataSource {
 
     if (updateDay != null) {
       updateDay.calorieGoal -= amount;
-      updateDay.save();
+      await updateDay.save();
     }
   }
 
@@ -82,7 +82,7 @@ class TrackedDayDataSource {
 
     if (updateDay != null) {
       updateDay.caloriesTracked += addCalories;
-      updateDay.save();
+      await updateDay.save();
     }
   }
 
@@ -95,7 +95,7 @@ class TrackedDayDataSource {
 
     if (updateDay != null) {
       updateDay.caloriesTracked -= addCalories;
-      updateDay.save();
+      await updateDay.save();
     }
   }
 
@@ -119,7 +119,7 @@ class TrackedDayDataSource {
       if (proteinGoal != null) {
         updateDay.proteinGoal = proteinGoal;
       }
-      updateDay.save();
+      await updateDay.save();
     }
   }
 
@@ -142,7 +142,7 @@ class TrackedDayDataSource {
       if (proteinAmount != null) {
         updateDay.proteinGoal = (updateDay.proteinGoal ?? 0) + proteinAmount;
       }
-      updateDay.save();
+      await updateDay.save();
     }
   }
 
@@ -165,7 +165,7 @@ class TrackedDayDataSource {
       if (proteinAmount != null) {
         updateDay.proteinGoal = (updateDay.proteinGoal ?? 0) - proteinAmount;
       }
-      updateDay.save();
+      await updateDay.save();
     }
   }
 
@@ -189,7 +189,7 @@ class TrackedDayDataSource {
         updateDay.proteinTracked =
             (updateDay.proteinTracked ?? 0) + proteinAmount;
       }
-      updateDay.save();
+      await updateDay.save();
     }
   }
 
@@ -213,7 +213,7 @@ class TrackedDayDataSource {
         updateDay.proteinTracked =
             (updateDay.proteinTracked ?? 0) - proteinAmount;
       }
-      updateDay.save();
+      await updateDay.save();
     }
   }
 
@@ -231,7 +231,7 @@ class TrackedDayDataSource {
       updateDay.carbsTracked = carbs;
       updateDay.fatTracked = fat;
       updateDay.proteinTracked = protein;
-      updateDay.save();
+      await updateDay.save();
     }
   }
 }

--- a/lib/core/data/data_source/user_activity_data_source.dart
+++ b/lib/core/data/data_source/user_activity_data_source.dart
@@ -12,14 +12,14 @@ class UserActivityDataSource {
 
   Future<void> addUserActivity(UserActivityDBO userActivityDBO) async {
     log.fine('Adding new user activity to db');
-    _userActivityBox.add(userActivityDBO);
+    await _userActivityBox.add(userActivityDBO);
   }
 
   Future<void> addAllUserActivities(
     List<UserActivityDBO> userActivityDBOList,
   ) async {
     log.fine('Adding new user activities to db');
-    _userActivityBox.addAll(userActivityDBOList);
+    await _userActivityBox.addAll(userActivityDBOList);
   }
 
   Future<UserActivityDBO?> updateUserActivity(
@@ -45,12 +45,12 @@ class UserActivityDataSource {
 
   Future<void> deleteIntakeFromId(String activityId) async {
     log.fine('Deleting activity item from db');
-    _userActivityBox.values
+    final toDelete = _userActivityBox.values
         .where((dbo) => dbo.id == activityId)
-        .toList()
-        .forEach((element) {
-      element.delete();
-    });
+        .toList();
+    for (final element in toDelete) {
+      await element.delete();
+    }
   }
 
   Future<List<UserActivityDBO>> getAllUserActivities() async {

--- a/lib/core/data/data_source/user_data_source.dart
+++ b/lib/core/data/data_source/user_data_source.dart
@@ -1,9 +1,6 @@
 import 'package:hive_ce_flutter/hive_flutter.dart';
 import 'package:logging/logging.dart';
 import 'package:opennutritracker/core/data/dbo/user_dbo.dart';
-import 'package:opennutritracker/core/data/dbo/user_gender_dbo.dart';
-import 'package:opennutritracker/core/data/dbo/user_pal_dbo.dart';
-import 'package:opennutritracker/core/data/dbo/user_weight_goal_dbo.dart';
 
 class UserDataSource {
   static const _userKey = "UserKey";
@@ -14,21 +11,19 @@ class UserDataSource {
 
   Future<void> saveUserData(UserDBO userDBO) async {
     log.fine('Updating user in db');
-    _userBox.put(_userKey, userDBO);
+    await _userBox.put(_userKey, userDBO);
   }
 
   Future<bool> hasUserData() async => _userBox.containsKey(_userKey);
 
-  // TODO remove dummy data
   Future<UserDBO> getUserData() async {
-    return _userBox.get(_userKey) ??
-        UserDBO(
-          birthday: DateTime(2000, 1, 1),
-          heightCM: 180,
-          weightKG: 80,
-          gender: UserGenderDBO.male,
-          goal: UserWeightGoalDBO.maintainWeight,
-          pal: UserPALDBO.active,
-        );
+    final user = _userBox.get(_userKey);
+    if (user == null) {
+      throw StateError(
+        'UserDataSource.getUserData() called before user was saved — '
+        'check hasUserData() first or ensure onboarding has completed.',
+      );
+    }
+    return user;
   }
 }

--- a/lib/core/data/repository/config_repository.dart
+++ b/lib/core/data/repository/config_repository.dart
@@ -11,11 +11,11 @@ class ConfigRepository {
 
   Future<void> updateConfig(ConfigEntity configEntity) async {
     final configDBO = ConfigDBO.fromConfigEntity(configEntity);
-    _configDataSource.addConfig(configDBO);
+    await _configDataSource.addConfig(configDBO);
   }
 
   Future<void> setConfigDisclaimer(bool hasAcceptedDisclaimer) async {
-    _configDataSource.setConfigDisclaimer(hasAcceptedDisclaimer);
+    await _configDataSource.setConfigDisclaimer(hasAcceptedDisclaimer);
   }
 
   Future<void> setConfigHasAcceptedAnonymousData(
@@ -60,29 +60,29 @@ class ConfigRepository {
   }
 
   Future<void> setConfigKcalAdjustment(double kcalAdjustment) async {
-    _configDataSource.setConfigKcalAdjustment(kcalAdjustment);
+    await _configDataSource.setConfigKcalAdjustment(kcalAdjustment);
   }
 
   Future<void> setConfigShowActivityTracking(bool show) async {
-    _configDataSource.setConfigShowActivityTracking(show);
+    await _configDataSource.setConfigShowActivityTracking(show);
   }
 
   Future<void> setConfigShowMealMacros(bool show) async {
-    _configDataSource.setConfigShowMealMacros(show);
+    await _configDataSource.setConfigShowMealMacros(show);
   }
 
   Future<void> setUserMacroPct(double carbs, double protein, double fat) async {
-    _configDataSource.setConfigCarbGoalPct(carbs);
-    _configDataSource.setConfigProteinGoalPct(protein);
-    _configDataSource.setConfigFatGoalPct(fat);
+    await _configDataSource.setConfigCarbGoalPct(carbs);
+    await _configDataSource.setConfigProteinGoalPct(protein);
+    await _configDataSource.setConfigFatGoalPct(fat);
   }
 
   Future<void> setNotificationsEnabled(bool enabled) async {
-    _configDataSource.setNotificationsEnabled(enabled);
+    await _configDataSource.setNotificationsEnabled(enabled);
   }
 
   Future<void> setNotificationTime(int hour, int minute) async {
-    _configDataSource.setNotificationTime(hour, minute);
+    await _configDataSource.setNotificationTime(hour, minute);
   }
 
   Future<String?> getSelectedLocale() async {
@@ -90,10 +90,10 @@ class ConfigRepository {
   }
 
   Future<void> setSelectedLocale(String? locale) async {
-    _configDataSource.setSelectedLocale(locale);
+    await _configDataSource.setSelectedLocale(locale);
   }
 
   Future<void> setConfigShowMicronutrients(bool show) async {
-    _configDataSource.setConfigShowMicronutrients(show);
+    await _configDataSource.setConfigShowMicronutrients(show);
   }
 }

--- a/lib/core/data/repository/config_repository.dart
+++ b/lib/core/data/repository/config_repository.dart
@@ -21,7 +21,9 @@ class ConfigRepository {
   Future<void> setConfigHasAcceptedAnonymousData(
     bool hasAcceptedAnonymousData,
   ) async {
-    _configDataSource.setConfigAcceptedAnonymousData(hasAcceptedAnonymousData);
+    await _configDataSource.setConfigAcceptedAnonymousData(
+      hasAcceptedAnonymousData,
+    );
   }
 
   Future<bool> getConfigHasAcceptedAnonymousData() async {
@@ -50,7 +52,7 @@ class ConfigRepository {
   }
 
   Future<void> setConfigUsesImperialUnits(bool usesImperialUnits) async {
-    _configDataSource.setConfigUsesImperialUnits(usesImperialUnits);
+    await _configDataSource.setConfigUsesImperialUnits(usesImperialUnits);
   }
 
   Future<double> getConfigKcalAdjustment() async {

--- a/lib/core/data/repository/tracked_day_repository.dart
+++ b/lib/core/data/repository/tracked_day_repository.dart
@@ -44,15 +44,15 @@ class TrackedDayRepository {
   }
 
   Future<void> updateDayCalorieGoal(DateTime day, double calorieGoal) async {
-    _trackedDayDataSource.updateDayCalorieGoal(day, calorieGoal);
+    await _trackedDayDataSource.updateDayCalorieGoal(day, calorieGoal);
   }
 
   Future<void> increaseDayCalorieGoal(DateTime day, double amount) async {
-    _trackedDayDataSource.increaseDayCalorieGoal(day, amount);
+    await _trackedDayDataSource.increaseDayCalorieGoal(day, amount);
   }
 
   Future<void> reduceDayCalorieGoal(DateTime day, double amount) async {
-    _trackedDayDataSource.reduceDayCalorieGoal(day, amount);
+    await _trackedDayDataSource.reduceDayCalorieGoal(day, amount);
   }
 
   Future<void> addNewTrackedDay(
@@ -62,7 +62,7 @@ class TrackedDayRepository {
     double totalFatGoal,
     double totalProteinGoal,
   ) async {
-    _trackedDayDataSource.saveTrackedDay(
+    await _trackedDayDataSource.saveTrackedDay(
       TrackedDayDBO(
         day: day,
         calorieGoal: totalKcalGoal,
@@ -83,7 +83,7 @@ class TrackedDayRepository {
 
   Future<void> addDayTrackedCalories(DateTime day, double addCalories) async {
     if (await _trackedDayDataSource.hasTrackedDay(day)) {
-      _trackedDayDataSource.addDayCaloriesTracked(day, addCalories);
+      await _trackedDayDataSource.addDayCaloriesTracked(day, addCalories);
     }
   }
 
@@ -92,7 +92,7 @@ class TrackedDayRepository {
     double addCalories,
   ) async {
     if (await _trackedDayDataSource.hasTrackedDay(day)) {
-      _trackedDayDataSource.decreaseDayCaloriesTracked(day, addCalories);
+      await _trackedDayDataSource.decreaseDayCaloriesTracked(day, addCalories);
     }
   }
 
@@ -102,7 +102,7 @@ class TrackedDayRepository {
     double? fatGoal,
     double? proteinGoal,
   }) async {
-    _trackedDayDataSource.updateDayMacroGoals(
+    await _trackedDayDataSource.updateDayMacroGoals(
       day,
       carbsGoal: carbGoal,
       fatGoal: fatGoal,
@@ -116,7 +116,7 @@ class TrackedDayRepository {
     double? fatGoal,
     double? proteinGoal,
   }) async {
-    _trackedDayDataSource.increaseDayMacroGoal(
+    await _trackedDayDataSource.increaseDayMacroGoal(
       day,
       carbsAmount: carbGoal,
       fatAmount: fatGoal,
@@ -130,7 +130,7 @@ class TrackedDayRepository {
     double? fatGoal,
     double? proteinGoal,
   }) async {
-    _trackedDayDataSource.reduceDayMacroGoal(
+    await _trackedDayDataSource.reduceDayMacroGoal(
       day,
       carbsAmount: carbGoal,
       fatAmount: fatGoal,
@@ -144,7 +144,7 @@ class TrackedDayRepository {
     double? fatTracked,
     double? proteinTracked,
   }) async {
-    _trackedDayDataSource.addDayMacroTracked(
+    await _trackedDayDataSource.addDayMacroTracked(
       day,
       carbsAmount: carbsTracked,
       fatAmount: fatTracked,
@@ -158,7 +158,7 @@ class TrackedDayRepository {
     double? fatTracked,
     double? proteinTracked,
   }) async {
-    _trackedDayDataSource.removeDayMacroTracked(
+    await _trackedDayDataSource.removeDayMacroTracked(
       day,
       carbsAmount: carbsTracked,
       fatAmount: fatTracked,

--- a/lib/core/data/repository/user_activity_repository.dart
+++ b/lib/core/data/repository/user_activity_repository.dart
@@ -10,7 +10,7 @@ class UserActivityRepository {
   Future<void> addUserActivity(UserActivityEntity activityEntity) async {
     final activityDBO = UserActivityDBO.fromUserActivityEntity(activityEntity);
 
-    _userActivityDataSource.addUserActivity(activityDBO);
+    await _userActivityDataSource.addUserActivity(activityDBO);
   }
 
   Future<void> addAllUserActivityDBOs(

--- a/lib/core/data/repository/user_repository.dart
+++ b/lib/core/data/repository/user_repository.dart
@@ -9,7 +9,7 @@ class UserRepository {
 
   Future<void> updateUserData(UserEntity userEntity) async {
     final userDBO = UserDBO.fromUserEntity(userEntity);
-    _userDataSource.saveUserData(userDBO);
+    await _userDataSource.saveUserData(userDBO);
   }
 
   Future<bool> hasUserData() async => await _userDataSource.hasUserData();

--- a/lib/core/domain/usecase/add_config_usecase.dart
+++ b/lib/core/domain/usecase/add_config_usecase.dart
@@ -18,7 +18,7 @@ class AddConfigUsecase {
   Future<void> setConfigHasAcceptedAnonymousData(
     bool hasAcceptedAnonymousData,
   ) async {
-    _configRepository.setConfigHasAcceptedAnonymousData(
+    await _configRepository.setConfigHasAcceptedAnonymousData(
       hasAcceptedAnonymousData,
     );
   }
@@ -28,7 +28,7 @@ class AddConfigUsecase {
   }
 
   Future<void> setConfigUsesImperialUnits(bool usesImperialUnits) async {
-    _configRepository.setConfigUsesImperialUnits(usesImperialUnits);
+    await _configRepository.setConfigUsesImperialUnits(usesImperialUnits);
   }
 
   Future<void> setConfigKcalAdjustment(double kcalAdjustment) async {

--- a/lib/core/domain/usecase/add_config_usecase.dart
+++ b/lib/core/domain/usecase/add_config_usecase.dart
@@ -32,7 +32,7 @@ class AddConfigUsecase {
   }
 
   Future<void> setConfigKcalAdjustment(double kcalAdjustment) async {
-    _configRepository.setConfigKcalAdjustment(kcalAdjustment);
+    await _configRepository.setConfigKcalAdjustment(kcalAdjustment);
   }
 
   Future<void> setConfigMacroGoalPct(
@@ -40,7 +40,11 @@ class AddConfigUsecase {
     double proteinGoalPct,
     double fatPctGoal,
   ) async {
-    _configRepository.setUserMacroPct(carbGoalPct, proteinGoalPct, fatPctGoal);
+    await _configRepository.setUserMacroPct(
+      carbGoalPct,
+      proteinGoalPct,
+      fatPctGoal,
+    );
   }
 
 

--- a/lib/core/presentation/widgets/calories_profile_info_dialog.dart
+++ b/lib/core/presentation/widgets/calories_profile_info_dialog.dart
@@ -39,24 +39,33 @@ class _CaloriesProfileInfoDialogState extends State<CaloriesProfileInfoDialog> {
               style: Theme.of(context).textTheme.bodyMedium,
             ),
             const SizedBox(height: 16),
-            RadioGroup<CaloriesProfileEntity>(
-              groupValue: _selected,
-              onChanged: (value) {
-                if (value != null) {
-                  setState(() => _selected = value);
-                }
-              },
-              child: Column(
-                mainAxisSize: MainAxisSize.min,
-                children: [
-                  for (final profile in CaloriesProfileEntity.values)
-                    RadioListTile<CaloriesProfileEntity>(
-                      value: profile,
-                      contentPadding: EdgeInsets.zero,
-                      title: Text(profile.getName(context)),
-                    ),
-                ],
-              ),
+            // Use the per-tile groupValue/onChanged form rather than a
+            // RadioGroup ancestor: the ancestor form does not always
+            // propagate taps to RadioListTile children (the bug surfaced
+            // here was that switching estrogen ↔ testosterone produced
+            // no kcal change because OK kept returning the initial value).
+            // The per-tile API is marked deprecated in newer SDKs, but it
+            // is the only form that captures the selection reliably.
+            // ignore: deprecated_member_use
+            Column(
+              mainAxisSize: MainAxisSize.min,
+              children: [
+                for (final profile in CaloriesProfileEntity.values)
+                  // ignore: deprecated_member_use
+                  RadioListTile<CaloriesProfileEntity>(
+                    value: profile,
+                    // ignore: deprecated_member_use
+                    groupValue: _selected,
+                    // ignore: deprecated_member_use
+                    onChanged: (value) {
+                      if (value != null) {
+                        setState(() => _selected = value);
+                      }
+                    },
+                    contentPadding: EdgeInsets.zero,
+                    title: Text(profile.getName(context)),
+                  ),
+              ],
             ),
           ],
         ),

--- a/lib/core/utils/calc/pal_calc.dart
+++ b/lib/core/utils/calc/pal_calc.dart
@@ -33,7 +33,13 @@ class PalCalc {
 
   ///
   /// Returns the physical activity coefficient (PA) from the PAL value
-  /// and user gender based on IOM recommendation
+  /// and the formula's gender reference based on IOM recommendation.
+  ///
+  /// `isMaleFormula` decouples the PA constant from the user's stored
+  /// gender — needed so non-binary `averaged` TDEE feeds male PA into the
+  /// male half of the average and female PA into the female half. Picking
+  /// PA from `userEntity.gender` directly would route both halves to the
+  /// female constant for any non-binary user.
   ///
   /// Institute of Medicine. 2005. Dietary Reference Intakes for Energy,
   /// Carbohydrate, Fiber, Fat, Fatty Acids, Cholesterol, Protein,
@@ -41,21 +47,24 @@ class PalCalc {
   /// Washington, DC: The National Academies Press.
   /// https://doi.org/10.17226/10490.
   /// https://nap.nationalacademies.org/catalog/10490/dietary-reference-intakes-for-energy-carbohydrate-fiber-fat-fatty-acids-cholesterol-protein-and-amino-acids
+  static double getPAValueForFormula({
+    required double palValue,
+    required bool isMaleFormula,
+  }) {
+    if (palValue < 1.4) return 1.0;
+    if (palValue < 1.6) return isMaleFormula ? 1.12 : 1.14;
+    if (palValue < 1.9) return 1.27;
+    return isMaleFormula ? 1.54 : 1.45;
+  }
+
+  /// Convenience wrapper that picks the PA constant from the user's stored
+  /// gender. Non-binary users go through the female PA — callers that need
+  /// to compute male and female references separately (e.g. averaged TDEE)
+  /// should call [getPAValueForFormula] directly with explicit flags.
   static double getPAValueFromPALValue(UserEntity userEntity, double palValue) {
-    double paValue = 1.0;
-    if (palValue < 1.4) {
-      paValue = 1.0;
-    } else if (palValue < 1.6) {
-      userEntity.gender == UserGenderEntity.male
-          ? paValue = 1.12
-          : paValue = 1.14;
-    } else if (palValue < 1.9) {
-      paValue = 1.27;
-    } else {
-      userEntity.gender == UserGenderEntity.male
-          ? paValue = 1.54
-          : paValue = 1.45;
-    }
-    return paValue;
+    return getPAValueForFormula(
+      palValue: palValue,
+      isMaleFormula: userEntity.gender == UserGenderEntity.male,
+    );
   }
 }

--- a/lib/core/utils/calc/tdee_calc.dart
+++ b/lib/core/utils/calc/tdee_calc.dart
@@ -50,26 +50,26 @@ class TDEECalc {
   }
 
   static double _iom2005MaleKcal(UserEntity userEntity) {
+    final palValue = PalCalc.getPALValueFromActivityCategory(userEntity);
+    final paValue = PalCalc.getPAValueForFormula(
+      palValue: palValue,
+      isMaleFormula: true,
+    );
     return 864 -
         9.72 * userEntity.age +
-        PalCalc.getPAValueFromPALValue(
-              userEntity,
-              PalCalc.getPALValueFromActivityCategory(userEntity),
-            ) *
-            14.2 *
-            userEntity.weightKG +
+        paValue * 14.2 * userEntity.weightKG +
         503 * (userEntity.heightCM / 100);
   }
 
   static double _iom2005FemaleKcal(UserEntity userEntity) {
+    final palValue = PalCalc.getPALValueFromActivityCategory(userEntity);
+    final paValue = PalCalc.getPAValueForFormula(
+      palValue: palValue,
+      isMaleFormula: false,
+    );
     return 387 -
         7.31 * userEntity.age +
-        PalCalc.getPAValueFromPALValue(
-              userEntity,
-              PalCalc.getPALValueFromActivityCategory(userEntity),
-            ) *
-            10.9 *
-            userEntity.weightKG +
+        paValue * 10.9 * userEntity.weightKG +
         660.7 * (userEntity.heightCM / 100);
   }
 }

--- a/lib/core/utils/hive_db_provider.dart
+++ b/lib/core/utils/hive_db_provider.dart
@@ -3,20 +3,13 @@ import 'dart:typed_data';
 import 'package:flutter/material.dart';
 import 'package:hive_ce_flutter/hive_flutter.dart';
 import 'package:opennutritracker/core/data/data_source/user_activity_dbo.dart';
-import 'package:opennutritracker/core/data/dbo/app_theme_dbo.dart';
 import 'package:opennutritracker/core/data/dbo/config_dbo.dart';
 import 'package:opennutritracker/core/data/dbo/intake_dbo.dart';
-import 'package:opennutritracker/core/data/dbo/intake_type_dbo.dart';
-import 'package:opennutritracker/core/data/dbo/physical_activity_dbo.dart';
 import 'package:opennutritracker/core/data/dbo/meal_dbo.dart';
-import 'package:opennutritracker/core/data/dbo/meal_nutriments_dbo.dart';
 import 'package:opennutritracker/core/data/dbo/recipe_dbo.dart';
-import 'package:opennutritracker/core/data/dbo/recipe_ingredient_dbo.dart';
 import 'package:opennutritracker/core/data/dbo/tracked_day_dbo.dart';
 import 'package:opennutritracker/core/data/dbo/user_dbo.dart';
-import 'package:opennutritracker/core/data/dbo/user_gender_dbo.dart';
-import 'package:opennutritracker/core/data/dbo/user_pal_dbo.dart';
-import 'package:opennutritracker/core/data/dbo/user_weight_goal_dbo.dart';
+import 'package:opennutritracker/hive_registrar.g.dart';
 
 class HiveDBProvider extends ChangeNotifier {
   static const configBoxName = 'ConfigBox';
@@ -45,23 +38,13 @@ class HiveDBProvider extends ChangeNotifier {
   Future<void> initHiveDB(Uint8List encryptionKey) async {
     final encryptionCypher = HiveAesCipher(encryptionKey);
     await Hive.initFlutter();
-    Hive.registerAdapter(ConfigDBOAdapter());
-    Hive.registerAdapter(IntakeDBOAdapter());
-    Hive.registerAdapter(MealDBOAdapter());
-    Hive.registerAdapter(MealNutrimentsDBOAdapter());
-    Hive.registerAdapter(MealSourceDBOAdapter());
-    Hive.registerAdapter(IntakeTypeDBOAdapter());
-    Hive.registerAdapter(UserDBOAdapter());
-    Hive.registerAdapter(UserGenderDBOAdapter());
-    Hive.registerAdapter(UserWeightGoalDBOAdapter());
-    Hive.registerAdapter(UserPALDBOAdapter());
-    Hive.registerAdapter(TrackedDayDBOAdapter());
-    Hive.registerAdapter(UserActivityDBOAdapter());
-    Hive.registerAdapter(PhysicalActivityDBOAdapter());
-    Hive.registerAdapter(PhysicalActivityTypeDBOAdapter());
-    Hive.registerAdapter(AppThemeDBOAdapter());
-    Hive.registerAdapter(RecipeDBOAdapter());
-    Hive.registerAdapter(RecipeIngredientDBOAdapter());
+    // Delegate to the generated registrar so any new DBO type added to
+    // the project is registered automatically on the next `just build`.
+    // Registering by hand had drifted out of sync — `CaloriesProfileDBO`
+    // (#7 on UserDBO) was missing, causing every save with a non-null
+    // hormone profile to throw, which the previous broken async chains
+    // swallowed silently. Result: profile reset to null on app relaunch.
+    Hive.registerAdapters();
 
     configBox = await Hive.openBox(
       configBoxName,

--- a/lib/core/utils/locator.dart
+++ b/lib/core/utils/locator.dart
@@ -119,6 +119,7 @@ Future<void> initLocator() async {
       locator(),
       locator(),
       locator(),
+      locator(),
     ),
   );
   locator.registerLazySingleton(() => DiaryBloc(locator(), locator()));

--- a/lib/features/home/home_page.dart
+++ b/lib/features/home/home_page.dart
@@ -77,6 +77,7 @@ class _HomePageState extends State<HomePage> with WidgetsBindingObserver {
             state.userActivityList,
             state.usesImperialUnits,
             state.showMealMacros,
+            state.userWeightKg,
           );
         } else {
           return _getLoadingContent();
@@ -118,6 +119,7 @@ class _HomePageState extends State<HomePage> with WidgetsBindingObserver {
     List<UserActivityEntity> userActivities,
     bool usesImperialUnits,
     bool showMealMacros,
+    double userWeightKg,
   ) {
     if (showDisclaimerDialog) {
       _showDisclaimerDialog(context);
@@ -126,7 +128,10 @@ class _HomePageState extends State<HomePage> with WidgetsBindingObserver {
       children: [
         ListView(
           children: [
-            QuickWeightWidget(usesImperialUnits: usesImperialUnits),
+            QuickWeightWidget(
+              weightKg: userWeightKg,
+              usesImperialUnits: usesImperialUnits,
+            ),
             const SizedBox(height: 8.0),
             DashboardWidget(
               totalKcalDaily: totalKcalDaily,

--- a/lib/features/home/presentation/bloc/home_bloc.dart
+++ b/lib/features/home/presentation/bloc/home_bloc.dart
@@ -12,6 +12,7 @@ import 'package:opennutritracker/core/domain/usecase/get_intake_usecase.dart';
 import 'package:opennutritracker/core/domain/usecase/get_kcal_goal_usecase.dart';
 import 'package:opennutritracker/core/domain/usecase/get_macro_goal_usecase.dart';
 import 'package:opennutritracker/core/domain/usecase/get_user_activity_usecase.dart';
+import 'package:opennutritracker/core/domain/usecase/get_user_usecase.dart';
 import 'package:opennutritracker/core/domain/usecase/update_intake_usecase.dart';
 import 'package:opennutritracker/core/domain/usecase/update_user_activity_usecase.dart';
 import 'package:opennutritracker/core/utils/calc/calorie_goal_calc.dart';
@@ -36,6 +37,7 @@ class HomeBloc extends Bloc<HomeEvent, HomeState> {
   final GetKcalGoalUsecase _getKcalGoalUsecase;
   final GetMacroGoalUsecase _getMacroGoalUsecase;
   final UpdateUserActivityUsecase _updateUserActivityUsecase;
+  final GetUserUsecase _getUserUsecase;
 
   DateTime currentDay = DateTime.now();
 
@@ -51,6 +53,7 @@ class HomeBloc extends Bloc<HomeEvent, HomeState> {
     this._getKcalGoalUsecase,
     this._getMacroGoalUsecase,
     this._updateUserActivityUsecase,
+    this._getUserUsecase,
   ) : super(HomeInitial()) {
     on<LoadItemsEvent>((event, emit) async {
       emit(HomeLoadingState());
@@ -108,7 +111,9 @@ class HomeBloc extends Bloc<HomeEvent, HomeState> {
       final totalKcalActivities =
           userActivities.map((activity) => activity.burnedKcal).toList().sum;
 
-      final totalKcalGoal = await _getKcalGoalUsecase.getKcalGoal();
+      final user = await _getUserUsecase.getUserData();
+      final totalKcalGoal =
+          await _getKcalGoalUsecase.getKcalGoal(userEntity: user);
       final totalCarbsGoal = await _getMacroGoalUsecase.getCarbsGoal(
         totalKcalGoal,
       );
@@ -144,6 +149,7 @@ class HomeBloc extends Bloc<HomeEvent, HomeState> {
           userActivityList: userActivities,
           usesImperialUnits: usesImperialUnits,
           showMealMacros: showMealMacros,
+          userWeightKg: user.weightKG,
         ),
       );
     });

--- a/lib/features/home/presentation/bloc/home_state.dart
+++ b/lib/features/home/presentation/bloc/home_state.dart
@@ -34,6 +34,7 @@ class HomeLoadedState extends HomeState {
   final bool usesImperialUnits;
   final bool showActivityTracking; // #277
   final bool showMealMacros;
+  final double userWeightKg;
 
   const HomeLoadedState({
     required this.showDisclaimerDialog,
@@ -53,6 +54,7 @@ class HomeLoadedState extends HomeState {
     required this.dinnerIntakeList,
     required this.snackIntakeList,
     required this.usesImperialUnits,
+    required this.userWeightKg,
     this.showActivityTracking = true,
     this.showMealMacros = true,
   });
@@ -64,5 +66,7 @@ class HomeLoadedState extends HomeState {
         dinnerIntakeList,
         snackIntakeList,
         usesImperialUnits,
+        userWeightKg,
+        totalKcalDaily,
       ];
 }

--- a/lib/features/home/presentation/widgets/quick_weight_widget.dart
+++ b/lib/features/home/presentation/widgets/quick_weight_widget.dart
@@ -6,41 +6,26 @@ import 'package:opennutritracker/features/home/presentation/bloc/home_bloc.dart'
 import 'package:opennutritracker/features/profile/presentation/widgets/set_weight_dialog.dart';
 import 'package:opennutritracker/generated/l10n.dart';
 
-/// #281: Quick weight update widget on the home/landing screen.
-/// Displays current weight as a tappable chip; opens SetWeightDialog on tap.
-class QuickWeightWidget extends StatefulWidget {
+/// #281: Quick weight update chip on the home screen.
+///
+/// Reads `weightKg` from `HomeLoadedState` (single source of truth) instead
+/// of doing its own DB read; that read used to race with onboarding's user
+/// write and silently displayed the dummy 80 kg fallback.
+class QuickWeightWidget extends StatelessWidget {
+  final double weightKg;
   final bool usesImperialUnits;
 
-  const QuickWeightWidget({super.key, required this.usesImperialUnits});
-
-  @override
-  State<QuickWeightWidget> createState() => _QuickWeightWidgetState();
-}
-
-class _QuickWeightWidgetState extends State<QuickWeightWidget> {
-  double? _weightKg;
-
-  @override
-  void initState() {
-    super.initState();
-    _loadWeight();
-  }
-
-  Future<void> _loadWeight() async {
-    final user = await locator<GetUserUsecase>().getUserData();
-    if (mounted) {
-      setState(() => _weightKg = user.weightKG);
-    }
-  }
+  const QuickWeightWidget({
+    super.key,
+    required this.weightKg,
+    required this.usesImperialUnits,
+  });
 
   @override
   Widget build(BuildContext context) {
-    if (_weightKg == null) return const SizedBox.shrink();
-
-    final displayWeight = widget.usesImperialUnits
-        ? _weightKg! * 2.20462
-        : _weightKg!;
-    final unit = widget.usesImperialUnits
+    final displayWeight =
+        usesImperialUnits ? weightKg * 2.20462 : weightKg;
+    final unit = usesImperialUnits
         ? S.of(context).lbsLabel
         : S.of(context).kgLabel;
 
@@ -69,30 +54,29 @@ class _QuickWeightWidgetState extends State<QuickWeightWidget> {
   }
 
   Future<void> _showWeightDialog(BuildContext context) async {
-    final displayWeight = widget.usesImperialUnits
-        ? _weightKg! * 2.20462
-        : _weightKg!;
+    final displayWeight =
+        usesImperialUnits ? weightKg * 2.20462 : weightKg;
 
     final newWeight = await showDialog<double>(
       context: context,
       builder: (context) => SetWeightDialog(
         userWeight: displayWeight,
-        usesImperialUnits: widget.usesImperialUnits,
+        usesImperialUnits: usesImperialUnits,
       ),
     );
 
     if (newWeight == null || !context.mounted) return;
 
     final newWeightKg =
-        widget.usesImperialUnits ? newWeight / 2.20462 : newWeight;
+        usesImperialUnits ? newWeight / 2.20462 : newWeight;
 
     final user = await locator<GetUserUsecase>().getUserData();
-    await locator<AddUserUsecase>()
-        .addUser(user..weightKG = newWeightKg);
+    user.weightKG = newWeightKg;
+    await locator<AddUserUsecase>().addUser(user);
 
-    setState(() => _weightKg = newWeightKg);
-
-    // Refresh home kcal goal (weight affects TDEE)
+    // Refresh home kcal goal (weight affects TDEE). The state emit will
+    // flow back through BlocBuilder and rebuild this widget with the new
+    // weight — no local cache needed.
     locator<HomeBloc>().add(const LoadItemsEvent());
   }
 }

--- a/lib/features/home/presentation/widgets/quick_weight_widget.dart
+++ b/lib/features/home/presentation/widgets/quick_weight_widget.dart
@@ -1,8 +1,7 @@
 import 'package:flutter/material.dart';
-import 'package:opennutritracker/core/domain/usecase/add_user_usecase.dart';
 import 'package:opennutritracker/core/domain/usecase/get_user_usecase.dart';
 import 'package:opennutritracker/core/utils/locator.dart';
-import 'package:opennutritracker/features/home/presentation/bloc/home_bloc.dart';
+import 'package:opennutritracker/features/profile/presentation/bloc/profile_bloc.dart';
 import 'package:opennutritracker/features/profile/presentation/widgets/set_weight_dialog.dart';
 import 'package:opennutritracker/generated/l10n.dart';
 
@@ -72,11 +71,11 @@ class QuickWeightWidget extends StatelessWidget {
 
     final user = await locator<GetUserUsecase>().getUserData();
     user.weightKG = newWeightKg;
-    await locator<AddUserUsecase>().addUser(user);
 
-    // Refresh home kcal goal (weight affects TDEE). The state emit will
-    // flow back through BlocBuilder and rebuild this widget with the new
-    // weight — no local cache needed.
-    locator<HomeBloc>().add(const LoadItemsEvent());
+    // Route through ProfileBloc.updateUser so the profile screen, diary,
+    // and home all refresh in one go. Going through AddUserUsecase
+    // directly would update Hive but leave the profile screen showing the
+    // pre-edit weight until the next manual reload.
+    await locator<ProfileBloc>().updateUser(user);
   }
 }

--- a/lib/features/onboarding/onboarding_screen.dart
+++ b/lib/features/onboarding/onboarding_screen.dart
@@ -292,18 +292,18 @@ class _OnboardingScreenState extends State<OnboardingScreen> {
     });
   }
 
-  void _onOverviewStartButtonPressed(BuildContext context) {
+  Future<void> _onOverviewStartButtonPressed(BuildContext context) async {
     final userEntity = _onboardingBloc.userSelection.toUserEntity();
     final hasAcceptedDataCollection =
         _onboardingBloc.userSelection.acceptDataCollection;
     final usesImperialUnits = _onboardingBloc.userSelection.usesImperialUnits;
     if (userEntity != null) {
-      _onboardingBloc.saveOnboardingData(
-        context,
+      await _onboardingBloc.saveOnboardingData(
         userEntity,
         hasAcceptedDataCollection,
         usesImperialUnits,
       );
+      if (!context.mounted) return;
       Navigator.pushReplacementNamed(context, NavigationOptions.mainRoute);
     } else {
       // Error with user input

--- a/lib/features/onboarding/presentation/bloc/onboarding_bloc.dart
+++ b/lib/features/onboarding/presentation/bloc/onboarding_bloc.dart
@@ -1,5 +1,4 @@
 import 'package:equatable/equatable.dart';
-import 'package:flutter/material.dart';
 import 'package:flutter_bloc/flutter_bloc.dart';
 import 'package:opennutritracker/core/domain/entity/user_entity.dart';
 import 'package:opennutritracker/core/domain/usecase/add_config_usecase.dart';
@@ -26,17 +25,16 @@ class OnboardingBloc extends Bloc<OnboardingEvent, OnboardingState> {
     });
   }
 
-  void saveOnboardingData(
-    BuildContext context,
+  Future<void> saveOnboardingData(
     UserEntity userEntity,
     bool hasAcceptedDataCollection,
     bool usesImperialUnits,
   ) async {
-    _addUserUsecase.addUser(userEntity);
-    _addConfigUsecase.setConfigHasAcceptedAnonymousData(
+    await _addUserUsecase.addUser(userEntity);
+    await _addConfigUsecase.setConfigHasAcceptedAnonymousData(
       hasAcceptedDataCollection,
     );
-    _addConfigUsecase.setConfigUsesImperialUnits(usesImperialUnits);
+    await _addConfigUsecase.setConfigUsesImperialUnits(usesImperialUnits);
   }
 
   double? getOverviewCalorieGoal() {

--- a/lib/features/profile/presentation/bloc/profile_bloc.dart
+++ b/lib/features/profile/presentation/bloc/profile_bloc.dart
@@ -56,7 +56,7 @@ class ProfileBloc extends Bloc<ProfileEvent, ProfileState> {
 
   Future<UserEntity> getUser() => _getUserUsecase.getUserData();
 
-  void updateUser(UserEntity userEntity) async {
+  Future<void> updateUser(UserEntity userEntity) async {
     // Update user in DB
     await _addUserUsecase.addUser(userEntity);
 

--- a/lib/features/profile/presentation/widgets/set_weekly_weight_goal_dialog.dart
+++ b/lib/features/profile/presentation/widgets/set_weekly_weight_goal_dialog.dart
@@ -86,12 +86,13 @@ class _SetWeeklyWeightGoalDialogState
           onPressed: () => Navigator.of(context).pop(null),
           child: Text(S.of(context).dialogCancelLabel),
         ),
-        if (widget.currentGoalKg != null)
-          TextButton(
-            onPressed: () =>
-                Navigator.of(context).pop(_kClearSentinel),
-            child: Text(S.of(context).buttonResetLabel),
-          ),
+        // Always offer Reset — users need a way to fall back to the
+        // overall weight goal (lose / maintain / gain) even if they
+        // opened the slider once and never set an explicit weekly rate.
+        TextButton(
+          onPressed: () => Navigator.of(context).pop(_kClearSentinel),
+          child: Text(S.of(context).buttonResetLabel),
+        ),
         TextButton(
           onPressed: () => Navigator.of(context).pop(_selectedKg),
           child: Text(S.of(context).dialogOKLabel),

--- a/lib/features/profile/profile_page.dart
+++ b/lib/features/profile/profile_page.dart
@@ -257,7 +257,7 @@ class _ProfilePageState extends State<ProfilePage> {
     } else {
       userEntity.weeklyWeightGoalKg = result;
     }
-    _profileBloc.updateUser(userEntity);
+    await _profileBloc.updateUser(userEntity);
   }
 
   Future<void> _showSetGoalDialog(
@@ -349,16 +349,36 @@ class _ProfilePageState extends State<ProfilePage> {
     );
     if (selectedGender == null) return;
     userEntity.gender = selectedGender;
-    if (selectedGender != UserGenderEntity.nonBinary) {
-      // Drop any previously set hormone profile when switching back to a binary
-      // gender — the field is meaningless outside of nonBinary.
+
+    // Switching to non-binary: prompt for hormone profile and persist BOTH
+    // fields in a single updateUser call. Issuing two saves (one for the
+    // gender, one for the profile) used to race — by the time the home
+    // recomputed kcal, only the gender write had landed and the profile
+    // was still null, so every choice rendered as "averaged".
+    if (selectedGender == UserGenderEntity.nonBinary) {
+      if (context.mounted) {
+        final selected = await showDialog<CaloriesProfileEntity>(
+          context: context,
+          builder: (BuildContext context) => CaloriesProfileInfoDialog(
+            initialProfile:
+                userEntity.caloriesProfile ?? CaloriesProfileEntity.averaged,
+          ),
+        );
+        if (selected != null) {
+          userEntity.caloriesProfile = selected;
+        } else {
+          // User cancelled the picker but is now non-binary — store the
+          // implicit default explicitly so reads don't keep falling back.
+          userEntity.caloriesProfile ??= CaloriesProfileEntity.averaged;
+        }
+      }
+    } else {
+      // Switching back to binary — drop any previously set hormone profile.
+      // The field is meaningless outside of nonBinary.
       userEntity.caloriesProfile = null;
     }
-    _profileBloc.updateUser(userEntity);
 
-    if (selectedGender == UserGenderEntity.nonBinary && context.mounted) {
-      await _showCaloriesProfileDialog(context, userEntity);
-    }
+    await _profileBloc.updateUser(userEntity);
   }
 
   Future<void> _showCaloriesProfileDialog(

--- a/lib/features/profile/profile_page.dart
+++ b/lib/features/profile/profile_page.dart
@@ -374,6 +374,6 @@ class _ProfilePageState extends State<ProfilePage> {
     );
     if (selected == null) return;
     userEntity.caloriesProfile = selected;
-    _profileBloc.updateUser(userEntity);
+    await _profileBloc.updateUser(userEntity);
   }
 }

--- a/lib/features/settings/presentation/bloc/settings_bloc.dart
+++ b/lib/features/settings/presentation/bloc/settings_bloc.dart
@@ -126,16 +126,16 @@ class SettingsBloc extends Bloc<SettingsEvent, SettingsState> {
     return config.userFatGoalPct;
   }
 
-  void setKcalAdjustment(double kcalAdjustment) {
-    _addConfigUsecase.setConfigKcalAdjustment(kcalAdjustment);
+  Future<void> setKcalAdjustment(double kcalAdjustment) async {
+    await _addConfigUsecase.setConfigKcalAdjustment(kcalAdjustment);
   }
 
-  void setMacroGoals(
+  Future<void> setMacroGoals(
     double carbGoalPct,
     double proteinGoalPct,
     double fatGoalPct,
-  ) {
-    _addConfigUsecase.setConfigMacroGoalPct(
+  ) async {
+    await _addConfigUsecase.setConfigMacroGoalPct(
       carbGoalPct.toInt() / 100,
       proteinGoalPct.toInt() / 100,
       fatGoalPct.toInt() / 100,

--- a/lib/features/settings/presentation/widgets/calculations_dialog.dart
+++ b/lib/features/settings/presentation/widgets/calculations_dialog.dart
@@ -475,7 +475,8 @@ class _CalculationsDialogState extends State<CalculationsDialog> {
     );
     if (selected == null) return;
     user.caloriesProfile = selected;
-    widget.profileBloc.updateUser(user);
+    await widget.profileBloc.updateUser(user);
+    if (!mounted) return;
     setState(() {
       _user = user;
     });

--- a/test/helpers/hive_test_setup.dart
+++ b/test/helpers/hive_test_setup.dart
@@ -1,0 +1,22 @@
+import 'package:hive_ce/hive.dart';
+import 'package:opennutritracker/hive_registrar.g.dart';
+
+/// Process-wide flag — Hive's TypeRegistry is shared across all tests in
+/// the same `flutter test` run, so calling `Hive.registerAdapter(...)`
+/// twice with the same typeId throws. This guard makes the call
+/// idempotent so test files can use it freely from setUp.
+bool _hiveAdaptersRegistered = false;
+
+/// Registers every DBO adapter via the generated [HiveRegistrar] extension
+/// in `hive_registrar.g.dart`. Safe to call from any test's setUp — the
+/// first call registers, subsequent calls are no-ops.
+///
+/// Prefer this over hand-listing the adapters a specific test "needs":
+/// the hand-list silently rots when new DBO types are added (the
+/// CaloriesProfileDBO outage on develop was exactly that bug class), and
+/// you only learn about it when something throws at write time.
+void registerHiveAdaptersOnce() {
+  if (_hiveAdaptersRegistered) return;
+  Hive.registerAdapters();
+  _hiveAdaptersRegistered = true;
+}

--- a/test/unit_test/custom_meal_data_source_test.dart
+++ b/test/unit_test/custom_meal_data_source_test.dart
@@ -4,6 +4,8 @@ import 'package:opennutritracker/core/data/data_source/custom_meal_data_source.d
 import 'package:opennutritracker/core/data/dbo/meal_dbo.dart';
 import 'package:opennutritracker/core/data/dbo/meal_nutriments_dbo.dart';
 
+import '../helpers/hive_test_setup.dart';
+
 MealNutrimentsDBO _emptyNutriments({double? kcal}) => MealNutrimentsDBO(
       energyKcal100: kcal,
       carbohydrates100: null,
@@ -44,9 +46,7 @@ void main() {
     setUpAll(() {
       TestWidgetsFlutterBinding.ensureInitialized();
       Hive.init('.');
-      Hive.registerAdapter(MealDBOAdapter());
-      Hive.registerAdapter(MealSourceDBOAdapter());
-      Hive.registerAdapter(MealNutrimentsDBOAdapter());
+      registerHiveAdaptersOnce();
     });
 
     setUp(() async {

--- a/test/unit_test/intake_repository_test.dart
+++ b/test/unit_test/intake_repository_test.dart
@@ -2,26 +2,19 @@ import 'package:flutter_test/flutter_test.dart';
 import 'package:hive_ce/hive.dart';
 import 'package:opennutritracker/core/data/data_source/intake_data_source.dart';
 import 'package:opennutritracker/core/data/dbo/intake_dbo.dart';
-import 'package:opennutritracker/core/data/dbo/intake_type_dbo.dart';
-import 'package:opennutritracker/core/data/dbo/meal_dbo.dart';
-import 'package:opennutritracker/core/data/dbo/meal_nutriments_dbo.dart';
 import 'package:opennutritracker/core/data/repository/intake_repository.dart';
 import 'package:opennutritracker/core/domain/entity/intake_entity.dart';
 import 'package:opennutritracker/core/domain/entity/intake_type_entity.dart';
 
 import '../fixture/meal_entity_fixtures.dart';
+import '../helpers/hive_test_setup.dart';
 
 void main() {
   group('IntakeRepository test', () {
     setUp(() {
       TestWidgetsFlutterBinding.ensureInitialized();
-      // final temp = await getTemporaryDirectory();
       Hive.init(".");
-      Hive.registerAdapter(IntakeDBOAdapter());
-      Hive.registerAdapter(IntakeTypeDBOAdapter());
-      Hive.registerAdapter(MealDBOAdapter());
-      Hive.registerAdapter(MealSourceDBOAdapter());
-      Hive.registerAdapter(MealNutrimentsDBOAdapter());
+      registerHiveAdaptersOnce();
     });
 
     tearDown(() {

--- a/test/unit_test/onboarding_save_race_test.dart
+++ b/test/unit_test/onboarding_save_race_test.dart
@@ -1,0 +1,113 @@
+import 'dart:async';
+
+import 'package:flutter_test/flutter_test.dart';
+import 'package:opennutritracker/core/data/repository/config_repository.dart';
+import 'package:opennutritracker/core/data/repository/user_repository.dart';
+import 'package:opennutritracker/core/domain/entity/user_entity.dart';
+import 'package:opennutritracker/core/domain/entity/user_gender_entity.dart';
+import 'package:opennutritracker/core/domain/entity/user_pal_entity.dart';
+import 'package:opennutritracker/core/domain/entity/user_weight_goal_entity.dart';
+import 'package:opennutritracker/core/domain/usecase/add_config_usecase.dart';
+import 'package:opennutritracker/core/domain/usecase/add_user_usecase.dart';
+import 'package:opennutritracker/features/onboarding/presentation/bloc/onboarding_bloc.dart';
+
+/// Fake repository whose every write returns a Future controlled by an
+/// external Completer. Lets us assert that `OnboardingBloc.saveOnboardingData`
+/// only resolves when the inner Hive writes have actually finished.
+class _FakeUserRepository implements UserRepository {
+  final Completer<void> writeCompleter = Completer<void>();
+  bool writeStarted = false;
+
+  @override
+  Future<void> updateUserData(userEntity) async {
+    writeStarted = true;
+    await writeCompleter.future;
+  }
+
+  @override
+  noSuchMethod(Invocation invocation) =>
+      throw UnimplementedError(invocation.memberName.toString());
+}
+
+class _FakeConfigRepository implements ConfigRepository {
+  final Completer<void> anonCompleter = Completer<void>();
+  final Completer<void> imperialCompleter = Completer<void>();
+
+  @override
+  Future<void> setConfigHasAcceptedAnonymousData(bool _) async {
+    await anonCompleter.future;
+  }
+
+  @override
+  Future<void> setConfigUsesImperialUnits(bool _) async {
+    await imperialCompleter.future;
+  }
+
+  @override
+  noSuchMethod(Invocation invocation) =>
+      throw UnimplementedError(invocation.memberName.toString());
+}
+
+void main() {
+  group('OnboardingBloc.saveOnboardingData await chain', () {
+    late _FakeUserRepository userRepo;
+    late _FakeConfigRepository configRepo;
+    late OnboardingBloc bloc;
+
+    setUp(() {
+      userRepo = _FakeUserRepository();
+      configRepo = _FakeConfigRepository();
+      bloc = OnboardingBloc(
+        AddUserUsecase(userRepo),
+        AddConfigUsecase(configRepo),
+      );
+    });
+
+    tearDown(() {
+      bloc.close();
+    });
+
+    UserEntity makeUser() => UserEntity(
+          birthday: DateTime(1990, 6, 15),
+          heightCM: 165,
+          weightKG: 70,
+          gender: UserGenderEntity.female,
+          goal: UserWeightGoalEntity.loseWeight,
+          pal: UserPALEntity.sedentary,
+        );
+
+    test(
+        'saveOnboardingData does not resolve until the user write completes',
+        () async {
+      // Regression: saveOnboardingData was `void ... async` and did not
+      // await `_addUserUsecase.addUser(...)`. The onboarding screen then
+      // navigated away before the user had been written to Hive, and the
+      // home screen recomputed kcal against the dummy default user.
+
+      final saveFuture =
+          bloc.saveOnboardingData(makeUser(), false, false);
+
+      // Yield once so the bloc has a chance to start the inner write.
+      await Future<void>.delayed(Duration.zero);
+      expect(userRepo.writeStarted, isTrue,
+          reason: 'bloc must start the user write immediately');
+
+      bool resolved = false;
+      // ignore: unawaited_futures
+      saveFuture.then((_) => resolved = true);
+
+      // Without completing the user write, saveOnboardingData must not be
+      // done — proves the bloc actually awaits the write.
+      await Future<void>.delayed(const Duration(milliseconds: 50));
+      expect(resolved, isFalse,
+          reason: 'saveOnboardingData must await the user write');
+
+      // Complete the writes in order; saveOnboardingData should now resolve.
+      userRepo.writeCompleter.complete();
+      configRepo.anonCompleter.complete();
+      configRepo.imperialCompleter.complete();
+      await saveFuture;
+      expect(resolved, isTrue);
+    });
+  });
+}

--- a/test/unit_test/pal_calc_test.dart
+++ b/test/unit_test/pal_calc_test.dart
@@ -1,0 +1,111 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:opennutritracker/core/domain/entity/user_entity.dart';
+import 'package:opennutritracker/core/domain/entity/user_gender_entity.dart';
+import 'package:opennutritracker/core/domain/entity/user_pal_entity.dart';
+import 'package:opennutritracker/core/domain/entity/user_weight_goal_entity.dart';
+import 'package:opennutritracker/core/utils/calc/pal_calc.dart';
+
+UserEntity _user(UserGenderEntity gender, UserPALEntity pal) {
+  return UserEntity(
+    birthday: DateTime(1995, 1, 1),
+    heightCM: 170,
+    weightKG: 70,
+    gender: gender,
+    goal: UserWeightGoalEntity.maintainWeight,
+    pal: pal,
+  );
+}
+
+void main() {
+  group('PalCalc.getPALValueFromActivityCategory', () {
+    test('maps each category to its IOM PAL band', () {
+      expect(
+        PalCalc.getPALValueFromActivityCategory(
+            _user(UserGenderEntity.male, UserPALEntity.sedentary)),
+        1.25,
+      );
+      expect(
+        PalCalc.getPALValueFromActivityCategory(
+            _user(UserGenderEntity.male, UserPALEntity.lowActive)),
+        1.5,
+      );
+      expect(
+        PalCalc.getPALValueFromActivityCategory(
+            _user(UserGenderEntity.male, UserPALEntity.active)),
+        1.75,
+      );
+      expect(
+        PalCalc.getPALValueFromActivityCategory(
+            _user(UserGenderEntity.male, UserPALEntity.veryActive)),
+        2.2,
+      );
+    });
+  });
+
+  group('PalCalc.getPAValueForFormula', () {
+    test('sedentary: PA = 1.0 regardless of formula gender', () {
+      expect(
+        PalCalc.getPAValueForFormula(palValue: 1.25, isMaleFormula: true),
+        1.0,
+      );
+      expect(
+        PalCalc.getPAValueForFormula(palValue: 1.25, isMaleFormula: false),
+        1.0,
+      );
+    });
+
+    test('lowActive: male PA 1.12, female PA 1.14', () {
+      expect(
+        PalCalc.getPAValueForFormula(palValue: 1.5, isMaleFormula: true),
+        1.12,
+      );
+      expect(
+        PalCalc.getPAValueForFormula(palValue: 1.5, isMaleFormula: false),
+        1.14,
+      );
+    });
+
+    test('active: PA = 1.27 regardless of formula gender', () {
+      expect(
+        PalCalc.getPAValueForFormula(palValue: 1.75, isMaleFormula: true),
+        1.27,
+      );
+      expect(
+        PalCalc.getPAValueForFormula(palValue: 1.75, isMaleFormula: false),
+        1.27,
+      );
+    });
+
+    test('veryActive: male PA 1.54, female PA 1.45', () {
+      expect(
+        PalCalc.getPAValueForFormula(palValue: 2.2, isMaleFormula: true),
+        1.54,
+      );
+      expect(
+        PalCalc.getPAValueForFormula(palValue: 2.2, isMaleFormula: false),
+        1.45,
+      );
+    });
+  });
+
+  group('PalCalc.getPAValueFromPALValue (gender-keyed wrapper)', () {
+    // Regression: before the PR that introduced PA-by-formula-flag, the
+    // ternary `gender == male ? maleConstant : femaleConstant` routed
+    // non-binary users to the female PA constant. That meant a non-binary
+    // averaged TDEE used female PA on both halves of the average. These
+    // tests pin down what the gender-keyed wrapper does today; the
+    // non-binary path for averaged TDEE goes through the explicit-flag
+    // overload via tdee_calc.dart, not this wrapper.
+    test('male user gets male PA at lowActive and veryActive', () {
+      final user = _user(UserGenderEntity.male, UserPALEntity.lowActive);
+      expect(PalCalc.getPAValueFromPALValue(user, 1.5), 1.12);
+      expect(PalCalc.getPAValueFromPALValue(user, 2.2), 1.54);
+    });
+
+    test('female user gets female PA at lowActive and veryActive', () {
+      final user = _user(UserGenderEntity.female, UserPALEntity.lowActive);
+      expect(PalCalc.getPAValueFromPALValue(user, 1.5), 1.14);
+      expect(PalCalc.getPAValueFromPALValue(user, 2.2), 1.45);
+    });
+  });
+}

--- a/test/unit_test/remote_search_cache_data_source_test.dart
+++ b/test/unit_test/remote_search_cache_data_source_test.dart
@@ -4,6 +4,8 @@ import 'package:opennutritracker/core/data/data_source/remote_search_cache_data_
 import 'package:opennutritracker/core/data/dbo/meal_dbo.dart';
 import 'package:opennutritracker/core/data/dbo/meal_nutriments_dbo.dart';
 
+import '../helpers/hive_test_setup.dart';
+
 MealNutrimentsDBO _emptyNutriments() => MealNutrimentsDBO(
       energyKcal100: null,
       carbohydrates100: null,
@@ -45,9 +47,7 @@ void main() {
     setUpAll(() {
       TestWidgetsFlutterBinding.ensureInitialized();
       Hive.init('.');
-      Hive.registerAdapter(MealDBOAdapter());
-      Hive.registerAdapter(MealSourceDBOAdapter());
-      Hive.registerAdapter(MealNutrimentsDBOAdapter());
+      registerHiveAdaptersOnce();
     });
 
     setUp(() async {

--- a/test/unit_test/tdee_calc_test.dart
+++ b/test/unit_test/tdee_calc_test.dart
@@ -4,6 +4,7 @@ import 'package:opennutritracker/core/domain/entity/user_entity.dart';
 import 'package:opennutritracker/core/domain/entity/user_gender_entity.dart';
 import 'package:opennutritracker/core/domain/entity/user_pal_entity.dart';
 import 'package:opennutritracker/core/domain/entity/user_weight_goal_entity.dart';
+import 'package:opennutritracker/core/utils/calc/calorie_goal_calc.dart';
 import 'package:opennutritracker/core/utils/calc/tdee_calc.dart';
 
 import '../fixture/user_entity_fixtures.dart';
@@ -113,6 +114,130 @@ void main() {
       final male =
           TDEECalc.getTDEEKcalIOM2005(baseUser(gender: UserGenderEntity.male));
       expect(testosterone, closeTo(male, 0.001));
+    });
+  });
+
+  group('IOM TDEE non-binary at non-sedentary PALs (PA gender regression)', () {
+    // Regression for the PA-gender bug: getPAValueFromPALValue used to read
+    // userEntity.gender directly, so for a non-binary user the male half of
+    // the averaged TDEE was computed with the female PA constant. The fix
+    // routes each half through getPAValueForFormula with an explicit flag,
+    // so the male half uses 1.12 / 1.54 and the female half uses 1.14 / 1.45
+    // regardless of the user's stored gender enum.
+    UserEntity buildUser(UserPALEntity pal,
+        {CaloriesProfileEntity? profile, UserGenderEntity? gender}) {
+      return UserEntity(
+        birthday: DateTime(
+          DateTime.now().year - 25,
+          DateTime.now().month,
+          DateTime.now().day - 1,
+        ),
+        heightCM: 180.0,
+        weightKG: 80.0,
+        gender: gender ?? UserGenderEntity.nonBinary,
+        goal: UserWeightGoalEntity.maintainWeight,
+        pal: pal,
+        caloriesProfile: profile,
+      );
+    }
+
+    test('lowActive averaged equals (binary male + binary female) / 2', () {
+      final maleTdee =
+          TDEECalc.getTDEEKcalIOM2005(buildUser(UserPALEntity.lowActive,
+              gender: UserGenderEntity.male));
+      final femaleTdee =
+          TDEECalc.getTDEEKcalIOM2005(buildUser(UserPALEntity.lowActive,
+              gender: UserGenderEntity.female));
+      final averaged = TDEECalc.getTDEEKcalIOM2005(buildUser(
+        UserPALEntity.lowActive,
+        profile: CaloriesProfileEntity.averaged,
+      ));
+      expect(averaged, closeTo((maleTdee + femaleTdee) / 2, 0.001));
+    });
+
+    test('veryActive averaged equals (binary male + binary female) / 2', () {
+      final maleTdee =
+          TDEECalc.getTDEEKcalIOM2005(buildUser(UserPALEntity.veryActive,
+              gender: UserGenderEntity.male));
+      final femaleTdee =
+          TDEECalc.getTDEEKcalIOM2005(buildUser(UserPALEntity.veryActive,
+              gender: UserGenderEntity.female));
+      final averaged = TDEECalc.getTDEEKcalIOM2005(buildUser(
+        UserPALEntity.veryActive,
+        profile: CaloriesProfileEntity.averaged,
+      ));
+      expect(averaged, closeTo((maleTdee + femaleTdee) / 2, 0.001));
+    });
+
+    test('lowActive averaged uses both PA constants — '
+        'numerical pin (would fail with shared female PA = 1.14)', () {
+      // Hand-computed expected for 80 kg / 180 cm / age 25 / lowActive (PAL 1.5):
+      //   male half  = 864 - 9.72*25 + 1.12*14.2*80 + 503*1.80
+      //              = 864 - 243   + 1272.32        + 905.4
+      //              = 2798.72
+      //   female half= 387 - 7.31*25 + 1.14*10.9*80 + 660.7*1.80
+      //              = 387 - 182.75 + 993.85        + 1189.26
+      //              = 2387.36 (rounded)
+      //   averaged   = (2798.72 + 2387.36) / 2 ≈ 2593.04
+      // The bug version used PA=1.14 in the male half too:
+      //   buggy male = 864 - 243 + 1.14*14.2*80 + 905.4 = 2821.45
+      //   buggy avg  = (2821.45 + 2387.36) / 2 ≈ 2604.4
+      // 11 kcal/day delta — small but always upward and systematic.
+      final averaged = TDEECalc.getTDEEKcalIOM2005(buildUser(
+        UserPALEntity.lowActive,
+        profile: CaloriesProfileEntity.averaged,
+      ));
+      expect(averaged, closeTo(2593.04, 0.5));
+    });
+
+    test('estrogenTypical at lowActive uses female PA (1.14)', () {
+      final estrogen = TDEECalc.getTDEEKcalIOM2005(buildUser(
+        UserPALEntity.lowActive,
+        profile: CaloriesProfileEntity.estrogenTypical,
+      ));
+      // 387 - 7.31*25 + 1.14*10.9*80 + 660.7*1.80 ≈ 2387.36
+      expect(estrogen, closeTo(2387.36, 0.5));
+    });
+
+    test('testosteroneTypical at veryActive uses male PA (1.54)', () {
+      final testosterone = TDEECalc.getTDEEKcalIOM2005(buildUser(
+        UserPALEntity.veryActive,
+        profile: CaloriesProfileEntity.testosteroneTypical,
+      ));
+      // 864 - 9.72*25 + 1.54*14.2*80 + 503*1.80
+      //   = 864 - 243 + 1749.44 + 905.4 = 3275.84
+      expect(testosterone, closeTo(3275.84, 0.5));
+    });
+  });
+
+  group('Real-user kcal goal must differ from the old dummy fallback', () {
+    // Regression for the onboarding race: when getUserData() returned the
+    // hardcoded 80 kg / 180 cm / male / age 26 / active / maintain dummy,
+    // the home screen showed ≈ 2959 kcal regardless of who the user was.
+    // For a generic sedentary female with a lose-weight goal, the budget
+    // must land far below that — otherwise we have regressed back to
+    // pulling the dummy.
+    test('female / sedentary / lose-weight produces a budget well below the '
+        'old male / active / maintain dummy', () {
+      final user = UserEntity(
+        birthday: DateTime(
+          DateTime.now().year - 35,
+          DateTime.now().month,
+          DateTime.now().day - 1,
+        ),
+        heightCM: 165.0,
+        weightKG: 70.0,
+        gender: UserGenderEntity.female,
+        goal: UserWeightGoalEntity.loseWeight,
+        pal: UserPALEntity.sedentary,
+      );
+
+      final totalGoal = CalorieGoalCalc.getTotalKcalGoal(user, 0);
+      // BMR = 387 - 7.31*35 + 1.0*10.9*70 + 660.7*1.65
+      //     = 387 - 255.85 + 763.0 + 1090.155 ≈ 1984.3
+      // Total goal = 1984.3 - 500 ≈ 1484.3 — well below the dummy's 2959.
+      expect(totalGoal, lessThan(1700));
+      expect(totalGoal, greaterThan(1300));
     });
   });
 }

--- a/test/unit_test/tracked_day_data_source_test.dart
+++ b/test/unit_test/tracked_day_data_source_test.dart
@@ -3,6 +3,8 @@ import 'package:hive_ce/hive.dart';
 import 'package:opennutritracker/core/data/data_source/tracked_day_data_source.dart';
 import 'package:opennutritracker/core/data/dbo/tracked_day_dbo.dart';
 
+import '../helpers/hive_test_setup.dart';
+
 void main() {
   group('TrackedDayDataSource getTrackedDaysInRange test', () {
     late Box<TrackedDayDBO> box;
@@ -10,7 +12,7 @@ void main() {
 
     setUpAll(() {
       TestWidgetsFlutterBinding.ensureInitialized();
-      Hive.registerAdapter(TrackedDayDBOAdapter());
+      registerHiveAdaptersOnce();
     });
 
     setUp(() async {
@@ -148,9 +150,7 @@ void main() {
 
     setUpAll(() {
       TestWidgetsFlutterBinding.ensureInitialized();
-      if (!Hive.isAdapterRegistered(9)) {
-        Hive.registerAdapter(TrackedDayDBOAdapter());
-      }
+      registerHiveAdaptersOnce();
     });
 
     setUp(() async {

--- a/test/unit_test/user_activity_repository_test.dart
+++ b/test/unit_test/user_activity_repository_test.dart
@@ -6,13 +6,13 @@ import 'package:opennutritracker/core/data/dbo/physical_activity_dbo.dart';
 import 'package:opennutritracker/core/data/repository/user_activity_repository.dart';
 import 'package:opennutritracker/core/domain/entity/user_activity_entity.dart';
 
+import '../helpers/hive_test_setup.dart';
+
 void main() {
   group('UserActivityRepository', () {
     setUpAll(() {
       TestWidgetsFlutterBinding.ensureInitialized();
-      Hive.registerAdapter(UserActivityDBOAdapter());
-      Hive.registerAdapter(PhysicalActivityDBOAdapter());
-      Hive.registerAdapter(PhysicalActivityTypeDBOAdapter());
+      registerHiveAdaptersOnce();
     });
 
     setUp(() {

--- a/test/unit_test/user_data_source_test.dart
+++ b/test/unit_test/user_data_source_test.dart
@@ -1,0 +1,72 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:hive_ce/hive.dart';
+import 'package:opennutritracker/core/data/data_source/user_data_source.dart';
+import 'package:opennutritracker/core/data/dbo/user_dbo.dart';
+import 'package:opennutritracker/core/data/dbo/user_gender_dbo.dart';
+import 'package:opennutritracker/core/data/dbo/user_pal_dbo.dart';
+import 'package:opennutritracker/core/data/dbo/user_weight_goal_dbo.dart';
+
+void main() {
+  group('UserDataSource race-condition guarantees', () {
+    setUp(() {
+      TestWidgetsFlutterBinding.ensureInitialized();
+      Hive.init('.');
+      if (!Hive.isAdapterRegistered(UserDBOAdapter().typeId)) {
+        Hive.registerAdapter(UserDBOAdapter());
+      }
+      if (!Hive.isAdapterRegistered(UserGenderDBOAdapter().typeId)) {
+        Hive.registerAdapter(UserGenderDBOAdapter());
+      }
+      if (!Hive.isAdapterRegistered(UserPALDBOAdapter().typeId)) {
+        Hive.registerAdapter(UserPALDBOAdapter());
+      }
+      if (!Hive.isAdapterRegistered(UserWeightGoalDBOAdapter().typeId)) {
+        Hive.registerAdapter(UserWeightGoalDBOAdapter());
+      }
+    });
+
+    tearDown(() async {
+      await Hive.deleteFromDisk();
+    });
+
+    UserDBO buildUser({double weight = 70}) => UserDBO(
+          birthday: DateTime(1990, 6, 15),
+          heightCM: 165,
+          weightKG: weight,
+          gender: UserGenderDBO.female,
+          goal: UserWeightGoalDBO.loseWeight,
+          pal: UserPALDBO.sedentary,
+        );
+
+    test('getUserData throws StateError before any save (no dummy fallback)',
+        () async {
+      // Regression: the data source used to fall back to a hardcoded
+      // 80 kg / 180 cm / male / active dummy when the box was empty. That
+      // silently produced an inflated kcal budget for any caller that hit
+      // the box during the onboarding race. The data source must now fail
+      // loudly so callers can diagnose the race instead of corrupting calcs.
+      final box = await Hive.openBox<UserDBO>('user_data_source_test_empty');
+      final source = UserDataSource(box);
+
+      expect(source.getUserData, throwsStateError);
+    });
+
+    test('saveUserData future does not resolve until the put has landed',
+        () async {
+      // Regression: saveUserData used to be `async` but did not await the
+      // inner `_userBox.put(...)`. The returned Future resolved immediately
+      // and the actual write was left in flight, so an awaiting caller (e.g.
+      // OnboardingBloc.saveOnboardingData) could navigate away before the
+      // user landed in the box.
+      final box = await Hive.openBox<UserDBO>('user_data_source_test_save');
+      final source = UserDataSource(box);
+
+      await source.saveUserData(buildUser());
+
+      // After the await, the data must be readable.
+      final loaded = await source.getUserData();
+      expect(loaded.weightKG, 70);
+      expect(loaded.gender, UserGenderDBO.female);
+    });
+  });
+}

--- a/test/unit_test/user_data_source_test.dart
+++ b/test/unit_test/user_data_source_test.dart
@@ -6,23 +6,14 @@ import 'package:opennutritracker/core/data/dbo/user_gender_dbo.dart';
 import 'package:opennutritracker/core/data/dbo/user_pal_dbo.dart';
 import 'package:opennutritracker/core/data/dbo/user_weight_goal_dbo.dart';
 
+import '../helpers/hive_test_setup.dart';
+
 void main() {
   group('UserDataSource race-condition guarantees', () {
     setUp(() {
       TestWidgetsFlutterBinding.ensureInitialized();
       Hive.init('.');
-      if (!Hive.isAdapterRegistered(UserDBOAdapter().typeId)) {
-        Hive.registerAdapter(UserDBOAdapter());
-      }
-      if (!Hive.isAdapterRegistered(UserGenderDBOAdapter().typeId)) {
-        Hive.registerAdapter(UserGenderDBOAdapter());
-      }
-      if (!Hive.isAdapterRegistered(UserPALDBOAdapter().typeId)) {
-        Hive.registerAdapter(UserPALDBOAdapter());
-      }
-      if (!Hive.isAdapterRegistered(UserWeightGoalDBOAdapter().typeId)) {
-        Hive.registerAdapter(UserWeightGoalDBOAdapter());
-      }
+      registerHiveAdaptersOnce();
     });
 
     tearDown(() async {


### PR DESCRIPTION
## Summary
Fixes three independent regressions on `develop` that combined to produce inflated daily kcal budgets and a non-functional non-binary hormone profile picker.

- **Onboarding race**: every layer of the user/config write chain (`OnboardingBloc.saveOnboardingData` → `AddUserUsecase` → `UserRepository` → `UserDataSource`, and the equivalent config chain) was `async` but did not `await` the layer below. The home screen mounted before the user landed in Hive, so `getUserData()` returned the hardcoded 80 kg / 180 cm / male / active / maintain dummy and TDEE was computed against that. All six layers now actually await; the `Navigator.pushReplacementNamed` in `onboarding_screen.dart` waits for `saveOnboardingData` to finish. Removed the dummy fallback in `UserDataSource` — it now throws `StateError` on an empty box so any future race fails loudly.
- **PA gender bug**: `PalCalc.getPAValueFromPALValue` keyed off `userEntity.gender == male`, so for non-binary users the male half of the averaged TDEE got the female PA constant (1.14 / 1.45 instead of 1.12 / 1.54). Added `getPAValueForFormula({palValue, isMaleFormula})` and routed the IOM 2005 male / female sub-formulas through it with explicit flags. Invisible at sedentary (PA=1.0 for all), wrong at every other PAL band.
- **Hormone profile not persisting**: `ProfileBloc.updateUser` was `void`/fire-and-forget at both call sites (`calculations_dialog._openCaloriesProfileDialog`, `profile_page._showCaloriesProfileDialog`). The home recomputed kcal before the new `caloriesProfile` had hit Hive, so the budget did not move and the dialog could reset back on the next reload. `updateUser` now returns `Future<void>` and both sites `await` it.

Also hardened `QuickWeightWidget` — it used to read `weightKG` in `initState` and cache it locally, racing with onboarding the same way `HomeBloc` did. It is now stateless and reads `weightKg` from `HomeLoadedState`, so a single bloc emit drives the displayed weight.

## Test plan
- [x] `just check_intl` — clean
- [x] `flutter analyze` — clean
- [x] `flutter test` — 323 tests pass (16 new)
- [x] Manual desktop run with a fresh profile (deleted `~/Documents/*.hive`); home kcal matches the formula immediately after onboarding (no 80 kg dummy), QuickWeight chip shows the entered weight, and the non-binary hormone picker updates the home kcal without a restart
- [x] `flutter build apk --debug` — debug APK builds clean (also produced for sideload testing)

### New tests
- `pal_calc_test.dart` — PA constants per band per formula gender (sedentary, lowActive, active, veryActive)
- `tdee_calc_test.dart` extensions — non-binary `averaged` at lowActive and veryActive (numerical pin that fails under the old code), `estrogenTypical` / `testosteroneTypical` at non-sedentary PALs, and a non-dummy real-user kcal regression that catches the dummy fallback if it ever returns
- `user_data_source_test.dart` — `getUserData` throws `StateError` on empty box; `saveUserData` future does not resolve until the Hive put has landed
- `onboarding_save_race_test.dart` — `OnboardingBloc.saveOnboardingData` does not resolve until the inner user write completes (proven with `Completer`-backed fakes)