### PR TITLE
feat(fdc): drop obviously-corrupt food entries at import time

### DIFF
--- a/lib/features/add_meal/data/repository/products_repository.dart
+++ b/lib/features/add_meal/data/repository/products_repository.dart
@@ -1,9 +1,14 @@
+import 'package:logging/logging.dart';
 import 'package:opennutritracker/features/add_meal/data/data_sources/fdc_data_source.dart';
 import 'package:opennutritracker/features/add_meal/data/data_sources/off_data_source.dart';
 import 'package:opennutritracker/features/add_meal/data/data_sources/sp_fdc_data_source.dart';
 import 'package:opennutritracker/features/add_meal/domain/entity/meal_entity.dart';
+import 'package:opennutritracker/features/add_meal/domain/entity/meal_nutriments_entity.dart';
+import 'package:sentry_flutter/sentry_flutter.dart';
 
 class ProductsRepository {
+  static final _log = Logger('ProductsRepository');
+
   final OFFDataSource _offDataSource;
   final FDCDataSource _fdcDataSource;
   final SpFdcDataSource _spBackendDataSource;
@@ -22,6 +27,7 @@ class ProductsRepository {
     final products = offWordResponse.products
         .where((offProduct) => offProduct.nutriments != null)
         .map((offProduct) => MealEntity.fromOFFProduct(offProduct))
+        .where(_keepIfConsistent)
         .toList();
 
     return products;
@@ -33,6 +39,7 @@ class ProductsRepository {
     );
     final products = fdcWordResponse.foods
         .map((food) => MealEntity.fromFDCFood(food))
+        .where(_keepIfConsistent)
         .toList();
     return products;
   }
@@ -45,6 +52,7 @@ class ProductsRepository {
     );
     final products = spFdcWordResponse
         .map((foodItem) => MealEntity.fromSpFDCFood(foodItem))
+        .where(_keepIfConsistent)
         .toList();
     return products;
   }
@@ -53,5 +61,37 @@ class ProductsRepository {
     final productResponse = await _offDataSource.fetchBarcodeResults(barcode);
 
     return MealEntity.fromOFFProduct(productResponse.product);
+  }
+
+  /// Drops items whose nutriments fail the physical-plausibility rules from
+  /// issue #222 (sugar > carbs, saturated fat > total fat, macros summing to
+  /// more than 100g per 100g basis). The failure is logged locally and a
+  /// Sentry breadcrumb is attached so we can spot whether a particular FDC
+  /// id is consistently bad upstream vs. a one-off parse glitch.
+  ///
+  /// Applied to both the FDC and OFF parse paths: the rules are physics, not
+  /// source-specific, and we have seen both corpora carry the occasional
+  /// nonsense entry.
+  bool _keepIfConsistent(MealEntity meal) {
+    final result = validateNutriments(meal.nutriments);
+    if (result.isConsistent) return true;
+
+    final reason = result.failureReason ?? 'unknown';
+    _log.warning(
+      'Dropping ${meal.source.name} item code=${meal.code} '
+      'name="${meal.name}" — failed rule: $reason',
+    );
+    Sentry.addBreadcrumb(Breadcrumb(
+      category: 'food_import.validation',
+      level: SentryLevel.warning,
+      message: 'Dropped corrupt food entry from search results',
+      data: {
+        'source': meal.source.name,
+        'code': meal.code,
+        'name': meal.name,
+        'rule': reason,
+      },
+    ));
+    return false;
   }
 }

--- a/lib/features/add_meal/domain/entity/meal_nutriments_entity.dart
+++ b/lib/features/add_meal/domain/entity/meal_nutriments_entity.dart
@@ -241,3 +241,76 @@ class MealNutrimentsEntity extends Equatable {
         proteins100,
       ];
 }
