### PR TITLE
ci: stop firing default workflow twice on develop→main PRs

### DIFF
--- a/.github/workflows/default_workflow.yml
+++ b/.github/workflows/default_workflow.yml
@@ -1,10 +1,16 @@
 name: Default Workflow
 
 on:
+  # `push` is intentionally limited to `main` so the workflow doesn't
+  # double-fire on the `develop → main` release PR (where every push to
+  # `develop` would otherwise trigger both a `push` run *and* a
+  # `pull_request` synchronize run). All pre-merge validation happens via
+  # `pull_request`; the `push: main` trigger only catches post-merge runs
+  # on `main`. Direct pushes to `develop` are disallowed by project policy
+  # (see CLAUDE.md) so skipping CI for them is safe.
   push:
     branches:
       - main
-      - develop
   pull_request:
     branches:
       - main


### PR DESCRIPTION
## Summary

- Drop `develop` from the `push` triggers in `.github/workflows/default_workflow.yml`.
- While a `develop → main` release PR is open, every push to `develop` was firing both a `pull_request` synchronize event and a `push` event for the same SHA — that's the duplicate (`(push)` + `(pull_request)`) seen across every job in the checks list.
- After this change: pre-merge validation runs once per PR (covers feature → develop and develop → main); `push: main` only fires post-merge on `main`. Direct pushes to `develop` are forbidden by project policy, so the lost trigger is moot.

## Trigger matrix after this change

| Scenario | Fires |
|---|---|
| PR `feature → develop` | `pull_request` only |
| PR `develop → main` | `pull_request` only (was: both) |
| Merge into `develop` | nothing (already validated by the PR) |
| Merge into `main` | `push` |

## Test plan

- [x] Confirm only the `pull_request` runs appear in this PR's checks list (no `(push)` siblings).
- [x] After merge into `develop`, confirm no `(push)` run is triggered for `develop`.
- [x] On the next `develop → main` release PR, confirm no duplicate runs.
- [x] After that release merges into `main`, confirm a single `(push)` run on `main`.