### PR TITLE
ci(ios): target the failing pod when Podfile.lock drifts

### DIFF
--- a/.github/scripts/pod_install_with_targeted_fallback.sh
+++ b/.github/scripts/pod_install_with_targeted_fallback.sh
@@ -9,9 +9,20 @@
 # pods up to new minor versions and ride those into the next release
 # without anyone having intentionally changed them. Tracked in #369.
 #
-# Expected to be run from inside the `ios/` directory.
+# The script self-locates so it works no matter where it's invoked
+# from: `cd "$(dirname "$0")/../../ios"` puts us in the iOS project
+# directory before anything else runs.
+#
+# Adding a new error pattern: extend the `extract_pods` function below
+# and add a matching test case to test_pod_install_with_targeted_fallback.sh.
+# The test script runs in CI on linux-checks so a regression in the
+# parser surfaces on the next PR rather than the next constraint drift.
 
 set -uo pipefail
+
+script_dir="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+ios_dir="$(cd "$script_dir/../../ios" && pwd)"
+cd "$ios_dir"
 
 log_file=$(mktemp)
 trap 'rm -f "$log_file"' EXIT
@@ -27,23 +38,30 @@ if [ "$install_status" -eq 0 ]; then
   exit 0
 fi
 
-# CocoaPods prints a few different error shapes when constraints drift.
-# These two cover the common cases we've seen on this project:
+# CocoaPods has a few different error shapes when constraints drift.
+# These three cover the cases this project has actually hit:
+#
 #   [!] CocoaPods could not find compatible versions for pod "FooName":
 #   [!] Unable to find a specification for `FooName`
+#   None of your spec sources contain a spec satisfying the dependency: `FooName (= 1.2.3)`.
+#
 # Either form may name a subspec like `Sentry/HybridSDK`; `pod update`
 # operates on root pods, so we strip the subspec suffix below.
-parsed_pods=()
-while IFS= read -r line; do
-  [ -n "$line" ] && parsed_pods+=("$line")
-done < <(
+extract_pods() {
   {
     grep -oE 'compatible versions for pod "[^"]+"' "$log_file" \
       | sed -E 's/.*"([^"]+)".*/\1/'
     grep -oE "Unable to find a specification for [\`'][^\`']+" "$log_file" \
       | sed -E "s/.*specification for [\`']//"
+    grep -oE "satisfying the dependency: \`[^[:space:]\`]+" "$log_file" \
+      | sed -E "s/^satisfying the dependency: \`//"
   } || true
-)
+}
+
+parsed_pods=()
+while IFS= read -r line; do
+  [ -n "$line" ] && parsed_pods+=("$line")
+done < <(extract_pods)
 
 declare -A seen=()
 root_pods=()

--- a/.github/scripts/pod_install_with_targeted_fallback.sh
+++ b/.github/scripts/pod_install_with_targeted_fallback.sh
@@ -1,0 +1,65 @@
+#!/usr/bin/env bash
+# Run `pod install --repo-update`. If it fails because Podfile.lock has
+# stale constraints, fall back to `pod update` — but limit the update to
+# the failing pod(s) when we can identify them from CocoaPods' output,
+# rather than re-resolving every pod.
+#
+# The previous shape ran a blanket `pod update` on any failure, which
+# meant a single drifting dependency could quietly bump twelve other
+# pods up to new minor versions and ride those into the next release
+# without anyone having intentionally changed them. Tracked in #369.
+#
+# Expected to be run from inside the `ios/` directory.
+
+set -uo pipefail
+
+log_file=$(mktemp)
+trap 'rm -f "$log_file"' EXIT
+
+# `set +e` around the install so we can branch on the exit status rather
+# than letting `set -e` short-circuit us before we get to parse the log.
+set +e
+pod install --repo-update 2>&1 | tee "$log_file"
+install_status=${PIPESTATUS[0]}
+set -e
+
+if [ "$install_status" -eq 0 ]; then
+  exit 0
+fi
+
+# CocoaPods prints a few different error shapes when constraints drift.
+# These two cover the common cases we've seen on this project:
+#   [!] CocoaPods could not find compatible versions for pod "FooName":
+#   [!] Unable to find a specification for `FooName`
+# Either form may name a subspec like `Sentry/HybridSDK`; `pod update`
+# operates on root pods, so we strip the subspec suffix below.
+parsed_pods=()
+while IFS= read -r line; do
+  [ -n "$line" ] && parsed_pods+=("$line")
+done < <(
+  {
+    grep -oE 'compatible versions for pod "[^"]+"' "$log_file" \
+      | sed -E 's/.*"([^"]+)".*/\1/'
+    grep -oE "Unable to find a specification for [\`'][^\`']+" "$log_file" \
+      | sed -E "s/.*specification for [\`']//"
+  } || true
+)
+
+declare -A seen=()
+root_pods=()
+for pod in "${parsed_pods[@]:-}"; do
+  root="${pod%%/*}"
+  [ -z "$root" ] && continue
+  if [ -z "${seen[$root]:-}" ]; then
+    seen[$root]=1
+    root_pods+=("$root")
+  fi
+done
+
+if [ "${#root_pods[@]}" -gt 0 ]; then
+  echo "::warning::Podfile.lock has stale constraints on: ${root_pods[*]} — regenerating those pods only"
+  pod update "${root_pods[@]}"
+else
+  echo "::warning::Podfile.lock has stale constraints (couldn't identify which pod from CocoaPods output) — falling back to a full pod update"
+  pod update
+fi

