### PR TITLE
docs: add CONTRIBUTING.md (develop-branch policy + l10n steps)

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,82 @@
+# Contributing to OpenNutriTracker
+
+Thanks for taking an interest in contributing! This guide covers the conventions you need to follow so your pull request can be merged smoothly.
+
+For environment setup (Flutter / Android SDK / IDE), see [GettingStarted.md](GettingStarted.md).
+
+## Pull request target branch
+
+**All pull requests must target the `develop` branch, not `main`.**
+
+`main` is reserved for release merges only — it receives a single batched `develop → main` PR per release. If you open a PR against `main`, a maintainer will repoint it to `develop` before review.
+
+## Before you start
+
+- Create your branch from the latest `develop`:
+  ```sh
+  git fetch origin
+  git checkout -b feature/<short-name> origin/develop
+  ```
+- Keep changes scoped. Smaller, focused PRs are easier to review and faster to merge than sweeping ones.
+- If you are fixing or implementing an open issue, mention it in the PR description (e.g. `Closes #123`).
+
+## Adding or changing localized strings
+
+Source strings live in `lib/l10n/intl_en.arb`. Translations live in a separate ARB file per supported locale, plus manually-maintained Dart files under `lib/generated/`.
+
+> [!IMPORTANT]
+> The files under `lib/generated/` carry a `// GENERATED CODE - DO NOT MODIFY BY HAND` header but are **maintained manually** in this project. Do **not** run `intl_translation:generate_from_arb` — its output conflicts with the project's 120-character formatting and will fail CI. Edit those files by hand instead.
+
+When adding a new string key in the same PR you must:
+
+1. **Add the key to every ARB file** under `lib/l10n/`. The currently supported locales are:
+
+   | File | Language |
+   | --- | --- |
+   | `intl_en.arb` | English (source) |
+   | `intl_de.arb` | German |
+   | `intl_cs.arb` | Czech |
+   | `intl_it.arb` | Italian |
+   | `intl_pl.arb` | Polish |
+   | `intl_tr.arb` | Turkish |
+   | `intl_uk.arb` | Ukrainian |
+   | `intl_zh.arb` | Chinese (Simplified) |
+
+   Provide a real translation for each locale — do not leave the English string in as a placeholder. If you only speak one of the languages, machine translation is acceptable as a starting point; native-speaker review is welcome post-merge.
+
+2. **Add a getter to `lib/generated/l10n.dart`**, following the existing style.
+
+3. **Add a matching `MessageLookupByLibrary.simpleMessage(...)` entry to each `lib/generated/intl/messages_<locale>.dart` file**, one per locale.
+
+4. **Verify with `just check_intl`** — this is what CI runs and will fail the PR if any of the above is missing or out of sync.
+
+## Code generation
+
+Some files are produced by `build_runner` (Hive type adapters and JSON serialization). Run `just build` after touching any `@HiveType`, `@HiveField`, or `@JsonSerializable` source file. See `CLAUDE.md` for the full list of triggers.
+
+## Code style and tests
+
+- 120-character line width (configured in `analysis_options.yaml`).
+- Format with `just format` before committing — this targets only `lib/core`, `lib/features`, `lib/l10n`, and `test` and deliberately skips `lib/generated/`.
+- Run `flutter analyze` and `just test` locally before opening the PR.
+- `just ci` runs the full CI pipeline (install, format check, intl check, build, analyze, test) and is the closest thing to a one-shot pre-flight check.
+
+## Commit messages
+
+Use a short imperative subject line, optionally with a `type(scope):` prefix. Examples:
+
+```
+feat(activity): add high-intensity interval exercise
+fix(home): correct kcal budget after onboarding
+i18n(activity): wire HIIT codes 02210/02214 to translated strings
+```
+
+A body explaining the *why* is welcome but not required for small changes.
+
+## Platform support
+
+OpenNutriTracker ships on both iOS and Android. Any new dependency must support both platforms — check pub.dev before adding. Any platform-specific code must have a corresponding implementation for the other platform (or an explicit fallback). New runtime permissions on Android need a matching `Info.plist` entry on iOS, and vice versa.
+
+## Questions
+
+If you're unsure about anything, open a draft PR or an issue and ask — early feedback is much cheaper than reworking a finished change.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -25,7 +25,7 @@ For environment setup (Flutter / Android SDK / IDE), see [GettingStarted.md](Get
 Source strings live in `lib/l10n/intl_en.arb`. Translations live in a separate ARB file per supported locale, plus manually-maintained Dart files under `lib/generated/`.
 
 > [!IMPORTANT]
-> The files under `lib/generated/` carry a `// GENERATED CODE - DO NOT MODIFY BY HAND` header but are **maintained manually** in this project. Do **not** run `intl_translation:generate_from_arb` — its output conflicts with the project's 120-character formatting and will fail CI. Edit those files by hand instead.
+> **For now**, the files under `lib/generated/` carry a `// GENERATED CODE - DO NOT MODIFY BY HAND` header but are **maintained manually** in this project — the upstream generator's output conflicts with the repo's 120-character formatting and would fail CI. Until the generation pipeline is reconciled with the formatting rules, edit those files by hand. Do **not** run `intl_translation:generate_from_arb` — this caveat will go away once the generator output is fixed.
 
 When adding a new string key in the same PR you must:
 

--- a/README.md
+++ b/README.md
@@ -54,7 +54,7 @@ See [Data Protection](https://www.iubenda.com/privacy-policy/53501884)
 - Add support for Material You themes
 
 ## Contribution
-Contributions to OpenNutriTracker are welcome! If you find any issues or have suggestions for new features, please open an issue or submit a pull request. Make sure to follow the project's code style and guidelines.
+Contributions to OpenNutriTracker are welcome! If you find any issues or have suggestions for new features, please open an issue or submit a pull request. See [CONTRIBUTING.md](CONTRIBUTING.md) for the project's conventions — including the requirement to target the `develop` branch and the steps for adding localized strings.
 
 Thanks to all the contributors:
 <a href="https://github.com/simonoppowa/OpenNutriTracker/graphs/contributors">


### PR DESCRIPTION
Adds a `CONTRIBUTING.md` at the repo root, in response to @ayaadev's suggestion in [#364 (comment)](https://github.com/simonoppowa/OpenNutriTracker/pull/364#issuecomment-4387205298). Also updates the README's existing "Contribution" section to link to it.

## What it covers

- **PRs must target `develop`** — explains the `develop → main` release flow so first-time contributors don't open against `main`.
- **Localization workflow** — the eight ARB files that need updates for any new string, the manually-maintained `lib/generated/l10n.dart` getter, the per-locale `messages_<locale>.dart` `simpleMessage(...)` entries, and `just check_intl` as the CI gate.
- Brief pointers to existing material: `GettingStarted.md` for environment setup, `just build` triggers for code generation, `just format` / `just test` / `just ci` for code-style + tests, dual iOS/Android platform parity expectations, and a commit-message convention example.

Kept short and practical — anything more involved (DI registration order, Hive type IDs, BLoC layout) stays in `CLAUDE.md` since contributors typically don't need to touch those.

## Test plan

- [x] `CONTRIBUTING.md` renders cleanly on github.com
- [x] README "Contribution" section links to it
- [x] No code or generated files touched, so CI should be unaffected