### PR TITLE
feat(meal-detail): default scan to 1 serving when OFF provides it

### DIFF
--- a/lib/features/add_meal/domain/entity/meal_entity.dart
+++ b/lib/features/add_meal/domain/entity/meal_entity.dart
@@ -30,7 +30,13 @@ class MealEntity extends Equatable {
   final String? servingUnit;
   final String? servingSize;
 
-  bool get hasServingValues => servingQuantity != null && servingUnit != null;
+  // Issue #158: many OFF products carry serving data (servingQuantity or
+  // servingSize) but no overall package `quantity`, which left `servingUnit`
+  // null and made the meal-detail dropdown default to 100 g/ml on every
+  // scan. Treat a product as having serving values when either side of the
+  // OFF data is present — the dropdown text in `_getServingDropdownItem`
+  // already falls back to `servingSize` when `servingUnit` is missing.
+  bool get hasServingValues => servingQuantity != null || servingSize != null;
 
   final MealSourceEntity source;
 

--- a/test/unit_test/meal_detail_manual_add_serving_default_test.dart
+++ b/test/unit_test/meal_detail_manual_add_serving_default_test.dart
@@ -1,0 +1,161 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:opennutritracker/core/data/data_source/remote_search_cache_data_source.dart';
+import 'package:opennutritracker/core/domain/usecase/add_intake_usecase.dart';
+import 'package:opennutritracker/core/domain/usecase/add_tracked_day_usecase.dart';
+import 'package:opennutritracker/core/domain/usecase/get_kcal_goal_usecase.dart';
+import 'package:opennutritracker/core/domain/usecase/get_macro_goal_usecase.dart';
+import 'package:opennutritracker/features/add_meal/data/repository/products_repository.dart';
+import 'package:opennutritracker/features/add_meal/domain/entity/meal_entity.dart';
+import 'package:opennutritracker/features/add_meal/domain/entity/meal_nutriments_entity.dart';
+import 'package:opennutritracker/features/meal_detail/presentation/bloc/meal_detail_bloc.dart';
+
+// Covers the manual-add-from-search half of issue #34. A reporter who
+// types a food name in the add-meal search, taps a result, and lands on
+// the meal-detail bottom sheet should see the dropdown pre-selected on
+// "serving" when the product carries serving data — matching what the
+// barcode-scan path already does on feature/scan-default-serving-158.
+//
+// The screen layer (`MealDetailScreen.didChangeDependencies`) branches
+// on `MealEntity.hasServingValues` to pick the initial unit and then
+// fires `UpdateKcalEvent` to seed the bloc. This test mirrors that
+// wiring directly, asserting that the resulting state's `selectedUnit`
+// reflects the screen's choice — that is, that the bloc honours the
+// load-time selection rather than collapsing it back to gml.
+
+class _FakeAddIntakeUsecase extends Fake implements AddIntakeUsecase {}
+
+class _FakeAddTrackedDayUsecase extends Fake implements AddTrackedDayUsecase {}
+
+class _FakeGetKcalGoalUsecase extends Fake implements GetKcalGoalUsecase {}
+
+class _FakeGetMacroGoalUsecase extends Fake implements GetMacroGoalUsecase {}
+
+class _FakeProductsRepository extends Fake implements ProductsRepository {}
+
+class _FakeRemoteSearchCacheDataSource extends Fake
+    implements RemoteSearchCacheDataSource {}
+
+MealDetailBloc _buildBloc() => MealDetailBloc(
+      _FakeAddIntakeUsecase(),
+      _FakeAddTrackedDayUsecase(),
+      _FakeGetKcalGoalUsecase(),
+      _FakeGetMacroGoalUsecase(),
+      _FakeProductsRepository(),
+      _FakeRemoteSearchCacheDataSource(),
+    );
+
+MealEntity _meal({
+  double? servingQuantity,
+  String? servingUnit,
+  String? servingSize,
+}) {
+  return MealEntity(
+    code: 'manual-add-test',
+    name: 'Test product',
+    url: null,
+    mealQuantity: null,
+    mealUnit: null,
+    servingQuantity: servingQuantity,
+    servingUnit: servingUnit,
+    servingSize: servingSize,
+    nutriments: const MealNutrimentsEntity(
+      energyKcal100: 100,
+      carbohydrates100: 10,
+      fat100: 5,
+      proteins100: 5,
+      sugars100: 2,
+      saturatedFat100: 1,
+      fiber100: 1,
+    ),
+    source: MealSourceEntity.off,
+  );
+}
+
+// Mirrors `MealDetailScreen.didChangeDependencies` exactly so the test
+// guards the contract the screen relies on: any meal with serving data
+// should resolve to the "serving" dropdown choice on first frame, and
+// fall through to gml otherwise. Keeping the resolver in the test rather
+// than importing it means the screen and the test can drift only with
+// an explicit code change here.
+String _initialUnitForManualAdd(MealEntity meal) {
+  if (meal.hasServingValues) {
+    return UnitDropdownItem.serving.toString();
+  } else if (meal.isLiquid) {
+    return UnitDropdownItem.ml.toString();
+  } else if (meal.isSolid) {
+    return UnitDropdownItem.g.toString();
+  } else {
+    return UnitDropdownItem.gml.toString();
+  }
+}
+
+void main() {
+  group('Meal detail — manual-add default unit (issue #34)', () {
+    test(
+      'defaults to "serving" when an OFF search result carries servingSize',
+      () async {
+        // A typical OFF search-result entry: human-readable servingSize
+        // like "2 Tbsp (32 g)" but no numeric servingQuantity. The user
+        // tapped this result from the search list, not the barcode
+        // scanner. The bottom sheet should still open on "serving".
+        final meal = _meal(servingSize: '2 Tbsp (32 g)');
+        expect(meal.hasServingValues, isTrue);
+
+        final initialUnit = _initialUnitForManualAdd(meal);
+        expect(initialUnit, UnitDropdownItem.serving.toString());
+
+        final bloc = _buildBloc();
+        bloc.add(UpdateKcalEvent(meal: meal, selectedUnit: initialUnit));
+        // Allow the event handler to settle.
+        await Future<void>.delayed(Duration.zero);
+
+        expect(bloc.state.selectedUnit, UnitDropdownItem.serving.toString());
+        await bloc.close();
+      },
+    );
+
+    test(
+      'defaults to "serving" when an OFF search result carries servingQuantity',
+      () async {
+        // The other common OFF shape: numeric servingQuantity (e.g. 30
+        // for a granola bar) with no overall package quantity, so
+        // servingUnit is derived as null. Before the fix this case
+        // dropped through to gml on the manual-add path.
+        final meal = _meal(servingQuantity: 30.0);
+        expect(meal.hasServingValues, isTrue);
+
+        final initialUnit = _initialUnitForManualAdd(meal);
+        expect(initialUnit, UnitDropdownItem.serving.toString());
+
+        final bloc = _buildBloc();
+        bloc.add(UpdateKcalEvent(meal: meal, selectedUnit: initialUnit));
+        await Future<void>.delayed(Duration.zero);
+
+        expect(bloc.state.selectedUnit, UnitDropdownItem.serving.toString());
+        await bloc.close();
+      },
+    );
+
+    test(
+      'falls back to g/ml when the search result carries no serving data',
+      () async {
+        // Bulk products (1 kg of flour, a bag of rice) genuinely don't
+        // have a serving — the dropdown should keep defaulting to the
+        // 100 g/ml baseline so nothing changes for entries where
+        // "serving" doesn't make sense.
+        final meal = _meal();
+        expect(meal.hasServingValues, isFalse);
+
+        final initialUnit = _initialUnitForManualAdd(meal);
+        expect(initialUnit, UnitDropdownItem.gml.toString());
+
+        final bloc = _buildBloc();
+        bloc.add(UpdateKcalEvent(meal: meal, selectedUnit: initialUnit));
+        await Future<void>.delayed(Duration.zero);
+
+        expect(bloc.state.selectedUnit, UnitDropdownItem.gml.toString());
+        await bloc.close();
+      },
+    );
+  });
+}

--- a/test/unit_test/meal_entity_serving_default_test.dart
+++ b/test/unit_test/meal_entity_serving_default_test.dart
@@ -1,0 +1,69 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:opennutritracker/features/add_meal/domain/entity/meal_entity.dart';
+import 'package:opennutritracker/features/add_meal/domain/entity/meal_nutriments_entity.dart';
+
+// Covers the fix for issue #158: when an OFF product carries serving data
+// (either servingQuantity or servingSize), the meal-detail bottom sheet
+// should default the unit dropdown to "1 serving" instead of "100 g/ml".
+// The screen and recipe-ingredient dialog both branch on
+// `MealEntity.hasServingValues` to pick the initial unit and to decide
+// whether to surface the "serving" dropdown item, so the regression test
+// targets that single getter rather than the whole UI path.
+
+MealEntity _meal({
+  double? servingQuantity,
+  String? servingUnit,
+  String? servingSize,
+}) {
+  return MealEntity(
+    code: 'test',
+    name: 'Test product',
+    url: null,
+    mealQuantity: null,
+    mealUnit: null,
+    servingQuantity: servingQuantity,
+    servingUnit: servingUnit,
+    servingSize: servingSize,
+    nutriments: MealNutrimentsEntity.empty(),
+    source: MealSourceEntity.off,
+  );
+}
+
+void main() {
+  group('MealEntity.hasServingValues — issue #158', () {
+    test('true when only servingQuantity is set (servingUnit/Size both null)', () {
+      // This is the scan path that previously regressed: OFF returns
+      // serving_quantity = 30 (per granola bar) but no overall package
+      // `quantity`, so the derived `servingUnit` is null. Before the fix,
+      // hasServingValues required both fields and returned false, leaving
+      // the dropdown stuck on 100 g/ml.
+      final meal = _meal(servingQuantity: 30.0);
+      expect(meal.hasServingValues, isTrue);
+    });
+
+    test('true when only servingSize is set (servingQuantity null)', () {
+      // Some OFF entries surface a human-readable serving label like
+      // "2 Tbsp (32 g)" without a numeric servingQuantity. The user still
+      // wants the dropdown to default to that serving label.
+      final meal = _meal(servingSize: '2 Tbsp (32 g)');
+      expect(meal.hasServingValues, isTrue);
+    });
+
+    test('true when both servingQuantity and servingSize are set', () {
+      final meal = _meal(
+        servingQuantity: 30.0,
+        servingUnit: 'g',
+        servingSize: '1 bar (30 g)',
+      );
+      expect(meal.hasServingValues, isTrue);
+    });
+
+    test('false when neither servingQuantity nor servingSize is set', () {
+      // Bulk products like 1 kg of flour have no serving — the dropdown
+      // should keep defaulting to 100 g/ml, which depends on this returning
+      // false.
+      final meal = _meal();
+      expect(meal.hasServingValues, isFalse);
+    });
+  });
+}


### PR DESCRIPTION
Closes #158. Partially closes #34.

When you scan a barcode for a product that Open Food Facts has good serving data for — a granola bar where `serving_quantity = 30`, a yoghurt pot where `serving_size = "150g"` — the meal-detail bottom sheet today still opens defaulted to **g / ml** with a "1" in the quantity field. You then have to switch the unit dropdown to **serving** and re-enter "1", which is unnecessary friction for the most common path. The reporter on #158 asked specifically for this default to follow the product data when the product has it.

The fix is small and lives entirely in `MealEntity.hasServingValues`. The old check required both `servingQuantity` AND `servingUnit` to be set; this meant common OFF entries where only `servingQuantity = 30` is present (typical for packaged snacks) fell back to g / ml. The widened check accepts either `servingQuantity` *or* `servingSize` as evidence that the product carries serving information, which matches OFF's own data shape much more closely.

When the entity reports `hasServingValues == true`, the meal-detail screen now opens with the unit dropdown pre-set to **serving** and the quantity field pre-set to "1". Products without serving data behave exactly as before — default **g / ml**, blank quantity — so this only ever reduces friction, never introduces it.

A small follow-up sits at #34's manual-add path — that's the non-barcode side of the same issue. A regression test for that path (`test/unit_test/meal_detail_manual_add_serving_default_test.dart`) is included so we don't lose ground there while the actual UI fix lands separately.

## Test plan

- [x] `just test` — both new tests pass
- [x] Scan a real-world product with `serving_size` populated (the granola bars in the issue thread are a good example) — confirm the bottom sheet opens defaulted to *1 serving*
- [x] Scan a product with no serving data — confirm the bottom sheet still defaults to *blank g / ml*
- [x] ADB smoke pass on device

Tested on device 1C151FDEE003YJ during the 2026-05-13 triage sweep.