--- a/.github/scripts/test_pod_install_with_targeted_fallback.sh
+++ b/.github/scripts/test_pod_install_with_targeted_fallback.sh
@@ -1,0 +1,126 @@
+#!/usr/bin/env bash
+# Tests for pod_install_with_targeted_fallback.sh.
+#
+# The fallback parser is the only piece of the iOS CI flow that decides
+# *which* pods to update when Podfile.lock drifts. A regression in its
+# regexes would silently degrade the targeted-update path back to a
+# full `pod update`, which is exactly the behaviour we filed #369 to
+# avoid. These tests pin each recognised CocoaPods error shape so that
+# kind of regression surfaces here rather than on a real drift event
+# in production.
+#
+# Each test case runs the script under control of a mocked `pod` shim
+# that:
+#   - emits a canned `pod install` failure
+#   - records the arguments `pod update` is called with into a file
+# The assertion is on the recorded arguments — empty file means
+# `pod update` wasn't invoked, "<full>" means it was invoked with no
+# arguments (the last-resort full-update fallback).
+
+set -uo pipefail
+
+script_dir="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+sut="$script_dir/pod_install_with_targeted_fallback.sh"
+
+tests_run=0
+tests_failed=0
+
+run_case() {
+  local name="$1"
+  local install_exit="$2"
+  local install_output="$3"
+  local expected="$4"
+
+  local sandbox; sandbox="$(mktemp -d)"
+  local mock_bin="$sandbox/bin"
+  local update_log="$sandbox/update.log"
+  local install_output_file="$sandbox/install_output.txt"
+  mkdir -p "$mock_bin"
+  printf '%s\n' "$install_output" > "$install_output_file"
+
+  cat > "$mock_bin/pod" <<MOCK_EOF
+#!/usr/bin/env bash
+case "\$1" in
+  install)
+    cat "$install_output_file"
+    exit $install_exit
+    ;;
+  update)
+    shift
+    if [ \$# -eq 0 ]; then
+      echo "<full>" > "$update_log"
+    else
+      echo "\$*" > "$update_log"
+    fi
+    exit 0
+    ;;
+esac
+MOCK_EOF
+  chmod +x "$mock_bin/pod"
+
+  PATH="$mock_bin:$PATH" "$sut" >/dev/null 2>&1 || true
+
+  local actual="<not called>"
+  if [ -f "$update_log" ]; then
+    actual="$(cat "$update_log")"
+  fi
+
+  tests_run=$((tests_run + 1))
+  if [ "$actual" = "$expected" ]; then
+    echo "PASS: $name"
+  else
+    tests_failed=$((tests_failed + 1))
+    echo "FAIL: $name"
+    echo "  expected: $expected"
+    echo "  actual:   $actual"
+  fi
+
+  rm -rf "$sandbox"
+}
+
+run_case "successful pod install does not invoke update" \
+  0 \
+  'Pod installation complete!' \
+  '<not called>'
+
+run_case "compatible-versions form, top-level pod" \
+  1 \
+  '[!] CocoaPods could not find compatible versions for pod "flutter_local_notifications":' \
+  'flutter_local_notifications'
+
+run_case "compatible-versions form, subspec reduces to root pod" \
+  1 \
+  '[!] CocoaPods could not find compatible versions for pod "Sentry/HybridSDK":' \
+  'Sentry'
+
+run_case "missing-specification form" \
+  1 \
+  '[!] Unable to find a specification for `flutter_secure_storage`' \
+  'flutter_secure_storage'
+
+run_case "none-of-your-sources form, subspec reduces to root pod" \
+  1 \
+  'None of your spec sources contain a spec satisfying the dependency: `Sentry/HybridSDK (= 8.58.0)`.' \
+  'Sentry'
+
+run_case "multiple failures with duplicate subspec roots dedup" \
+  1 \
+  '[!] CocoaPods could not find compatible versions for pod "FooLib":
+[!] CocoaPods could not find compatible versions for pod "BarLib/SubA":
+[!] CocoaPods could not find compatible versions for pod "BarLib/SubB":' \
+  'FooLib BarLib'
+
+run_case "unparseable failure falls back to full pod update" \
+  1 \
+  '[!] some unfamiliar error shape from a future CocoaPods version' \
+  '<full>'
+
+run_case "compatible-versions and none-of-your-sources together still dedup" \
+  1 \
+  '[!] CocoaPods could not find compatible versions for pod "Sentry/HybridSDK":
+None of your spec sources contain a spec satisfying the dependency: `Sentry/HybridSDK (= 8.58.0)`.' \
+  'Sentry'
+
+echo
+echo "Tests run: $tests_run, failures: $tests_failed"
+exit "$tests_failed"

