### PR TITLE
Remove exact alarm permission

### DIFF
--- a/android/app/src/main/AndroidManifest.xml
+++ b/android/app/src/main/AndroidManifest.xml
@@ -5,7 +5,6 @@
     <!-- #312: Notification reminders -->
     <uses-permission android:name="android.permission.RECEIVE_BOOT_COMPLETED"/>
     <uses-permission android:name="android.permission.SCHEDULE_EXACT_ALARM" />
-    <uses-permission android:name="android.permission.USE_EXACT_ALARM" />
     <uses-permission android:name="android.permission.POST_NOTIFICATIONS"/>
 
     <!-- Provide required visibility configuration for API level 30 and above -->

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -15,7 +15,7 @@ publish_to: 'none' # Remove this line if you wish to publish to pub.dev
 # In iOS, build-name is used as CFBundleShortVersionString while build-number is used as CFBundleVersion.
 # Read more about iOS versioning at
 # https://developer.apple.com/library/archive/documentation/General/Reference/InfoPlistKeyReference/Articles/CoreFoundationKeys.html
-version: 1.3.0+47
+version: 1.3.0+48
 
 environment:
   sdk: '>=3.11.0 <4.0.0'


### PR DESCRIPTION
This pull request includes a minor update to remove the conflict with permissions in the Android manifest and Google Play Store Guidelines

- Version update:
  * Incremented the application version from `1.3.0+47` to `1.3.0+48` in `pubspec.yaml` to reflect a new build.

- Android permission cleanup:
  * Removed the `android.permission.USE_EXACT_ALARM` permission from `AndroidManifest.xml`