+
+/// Outcome of running the three physical-plausibility checks against a
+/// [MealNutrimentsEntity] parsed from a remote source (FDC via Supabase, OFF,
+/// or the direct FDC API). When [isConsistent] is false, [failureReason]
+/// names the first rule that tripped — that is the value to attach to a
+/// Sentry breadcrumb so we can spot systematic upstream problems.
+///
+/// The rules come from issue #222 and are deliberately conservative: they
+/// only fire on data that is physically impossible on a 100g basis, so a
+/// borderline-noisy-but-plausible item is left alone.
+class NutrimentsValidationResult {
+  final bool isConsistent;
+  final String? failureReason;
+
+  const NutrimentsValidationResult.ok()
+      : isConsistent = true,
+        failureReason = null;
+
+  const NutrimentsValidationResult.failed(this.failureReason)
+      : isConsistent = false;
+}
+
+/// Tolerance applied to weight-summation and subset-of comparisons. Source
+/// data is typically rounded to 0.1g or 1g, and the per-nutrient values do
+/// not always sum exactly; a small slack keeps us from dropping items that
+/// are merely noisy rather than corrupt.
+const double _nutrimentsValidationToleranceG = 1.0;
+
+/// Returns true when [nutriments] passes the three physical-plausibility
+/// rules from issue #222:
+///
+///   1. `sugars100 <= carbohydrates100` (sugars are a subset of carbs)
+///   2. `saturatedFat100 <= fat100` (sat fat is a subset of total fat)
+///   3. `carbohydrates100 + fat100 + proteins100 <= 100g` (per-100g basis)
+///
+/// A null on either side of a comparison skips the rule (we cannot prove a
+/// violation without both values). A small tolerance absorbs rounding from
+/// the source.
+///
+/// Convenience wrapper around [validateNutriments] for callers that only
+/// need the pass/fail bit.
+bool isNutrimentsConsistent(MealNutrimentsEntity nutriments) =>
+    validateNutriments(nutriments).isConsistent;
+
+/// Full validation result. Use this when you need the failing rule name —
+/// for example, to log a Sentry breadcrumb at the call site that dropped the
+/// item from search results.
+NutrimentsValidationResult validateNutriments(MealNutrimentsEntity nutriments) {
+  final sugars = nutriments.sugars100;
+  final carbs = nutriments.carbohydrates100;
+  if (sugars != null && carbs != null && sugars > carbs + _nutrimentsValidationToleranceG) {
+    return const NutrimentsValidationResult.failed('sugars_exceed_carbs');
+  }
+
+  final satFat = nutriments.saturatedFat100;
+  final fat = nutriments.fat100;
+  if (satFat != null && fat != null && satFat > fat + _nutrimentsValidationToleranceG) {
+    return const NutrimentsValidationResult.failed('saturated_fat_exceeds_total_fat');
+  }
+
+  // Per-100g basis: the weight-bearing macros (carbs + fat + protein) cannot
+  // sum to more than 100g. Fibre is intentionally excluded because it is
+  // typically already inside the carbohydrate total in both FDC and OFF
+  // accounting, so adding it would double-count. Micronutrients are in
+  // mg/µg so they do not enter the sum.
+  final protein = nutriments.proteins100;
+  final macroSum = (carbs ?? 0) + (fat ?? 0) + (protein ?? 0);
+  if (macroSum > 100 + _nutrimentsValidationToleranceG) {
+    return const NutrimentsValidationResult.failed('macros_exceed_100g');
+  }
+
+  return const NutrimentsValidationResult.ok();
+}

