### PR TITLE
feat(a11y): add Semantics identifiers for ADB-driven UI testing

### DIFF
--- a/lib/core/presentation/main_screen.dart
+++ b/lib/core/presentation/main_screen.dart
@@ -103,10 +103,13 @@ class _MainScreenState extends State<MainScreen> {
       appBar: _appbarPages[_selectedPageIndex],
       body: _bodyPages[_selectedPageIndex],
       floatingActionButton: _selectedPageIndex == 0
-          ? FloatingActionButton(
-              onPressed: () => _onFabPressed(context),
-              tooltip: S.of(context).addLabel,
-              child: const Icon(Icons.add),
+          ? Semantics(
+              identifier: 'fab-add-item',
+              child: FloatingActionButton(
+                onPressed: () => _onFabPressed(context),
+                tooltip: S.of(context).addLabel,
+                child: const Icon(Icons.add),
+              ),
             )
           : null,
       bottomNavigationBar: NavigationBar(
@@ -114,27 +117,39 @@ class _MainScreenState extends State<MainScreen> {
         onDestinationSelected: _setPage,
         destinations: [
           NavigationDestination(
-            icon: _selectedPageIndex == 0
-                ? const Icon(Icons.home)
-                : const Icon(Icons.home_outlined),
+            icon: Semantics(
+              identifier: 'nav-home',
+              child: _selectedPageIndex == 0
+                  ? const Icon(Icons.home)
+                  : const Icon(Icons.home_outlined),
+            ),
             label: S.of(context).homeLabel,
           ),
           NavigationDestination(
-            icon: _selectedPageIndex == 1
-                ? const Icon(Icons.book)
-                : const Icon((Icons.book_outlined)),
+            icon: Semantics(
+              identifier: 'nav-diary',
+              child: _selectedPageIndex == 1
+                  ? const Icon(Icons.book)
+                  : const Icon((Icons.book_outlined)),
+            ),
             label: S.of(context).diaryLabel,
           ),
           NavigationDestination(
-            icon: _selectedPageIndex == 2
-                ? const Icon(Icons.menu_book)
-                : const Icon(Icons.menu_book_outlined),
+            icon: Semantics(
+              identifier: 'nav-recipes',
+              child: _selectedPageIndex == 2
+                  ? const Icon(Icons.menu_book)
+                  : const Icon(Icons.menu_book_outlined),
+            ),
             label: S.of(context).recipesLabel,
           ),
           NavigationDestination(
-            icon: _selectedPageIndex == 3
-                ? const Icon(Icons.account_circle)
-                : const Icon(Icons.account_circle_outlined),
+            icon: Semantics(
+              identifier: 'nav-profile',
+              child: _selectedPageIndex == 3
+                  ? const Icon(Icons.account_circle)
+                  : const Icon(Icons.account_circle_outlined),
+            ),
             label: S.of(context).profileLabel,
           ),
         ],

--- a/lib/core/presentation/widgets/add_item_bottom_sheet.dart
+++ b/lib/core/presentation/widgets/add_item_bottom_sheet.dart
@@ -29,129 +29,144 @@ class AddItemBottomSheet extends StatelessWidget {
                   ),
             ),
           ),
-          ListTile(
-            title: Text(
-              S.of(context).activityLabel,
-              style: Theme.of(context).textTheme.titleLarge?.copyWith(
-                    color: Theme.of(context).colorScheme.onSurface,
-                  ),
-            ),
-            subtitle: Text(
-              S.of(context).activityExample,
-              style: Theme.of(context).textTheme.titleMedium?.copyWith(
-                    color: Theme.of(
-                      context,
-                    ).colorScheme.onSurface.withValues(alpha: 0.7),
-                  ),
-            ),
-            // ignore: sized_box_for_whitespace
-            leading: Container(
-              height: double.infinity,
-              child: Icon(
-                UserActivityEntity.getIconData(),
-                color: Theme.of(context).colorScheme.onSurface,
+          Semantics(
+            identifier: 'add-item-activity',
+            child: ListTile(
+              title: Text(
+                S.of(context).activityLabel,
+                style: Theme.of(context).textTheme.titleLarge?.copyWith(
+                      color: Theme.of(context).colorScheme.onSurface,
+                    ),
               ),
+              subtitle: Text(
+                S.of(context).activityExample,
+                style: Theme.of(context).textTheme.titleMedium?.copyWith(
+                      color: Theme.of(
+                        context,
+                      ).colorScheme.onSurface.withValues(alpha: 0.7),
+                    ),
+              ),
+              // ignore: sized_box_for_whitespace
+              leading: Container(
+                height: double.infinity,
+                child: Icon(
+                  UserActivityEntity.getIconData(),
+                  color: Theme.of(context).colorScheme.onSurface,
+                ),
+              ),
+              onTap: () {
+                _showAddActivityScreen(context);
+              },
             ),
-            onTap: () {
-              _showAddActivityScreen(context);
-            },
           ),
           const Divider(indent: 16, endIndent: 16),
-          ListTile(
-            title: Text(
-              S.of(context).breakfastLabel,
-              style: Theme.of(context).textTheme.titleLarge?.copyWith(
-                    color: Theme.of(context).colorScheme.onSurface,
-                  ),
+          Semantics(
+            identifier: 'add-item-breakfast',
+            child: ListTile(
+              title: Text(
+                S.of(context).breakfastLabel,
+                style: Theme.of(context).textTheme.titleLarge?.copyWith(
+                      color: Theme.of(context).colorScheme.onSurface,
+                    ),
+              ),
+              subtitle: Text(
+                S.of(context).breakfastExample,
+                style: Theme.of(context).textTheme.titleMedium?.copyWith(
+                      color: Theme.of(
+                        context,
+                      ).colorScheme.onSurface.withValues(alpha: 0.7),
+                    ),
+              ),
+              // ignore: sized_box_for_whitespace
+              leading: Container(
+                height: double.infinity,
+                child: Icon(IntakeTypeEntity.breakfast.getIconData()),
+              ),
+              onTap: () {
+                _showAddItemScreen(context, AddMealType.breakfastType);
+              },
             ),
-            subtitle: Text(
-              S.of(context).breakfastExample,
-              style: Theme.of(context).textTheme.titleMedium?.copyWith(
-                    color: Theme.of(
-                      context,
-                    ).colorScheme.onSurface.withValues(alpha: 0.7),
-                  ),
-            ),
-            // ignore: sized_box_for_whitespace
-            leading: Container(
-              height: double.infinity,
-              child: Icon(IntakeTypeEntity.breakfast.getIconData()),
-            ),
-            onTap: () {
-              _showAddItemScreen(context, AddMealType.breakfastType);
-            },
           ),
-          ListTile(
-            title: Text(
-              S.of(context).lunchLabel,
-              style: Theme.of(context).textTheme.titleLarge?.copyWith(
-                    color: Theme.of(context).colorScheme.onSurface,
-                  ),
+          Semantics(
+            identifier: 'add-item-lunch',
+            child: ListTile(
+              title: Text(
+                S.of(context).lunchLabel,
+                style: Theme.of(context).textTheme.titleLarge?.copyWith(
+                      color: Theme.of(context).colorScheme.onSurface,
+                    ),
+              ),
+              subtitle: Text(
+                S.of(context).lunchExample,
+                style: Theme.of(context).textTheme.titleMedium?.copyWith(
+                      color: Theme.of(
+                        context,
+                      ).colorScheme.onSurface.withValues(alpha: 0.7),
+                    ),
+              ),
+              // ignore: sized_box_for_whitespace
+              leading: Container(
+                height: double.infinity,
+                child: Icon(IntakeTypeEntity.lunch.getIconData()),
+              ),
+              onTap: () {
+                _showAddItemScreen(context, AddMealType.lunchType);
+              },
             ),
-            subtitle: Text(
-              S.of(context).lunchExample,
-              style: Theme.of(context).textTheme.titleMedium?.copyWith(
-                    color: Theme.of(
-                      context,
-                    ).colorScheme.onSurface.withValues(alpha: 0.7),
-                  ),
-            ),
-            // ignore: sized_box_for_whitespace
-            leading: Container(
-              height: double.infinity,
-              child: Icon(IntakeTypeEntity.lunch.getIconData()),
-            ),
-            onTap: () {
-              _showAddItemScreen(context, AddMealType.lunchType);
-            },
           ),
-          ListTile(
-            title: Text(
-              S.of(context).dinnerLabel,
-              style: Theme.of(context).textTheme.titleLarge?.copyWith(
-                    color: Theme.of(context).colorScheme.onSurface,
-                  ),
+          Semantics(
+            identifier: 'add-item-dinner',
+            child: ListTile(
+              title: Text(
+                S.of(context).dinnerLabel,
+                style: Theme.of(context).textTheme.titleLarge?.copyWith(
+                      color: Theme.of(context).colorScheme.onSurface,
+                    ),
+              ),
+              subtitle: Text(
+                S.of(context).dinnerExample,
+                style: Theme.of(context).textTheme.titleMedium?.copyWith(
+                      color: Theme.of(
+                        context,
+                      ).colorScheme.onSurface.withValues(alpha: 0.7),
+                    ),
+              ),
+              // ignore: sized_box_for_whitespace
+              leading: Container(
+                height: double.infinity,
+                child: Icon(IntakeTypeEntity.dinner.getIconData()),
+              ),
+              onTap: () {
+                _showAddItemScreen(context, AddMealType.dinnerType);
+              },
             ),
-            subtitle: Text(
-              S.of(context).dinnerExample,
-              style: Theme.of(context).textTheme.titleMedium?.copyWith(
-                    color: Theme.of(
-                      context,
-                    ).colorScheme.onSurface.withValues(alpha: 0.7),
-                  ),
-            ),
-            // ignore: sized_box_for_whitespace
-            leading: Container(
-              height: double.infinity,
-              child: Icon(IntakeTypeEntity.dinner.getIconData()),
-            ),
-            onTap: () {
-              _showAddItemScreen(context, AddMealType.dinnerType);
-            },
           ),
-          ListTile(
-            title: Text(
-              S.of(context).snackLabel,
-              style: Theme.of(context).textTheme.titleLarge?.copyWith(
-                    color: Theme.of(context).colorScheme.onSurface,
-                  ),
+          Semantics(
+            identifier: 'add-item-snack',
+            child: ListTile(
+              title: Text(
+                S.of(context).snackLabel,
+                style: Theme.of(context).textTheme.titleLarge?.copyWith(
+                      color: Theme.of(context).colorScheme.onSurface,
+                    ),
+              ),
+              subtitle: Text(
+                S.of(context).snackExample,
+                style: Theme.of(context).textTheme.titleMedium?.copyWith(
+                      color: Theme.of(
+                        context,
+                      ).colorScheme.onSurface.withValues(alpha: 0.7),
+                    ),
+              ),
+              // ignore: sized_box_for_whitespace
+              leading: Container(
+                height: double.infinity,
+                child: Icon(IntakeTypeEntity.snack.getIconData()),
+              ),
+              onTap: () {
+                _showAddItemScreen(context, AddMealType.snackType);
+              },
             ),
-            subtitle: Text(
-              S.of(context).snackExample,
-              style: Theme.of(context).textTheme.titleMedium?.copyWith(
-                    color: Theme.of(
-                      context,
-                    ).colorScheme.onSurface.withValues(alpha: 0.7),
-                  ),
-            ),
-            // ignore: sized_box_for_whitespace
-            leading: Container(
-              height: double.infinity,
-              child: Icon(IntakeTypeEntity.snack.getIconData()),
-            ),
-            onTap: () {
-              _showAddItemScreen(context, AddMealType.snackType);
-            },
           ),
         ],
       ),

--- a/lib/features/onboarding/presentation/onboarding_intro_page_body.dart
+++ b/lib/features/onboarding/presentation/onboarding_intro_page_body.dart
@@ -71,13 +71,16 @@ class _OnboardingIntroPageBodyState extends State<OnboardingIntroPageBody> {
                     ],
                   ),
                 ),
-                leading: Checkbox(
-                  value: _acceptedPolicy,
-                  onChanged: (value) {
-                    if (value != null) {
-                      _togglePolicy();
-                    }
-                  },
+                leading: Semantics(
+                  identifier: 'onboarding-checkbox-privacy',
+                  child: Checkbox(
+                    value: _acceptedPolicy,
+                    onChanged: (value) {
+                      if (value != null) {
+                        _togglePolicy();
+                      }
+                    },
+                  ),
                 ),
               ),
               ListTile(
@@ -87,9 +90,12 @@ class _OnboardingIntroPageBodyState extends State<OnboardingIntroPageBody> {
                   textAlign: TextAlign.center,
                   style: Theme.of(context).textTheme.bodySmall,
                 ),
-                leading: Checkbox(
-                  value: _acceptedDataCollection,
-                  onChanged: (value) => _toggleDataCollection(),
+                leading: Semantics(
+                  identifier: 'onboarding-checkbox-data',
+                  child: Checkbox(
+                    value: _acceptedDataCollection,
+                    onChanged: (value) => _toggleDataCollection(),
+                  ),
                 ),
               ),
             ],

--- a/lib/features/onboarding/presentation/widgets/highlight_button.dart
+++ b/lib/features/onboarding/presentation/widgets/highlight_button.dart
@@ -21,16 +21,29 @@ class _HighlightButtonState extends State<HighlightButton> {
   Widget build(BuildContext context) {
     return Container(
       margin: const EdgeInsets.symmetric(horizontal: 16),
-      child: ElevatedButton.icon(
-        onPressed: widget.buttonActive ? widget.onButtonPressed : null,
-        style: ElevatedButton.styleFrom(
-          foregroundColor: Theme.of(context).colorScheme.onPrimaryContainer,
-          backgroundColor: Theme.of(context).colorScheme.primaryContainer,
-        ).copyWith(elevation: ButtonStyleButton.allOrNull(0.0)),
-        icon: const Icon(Icons.navigate_next_outlined),
-        label: Text(
-          widget.buttonLabel,
-          style: Theme.of(context).textTheme.labelLarge,
+      alignment: Alignment.bottomCenter,
+      child: Align(
+        alignment: Alignment.bottomCenter,
+        child: Semantics(
+          identifier: 'onboarding-button',
+          // `container: true` is load-bearing: without it the Semantics node
+          // inherits the surrounding Expanded/Container bounds (the full
+          // footer area) and uiautomator-based tests tap mid-screen instead
+          // of the button. Visible/TalkBack behavior is unchanged — this
+          // Semantics carries no role or label, only the test identifier.
+          container: true,
+          child: ElevatedButton.icon(
+            onPressed: widget.buttonActive ? widget.onButtonPressed : null,
+            style: ElevatedButton.styleFrom(
+              foregroundColor: Theme.of(context).colorScheme.onPrimaryContainer,
+              backgroundColor: Theme.of(context).colorScheme.primaryContainer,
+            ).copyWith(elevation: ButtonStyleButton.allOrNull(0.0)),
+            icon: const Icon(Icons.navigate_next_outlined),
+            label: Text(
+              widget.buttonLabel,
+              style: Theme.of(context).textTheme.labelLarge,
+            ),
+          ),
         ),
       ),
     );

--- a/lib/features/onboarding/presentation/widgets/onboarding_first_page_body.dart
+++ b/lib/features/onboarding/presentation/widgets/onboarding_first_page_body.dart
@@ -186,19 +186,22 @@ class _OnboardingFirstPageBodyState extends State<OnboardingFirstPageBody> {
             style: Theme.of(context).textTheme.titleMedium,
           ),
           const SizedBox(height: 16.0),
-          TextFormField(
-            controller: _dateInput,
-            readOnly: true,
-            decoration: InputDecoration(
-              hintText: S.of(context).onboardingEnterBirthdayLabel,
-              labelText: S.of(context).onboardingEnterBirthdayLabel,
-              prefixIcon: const Icon(Icons.calendar_month_outlined),
-              filled: true,
-              border: OutlineInputBorder(
-                borderRadius: BorderRadius.circular(10),
+          Semantics(
+            identifier: 'onboarding-birthday-field',
+            child: TextFormField(
+              controller: _dateInput,
+              readOnly: true,
+              decoration: InputDecoration(
+                hintText: S.of(context).onboardingEnterBirthdayLabel,
+                labelText: S.of(context).onboardingEnterBirthdayLabel,
+                prefixIcon: const Icon(Icons.calendar_month_outlined),
+                filled: true,
+                border: OutlineInputBorder(
+                  borderRadius: BorderRadius.circular(10),
+                ),
               ),
+              onTap: onDateInputClicked,
             ),
-            onTap: onDateInputClicked,
           ),
         ],
       ),
@@ -207,11 +210,14 @@ class _OnboardingFirstPageBodyState extends State<OnboardingFirstPageBody> {
 
   Widget _buildGenderChip(UserGenderSelectionEntity selection) {
     final entity = _toEntity(selection);
-    return ChoiceChip(
-      label: Text(entity.getName(context)),
-      avatar: entity.getIcon(size: 18),
-      selected: _selectedGender == selection,
-      onSelected: (_) => _onGenderSelected(selection),
+    return Semantics(
+      identifier: 'onboarding-gender-${selection.name}',
+      child: ChoiceChip(
+        label: Text(entity.getName(context)),
+        avatar: entity.getIcon(size: 18),
+        selected: _selectedGender == selection,
+        onSelected: (_) => _onGenderSelected(selection),
+      ),
     );
   }
 

--- a/lib/features/onboarding/presentation/widgets/onboarding_fourth_page_body.dart
+++ b/lib/features/onboarding/presentation/widgets/onboarding_fourth_page_body.dart
@@ -43,46 +43,55 @@ class _OnboardingFourthPageBodyState extends State<OnboardingFourthPageBody> {
             style: Theme.of(context).textTheme.titleMedium,
           ),
           const SizedBox(height: 16.0),
-          ChoiceChip(
-            label: Text(
-              S.of(context).goalLoseWeight,
-              style: Theme.of(context).textTheme.titleLarge,
+          Semantics(
+            identifier: 'onboarding-goal-lose',
+            child: ChoiceChip(
+              label: Text(
+                S.of(context).goalLoseWeight,
+                style: Theme.of(context).textTheme.titleLarge,
+              ),
+              selected: _looseWeightSelected,
+              onSelected: (bool selected) {
+                setState(() {
+                  _setSelectedChoiceChip(looseWeight: true);
+                  _checkCorrectInput();
+                });
+              },
             ),
-            selected: _looseWeightSelected,
-            onSelected: (bool selected) {
-              setState(() {
-                _setSelectedChoiceChip(looseWeight: true);
-                _checkCorrectInput();
-              });
-            },
           ),
           const SizedBox(height: 8.0),
-          ChoiceChip(
-            label: Text(
-              S.of(context).goalMaintainWeight,
-              style: Theme.of(context).textTheme.titleLarge,
+          Semantics(
+            identifier: 'onboarding-goal-maintain',
+            child: ChoiceChip(
+              label: Text(
+                S.of(context).goalMaintainWeight,
+                style: Theme.of(context).textTheme.titleLarge,
+              ),
+              selected: _maintainWeightSelected,
+              onSelected: (bool selected) {
+                setState(() {
+                  _setSelectedChoiceChip(maintainWeigh: true);
+                  _checkCorrectInput();
+                });
+              },
             ),
-            selected: _maintainWeightSelected,
-            onSelected: (bool selected) {
-              setState(() {
-                _setSelectedChoiceChip(maintainWeigh: true);
-                _checkCorrectInput();
-              });
-            },
           ),
           const SizedBox(height: 8.0),
-          ChoiceChip(
-            label: Text(
-              S.of(context).goalGainWeight,
-              style: Theme.of(context).textTheme.titleLarge,
+          Semantics(
+            identifier: 'onboarding-goal-gain',
+            child: ChoiceChip(
+              label: Text(
+                S.of(context).goalGainWeight,
+                style: Theme.of(context).textTheme.titleLarge,
+              ),
+              selected: _gainWeightSelected,
+              onSelected: (bool selected) {
+                setState(() {
+                  _setSelectedChoiceChip(gainWeight: true);
+                  _checkCorrectInput();
+                });
+              },
             ),
-            selected: _gainWeightSelected,
-            onSelected: (bool selected) {
-              setState(() {
-                _setSelectedChoiceChip(gainWeight: true);
-                _checkCorrectInput();
-              });
-            },
           ),
         ],
       ),

--- a/lib/features/onboarding/presentation/widgets/onboarding_second_page_body.dart
+++ b/lib/features/onboarding/presentation/widgets/onboarding_second_page_body.dart
@@ -116,44 +116,47 @@ class _OnboardingSecondPageBodyState extends State<OnboardingSecondPageBody> {
           const SizedBox(height: 16.0),
           Form(
             key: _heightFormKey,
-            child: TextFormField(
-              controller: _heightController,
-              focusNode: _heightFocusNode,
-              onChanged: (text) {
-                if (_heightFormKey.currentState!.validate()) {
-                  _parsedHeight = ValueValidator.parseHeightInCm(
-                    double.tryParse(text.replaceAll(',', '.')),
-                    isImperial: _isImperialSelected,
-                  );
-                  checkCorrectInput();
-                } else {
-                  _parsedHeight = null;
-                  checkCorrectInput();
-                }
-              },
-              onFieldSubmitted: (_) {
-                FocusScope.of(context).requestFocus(_weightFocusNode);
-              },
-              validator: validateHeight,
-              decoration: InputDecoration(
-                labelText: _isImperialSelected ? 'ft' : 'cm',
-                hintText: _isImperialSelected
-                    ? S.of(context).onboardingHeightExampleHintFt
-                    : S.of(context).onboardingHeightExampleHintCm,
-                filled: true,
-                border: OutlineInputBorder(
-                  borderRadius: BorderRadius.circular(10),
+            child: Semantics(
+              identifier: 'onboarding-height-field',
+              child: TextFormField(
+                controller: _heightController,
+                focusNode: _heightFocusNode,
+                onChanged: (text) {
+                  if (_heightFormKey.currentState!.validate()) {
+                    _parsedHeight = ValueValidator.parseHeightInCm(
+                      double.tryParse(text.replaceAll(',', '.')),
+                      isImperial: _isImperialSelected,
+                    );
+                    checkCorrectInput();
+                  } else {
+                    _parsedHeight = null;
+                    checkCorrectInput();
+                  }
+                },
+                onFieldSubmitted: (_) {
+                  FocusScope.of(context).requestFocus(_weightFocusNode);
+                },
+                validator: validateHeight,
+                decoration: InputDecoration(
+                  labelText: _isImperialSelected ? 'ft' : 'cm',
+                  hintText: _isImperialSelected
+                      ? S.of(context).onboardingHeightExampleHintFt
+                      : S.of(context).onboardingHeightExampleHintCm,
+                  filled: true,
+                  border: OutlineInputBorder(
+                    borderRadius: BorderRadius.circular(10),
+                  ),
                 ),
+                keyboardType:
+                    const TextInputType.numberWithOptions(decimal: true),
+                inputFormatters: [
+                  !_isImperialSelected
+                      ? FilteringTextInputFormatter.digitsOnly
+                      : FilteringTextInputFormatter.allow(
+                          RegExp(r'^\d+([.,]\d{0,1})?$'),
+                        ),
+                ],
               ),
-              keyboardType:
-                  const TextInputType.numberWithOptions(decimal: true),
-              inputFormatters: [
-                !_isImperialSelected
-                    ? FilteringTextInputFormatter.digitsOnly
-                    : FilteringTextInputFormatter.allow(
-                        RegExp(r'^\d+([.,]\d{0,1})?$'),
-                      ),
-              ],
             ),
           ),
           Padding(
@@ -194,45 +197,48 @@ class _OnboardingSecondPageBodyState extends State<OnboardingSecondPageBody> {
           const SizedBox(height: 16.0),
           Form(
             key: _weightFormKey,
-            child: TextFormField(
-              controller: _weightController,
-              focusNode: _weightFocusNode,
-              onChanged: (text) {
-                if (_weightFormKey.currentState!.validate()) {
-                  _parsedWeight = ValueValidator.parseWeightInKg(
-                    double.tryParse(text.replaceAll(',', '.')),
-                    isImperial: _isImperialSelected,
-                  );
-                  checkCorrectInput();
-                } else {
-                  _parsedWeight = null;
-                  checkCorrectInput();
-                }
-              },
-              onFieldSubmitted: (_) {
-                FocusScope.of(context).unfocus();
-              },
-              validator: validateWeight,
-              decoration: InputDecoration(
-                labelText: _isImperialSelected
-                    ? S.of(context).lbsLabel
-                    : S.of(context).kgLabel,
-                hintText: _isImperialSelected
-                    ? S.of(context).onboardingWeightExampleHintLbs
-                    : S.of(context).onboardingWeightExampleHintKg,
-                filled: true,
-                border: OutlineInputBorder(
-                  borderRadius: BorderRadius.circular(10),
+            child: Semantics(
+              identifier: 'onboarding-weight-field',
+              child: TextFormField(
+                controller: _weightController,
+                focusNode: _weightFocusNode,
+                onChanged: (text) {
+                  if (_weightFormKey.currentState!.validate()) {
+                    _parsedWeight = ValueValidator.parseWeightInKg(
+                      double.tryParse(text.replaceAll(',', '.')),
+                      isImperial: _isImperialSelected,
+                    );
+                    checkCorrectInput();
+                  } else {
+                    _parsedWeight = null;
+                    checkCorrectInput();
+                  }
+                },
+                onFieldSubmitted: (_) {
+                  FocusScope.of(context).unfocus();
+                },
+                validator: validateWeight,
+                decoration: InputDecoration(
+                  labelText: _isImperialSelected
+                      ? S.of(context).lbsLabel
+                      : S.of(context).kgLabel,
+                  hintText: _isImperialSelected
+                      ? S.of(context).onboardingWeightExampleHintLbs
+                      : S.of(context).onboardingWeightExampleHintKg,
+                  filled: true,
+                  border: OutlineInputBorder(
+                    borderRadius: BorderRadius.circular(10),
+                  ),
                 ),
+                keyboardType:
+                    const TextInputType.numberWithOptions(decimal: true),
+                textInputAction: TextInputAction.done,
+                inputFormatters: [
+                  FilteringTextInputFormatter.allow(
+                    RegExp(r'^\d+([.,]\d{0,1})?$'),
+                  ),
+                ],
               ),
-              keyboardType:
-                  const TextInputType.numberWithOptions(decimal: true),
-              textInputAction: TextInputAction.done,
-              inputFormatters: [
-                FilteringTextInputFormatter.allow(
-                  RegExp(r'^\d+([.,]\d{0,1})?$'),
-                ),
-              ],
             ),
           ),
           Padding(

--- a/lib/features/onboarding/presentation/widgets/onboarding_third_page_body.dart
+++ b/lib/features/onboarding/presentation/widgets/onboarding_third_page_body.dart
@@ -50,18 +50,21 @@ class _OnboardingThirdPageBodyState extends State<OnboardingThirdPageBody> {
             width: 300,
             child: Row(
               children: [
-                ChoiceChip(
-                  label: Text(
-                    S.of(context).palSedentaryLabel,
-                    style: Theme.of(context).textTheme.titleLarge,
+                Semantics(
+                  identifier: 'onboarding-activity-sedentary',
+                  child: ChoiceChip(
+                    label: Text(
+                      S.of(context).palSedentaryLabel,
+                      style: Theme.of(context).textTheme.titleLarge,
+                    ),
+                    selected: _sedentarySelected,
+                    onSelected: (bool selected) {
+                      setState(() {
+                        _setSelectedChoiceChip(sedentary: true);
+                        checkCorrectInput();
+                      });
+                    },
                   ),
-                  selected: _sedentarySelected,
-                  onSelected: (bool selected) {
-                    setState(() {
-                      _setSelectedChoiceChip(sedentary: true);
-                      checkCorrectInput();
-                    });
-                  },
                 ),
                 Padding(
                   padding: const EdgeInsets.all(8.0),
@@ -86,18 +89,21 @@ class _OnboardingThirdPageBodyState extends State<OnboardingThirdPageBody> {
             width: 400,
             child: Row(
               children: [
-                ChoiceChip(
-                  label: Text(
-                    S.of(context).palLowLActiveLabel,
-                    style: Theme.of(context).textTheme.titleLarge,
+                Semantics(
+                  identifier: 'onboarding-activity-low',
+                  child: ChoiceChip(
+                    label: Text(
+                      S.of(context).palLowLActiveLabel,
+                      style: Theme.of(context).textTheme.titleLarge,
+                    ),
+                    selected: _lowActiveSelected,
+                    onSelected: (bool selected) {
+                      setState(() {
+                        _setSelectedChoiceChip(lowActive: true);
+                        checkCorrectInput();
+                      });
+                    },
                   ),
-                  selected: _lowActiveSelected,
-                  onSelected: (bool selected) {
-                    setState(() {
-                      _setSelectedChoiceChip(lowActive: true);
-                      checkCorrectInput();
-                    });
-                  },
                 ),
                 Padding(
                   padding: const EdgeInsets.all(8.0),
@@ -122,18 +128,21 @@ class _OnboardingThirdPageBodyState extends State<OnboardingThirdPageBody> {
             width: 400,
             child: Row(
               children: [
-                ChoiceChip(
-                  label: Text(
-                    S.of(context).palActiveLabel,
-                    style: Theme.of(context).textTheme.titleLarge,
+                Semantics(
+                  identifier: 'onboarding-activity-active',
+                  child: ChoiceChip(
+                    label: Text(
+                      S.of(context).palActiveLabel,
+                      style: Theme.of(context).textTheme.titleLarge,
+                    ),
+                    selected: _activeSelected,
+                    onSelected: (bool selected) {
+                      setState(() {
+                        _setSelectedChoiceChip(active: true);
+                        checkCorrectInput();
+                      });
+                    },
                   ),
-                  selected: _activeSelected,
-                  onSelected: (bool selected) {
-                    setState(() {
-                      _setSelectedChoiceChip(active: true);
-                      checkCorrectInput();
-                    });
-                  },
                 ),
                 Padding(
                   padding: const EdgeInsets.all(8.0),
@@ -158,18 +167,21 @@ class _OnboardingThirdPageBodyState extends State<OnboardingThirdPageBody> {
             width: 400,
             child: Row(
               children: [
-                ChoiceChip(
-                  label: Text(
-                    S.of(context).palVeryActiveLabel,
-                    style: Theme.of(context).textTheme.titleLarge,
+                Semantics(
+                  identifier: 'onboarding-activity-very',
+                  child: ChoiceChip(
+                    label: Text(
+                      S.of(context).palVeryActiveLabel,
+                      style: Theme.of(context).textTheme.titleLarge,
+                    ),
+                    selected: _veryActiveSelected,
+                    onSelected: (bool selected) {
+                      setState(() {
+                        _setSelectedChoiceChip(veryActive: true);
+                        checkCorrectInput();
+                      });
+                    },
                   ),
-                  selected: _veryActiveSelected,
-                  onSelected: (bool selected) {
-                    setState(() {
-                      _setSelectedChoiceChip(veryActive: true);
-                      checkCorrectInput();
-                    });
-                  },
                 ),
                 Padding(
                   padding: const EdgeInsets.all(8.0),

--- a/lib/features/profile/profile_page.dart
+++ b/lib/features/profile/profile_page.dart
@@ -77,138 +77,162 @@ class _ProfilePageState extends State<ProfilePage> {
           nutritionalStatus: userBMIEntity.nutritionalStatus,
         ),
         const SizedBox(height: 32.0),
-        ListTile(
-          title: Text(
-            S.of(context).activityLabel,
-            style: Theme.of(context).textTheme.titleLarge,
-          ),
-          subtitle: Text(
-            user.pal.getName(context),
-            style: Theme.of(context).textTheme.titleMedium,
-          ),
-          leading: const SizedBox(
-            height: double.infinity,
-            child: Icon(Icons.directions_walk_outlined),
-          ),
-          onTap: () => _showSetPALCategoryDialog(context, user),
-        ),
-        ListTile(
-          title: Text(
-            S.of(context).goalLabel,
-            style: Theme.of(context).textTheme.titleLarge,
-          ),
-          subtitle: Text(
-            user.goal.getName(context),
-            style: Theme.of(context).textTheme.titleMedium,
-          ),
-          leading: const SizedBox(
-            height: double.infinity,
-            child: Icon(Icons.flag_outlined),
-          ),
-          onTap: () => _showSetGoalDialog(context, user),
-        ),
-        ListTile(
-          title: Text(
-            S.of(context).weeklyWeightGoalLabel,
-            style: Theme.of(context).textTheme.titleLarge,
-          ),
-          subtitle: Text(
-            _weeklyGoalSubtitle(context, user, usesImperialUnits),
-            style: Theme.of(context).textTheme.titleMedium,
-          ),
-          leading: const SizedBox(
-            height: double.infinity,
-            child: Icon(Icons.trending_down_outlined),
-          ),
-          onTap: () =>
-              _showSetWeeklyWeightGoalDialog(context, user, usesImperialUnits),
-        ),
-        ListTile(
-          title: Text(
-            S.of(context).weightLabel,
-            style: Theme.of(context).textTheme.titleLarge,
-          ),
-          subtitle: Text(
-            '${_profileBloc.getDisplayWeight(user, usesImperialUnits)} ${usesImperialUnits ? S.of(context).lbsLabel : S.of(context).kgLabel}',
-            style: Theme.of(context).textTheme.titleMedium,
-          ),
-          leading: const SizedBox(
-            height: double.infinity,
-            child: Icon(Icons.monitor_weight_outlined),
-          ),
-          onTap: () {
-            _showSetWeightDialog(context, user, usesImperialUnits);
-          },
-        ),
-        ListTile(
-          title: Text(
-            S.of(context).heightLabel,
-            style: Theme.of(context).textTheme.titleLarge,
-          ),
-          subtitle: Text(
-            '${_profileBloc.getDisplayHeight(user, usesImperialUnits)} ${usesImperialUnits ? S.of(context).ftLabel : S.of(context).cmLabel}',
-            style: Theme.of(context).textTheme.titleMedium,
-          ),
-          leading: const SizedBox(
-            height: double.infinity,
-            child: Icon(Icons.height_outlined),
-          ),
-          onTap: () {
-            _showSetHeightDialog(context, user, usesImperialUnits);
-          },
-        ),
-        ListTile(
-          title: Text(
-            S.of(context).ageLabel,
-            style: Theme.of(context).textTheme.titleLarge,
-          ),
-          subtitle: Text(
-            S.of(context).yearsLabel(user.age),
-            style: Theme.of(context).textTheme.titleMedium,
-          ),
-          leading: const SizedBox(
-            height: double.infinity,
-            child: Icon(Icons.cake_outlined),
-          ),
-          onTap: () {
-            _showSetBirthdayDialog(context, user);
-          },
-        ),
-        ListTile(
-          title: Text(
-            S.of(context).genderLabel,
-            style: Theme.of(context).textTheme.titleLarge,
-          ),
-          subtitle: Text(
-            user.gender.getName(context),
-            style: Theme.of(context).textTheme.titleMedium,
-          ),
-          leading: SizedBox(
-            height: double.infinity,
-            child: user.gender.getIcon(),
-          ),
-          onTap: () {
-            _showSetGenderDialog(context, user);
-          },
-        ),
-        if (user.gender == UserGenderEntity.nonBinary)
-          ListTile(
+        Semantics(
+          identifier: 'profile-activity',
+          child: ListTile(
             title: Text(
-              S.of(context).caloriesProfileInfoTitle,
+              S.of(context).activityLabel,
               style: Theme.of(context).textTheme.titleLarge,
             ),
             subtitle: Text(
-              (user.caloriesProfile ?? CaloriesProfileEntity.averaged)
-                  .getName(context),
+              user.pal.getName(context),
               style: Theme.of(context).textTheme.titleMedium,
             ),
             leading: const SizedBox(
               height: double.infinity,
-              child: Icon(Icons.tune_outlined),
+              child: Icon(Icons.directions_walk_outlined),
+            ),
+            onTap: () => _showSetPALCategoryDialog(context, user),
+          ),
+        ),
+        Semantics(
+          identifier: 'profile-goal',
+          child: ListTile(
+            title: Text(
+              S.of(context).goalLabel,
+              style: Theme.of(context).textTheme.titleLarge,
+            ),
+            subtitle: Text(
+              user.goal.getName(context),
+              style: Theme.of(context).textTheme.titleMedium,
+            ),
+            leading: const SizedBox(
+              height: double.infinity,
+              child: Icon(Icons.flag_outlined),
+            ),
+            onTap: () => _showSetGoalDialog(context, user),
+          ),
+        ),
+        Semantics(
+          identifier: 'profile-weekly-goal',
+          child: ListTile(
+            title: Text(
+              S.of(context).weeklyWeightGoalLabel,
+              style: Theme.of(context).textTheme.titleLarge,
+            ),
+            subtitle: Text(
+              _weeklyGoalSubtitle(context, user, usesImperialUnits),
+              style: Theme.of(context).textTheme.titleMedium,
+            ),
+            leading: const SizedBox(
+              height: double.infinity,
+              child: Icon(Icons.trending_down_outlined),
+            ),
+            onTap: () => _showSetWeeklyWeightGoalDialog(
+                context, user, usesImperialUnits),
+          ),
+        ),
+        Semantics(
+          identifier: 'profile-weight',
+          child: ListTile(
+            title: Text(
+              S.of(context).weightLabel,
+              style: Theme.of(context).textTheme.titleLarge,
+            ),
+            subtitle: Text(
+              '${_profileBloc.getDisplayWeight(user, usesImperialUnits)} ${usesImperialUnits ? S.of(context).lbsLabel : S.of(context).kgLabel}',
+              style: Theme.of(context).textTheme.titleMedium,
+            ),
+            leading: const SizedBox(
+              height: double.infinity,
+              child: Icon(Icons.monitor_weight_outlined),
             ),
             onTap: () {
-              _showCaloriesProfileDialog(context, user);
+              _showSetWeightDialog(context, user, usesImperialUnits);
             },
+          ),
+        ),
+        Semantics(
+          identifier: 'profile-height',
+          child: ListTile(
+            title: Text(
+              S.of(context).heightLabel,
+              style: Theme.of(context).textTheme.titleLarge,
+            ),
+            subtitle: Text(
+              '${_profileBloc.getDisplayHeight(user, usesImperialUnits)} ${usesImperialUnits ? S.of(context).ftLabel : S.of(context).cmLabel}',
+              style: Theme.of(context).textTheme.titleMedium,
+            ),
+            leading: const SizedBox(
+              height: double.infinity,
+              child: Icon(Icons.height_outlined),
+            ),
+            onTap: () {
+              _showSetHeightDialog(context, user, usesImperialUnits);
+            },
+          ),
+        ),
+        Semantics(
+          identifier: 'profile-age',
+          child: ListTile(
+            title: Text(
+              S.of(context).ageLabel,
+              style: Theme.of(context).textTheme.titleLarge,
+            ),
+            subtitle: Text(
+              S.of(context).yearsLabel(user.age),
+              style: Theme.of(context).textTheme.titleMedium,
+            ),
+            leading: const SizedBox(
+              height: double.infinity,
+              child: Icon(Icons.cake_outlined),
+            ),
+            onTap: () {
+              _showSetBirthdayDialog(context, user);
+            },
+          ),
+        ),
+        Semantics(
+          identifier: 'profile-gender',
+          child: ListTile(
+            title: Text(
+              S.of(context).genderLabel,
+              style: Theme.of(context).textTheme.titleLarge,
+            ),
+            subtitle: Text(
+              user.gender.getName(context),
+              style: Theme.of(context).textTheme.titleMedium,
+            ),
+            leading: SizedBox(
+              height: double.infinity,
+              child: user.gender.getIcon(),
+            ),
+            onTap: () {
+              _showSetGenderDialog(context, user);
+            },
+          ),
+        ),
+        if (user.gender == UserGenderEntity.nonBinary)
+          Semantics(
+            identifier: 'profile-calories-profile',
+            child: ListTile(
+              title: Text(
+                S.of(context).caloriesProfileInfoTitle,
+                style: Theme.of(context).textTheme.titleLarge,
+              ),
+              subtitle: Text(
+                (user.caloriesProfile ?? CaloriesProfileEntity.averaged)
+                    .getName(context),
+                style: Theme.of(context).textTheme.titleMedium,
+              ),
+              leading: const SizedBox(
+                height: double.infinity,
+                child: Icon(Icons.tune_outlined),
+              ),
+              onTap: () {
+                _showCaloriesProfileDialog(context, user);
+              },
+            ),
           ),
       ],
     );


### PR DESCRIPTION
## Summary

Wraps onboarding, main shell, profile, and add-item bottom-sheet widgets in `Semantics(identifier: ...)` so that UI-automation drivers (uiautomator on Android, XCUITest on iOS) can find them by stable handle and tap by coordinate. This unblocks the per-branch feature-verification work for the 25 triage branches from the 2026-05-13 sweep — each verifier can lean on these labels for onboarding + navigation and only add branch-local identifiers for the new widgets that branch introduces.

The `identifier` parameter is never read aloud by TalkBack or VoiceOver — it carries no user-facing label, only a stable handle for automation (it maps to `resource-id` on Android and `accessibilityIdentifier` on iOS). The wrapped widgets keep all their existing roles, callbacks, and tooltips.

## What's labeled (33 identifiers across 9 files)

| Surface | Identifiers |
|---------|-------------|
| Onboarding intro | `onboarding-checkbox-privacy`, `onboarding-checkbox-data` |
| Onboarding gender + birthday | `onboarding-gender-genderMale/Female/NonBinary`, `onboarding-birthday-field` |
| Onboarding height/weight | `onboarding-height-field`, `onboarding-weight-field` |
| Onboarding activity | `onboarding-activity-sedentary/low/active/very` |
| Onboarding goal | `onboarding-goal-lose/maintain/gain` |
| Onboarding NEXT/START | `onboarding-button` (single handle, one button per page) |
| Main shell | `nav-home`, `nav-diary`, `nav-recipes`, `nav-profile`, `fab-add-item` |
| Profile screen | `profile-activity`, `profile-goal`, `profile-weekly-goal`, `profile-weight`, `profile-height`, `profile-age`, `profile-gender`, `profile-calories-profile` |
| Add-item bottom sheet | `add-item-activity`, `add-item-breakfast`, `add-item-lunch`, `add-item-dinner`, `add-item-snack` |

Deferred for follow-up label passes (only added when a specific feature verifier needs them): Settings ListTiles (22), Diary calendar, Home/Diary intake cards, Calculations dialog internals, Add-meal search results.

## One layout adjustment

`HighlightButton` (the onboarding NEXT/START button) sits inside `introduction_screen`'s `Expanded` footer slot. Wrapping `ElevatedButton.icon` in plain `Semantics(identifier:)` made the semantic node inherit the full Expanded area as its bounds (`[0,145][1440,3036]`), which broke coordinate-based taps from uiautomator. The fix:

- Add `container: true` to the `Semantics` so it builds a separate node from the surrounding layout.
- Wrap the button in `Align(alignment: Alignment.bottomCenter)` to give the Semantics a tight render context.
- Container already had no explicit alignment, so `alignment: Alignment.bottomCenter` is added there too for symmetry.

Visual placement of the START/NEXT button is unchanged — I verified the screenshots before/after on the connected device. TalkBack behaviour should also be unchanged: the new Semantics carries no role or label, only the identifier, and the underlying `ElevatedButton` continues to provide its own button semantics. A code comment in `highlight_button.dart` explains why `container: true` is load-bearing in case anyone is tempted to drop it.

## Redundant role flags deliberately omitted

While wiring this up I initially added `button: true` on chip wrappers and `textField: true` on `TextFormField` wrappers, then removed them on review — `ChoiceChip`, `FloatingActionButton`, and `TextFormField` already publish those roles to the accessibility tree, and stacking the flag risks double-announcement (e.g. "button, button") in TalkBack. The cleanup commit (folded into this single commit) restored the minimal-noise wrapping pattern of `Semantics(identifier: ..., child: widget)` everywhere except the one place `container: true` is actually needed.

## Test plan

- [x] `flutter analyze lib/` — clean (one pre-existing `env.g.dart` warning, not introduced here)
- [x] `flutter test` — all 352 tests pass
- [x] `just check_intl` — clean
- [x] End-to-end run on a physical device (Pixel-class, 1440×3120, Android 15): fresh install, walked the full onboarding flow via uiautomator using the new identifiers, landed on Home, navigated to Profile, opened the Weight dialog. Screenshot evidence in conversation notes.

## Why this lands on develop rather than per branch

Doing this as a develop PR means each of the 25 triage branches can rebase cleanly onto the new develop and inherit the labels rather than carrying them as merge churn. The follow-up verifier scripts (one per branch, building on these labels) then sit as clean, self-contained additions on each triage branch.