### PR TITLE
docs(release): document SHA256 signing fingerprint

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,6 +53,24 @@ See [Data Protection](https://www.iubenda.com/privacy-policy/53501884)
 - ~~Add Imperial unit support~~
 - Add support for Material You themes
 
+## Verifying APK signatures
+
+If you are side-loading an OpenNutriTracker APK from GitHub Releases — or from F-Droid, once the app is published there — you may reasonably want to confirm that the file you downloaded was signed by the same key the maintainer uses for every release, rather than by someone who intercepted the download or repackaged the app. The check below is for anyone who would like that extra reassurance before installing.
+
+The official SHA256 fingerprint of the Android release signing certificate is:
+
+```
+TODO(simon): paste fingerprint from release keystore — see "Generating the SHA256 fingerprint" in RELEASE.md
+```
+
+To verify a downloaded APK against that fingerprint, run:
+
+```sh
+apksigner verify --print-certs /path/to/opennutritracker.apk
+```
+
+The `SHA-256` line in the output should match the value above exactly.
+
 ## Contribution
 Contributions to OpenNutriTracker are welcome! If you find any issues or have suggestions for new features, please open an issue or submit a pull request. See [CONTRIBUTING.md](CONTRIBUTING.md) for the project's conventions — including the requirement to target the `develop` branch and the steps for adding localized strings.
 

--- a/RELEASE.md
+++ b/RELEASE.md
@@ -1,0 +1,17 @@
+# Release notes for maintainers
+
+This file collects small, practical notes for cutting an OpenNutriTracker release. It is aimed at Simon and anyone helping him with the release pipeline, rather than at people installing the app.
+
+## Generating the SHA256 fingerprint
+
+When publishing a new APK to GitHub Releases (and in future to F-Droid), a security-conscious person installing the build may want to verify that it was signed by the same release key as every other official build. The README has a `Verifying APK signatures` section that points them at the canonical SHA256 fingerprint of the release certificate — this section is the reference for keeping that value accurate.
+
+The fingerprint comes straight from the release keystore. With the keystore path and alias from `android/key.properties`, run:
+
+```sh
+keytool -list -v -keystore /path/to/release.keystore -alias <alias>
+```
+
+Look for the `SHA256:` line under `Certificate fingerprints`. The value is stable for the lifetime of the keystore — it only changes if the signing key itself is rotated, which would also force every existing installation to uninstall before upgrading — so once the README has the right value, it should not need to be touched again on routine releases.
+
+If the key is ever rotated, update the fingerprint in `README.md` in the same commit as the key change, so that anyone verifying a freshly downloaded APK against the README sees the new value as soon as the new build is published.


### PR DESCRIPTION
Closes #321.

Users who side-load the APK from GitHub Releases have asked for a way to verify the file they downloaded is genuinely the one we signed, not a tampered copy from a mirror. This PR adds the documentation for that flow without changing any code.

Two additions:

- **README** gains a *Verifying APK signatures* section explaining how to use `apksigner verify --print-certs` against a downloaded APK and compare the SHA-256 hash against the canonical fingerprint published in the README.
- **RELEASE.md** gains a *Generating the SHA256 fingerprint* note so that the next person cutting a release knows how to extract the value from the release keystore.

The fingerprint itself is left as a `TODO(simonoppowa)` marker — only the holder of the release keystore can paste the correct value. The doc explains exactly which `keytool` invocation produces it.

## Test plan

- [ ] Run `keytool -list -v -keystore <release-keystore>` against the production keystore and confirm the printed SHA-256 line matches the format the README describes
- [ ] Substitute the real fingerprint in for the `TODO` marker before merging, or merge as-is and follow up with the value in a small one-line PR