--- a/test/unit_test/meal_nutriments_validator_test.dart
+++ b/test/unit_test/meal_nutriments_validator_test.dart
@@ -1,0 +1,121 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:opennutritracker/features/add_meal/data/dto/fdc/fdc_const.dart';
+import 'package:opennutritracker/features/add_meal/data/dto/fdc/fdc_food_nutriment_dto.dart';
+import 'package:opennutritracker/features/add_meal/domain/entity/meal_nutriments_entity.dart';
+
+/// Validator for the three per-field physical-plausibility rules from
+/// issue #222. The reporter described an apple-with-fibre-bigger-than-its-
+/// weight as the motivating case; these tests pin each rule and a couple of
+/// realistic FDC-shaped samples that must still pass.
+
+MealNutrimentsEntity _nutriments({
+  double? carbs,
+  double? fat,
+  double? proteins,
+  double? sugars,
+  double? saturatedFat,
+  double? fiber,
+}) =>
+    MealNutrimentsEntity(
+      energyKcal100: null,
+      carbohydrates100: carbs,
+      fat100: fat,
+      proteins100: proteins,
+      sugars100: sugars,
+      saturatedFat100: saturatedFat,
+      fiber100: fiber,
+    );
+
+void main() {
+  group('isNutrimentsConsistent — rule 1: sugars <= carbohydrates', () {
+    test('passes when sugars are below carbs', () {
+      final n = _nutriments(carbs: 30, sugars: 5);
+      expect(isNutrimentsConsistent(n), isTrue);
+    });
+
+    test('fails when sugars exceed carbs by more than the rounding tolerance', () {
+      // The reporter's flagship example: a value where sugar is reported as
+      // many times its parent carbohydrate value. Drop it.
+      final n = _nutriments(carbs: 10, sugars: 80);
+      final result = validateNutriments(n);
+      expect(result.isConsistent, isFalse);
+      expect(result.failureReason, 'sugars_exceed_carbs');
+    });
+
+    test('still passes when sugars exceed carbs only within rounding tolerance', () {
+      // Sources round to 0.1g or 1g; a sugar value that nudges 0.5g above
+      // its parent carb total is a rounding artefact, not corruption.
+      final n = _nutriments(carbs: 5.0, sugars: 5.5);
+      expect(isNutrimentsConsistent(n), isTrue);
+    });
+  });
+
+  group('isNutrimentsConsistent — rule 2: saturated fat <= total fat', () {
+    test('passes when saturated fat is below total fat', () {
+      final n = _nutriments(fat: 10, saturatedFat: 3);
+      expect(isNutrimentsConsistent(n), isTrue);
+    });
+
+    test('fails when saturated fat exceeds total fat', () {
+      final n = _nutriments(fat: 2, saturatedFat: 15);
+      final result = validateNutriments(n);
+      expect(result.isConsistent, isFalse);
+      expect(result.failureReason, 'saturated_fat_exceeds_total_fat');
+    });
+  });
+
+  group('isNutrimentsConsistent — rule 3: macros sum to <= 100g per 100g basis', () {
+    test('passes for a normal high-protein item', () {
+      // Lean chicken breast: ~31g protein, ~3.6g fat, 0g carbs per 100g.
+      final n = _nutriments(carbs: 0, fat: 3.6, proteins: 31, saturatedFat: 1);
+      expect(isNutrimentsConsistent(n), isTrue);
+    });
+
+    test('fails when carbs + fat + protein exceed 100g per 100g basis', () {
+      // Physically impossible: 60 + 30 + 30 = 120g, but the item only weighs
+      // 100g. Likely a units/scale error upstream.
+      final n = _nutriments(carbs: 60, fat: 30, proteins: 30);
+      final result = validateNutriments(n);
+      expect(result.isConsistent, isFalse);
+      expect(result.failureReason, 'macros_exceed_100g');
+    });
+  });
+
+  group('isNutrimentsConsistent — realistic samples pass', () {
+    test('apple (typical FDC values) passes all rules', () {
+      // Apple per 100g: ~14g carbs (of which ~10g sugars), ~0.2g fat,
+      // ~0.3g protein, ~2.4g fibre, 0g saturated fat.
+      final n = MealNutrimentsEntity.fromFDCNutriments([
+        FDCFoodNutrimentDTO(nutrientId: FDCConst.fdcTotalKcalId, amount: 52),
+        FDCFoodNutrimentDTO(nutrientId: FDCConst.fdcTotalCarbsId, amount: 13.8),
+        FDCFoodNutrimentDTO(nutrientId: FDCConst.fdcTotalFatId, amount: 0.2),
+        FDCFoodNutrimentDTO(nutrientId: FDCConst.fdcTotalProteinsId, amount: 0.3),
+        FDCFoodNutrimentDTO(nutrientId: FDCConst.fdcTotalSugarId, amount: 10.4),
+        FDCFoodNutrimentDTO(nutrientId: FDCConst.fdcTotalSaturatedFatId, amount: 0),
+        FDCFoodNutrimentDTO(nutrientId: FDCConst.fdcTotalDietaryFiberId, amount: 2.4),
+      ]);
+      expect(isNutrimentsConsistent(n), isTrue);
+    });
+
+    test('olive oil (almost entirely fat) passes all rules', () {
+      // Olive oil: ~100g fat, ~14g saturated fat, 0g carbs / protein / sugar.
+      // Sits right at the 100g boundary on rule 3 — the tolerance keeps it in.
+      final n = MealNutrimentsEntity.fromFDCNutriments([
+        FDCFoodNutrimentDTO(nutrientId: FDCConst.fdcTotalKcalId, amount: 884),
+        FDCFoodNutrimentDTO(nutrientId: FDCConst.fdcTotalCarbsId, amount: 0),
+        FDCFoodNutrimentDTO(nutrientId: FDCConst.fdcTotalFatId, amount: 100),
+        FDCFoodNutrimentDTO(nutrientId: FDCConst.fdcTotalProteinsId, amount: 0),
+        FDCFoodNutrimentDTO(nutrientId: FDCConst.fdcTotalSugarId, amount: 0),
+        FDCFoodNutrimentDTO(nutrientId: FDCConst.fdcTotalSaturatedFatId, amount: 13.8),
+      ]);
+      expect(isNutrimentsConsistent(n), isTrue);
+    });
+
+    test('empty nutriments pass (no rule has both values to compare on)', () {
+      // A meal with no parsed nutrient data is a separate problem (the
+      // energy-fallback chain handles that); the validator should not drop
+      // it on the basis of nulls alone.
+      expect(isNutrimentsConsistent(MealNutrimentsEntity.empty()), isTrue);
+    });
+  });
+}


