### PR TITLE
feat(testing): add ADB UI driver and branch smoke-test scripts

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -151,7 +151,33 @@ Always verify with `adb shell uiautomator dump /sdcard/d.xml && adb pull /sdcard
 
 ### Flutter widgets on Android use `content-desc`, not `text`
 
-When inspecting the uiautomator dump, the visible text of Flutter widgets is reported under `content-desc`, not `text`. System dialogs (DatePicker, AlertDialog) use `text`. Test drivers that find widgets by visible label must check both. The reference implementation lives in `.claude/scripts/adb-driver.sh` (locally-excluded tooling).
+When inspecting the uiautomator dump, the visible text of Flutter widgets is reported under `content-desc`, not `text`. System dialogs (DatePicker, AlertDialog) use `text`. Test drivers that find widgets by visible label must check both.
+
+### ADB test tooling
+
+Reusable ADB scripts live in `tools/adb/`:
+
+| Script | Purpose |
+|--------|---------|
+| `adb-driver.sh` | Core driver library: `tap_id`, `wait_for_id`, `enter_text_at`, `_tap_text`, `screenshot`, `list_ids`, etc. Source from any test script. |
+| `walk-onboarding.sh` | Walks the 6-page onboarding flow, lands the app on the main screen. Exports `walk_onboarding()`. Run standalone or source it. |
+| `run-branch-tests.sh` | Sequential smoke-test runner for all triage branches: builds a debug APK, installs it, walks onboarding, and runs a branch-specific probe. Produces a pass/fail summary and per-branch screenshots. |
+
+Usage:
+
+```bash
+# Source the driver in a one-off script
+source tools/adb/adb-driver.sh
+wait_for_id 'nav-home' 15 && echo "on main screen"
+
+# Walk onboarding standalone (clears app data first)
+DEVICE=1C151FDEE003YJ bash tools/adb/walk-onboarding.sh
+
+# Run the full branch test pass (unattended, ~90 min)
+DEVICE=1C151FDEE003YJ bash tools/adb/run-branch-tests.sh
+```
+
+`DEVICE` defaults to the first device returned by `adb devices` when not set.
 
 ### Enforcement
 

--- a/tools/adb/adb-driver.sh
+++ b/tools/adb/adb-driver.sh
@@ -1,0 +1,163 @@
+#!/usr/bin/env bash
+# tools/adb/adb-driver.sh
+#
+# ADB UI driver for OpenNutriTracker.
+#
+# Finds Flutter widgets via the `resource-id` attribute (set by
+# `Semantics(identifier:)` in the app) and drives them with
+# `adb shell input tap` / `input text`.
+#
+# Source this from other scripts:
+#   source "$(dirname "$0")/adb-driver.sh"
+#   tap_id 'nav-profile'
+#   enter_text_at 'onboarding-height-field' '170'
+#
+# Required env (set by sourcing script, or uses default):
+#   DEVICE — adb device serial (default: first connected device)
+#
+# Dependencies: adb, python3 (stdlib only)
+# ---------------------------------------------------------------------------
+
+DEVICE="${DEVICE:-$(adb devices | awk '/device$/{print $1; exit}')}"
+DUMP_PATH="/sdcard/window_dump.xml"
+LOCAL_DUMP="/tmp/ont-window-dump.xml"
+
+# Dump the current UI tree to /tmp/ont-window-dump.xml and echo the local path.
+dump_ui() {
+  adb -s "$DEVICE" shell uiautomator dump "$DUMP_PATH" > /dev/null 2>&1
+  adb -s "$DEVICE" pull "$DUMP_PATH" "$LOCAL_DUMP" > /dev/null 2>&1
+  echo "$LOCAL_DUMP"
+}
+
+# Print the center (x y) coordinates of the widget with the given resource-id,
+# or empty string if not found.
+_center_of_id() {
+  local id="$1"
+  local dump_file
+  dump_file=$(dump_ui)
+
+  python3 <<EOF
+import re, sys, xml.etree.ElementTree as ET
+try:
+    tree = ET.parse("$dump_file")
+except Exception:
+    sys.exit(0)
+for n in tree.getroot().iter():
+    if n.attrib.get('resource-id', '') == "$id":
+        m = re.match(r'\[(\d+),(\d+)\]\[(\d+),(\d+)\]', n.attrib.get('bounds', ''))
+        if m:
+            x1, y1, x2, y2 = (int(g) for g in m.groups())
+            print(f"{(x1+x2)//2} {(y1+y2)//2}")
+        sys.exit(0)
+EOF
+}
+
+# Tap the widget with the given resource-id. Returns 1 if not found.
+# Usage: tap_id 'nav-profile'
+tap_id() {
+  local id="$1"
+  local coords
+  coords=$(_center_of_id "$id")
+  if [[ -z "$coords" ]]; then
+    echo "tap_id: '$id' not found in current UI tree" >&2
+    return 1
+  fi
+  adb -s "$DEVICE" shell input tap $coords
+}
+
+# Wait up to N seconds for a widget with the given resource-id to appear.
+# Re-dumps the UI tree every second.
+# Usage: wait_for_id 'nav-home' 20
+wait_for_id() {
+  local id="$1"
+  local timeout="${2:-15}"
+  local start=$SECONDS
+  while (( SECONDS - start < timeout )); do
+    local coords
+    coords=$(_center_of_id "$id")
+    if [[ -n "$coords" ]]; then
+      return 0
+    fi
+    sleep 1
+  done
+  echo "wait_for_id: timed out waiting for '$id' after ${timeout}s" >&2
+  return 1
+}
+
+# Tap a widget and type text into it (assumes it's a text field).
+# Spaces in text must be escaped as %s — adb shell input text limitation.
+# Usage: enter_text_at 'onboarding-height-field' '170'
+enter_text_at() {
+  local id="$1"
+  local text="$2"
+  tap_id "$id" || return 1
+  sleep 0.5
+  adb -s "$DEVICE" shell input text "${text// /%s}"
+}
+
+# Tap a widget by its visible text or content-desc.
+# Flutter widgets expose labels via content-desc; system dialogs use text.
+# Checks both so this works for native dialogs (DatePicker OK) and Flutter.
+# Usage: _tap_text 'OK'
+_tap_text() {
+  local needle="$1"
+  local dump_file
+  dump_file=$(dump_ui)
+  local coords
+  coords=$(python3 <<EOF
+import re, sys, xml.etree.ElementTree as ET
+tree = ET.parse("$dump_file")
+for n in tree.getroot().iter():
+    if n.attrib.get('text', '') == "$needle" or n.attrib.get('content-desc', '') == "$needle":
+        m = re.match(r'\[(\d+),(\d+)\]\[(\d+),(\d+)\]', n.attrib.get('bounds', ''))
+        if m:
+            x1, y1, x2, y2 = (int(g) for g in m.groups())
+            print(f"{(x1+x2)//2} {(y1+y2)//2}")
+            sys.exit(0)
+EOF
+)
+  if [[ -z "$coords" ]]; then
+    return 1
+  fi
+  adb -s "$DEVICE" shell input tap $coords
+}
+
+# Press the device back button.
+press_back() {
+  adb -s "$DEVICE" shell input keyevent 4
+}
+
+# Press the home button.
+press_home() {
+  adb -s "$DEVICE" shell input keyevent 3
+}
+
+# Take a screenshot. Prints the output path.
+# Usage: screenshot /tmp/foo.png
+screenshot() {
+  local out="${1:-/tmp/ont-screenshot-$(date +%s).png}"
+  adb -s "$DEVICE" exec-out screencap -p > "$out"
+  echo "$out"
+}
+
+# Return 0 if a widget with the given resource-id is visible.
+# Usage: id_exists 'nav-profile' && echo "on main screen"
+id_exists() {
+  local coords
+  coords=$(_center_of_id "$1")
+  [[ -n "$coords" ]]
+}
+
+# Print all resource-ids currently visible (useful for debugging).
+list_ids() {
+  local dump_file
+  dump_file=$(dump_ui)
+  python3 <<EOF
+import xml.etree.ElementTree as ET
+tree = ET.parse("$dump_file")
+for n in tree.getroot().iter():
+    rid = n.attrib.get('resource-id', '')
+    if rid:
+        print(rid)
+EOF
+}

--- a/tools/adb/run-branch-tests.sh
+++ b/tools/adb/run-branch-tests.sh
@@ -1,0 +1,377 @@
+#!/usr/bin/env bash
+# tools/adb/run-branch-tests.sh
+#
+# Sequential ADB smoke-test pass for all triage branches.
+#
+# For each branch:
+#   1. Checkout + flutter pub get + flutter build apk --debug
+#   2. adb install -r
+#   3. Clear app data, launch, walk onboarding (tools/adb/walk-onboarding.sh)
+#   4. Run the branch-specific feature probe (finds widgets by Semantics identifier)
+#   5. Screenshot + log PASS/FAIL
+#
+# Usage:
+#   bash tools/adb/run-branch-tests.sh               # all branches
+#   bash tools/adb/run-branch-tests.sh <branch>       # single branch re-run
+#
+# Environment:
+#   DEVICE    — adb serial (default: first connected device)
+#   FVM       — path to fvm binary (default: fvm on PATH, or ~/fvm/bin/fvm)
+#
+# Outputs:
+#   /tmp/ont-branch-screenshots/<branch>.png
+#   /tmp/ont-branch-test.log
+# ---------------------------------------------------------------------------
+set -uo pipefail
+
+__DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+source "$__DIR/walk-onboarding.sh"   # also pulls in adb-driver.sh
+
+DEVICE="${DEVICE:-$(adb devices | awk '/device$/{print $1; exit}')}"
+PACKAGE="com.opennutritracker.ont.opennutritracker"
+ACTIVITY="com.opennutritracker.ont.opennutritracker.MainActivity"
+REPO="$(cd "$__DIR/../.." && pwd)"
+FVM="${FVM:-$(command -v fvm 2>/dev/null || echo "$HOME/fvm/bin/fvm")}"
+APK="$REPO/build/app/outputs/flutter-apk/app-debug.apk"
+SCREENSHOTS="/tmp/ont-branch-screenshots"
+LOG="/tmp/ont-branch-test.log"
+SECRETS="/tmp/ont-secrets"
+
+# ---------------------------------------------------------------------------
+# Branch list (add new branches here as the project grows)
+# ---------------------------------------------------------------------------
+ALL_BRANCHES=(
+  docs/publish-signing-fingerprint-321
+  docs/supabase-fdc-self-hosting-344
+  docs/project-website-266
+  fix/safearea-add-meal-156
+  feature/scan-default-serving-158
+  feature/fdc-import-sanity-checks-222
+  feature/slovak-translation-142
+  feature/weight-tracking-log-38
+  feature/csv-export-132
+  feature/json-meal-import-181
+  feature/target-weight-119
+  feature/custom-activity-kcal-70
+  feature/custom-meal-barcode-167
+  feature/custom-meal-pictures-64
+  fix/atwater-consistency-warning-213
+  feature/ephemeral-meal-249
+  feature/kj-display-unit-177
+  feature/diary-progress-circles-175
+  feature/sortable-diary-list-82
+  feature/per-meal-calorie-target-150
+  feature/daily-micronutrient-panel-160
+  feature/simplify-custom-meal-232
+  feature/midnight-reset-offset-139
+  feature/per-nutrient-planning-goals-173
+)
+
+if [[ -n "${1:-}" ]]; then
+  BRANCHES=("$1")
+else
+  BRANCHES=("${ALL_BRANCHES[@]}")
+fi
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+_log() { echo "$*" | tee -a "$LOG"; }
+
+_launch_fresh() {
+  adb -s "$DEVICE" shell pm clear "$PACKAGE" > /dev/null 2>&1 || true
+  adb -s "$DEVICE" shell am start -n "$PACKAGE/$ACTIVITY" > /dev/null 2>&1
+  sleep 4
+}
+
+_nav_smoke() {
+  # Onboarding + all four nav tabs
+  walk_onboarding || return 1
+  for tab in nav-home nav-diary nav-recipes nav-profile; do
+    tap_id "$tab" || { _log "  ✗ $tab not found"; return 1; }
+    sleep 1.5
+  done
+  tap_id 'nav-home'; sleep 1
+}
+
+_open_settings() {
+  tap_id 'nav-home' || return 1; sleep 1
+  # Settings IconButton has tooltip="Settings" → content-desc="Settings"
+  _tap_text 'Settings' || { _log "  ✗ could not open Settings"; return 1; }
+  sleep 2
+}
+
+_check_settings_entry() {
+  local id="$1"
+  walk_onboarding || return 1
+  _open_settings || return 1
+  wait_for_id "$id" 8 || { _log "  ✗ '$id' not found in Settings"; return 1; }
+  _log "  ✓ '$id' visible in Settings"
+}
+
+_check_profile_entry() {
+  local id="$1"
+  walk_onboarding || return 1
+  tap_id 'nav-profile' || return 1; sleep 1.5
+  wait_for_id "$id" 8 || { _log "  ✗ '$id' not found in Profile"; return 1; }
+  _log "  ✓ '$id' visible in Profile"
+}
+
+_open_recipe_builder() {
+  # Recipes tab → "+" PopupMenu → "Create Recipe"
+  tap_id 'nav-recipes' || return 1; sleep 1.5
+  _tap_text 'Add' || { _log "  ✗ Add menu not found on Recipes tab"; return 1; }
+  sleep 1
+  _tap_text 'Create Recipe' || { _log "  ✗ Create Recipe menu item not found"; return 1; }
+  sleep 2
+}
+
+# ---------------------------------------------------------------------------
+# Per-branch feature probes
+# ---------------------------------------------------------------------------
+
+probe_docs()                       { _nav_smoke; }
+probe_fix_safearea()               { _nav_smoke; }
+probe_scan_default_serving_158()   { _nav_smoke; }
+probe_fdc_sanity_222()             { _nav_smoke; }
+probe_slovak_142()                 { _nav_smoke; }
+probe_csv_export_132()             { _nav_smoke; }
+probe_diary_progress_175()         { _nav_smoke; }
+probe_atwater_213()                { _nav_smoke; }
+probe_sortable_82()                { _nav_smoke; }  # sort menu needs diary entries
+
+probe_kj_display_177()             { _check_settings_entry 'settings-energy-unit'; }
+probe_per_meal_calorie_150()       { _check_settings_entry 'settings-energy-unit'; }
+probe_midnight_offset_139()        { _check_settings_entry 'settings-energy-unit'; }
+probe_json_import_181()            { _check_settings_entry 'settings-paste-json'; }
+probe_daily_micronutrient_160()    { _check_settings_entry 'settings-nutrient-visibility'; }
+probe_target_weight_119()          { _check_profile_entry  'profile-weight'; }
+
+probe_weight_tracking_38() {
+  walk_onboarding || return 1
+  tap_id 'nav-profile' || return 1; sleep 1.5
+  wait_for_id 'profile-weight-history' 8 || { _log "  ✗ profile-weight-history not found"; return 1; }
+  _log "  ✓ profile-weight-history visible"
+  tap_id 'profile-weight-history'; sleep 2
+  wait_for_id 'weight-history-add' 8 || { _log "  ✗ weight-history-add FAB not found"; return 1; }
+  _log "  ✓ weight-history-add FAB visible"
+  tap_id 'weight-history-add'; sleep 1.5
+  wait_for_id 'weight-history-weight-input' 5 || { _log "  ✗ weight-history-weight-input not found"; return 1; }
+  _log "  ✓ weight-history-weight-input visible"
+  press_back; sleep 0.5
+}
+
+probe_custom_activity_70() {
+  walk_onboarding || return 1
+  tap_id 'fab-add-item' || return 1; sleep 1
+  wait_for_id 'add-item-activity' 5 || { _log "  ✗ add-item-activity not found"; return 1; }
+  _log "  ✓ add-item-activity visible"
+  tap_id 'add-item-activity'; sleep 2
+  _log "  ✓ activity screen loaded"
+  press_back; sleep 0.5
+}
+
+probe_custom_meal_barcode_167() {
+  walk_onboarding || return 1
+  _open_recipe_builder || return 1
+  wait_for_id 'recipe-builder-barcode-input' 8 || { _log "  ✗ recipe-builder-barcode-input not found"; return 1; }
+  _log "  ✓ recipe-builder-barcode-input visible"
+}
+
+probe_custom_meal_pictures_64() {
+  walk_onboarding || return 1
+  _open_recipe_builder || return 1
+  wait_for_id 'recipe-builder-image-picker' 8 || { _log "  ✗ recipe-builder-image-picker not found"; return 1; }
+  _log "  ✓ recipe-builder-image-picker visible"
+}
+
+probe_ephemeral_249() {
+  # edit-meal-save-for-later only shows when !editOnly (a real food item is
+  # selected). Navigate to the breakfast search screen and prompt the tester
+  # to scan a barcode or tap a search result, then verify.
+  walk_onboarding || return 1
+  tap_id 'fab-add-item' || return 1; sleep 1
+  wait_for_id 'add-item-breakfast' 5 || return 1
+  tap_id 'add-item-breakfast'; sleep 2
+  _log "  ── MANUAL STEP ───────────────────────────────────────"
+  _log "  App is on the Breakfast search screen."
+  _log "  Scan a food barcode or search for and tap a food item."
+  _log "  Polling for edit-meal-save-for-later (120 s)..."
+  _log "  ──────────────────────────────────────────────────────"
+  wait_for_id 'edit-meal-save-for-later' 120 || { _log "  ✗ edit-meal-save-for-later not found"; return 1; }
+  _log "  ✓ edit-meal-save-for-later visible"
+}
+
+probe_simplify_custom_232() {
+  # "New Custom Food" pushes EditMealScreen with an empty MealEntity,
+  # which shows the Simple / Advanced mode toggle.
+  walk_onboarding || return 1
+  tap_id 'nav-recipes' || return 1; sleep 1.5
+  _tap_text 'Add' || { _log "  ✗ Add menu not found on Recipes tab"; return 1; }
+  sleep 1
+  _tap_text 'New Custom Food' || { _log "  ✗ New Custom Food not found"; return 1; }
+  sleep 2
+  wait_for_id 'edit-meal-mode-toggle' 8 || { _log "  ✗ edit-meal-mode-toggle not found"; return 1; }
+  _log "  ✓ edit-meal-mode-toggle visible"
+}
+
+probe_per_nutrient_173() {
+  # Nutrient goal sliders live inside the Calculations dialog in Settings.
+  walk_onboarding || return 1
+  _open_settings || return 1
+  _tap_text 'Calculations' || {
+    adb -s "$DEVICE" shell input swipe 720 1400 720 800 400; sleep 1
+    _tap_text 'Calculations' || { _log "  ✗ Calculations tile not found"; return 1; }
+  }
+  sleep 2
+  # kcal-input is at the top of the dialog; fibre-slider may require scrolling
+  wait_for_id 'calculations-kcal-input' 8 || { _log "  ✗ calculations-kcal-input not found"; return 1; }
+  _log "  ✓ calculations-kcal-input visible (dialog opened correctly)"
+}
+
+# ---------------------------------------------------------------------------
+# Probe dispatch
+# ---------------------------------------------------------------------------
+probe_for_branch() {
+  case "$1" in
+    docs/*)                               probe_docs ;;
+    fix/safearea-add-meal-156)            probe_fix_safearea ;;
+    feature/scan-default-serving-158)     probe_scan_default_serving_158 ;;
+    feature/fdc-import-sanity-checks-222) probe_fdc_sanity_222 ;;
+    feature/slovak-translation-142)       probe_slovak_142 ;;
+    feature/csv-export-132)               probe_csv_export_132 ;;
+    feature/diary-progress-circles-175)   probe_diary_progress_175 ;;
+    fix/atwater-consistency-warning-213)  probe_atwater_213 ;;
+    feature/weight-tracking-log-38)       probe_weight_tracking_38 ;;
+    feature/json-meal-import-181)         probe_json_import_181 ;;
+    feature/target-weight-119)            probe_target_weight_119 ;;
+    feature/custom-activity-kcal-70)      probe_custom_activity_70 ;;
+    feature/custom-meal-barcode-167)      probe_custom_meal_barcode_167 ;;
+    feature/custom-meal-pictures-64)      probe_custom_meal_pictures_64 ;;
+    feature/ephemeral-meal-249)           probe_ephemeral_249 ;;
+    feature/kj-display-unit-177)          probe_kj_display_177 ;;
+    feature/sortable-diary-list-82)       probe_sortable_82 ;;
+    feature/per-meal-calorie-target-150)  probe_per_meal_calorie_150 ;;
+    feature/daily-micronutrient-panel-160) probe_daily_micronutrient_160 ;;
+    feature/simplify-custom-meal-232)     probe_simplify_custom_232 ;;
+    feature/midnight-reset-offset-139)    probe_midnight_offset_139 ;;
+    feature/per-nutrient-planning-goals-173) probe_per_nutrient_173 ;;
+    *)                                    probe_docs ;;
+  esac
+}
+
+# ---------------------------------------------------------------------------
+# Pre-flight
+# ---------------------------------------------------------------------------
+cd "$REPO"
+
+_log "=== ONT branch test pass — $(date) ==="
+_log "Device  : $DEVICE"
+_log "Branches: ${#BRANCHES[@]}"
+_log ""
+
+if ! adb -s "$DEVICE" get-state &>/dev/null; then
+  echo "ERROR: device $DEVICE not connected. Aborting." | tee -a "$LOG"
+  exit 1
+fi
+
+mkdir -p "$SECRETS" "$SCREENSHOTS"
+chmod 700 "$SECRETS"
+
+# Stash gitignored credential files outside the repo so they survive checkouts
+[[ -f "$REPO/.env" ]]                      && cp "$REPO/.env"                      "$SECRETS/env"          || _log "WARNING: .env not found"
+[[ -f "$REPO/android/key.properties" ]]    && cp "$REPO/android/key.properties"    "$SECRETS/key.properties" || true
+[[ -f "$REPO/android/keystore.jks" ]]      && cp "$REPO/android/keystore.jks"      "$SECRETS/keystore.jks"   || true
+
+ORIGINAL_BRANCH=$(git branch --show-current)
+declare -A RESULTS
+
+_log "  fetching all remote branches..."
+git fetch --all --quiet 2>&1 | tee -a "$LOG" || true
+
+# ---------------------------------------------------------------------------
+# Main loop
+# ---------------------------------------------------------------------------
+for BRANCH in "${BRANCHES[@]}"; do
+  _log "=== $BRANCH ==="
+
+  if ! git show-ref --verify --quiet "refs/heads/$BRANCH"; then
+    _log "  SKIP: branch not found locally"
+    RESULTS[$BRANCH]="MISSING"; _log ""; continue
+  fi
+
+  git checkout "$BRANCH" 2>&1 | tail -1 | tee -a "$LOG"
+  git pull --ff-only origin "$BRANCH" 2>&1 | tail -1 | tee -a "$LOG" || true
+
+  [[ -f "$SECRETS/env"            ]] && cp "$SECRETS/env"            "$REPO/.env"
+  [[ -f "$SECRETS/key.properties" ]] && cp "$SECRETS/key.properties" "$REPO/android/key.properties"
+  [[ -f "$SECRETS/keystore.jks"   ]] && cp "$SECRETS/keystore.jks"   "$REPO/android/keystore.jks"
+
+  _log "  pub get..."
+  "$FVM" flutter pub get --no-example 2>&1 | tail -2 | tee -a "$LOG"
+
+  _log "  building debug APK..."
+  BUILD_OUT=$("$FVM" flutter build apk --debug 2>&1)
+  BUILD_EXIT=$?
+  echo "$BUILD_OUT" | tail -3 | sed 's/^/  /' | tee -a "$LOG"
+
+  if [[ $BUILD_EXIT -ne 0 ]]; then
+    _log "  ✗ BUILD FAILED"
+    RESULTS[$BRANCH]="BUILD_FAIL"; _log ""; continue
+  fi
+
+  _log "  installing APK..."
+  adb -s "$DEVICE" install -r "$APK" > /dev/null 2>&1 || {
+    _log "  ✗ install failed"
+    RESULTS[$BRANCH]="INSTALL_FAIL"; _log ""; continue
+  }
+
+  _log "  launching fresh..."
+  _launch_fresh
+
+  _log "  running feature probe..."
+  probe_for_branch "$BRANCH"
+  PROBE_EXIT=$?
+
+  SAFE="${BRANCH//\//_}"
+  adb -s "$DEVICE" exec-out screencap -p > "$SCREENSHOTS/${SAFE}.png" 2>/dev/null || true
+
+  if [[ $PROBE_EXIT -eq 0 ]]; then
+    RESULTS[$BRANCH]="PASS"; _log "  → PASS"
+  else
+    RESULTS[$BRANCH]="FAIL"; _log "  → FAIL"
+  fi
+
+  adb -s "$DEVICE" shell pm clear "$PACKAGE" > /dev/null 2>&1 || true
+  _log ""
+done
+
+# ---------------------------------------------------------------------------
+# Teardown
+# ---------------------------------------------------------------------------
+git checkout "$ORIGINAL_BRANCH" 2>&1 | tail -1 | tee -a "$LOG"
+[[ -f "$SECRETS/env"            ]] && cp "$SECRETS/env"            "$REPO/.env"
+[[ -f "$SECRETS/key.properties" ]] && cp "$SECRETS/key.properties" "$REPO/android/key.properties"
+[[ -f "$SECRETS/keystore.jks"   ]] && cp "$SECRETS/keystore.jks"   "$REPO/android/keystore.jks"
+
+# ---------------------------------------------------------------------------
+# Summary
+# ---------------------------------------------------------------------------
+_log ""
+_log "===== SUMMARY ====="
+PASS_COUNT=0; FAIL_COUNT=0; SKIP_COUNT=0
+for BRANCH in "${BRANCHES[@]}"; do
+  STATUS="${RESULTS[$BRANCH]:-UNKNOWN}"
+  printf "  %-12s %s\n" "$STATUS" "$BRANCH" | tee -a "$LOG"
+  case $STATUS in
+    PASS)                          ((PASS_COUNT++)) ;;
+    FAIL|BUILD_FAIL|INSTALL_FAIL)  ((FAIL_COUNT++)) ;;
+    *)                             ((SKIP_COUNT++)) ;;
+  esac
+done
+_log ""
+_log "  $PASS_COUNT passed · $FAIL_COUNT failed · $SKIP_COUNT skipped"
+_log "  Screenshots → $SCREENSHOTS"
+_log "  Log         → $LOG"
+
+[[ $FAIL_COUNT -eq 0 ]]

--- a/tools/adb/walk-onboarding.sh
+++ b/tools/adb/walk-onboarding.sh
@@ -1,0 +1,94 @@
+#!/usr/bin/env bash
+# tools/adb/walk-onboarding.sh
+#
+# Walks the OpenNutriTracker onboarding flow using the ADB driver.
+# Assumes the app is freshly installed (or app data cleared) and the
+# onboarding intro page is visible.
+#
+# Source it from per-branch verifier scripts:
+#   source "$(dirname "$0")/walk-onboarding.sh"
+#   walk_onboarding   # leaves the app on the main Home tab
+#
+# Or run it standalone to verify the walker end-to-end:
+#   DEVICE=<serial> bash tools/adb/walk-onboarding.sh
+#
+# Dummy data filled: female / default birthday / 170 cm / 65 kg /
+# Active / Maintain weight.
+# ---------------------------------------------------------------------------
+
+__WO_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+source "$__WO_DIR/adb-driver.sh"
+
+walk_onboarding() {
+  echo "  walk_onboarding: waiting for intro page..."
+  wait_for_id 'onboarding-checkbox-privacy' 20 || return 1
+
+  echo "  page 0 — privacy + data collection"
+  tap_id 'onboarding-checkbox-privacy' || return 1; sleep 0.3
+  tap_id 'onboarding-checkbox-data'    || return 1; sleep 0.3
+  tap_id 'onboarding-button'           || return 1; sleep 1
+
+  echo "  page 1 — gender + birthday"
+  wait_for_id 'onboarding-gender-genderFemale' 10 || return 1
+  tap_id 'onboarding-gender-genderFemale' || return 1; sleep 0.5
+  tap_id 'onboarding-birthday-field'      || return 1; sleep 1
+  # Material DatePicker OK — check both text and content-desc (system vs Flutter dialog)
+  _tap_text 'OK' || _tap_text 'Ok' || _tap_text 'ok' || return 1; sleep 0.8
+  tap_id 'onboarding-button' || return 1; sleep 1
+
+  echo "  page 2 — height + weight"
+  wait_for_id 'onboarding-height-field' 10 || return 1
+  enter_text_at 'onboarding-height-field' '170' || return 1; sleep 0.3
+  enter_text_at 'onboarding-weight-field' '65'  || return 1; sleep 0.3
+  press_back; sleep 0.5  # dismiss keyboard so NEXT button is reachable
+  tap_id 'onboarding-button' || return 1; sleep 1
+
+  echo "  page 3 — activity level"
+  wait_for_id 'onboarding-activity-active' 10 || return 1
+  tap_id 'onboarding-activity-active' || return 1; sleep 0.4
+  tap_id 'onboarding-button'          || return 1; sleep 1
+
+  echo "  page 4 — weight goal"
+  wait_for_id 'onboarding-goal-maintain' 10 || return 1
+  tap_id 'onboarding-goal-maintain' || return 1; sleep 0.4
+  tap_id 'onboarding-button'        || return 1; sleep 1
+
+  echo "  page 5 — overview, tapping START"
+  wait_for_id 'onboarding-button' 10 || return 1
+  tap_id 'onboarding-button' || return 1; sleep 3
+
+  # Dismiss the first-launch disclaimer dialog if it appears.
+  echo "  dismissing disclaimer dialog (if present)"
+  for _ in 1 2 3; do
+    if _tap_text 'OK'; then sleep 1; break; fi
+    sleep 1
+  done
+
+  echo "  onboarding complete — waiting for main NavigationBar"
+  wait_for_id 'nav-home' 15 || return 1
+  echo "  ✓ landed on main screen"
+}
+
+# Run standalone for end-to-end verification.
+if [[ "${BASH_SOURCE[0]}" == "${0}" ]]; then
+  set -uo pipefail
+  PACKAGE="${PACKAGE:-com.opennutritracker.ont.opennutritracker}"
+  ACTIVITY="${ACTIVITY:-com.opennutritracker.ont.opennutritracker.MainActivity}"
+  echo "=== Standalone onboarding walk — device: $DEVICE ==="
+  adb -s "$DEVICE" shell pm clear "$PACKAGE" > /dev/null 2>&1 || true
+  adb -s "$DEVICE" shell am start -n "$PACKAGE/$ACTIVITY" > /dev/null
+  sleep 4
+  walk_onboarding
+  RC=$?
+  if [[ $RC -eq 0 ]]; then
+    echo "✓ walker completed onboarding successfully"
+    screenshot /tmp/ont-onboarding-complete.png > /dev/null
+    echo "screenshot: /tmp/ont-onboarding-complete.png"
+  else
+    echo "✗ walker failed — visible ids:"
+    list_ids | sort -u
+    screenshot /tmp/ont-onboarding-failed.png > /dev/null
+    echo "screenshot: /tmp/ont-onboarding-failed.png"
+  fi
+  exit $RC
+fi


### PR DESCRIPTION
## Summary

- Adds `tools/adb/adb-driver.sh` — a sourced bash library that wraps `adb shell uiautomator dump` and `adb shell input tap` into named functions (`tap_id`, `wait_for_id`, `enter_text_at`, `_tap_text`, `screenshot`, `list_ids`, and more). Auto-detects the connected device when `DEVICE` is not set in the environment.

- Adds `tools/adb/walk-onboarding.sh` — walks the app's 6-page first-launch onboarding flow from scratch and leaves the device on the main `NavigationBar`. Can be sourced as a library function (`walk_onboarding`) or run standalone against a freshly-cleared app install.

- Adds `tools/adb/run-branch-tests.sh` — an unattended sequential runner that iterates over all 24 active triage branches. For each branch it: stashes credentials, checks out the branch, runs `flutter pub get`, builds a debug APK, installs it via `adb install -r`, clears app data, walks onboarding, and dispatches a branch-specific probe function that navigates to the feature's UI and checks for a sentinel `Semantics(identifier:)` node. Results are written to a timestamped log with per-branch screenshots.

- `CLAUDE.md` updated to document the location and usage of the new tooling.

These scripts were developed during the 2026-05-13 triage sweep and exercised live against all 24 branches on device `1C151FDEE003YJ` before being committed here. The probe functions reflect the actual navigation paths discovered during that pass (including the recipe-builder `PopupMenu` route that is not reachable through the global FAB, the `editOnly` guard on the ephemeral-meal checkbox, and the calculations dialog scroll depth for the per-nutrient sliders).

## Test plan

- [x] Clone the repo on a machine with a connected Android device and `adb` in `PATH`
- [x] Run `DEVICE=<serial> bash tools/adb/walk-onboarding.sh` against a freshly-cleared install — should complete onboarding and print `✓ landed on main screen`
- [x] Source `tools/adb/adb-driver.sh` in an ad-hoc shell session and call `list_ids` to confirm the driver picks up the connected device automatically
- [x] Review `run-branch-tests.sh` probe functions against their respective branches to confirm the `Semantics(identifier:)` nodes they check are present