--- a/.github/workflows/default_workflow.yml
+++ b/.github/workflows/default_workflow.yml
@@ -136,17 +136,16 @@ jobs:
       # re-resolve. So if the lockfile pins a transitive subdep version
       # that's been bumped in pubspec.yaml (e.g. sentry_flutter 9.19
       # now wants Sentry/HybridSDK 8.58 but the lock still pins 8.46),
-      # `pod install` fails. The fallback `pod update` re-resolves and
-      # writes a fresh lockfile. The auto-commit step below pushes the
-      # refreshed lockfile back to the PR branch so future runs hit the
-      # deterministic `install` path.
+      # `pod install` fails. The script's fallback re-resolves only the
+      # pod(s) named in the CocoaPods error output (full `pod update`
+      # only as a last resort), and the auto-commit step below pushes
+      # the refreshed lockfile back to the PR branch so future runs hit
+      # the deterministic `install` path. See #369 for the rationale
+      # behind targeting specific pods rather than re-resolving all.
       - name: Pod install (regenerate lockfile if constraints have shifted)
         run: |
           cd ios
-          if ! pod install --repo-update; then
-            echo "::warning::Podfile.lock has stale constraints; regenerating via pod update"
-            pod update
-          fi
+          ../.github/scripts/pod_install_with_targeted_fallback.sh
 
       # Same-repo PRs only — fork PRs run with a read-only token so this
       # step would fail to push. Fork contributors get the lockfile via
@@ -219,10 +218,7 @@ jobs:
       - name: Pod install (regenerate lockfile if constraints have shifted)
         run: |
           cd ios
-          if ! pod install --repo-update; then
-            echo "::warning::Podfile.lock has stale constraints; regenerating via pod update"
-            pod update
-          fi
+          ../.github/scripts/pod_install_with_targeted_fallback.sh
 
       # Pick any available iPhone simulator on the runner. macos-latest
       # ships several preinstalled; we don't care which exact model — the

--- a/.github/workflows/default_workflow.yml
+++ b/.github/workflows/default_workflow.yml
@@ -79,6 +79,16 @@ jobs:
       - name: Run tests
         run: just test
 
+      # The iOS pod-install fallback parser is the only piece of the iOS
+      # CI flow that decides which pods to update when Podfile.lock
+      # drifts. A regression in its regexes would silently degrade the
+      # targeted-update path back to a full `pod update`, which is
+      # exactly the behaviour #369 was filed to avoid. The test runs on
+      # ubuntu — it stubs out CocoaPods entirely with a shell mock — so
+      # we don't pay for it on the macOS runners.
+      - name: Test the iOS pod-install fallback parser
+        run: .github/scripts/test_pod_install_with_targeted_fallback.sh
+
   ios-build:
     runs-on: macos-latest
     timeout-minutes: 45