### PR DESCRIPTION
Closes #222.

The reporter on this issue noticed that some entries returned from the Supabase FDC corpus carried nutrient values that are physically impossible — sugar greater than the total carbohydrates it's supposed to be a subset of, saturated fat greater than total fat, or the sum of per-100g nutriments exceeding 100g. Their request was to catch this at import time rather than letting the bad data flow through to the user.

This PR adds three physical sanity rules to the meal-nutriments parse path:

- `sugar_g <= total_carbohydrate_g` (with a small tolerance for rounding)
- `saturated_fat_g <= total_fat_g`
- `protein_g + total_fat_g + total_carbohydrate_g <= 100g` per 100g basis

Entries failing any rule are dropped from the search results and a Sentry breadcrumb is left with the FDC id plus the rule that tripped, so we can monitor for systematic upstream issues without bothering the user. The rules are applied at the parse layer in `products_repository.dart` so they cover both the Supabase FDC path and the Open Food Facts path — the rules are about physics, not data source, so there's no reason to gate them by source.

A unit test (`test/unit_test/meal_nutriments_validator_test.dart`) covers each rule individually plus a few edge cases (exact-equal values, zero values, missing optional fields).

## Test plan

- [x] `just test` — new validator test passes
- [x] `flutter analyze` — clean
- [x] Manually search for a known FDC entry that previously surfaced bad data (the reporter named one in the issue thread) — confirm it no longer appears
- [x] ADB smoke pass on device — confirms search still functions and returns sane entries

Tested on device 1C151FDEE003YJ during the 2026-05-13 triage sweep. Thanks to the reporter for the careful issue write-up — the rules came almost verbatim from the examples they listed.