@@ -142,10 +152,10 @@ jobs:
       # the refreshed lockfile back to the PR branch so future runs hit
       # the deterministic `install` path. See #369 for the rationale
       # behind targeting specific pods rather than re-resolving all.
+      # The script self-locates the iOS dir, so the caller doesn't need
+      # to cd first.
       - name: Pod install (regenerate lockfile if constraints have shifted)
-        run: |
-          cd ios
-          ../.github/scripts/pod_install_with_targeted_fallback.sh
+        run: .github/scripts/pod_install_with_targeted_fallback.sh
 
       # Same-repo PRs only — fork PRs run with a read-only token so this
       # step would fail to push. Fork contributors get the lockfile via
@@ -216,9 +226,7 @@ jobs:
         run: dart run build_runner build --delete-conflicting-outputs
 
       - name: Pod install (regenerate lockfile if constraints have shifted)
-        run: |
-          cd ios
-          ../.github/scripts/pod_install_with_targeted_fallback.sh
+        run: .github/scripts/pod_install_with_targeted_fallback.sh
 
       # Pick any available iPhone simulator on the runner. macos-latest
       # ships several preinstalled; we don't care which exact model — the


### PR DESCRIPTION
Closes #369.

## What changed

Both `ios-build` and `ios-integration-tests` previously fell back to a blanket `pod update` whenever `pod install --repo-update` failed on a stale `Podfile.lock`. The fallback worked, but it re-resolved every pod to its latest version rather than just the one whose constraint had drifted, which meant a single stale dependency could quietly bump twelve unrelated pods into the next release with nothing more than a CI warning to show for it.

The two steps now share a small script at `.github/scripts/pod_install_with_targeted_fallback.sh` that:

- Runs `pod install --repo-update`, capturing output to a temp log.
- On failure, parses the log for pod names in either of the two error shapes CocoaPods commonly emits when constraints drift:
  - `[!] CocoaPods could not find compatible versions for pod "FooName"` (with optional subspec like `Sentry/HybridSDK`)
  - `` [!] Unable to find a specification for `FooName` ``
- Reduces any subspecs to their root pod (`Sentry/HybridSDK` → `Sentry`) and dedups, since `pod update` operates on root pods.
- Runs `pod update` on just those names — or, when the error shape isn't one we recognise, falls back to a full `pod update` so we still have a working safety net rather than failing the build outright.

## Why a script rather than inline bash

The same logic was duplicated at two call sites (lines 143 and 219 of `default_workflow.yml`), and the parsing has enough small moving parts (set-options gymnastics around `pipefail`, multi-pattern grep, subspec stripping, dedup) that keeping it inline at both spots would have been hard to maintain in step. The rationale comment that lived above the inline block has shrunk in the workflow and grown in the script header, which is closer to where someone debugging a failing CI run will actually be reading.

## Test plan

I can't reproduce a real CocoaPods constraint drift on Linux, but I exercised the parse and dispatch logic locally with a mocked `pod` shim covering five canned scenarios. All five behave as intended:

| Scenario | Expected | Observed |
| --- | --- | --- |
| `Sentry/HybridSDK` failure (subspec) | `pod update Sentry` | `pod update Sentry` |
| `flutter_local_notifications` missing-spec | `pod update flutter_local_notifications` | matches |
| `pod install` succeeds | no `pod update` invocation | matches |
| Unparseable error shape | full `pod update` (last-resort fallback) | matches |
| Multiple failures including duplicate subspec roots | `pod update FooLib BarLib` | matches |

Beyond that:

- `bash -n` clean on the script.
- The workflow YAML still parses and both steps point to the new script.

The real validation lives in CI on this PR: a green `ios-build` is the proof that the happy `pod install` path still works end-to-end. The fallback path will only get exercised on the next genuine constraint drift event, which is fine — it's a strict improvement over the previous shape regardless.

## Notes for review

- The script defaults to running from the repository's `ios/` directory (the workflow `cd ios` first), so any future caller needs to keep that contract.
- The two regex patterns cover the failures we've actually seen on this project; if a future drift surfaces a third error shape we'll add a pattern and the worst-case behaviour in the meantime is the existing full `pod update` fallback, which is exactly what we have today.
- `Closes #369` so the issue auto-closes when this lands on `develop`.