### PR TITLE
feat(settings): configurable diary day-start with minute granularity

### DIFF
--- a/lib/core/data/data_source/config_data_source.dart
+++ b/lib/core/data/data_source/config_data_source.dart
@@ -231,6 +231,13 @@ class ConfigDataSource {
     await config?.save();
   }
 
+  Future<void> setConfigDayStartOffsetMinutes(int minutes) async {
+    _log.fine('Updating config dayStartOffsetMinutes to $minutes');
+    final config = _configBox.get(_configKey);
+    config?.dayStartOffsetMinutes = minutes;
+    await config?.save();
+  }
+
   Future<ConfigDBO> getConfig() async {
     return _configBox.get(_configKey) ?? ConfigDBO.empty();
   }

--- a/lib/core/data/data_source/config_data_source.dart
+++ b/lib/core/data/data_source/config_data_source.dart
@@ -224,6 +224,13 @@ class ConfigDataSource {
     await config?.save();
   }
 
+  Future<void> setConfigDayStartOffsetHours(int hours) async {
+    _log.fine('Updating config dayStartOffsetHours to $hours');
+    final config = _configBox.get(_configKey);
+    config?.dayStartOffsetHours = hours;
+    await config?.save();
+  }
+
   Future<ConfigDBO> getConfig() async {
     return _configBox.get(_configKey) ?? ConfigDBO.empty();
   }

--- a/lib/core/data/data_source/intake_data_source.dart
+++ b/lib/core/data/data_source/intake_data_source.dart
@@ -5,6 +5,7 @@ import 'package:logging/logging.dart';
 import 'package:opennutritracker/core/data/dbo/intake_dbo.dart';
 import 'package:opennutritracker/core/data/dbo/intake_type_dbo.dart';
 import 'package:opennutritracker/core/data/dbo/meal_dbo.dart';
+import 'package:opennutritracker/core/utils/calc/day_boundary_calc.dart';
 
 class IntakeDataSource {
   final log = Logger('IntakeDataSource');
@@ -62,12 +63,29 @@ class IntakeDataSource {
 
   Future<List<IntakeDBO>> getAllIntakesByDate(
     IntakeTypeDBO intakeType,
-    DateTime dateTime,
-  ) async {
+    DateTime dateTime, {
+    int dayStartOffsetHours = 0,
+  }) async {
+    // #139: when a non-zero day-start offset is configured, an entry
+    // logged before that hour rolls into the previous wall-clock day.
+    // dayStartOffsetHours = 0 preserves the original wall-clock behaviour.
+    if (dayStartOffsetHours == 0) {
+      return _intakeBox.values
+          .where(
+            (intake) =>
+                DateUtils.isSameDay(dateTime, intake.dateTime) &&
+                intake.type == intakeType,
+          )
+          .toList();
+    }
     return _intakeBox.values
         .where(
           (intake) =>
-              DateUtils.isSameDay(dateTime, intake.dateTime) &&
+              DayBoundaryCalc.isSameLogicalDay(
+                dateTime,
+                intake.dateTime,
+                dayStartOffsetHours,
+              ) &&
               intake.type == intakeType,
         )
         .toList();

--- a/lib/core/data/data_source/intake_data_source.dart
+++ b/lib/core/data/data_source/intake_data_source.dart
@@ -65,11 +65,16 @@ class IntakeDataSource {
     IntakeTypeDBO intakeType,
     DateTime dateTime, {
     int dayStartOffsetHours = 0,
+    int dayStartOffsetMinutes = 0,
   }) async {
     // #139: when a non-zero day-start offset is configured, an entry
     // logged before that hour rolls into the previous wall-clock day.
-    // dayStartOffsetHours = 0 preserves the original wall-clock behaviour.
-    if (dayStartOffsetHours == 0) {
+    // A zero total offset preserves the original wall-clock behaviour.
+    // The follow-up to #139 adds a minutes companion; both compose
+    // additively into a single total-minutes value here.
+    final totalMinutes = dayStartOffsetHours * 60 +
+        dayStartOffsetMinutes.clamp(0, 59);
+    if (totalMinutes == 0) {
       return _intakeBox.values
           .where(
             (intake) =>
@@ -81,10 +86,10 @@ class IntakeDataSource {
     return _intakeBox.values
         .where(
           (intake) =>
-              DayBoundaryCalc.isSameLogicalDay(
+              DayBoundaryCalc.isSameLogicalDayMinutes(
                 dateTime,
                 intake.dateTime,
-                dayStartOffsetHours,
+                totalMinutes,
               ) &&
               intake.type == intakeType,
         )

--- a/lib/core/data/data_source/user_activity_data_source.dart
+++ b/lib/core/data/data_source/user_activity_data_source.dart
@@ -63,20 +63,24 @@ class UserActivityDataSource {
   Future<List<UserActivityDBO>> getAllUserActivitiesByDate(
     DateTime dateTime, {
     int dayStartOffsetHours = 0,
+    int dayStartOffsetMinutes = 0,
   }) async {
-    // #139: see IntakeDataSource for the rationale — 0 preserves the
-    // original wall-clock day behaviour.
-    if (dayStartOffsetHours == 0) {
+    // #139: see IntakeDataSource for the rationale — a zero total offset
+    // preserves the original wall-clock day behaviour. The follow-up to
+    // #139 adds the minutes companion which composes additively here.
+    final totalMinutes = dayStartOffsetHours * 60 +
+        dayStartOffsetMinutes.clamp(0, 59);
+    if (totalMinutes == 0) {
       return _userActivityBox.values
           .where((activity) => DateUtils.isSameDay(dateTime, activity.date))
           .toList();
     }
     return _userActivityBox.values
         .where(
-          (activity) => DayBoundaryCalc.isSameLogicalDay(
+          (activity) => DayBoundaryCalc.isSameLogicalDayMinutes(
             dateTime,
             activity.date,
-            dayStartOffsetHours,
+            totalMinutes,
           ),
         )
         .toList();

--- a/lib/core/data/data_source/user_activity_data_source.dart
+++ b/lib/core/data/data_source/user_activity_data_source.dart
@@ -3,6 +3,7 @@ import 'package:flutter/material.dart';
 import 'package:hive_ce_flutter/hive_flutter.dart';
 import 'package:logging/logging.dart';
 import 'package:opennutritracker/core/data/data_source/user_activity_dbo.dart';
+import 'package:opennutritracker/core/utils/calc/day_boundary_calc.dart';
 
 class UserActivityDataSource {
   final log = Logger('UserActivityDataSource');
@@ -60,10 +61,24 @@ class UserActivityDataSource {
   }
 
   Future<List<UserActivityDBO>> getAllUserActivitiesByDate(
-    DateTime dateTime,
-  ) async {
+    DateTime dateTime, {
+    int dayStartOffsetHours = 0,
+  }) async {
+    // #139: see IntakeDataSource for the rationale — 0 preserves the
+    // original wall-clock day behaviour.
+    if (dayStartOffsetHours == 0) {
+      return _userActivityBox.values
+          .where((activity) => DateUtils.isSameDay(dateTime, activity.date))
+          .toList();
+    }
     return _userActivityBox.values
-        .where((activity) => DateUtils.isSameDay(dateTime, activity.date))
+        .where(
+          (activity) => DayBoundaryCalc.isSameLogicalDay(
+            dateTime,
+            activity.date,
+            dayStartOffsetHours,
+          ),
+        )
         .toList();
   }
 

--- a/lib/core/data/dbo/config_dbo.dart
+++ b/lib/core/data/dbo/config_dbo.dart
@@ -48,6 +48,8 @@ class ConfigDBO extends HiveObject {
   Map<String, int>? mealKcalSharesPct;
   @HiveField(18)
   String? customMealFormMode; // #232: 'simple' or 'advanced'; null means default (simple)
+  @HiveField(19)
+  int? dayStartOffsetHours; // #139: 0-23, null means default (0 = wall-clock midnight)
   @HiveField(20)
   bool caloriesTaperEnabled;
   // #160 follow-up: per-nutrient show/hide map for the daily nutrient panel.
@@ -83,6 +85,7 @@ class ConfigDBO extends HiveObject {
     this.usesKilojoules,
     this.mealKcalSharesPct,
     this.customMealFormMode,
+    this.dayStartOffsetHours,
     this.caloriesTaperEnabled = false,
     this.diarySortPreferences,
     this.nutrientPanelVisibility,

--- a/lib/core/data/dbo/config_dbo.dart
+++ b/lib/core/data/dbo/config_dbo.dart
@@ -67,6 +67,11 @@ class ConfigDBO extends HiveObject {
   /// (`DiarySortType.timeAdded`) until the user picks a sort.
   @HiveField(21)
   Map<String, int>? diarySortPreferences;
+  // #139 follow-up: 0-59 minute companion. Composes additively with
+  // dayStartOffsetHours so existing users with hours=4 and a null minutes
+  // value see a 4:00 boundary, unchanged.
+  @HiveField(23)
+  int? dayStartOffsetMinutes;
 
   ConfigDBO(
     this.hasAcceptedDisclaimer,
@@ -89,6 +94,7 @@ class ConfigDBO extends HiveObject {
     this.caloriesTaperEnabled = false,
     this.diarySortPreferences,
     this.nutrientPanelVisibility,
+    this.dayStartOffsetMinutes,
   });
 
   factory ConfigDBO.empty() =>

--- a/lib/core/data/dbo/config_dbo.g.dart
+++ b/lib/core/data/dbo/config_dbo.g.dart
@@ -33,6 +33,7 @@ class ConfigDBOAdapter extends TypeAdapter<ConfigDBO> {
         usesKilojoules: fields[16] as bool?,
         mealKcalSharesPct: (fields[17] as Map?)?.cast<String, int>(),
         customMealFormMode: fields[18] as String?,
+        dayStartOffsetHours: (fields[19] as num?)?.toInt(),
         caloriesTaperEnabled: fields[20] == null ? false : fields[20] as bool,
         diarySortPreferences: (fields[21] as Map?)?.cast<String, int>(),
         nutrientPanelVisibility: (fields[22] as Map?)?.cast<String, bool>(),
@@ -45,7 +46,7 @@ class ConfigDBOAdapter extends TypeAdapter<ConfigDBO> {
   @override
   void write(BinaryWriter writer, ConfigDBO obj) {
     writer
-      ..writeByte(22)
+      ..writeByte(23)
       ..writeByte(0)
       ..write(obj.hasAcceptedDisclaimer)
       ..writeByte(1)
@@ -84,6 +85,8 @@ class ConfigDBOAdapter extends TypeAdapter<ConfigDBO> {
       ..write(obj.mealKcalSharesPct)
       ..writeByte(18)
       ..write(obj.customMealFormMode)
+      ..writeByte(19)
+      ..write(obj.dayStartOffsetHours)
       ..writeByte(20)
       ..write(obj.caloriesTaperEnabled)
       ..writeByte(21)
@@ -126,6 +129,7 @@ ConfigDBO _$ConfigDBOFromJson(Map<String, dynamic> json) =>
         mealKcalSharesPct: (json['mealKcalSharesPct'] as Map<String, dynamic>?)
             ?.map((k, e) => MapEntry(k, (e as num).toInt())),
         customMealFormMode: json['customMealFormMode'] as String?,
+        dayStartOffsetHours: (json['dayStartOffsetHours'] as num?)?.toInt(),
         caloriesTaperEnabled: json['caloriesTaperEnabled'] as bool? ?? false,
         diarySortPreferences:
             (json['diarySortPreferences'] as Map<String, dynamic>?)?.map(
@@ -160,6 +164,7 @@ Map<String, dynamic> _$ConfigDBOToJson(ConfigDBO instance) => <String, dynamic>{
   'usesKilojoules': instance.usesKilojoules,
   'mealKcalSharesPct': instance.mealKcalSharesPct,
   'customMealFormMode': instance.customMealFormMode,
+  'dayStartOffsetHours': instance.dayStartOffsetHours,
   'caloriesTaperEnabled': instance.caloriesTaperEnabled,
   'nutrientPanelVisibility': instance.nutrientPanelVisibility,
   'diarySortPreferences': instance.diarySortPreferences,

--- a/lib/core/data/dbo/config_dbo.g.dart
+++ b/lib/core/data/dbo/config_dbo.g.dart
@@ -37,6 +37,7 @@ class ConfigDBOAdapter extends TypeAdapter<ConfigDBO> {
         caloriesTaperEnabled: fields[20] == null ? false : fields[20] as bool,
         diarySortPreferences: (fields[21] as Map?)?.cast<String, int>(),
         nutrientPanelVisibility: (fields[22] as Map?)?.cast<String, bool>(),
+        dayStartOffsetMinutes: (fields[23] as num?)?.toInt(),
       )
       ..userCarbGoalPct = (fields[6] as num?)?.toDouble()
       ..userProteinGoalPct = (fields[7] as num?)?.toDouble()
@@ -46,7 +47,7 @@ class ConfigDBOAdapter extends TypeAdapter<ConfigDBO> {
   @override
   void write(BinaryWriter writer, ConfigDBO obj) {
     writer
-      ..writeByte(23)
+      ..writeByte(24)
       ..writeByte(0)
       ..write(obj.hasAcceptedDisclaimer)
       ..writeByte(1)
@@ -92,7 +93,9 @@ class ConfigDBOAdapter extends TypeAdapter<ConfigDBO> {
       ..writeByte(21)
       ..write(obj.diarySortPreferences)
       ..writeByte(22)
-      ..write(obj.nutrientPanelVisibility);
+      ..write(obj.nutrientPanelVisibility)
+      ..writeByte(23)
+      ..write(obj.dayStartOffsetMinutes);
   }
 
   @override
@@ -139,6 +142,7 @@ ConfigDBO _$ConfigDBOFromJson(Map<String, dynamic> json) =>
             (json['nutrientPanelVisibility'] as Map<String, dynamic>?)?.map(
               (k, e) => MapEntry(k, e as bool),
             ),
+        dayStartOffsetMinutes: (json['dayStartOffsetMinutes'] as num?)?.toInt(),
       )
       ..userCarbGoalPct = (json['userCarbGoalPct'] as num?)?.toDouble()
       ..userProteinGoalPct = (json['userProteinGoalPct'] as num?)?.toDouble()
@@ -168,6 +172,7 @@ Map<String, dynamic> _$ConfigDBOToJson(ConfigDBO instance) => <String, dynamic>{
   'caloriesTaperEnabled': instance.caloriesTaperEnabled,
   'nutrientPanelVisibility': instance.nutrientPanelVisibility,
   'diarySortPreferences': instance.diarySortPreferences,
+  'dayStartOffsetMinutes': instance.dayStartOffsetMinutes,
 };
 
 const _$AppThemeDBOEnumMap = {

--- a/lib/core/data/repository/config_repository.dart
+++ b/lib/core/data/repository/config_repository.dart
@@ -134,4 +134,8 @@ class ConfigRepository {
   ) async {
     await _configDataSource.setConfigNutrientPanelVisibility(visibility);
   }
+
+  Future<void> setConfigDayStartOffsetHours(int hours) async {
+    await _configDataSource.setConfigDayStartOffsetHours(hours);
+  }
 }

--- a/lib/core/data/repository/config_repository.dart
+++ b/lib/core/data/repository/config_repository.dart
@@ -138,4 +138,8 @@ class ConfigRepository {
   Future<void> setConfigDayStartOffsetHours(int hours) async {
     await _configDataSource.setConfigDayStartOffsetHours(hours);
   }
+
+  Future<void> setConfigDayStartOffsetMinutes(int minutes) async {
+    await _configDataSource.setConfigDayStartOffsetMinutes(minutes);
+  }
 }

--- a/lib/core/data/repository/intake_repository.dart
+++ b/lib/core/data/repository/intake_repository.dart
@@ -37,11 +37,13 @@ class IntakeRepository {
 
   Future<List<IntakeEntity>> getIntakeByDateAndType(
     IntakeTypeEntity intakeType,
-    DateTime date,
-  ) async {
+    DateTime date, {
+    int dayStartOffsetHours = 0,
+  }) async {
     final intakeDBOList = await _intakeDataSource.getAllIntakesByDate(
       IntakeTypeDBO.fromIntakeTypeEntity(intakeType),
       date,
+      dayStartOffsetHours: dayStartOffsetHours,
     );
 
     return intakeDBOList

--- a/lib/core/data/repository/intake_repository.dart
+++ b/lib/core/data/repository/intake_repository.dart
@@ -39,11 +39,13 @@ class IntakeRepository {
     IntakeTypeEntity intakeType,
     DateTime date, {
     int dayStartOffsetHours = 0,
+    int dayStartOffsetMinutes = 0,
   }) async {
     final intakeDBOList = await _intakeDataSource.getAllIntakesByDate(
       IntakeTypeDBO.fromIntakeTypeEntity(intakeType),
       date,
       dayStartOffsetHours: dayStartOffsetHours,
+      dayStartOffsetMinutes: dayStartOffsetMinutes,
     );
 
     return intakeDBOList

--- a/lib/core/data/repository/user_activity_repository.dart
+++ b/lib/core/data/repository/user_activity_repository.dart
@@ -45,11 +45,13 @@ class UserActivityRepository {
   Future<List<UserActivityEntity>> getAllUserActivityByDate(
     DateTime dateTime, {
     int dayStartOffsetHours = 0,
+    int dayStartOffsetMinutes = 0,
   }) async {
     final userActivityDBOList =
         await _userActivityDataSource.getAllUserActivitiesByDate(
       dateTime,
       dayStartOffsetHours: dayStartOffsetHours,
+      dayStartOffsetMinutes: dayStartOffsetMinutes,
     );
 
     return userActivityDBOList

--- a/lib/core/data/repository/user_activity_repository.dart
+++ b/lib/core/data/repository/user_activity_repository.dart
@@ -43,10 +43,14 @@ class UserActivityRepository {
   }
 
   Future<List<UserActivityEntity>> getAllUserActivityByDate(
-    DateTime dateTime,
-  ) async {
+    DateTime dateTime, {
+    int dayStartOffsetHours = 0,
+  }) async {
     final userActivityDBOList =
-        await _userActivityDataSource.getAllUserActivitiesByDate(dateTime);
+        await _userActivityDataSource.getAllUserActivitiesByDate(
+      dateTime,
+      dayStartOffsetHours: dayStartOffsetHours,
+    );
 
     return userActivityDBOList
         .map(

--- a/lib/core/domain/entity/config_entity.dart
+++ b/lib/core/domain/entity/config_entity.dart
@@ -47,6 +47,7 @@ class ConfigEntity extends Equatable {
   // falls back to the default, which is currently "visible" for every
   // nutrient — see [isNutrientVisible].
   final Map<String, bool> nutrientPanelVisibility;
+  final int dayStartOffsetHours; // #139: 0-23, default 0 (wall-clock midnight)
 
   const ConfigEntity(
     this.hasAcceptedDisclaimer,
@@ -70,6 +71,7 @@ class ConfigEntity extends Equatable {
     this.caloriesTaperEnabled = false,
     this.diarySortPreferences,
     this.nutrientPanelVisibility = const <String, bool>{},
+    this.dayStartOffsetHours = 0,
   });
 
   /// Whether a particular nutrient on the daily panel should be rendered.
@@ -101,6 +103,7 @@ class ConfigEntity extends Equatable {
         diarySortPreferences: dbo.diarySortPreferences,
         nutrientPanelVisibility:
             dbo.nutrientPanelVisibility ?? const <String, bool>{},
+        dayStartOffsetHours: _normaliseOffset(dbo.dayStartOffsetHours),
       );
 
   /// Returns the recommended kcal target for [mealKey] given a daily goal.
@@ -117,6 +120,12 @@ class ConfigEntity extends Equatable {
     final keys = [mealKeyBreakfast, mealKeyLunch, mealKeyDinner, mealKeySnack];
     if (!keys.every(raw.containsKey)) return null;
     return {for (final k in keys) k: raw[k] ?? 0};
+  }
+
+  static int _normaliseOffset(int? raw) {
+    if (raw == null) return 0;
+    if (raw < 0 || raw > 23) return 0;
+    return raw;
   }
 
   @override
@@ -141,5 +150,6 @@ class ConfigEntity extends Equatable {
         caloriesTaperEnabled,
         diarySortPreferences,
         nutrientPanelVisibility,
+        dayStartOffsetHours,
       ];
 }

--- a/lib/core/domain/entity/config_entity.dart
+++ b/lib/core/domain/entity/config_entity.dart
@@ -48,6 +48,7 @@ class ConfigEntity extends Equatable {
   // nutrient — see [isNutrientVisible].
   final Map<String, bool> nutrientPanelVisibility;
   final int dayStartOffsetHours; // #139: 0-23, default 0 (wall-clock midnight)
+  final int dayStartOffsetMinutes; // #139 follow-up: 0-59, composes additively with hours
 
   const ConfigEntity(
     this.hasAcceptedDisclaimer,
@@ -72,12 +73,20 @@ class ConfigEntity extends Equatable {
     this.diarySortPreferences,
     this.nutrientPanelVisibility = const <String, bool>{},
     this.dayStartOffsetHours = 0,
+    this.dayStartOffsetMinutes = 0,
   });
 
   /// Whether a particular nutrient on the daily panel should be rendered.
   /// All nutrients default to visible; the user can hide individual ones
   /// from Settings → Nutrients.
   bool isNutrientVisible(String key) => nutrientPanelVisibility[key] ?? true;
+
+  /// The combined day-start offset in minutes — what callers actually need
+  /// when comparing two `DateTime`s under the configured boundary. Hours and
+  /// minutes compose additively, so 4 h + 30 m and 0 h + 270 m both resolve
+  /// to the same 270-minute shift.
+  int get dayStartOffsetTotalMinutes =>
+      dayStartOffsetHours * 60 + dayStartOffsetMinutes;
 
   factory ConfigEntity.fromConfigDBO(ConfigDBO dbo) => ConfigEntity(
         dbo.hasAcceptedDisclaimer,
@@ -103,7 +112,9 @@ class ConfigEntity extends Equatable {
         diarySortPreferences: dbo.diarySortPreferences,
         nutrientPanelVisibility:
             dbo.nutrientPanelVisibility ?? const <String, bool>{},
-        dayStartOffsetHours: _normaliseOffset(dbo.dayStartOffsetHours),
+        dayStartOffsetHours: _normaliseOffsetHours(dbo.dayStartOffsetHours),
+        dayStartOffsetMinutes:
+            _normaliseOffsetMinutes(dbo.dayStartOffsetMinutes),
       );
 
   /// Returns the recommended kcal target for [mealKey] given a daily goal.
@@ -122,9 +133,18 @@ class ConfigEntity extends Equatable {
     return {for (final k in keys) k: raw[k] ?? 0};
   }
 
-  static int _normaliseOffset(int? raw) {
+  static int _normaliseOffsetHours(int? raw) {
     if (raw == null) return 0;
     if (raw < 0 || raw > 23) return 0;
+    return raw;
+  }
+
+  // Defensive clamp so a corrupt or hand-edited Hive value can't push the
+  // total offset past the next wall-clock day. 0-59 is the supported range.
+  static int _normaliseOffsetMinutes(int? raw) {
+    if (raw == null) return 0;
+    if (raw < 0) return 0;
+    if (raw > 59) return 59;
     return raw;
   }
 
@@ -151,5 +171,6 @@ class ConfigEntity extends Equatable {
         diarySortPreferences,
         nutrientPanelVisibility,
         dayStartOffsetHours,
+        dayStartOffsetMinutes,
       ];
 }

--- a/lib/core/domain/usecase/add_config_usecase.dart
+++ b/lib/core/domain/usecase/add_config_usecase.dart
@@ -97,4 +97,8 @@ class AddConfigUsecase {
   Future<void> setConfigDayStartOffsetHours(int hours) async {
     await _configRepository.setConfigDayStartOffsetHours(hours);
   }
+
+  Future<void> setConfigDayStartOffsetMinutes(int minutes) async {
+    _configRepository.setConfigDayStartOffsetMinutes(minutes);
+  }
 }

--- a/lib/core/domain/usecase/add_config_usecase.dart
+++ b/lib/core/domain/usecase/add_config_usecase.dart
@@ -93,4 +93,8 @@ class AddConfigUsecase {
   ) async {
     await _configRepository.setConfigNutrientPanelVisibility(visibility);
   }
+
+  Future<void> setConfigDayStartOffsetHours(int hours) async {
+    await _configRepository.setConfigDayStartOffsetHours(hours);
+  }
 }

--- a/lib/core/domain/usecase/get_intake_usecase.dart
+++ b/lib/core/domain/usecase/get_intake_usecase.dart
@@ -11,68 +11,87 @@ class GetIntakeUsecase {
     IntakeTypeEntity type,
     DateTime day, {
     int dayStartOffsetHours = 0,
+    int dayStartOffsetMinutes = 0,
   }) async {
     return await _intakeRepository.getIntakeByDateAndType(
       type,
       day,
       dayStartOffsetHours: dayStartOffsetHours,
+      dayStartOffsetMinutes: dayStartOffsetMinutes,
     );
   }
 
-  // #139: callers pass [dayStartOffsetHours] when they have the user's
-  // configured boundary; defaulting to 0 keeps every existing caller's
-  // wall-clock-midnight behaviour exactly the same.
+  // #139: callers pass [dayStartOffsetHours] (and, since the follow-up,
+  // [dayStartOffsetMinutes]) when they have the user's configured boundary.
+  // Both default to 0 so every existing caller keeps wall-clock-midnight
+  // behaviour exactly the same.
   Future<List<IntakeEntity>> getBreakfastIntakeByDay(
     DateTime day, {
     int dayStartOffsetHours = 0,
+    int dayStartOffsetMinutes = 0,
   }) async =>
       await _getIntakeByDay(IntakeTypeEntity.breakfast, day,
-          dayStartOffsetHours: dayStartOffsetHours);
+          dayStartOffsetHours: dayStartOffsetHours,
+          dayStartOffsetMinutes: dayStartOffsetMinutes);
 
   Future<List<IntakeEntity>> getTodayBreakfastIntake({
     int dayStartOffsetHours = 0,
+    int dayStartOffsetMinutes = 0,
   }) async =>
       getBreakfastIntakeByDay(DateTime.now(),
-          dayStartOffsetHours: dayStartOffsetHours);
+          dayStartOffsetHours: dayStartOffsetHours,
+          dayStartOffsetMinutes: dayStartOffsetMinutes);
 
   Future<List<IntakeEntity>> getLunchIntakeByDay(
     DateTime day, {
     int dayStartOffsetHours = 0,
+    int dayStartOffsetMinutes = 0,
   }) async =>
       await _getIntakeByDay(IntakeTypeEntity.lunch, day,
-          dayStartOffsetHours: dayStartOffsetHours);
+          dayStartOffsetHours: dayStartOffsetHours,
+          dayStartOffsetMinutes: dayStartOffsetMinutes);
 
   Future<List<IntakeEntity>> getTodayLunchIntake({
     int dayStartOffsetHours = 0,
+    int dayStartOffsetMinutes = 0,
   }) async =>
       await getLunchIntakeByDay(DateTime.now(),
-          dayStartOffsetHours: dayStartOffsetHours);
+          dayStartOffsetHours: dayStartOffsetHours,
+          dayStartOffsetMinutes: dayStartOffsetMinutes);
 
   Future<List<IntakeEntity>> getDinnerIntakeByDay(
     DateTime day, {
     int dayStartOffsetHours = 0,
+    int dayStartOffsetMinutes = 0,
   }) async =>
       await _getIntakeByDay(IntakeTypeEntity.dinner, day,
-          dayStartOffsetHours: dayStartOffsetHours);
+          dayStartOffsetHours: dayStartOffsetHours,
+          dayStartOffsetMinutes: dayStartOffsetMinutes);
 
   Future<List<IntakeEntity>> getTodayDinnerIntake({
     int dayStartOffsetHours = 0,
+    int dayStartOffsetMinutes = 0,
   }) async =>
       await getDinnerIntakeByDay(DateTime.now(),
-          dayStartOffsetHours: dayStartOffsetHours);
+          dayStartOffsetHours: dayStartOffsetHours,
+          dayStartOffsetMinutes: dayStartOffsetMinutes);
 
   Future<List<IntakeEntity>> getSnackIntakeByDay(
     DateTime day, {
     int dayStartOffsetHours = 0,
+    int dayStartOffsetMinutes = 0,
   }) async =>
       await _getIntakeByDay(IntakeTypeEntity.snack, day,
-          dayStartOffsetHours: dayStartOffsetHours);
+          dayStartOffsetHours: dayStartOffsetHours,
+          dayStartOffsetMinutes: dayStartOffsetMinutes);
 
   Future<List<IntakeEntity>> getTodaySnackIntake({
     int dayStartOffsetHours = 0,
+    int dayStartOffsetMinutes = 0,
   }) async =>
       await getSnackIntakeByDay(DateTime.now(),
-          dayStartOffsetHours: dayStartOffsetHours);
+          dayStartOffsetHours: dayStartOffsetHours,
+          dayStartOffsetMinutes: dayStartOffsetMinutes);
 
   Future<List<IntakeEntity>> getRecentIntake() async {
     return _intakeRepository.getRecentIntake();

--- a/lib/core/domain/usecase/get_intake_usecase.dart
+++ b/lib/core/domain/usecase/get_intake_usecase.dart
@@ -9,34 +9,70 @@ class GetIntakeUsecase {
 
   Future<List<IntakeEntity>> _getIntakeByDay(
     IntakeTypeEntity type,
-    DateTime day,
-  ) async {
-    return await _intakeRepository.getIntakeByDateAndType(type, day);
+    DateTime day, {
+    int dayStartOffsetHours = 0,
+  }) async {
+    return await _intakeRepository.getIntakeByDateAndType(
+      type,
+      day,
+      dayStartOffsetHours: dayStartOffsetHours,
+    );
   }
 
-  Future<List<IntakeEntity>> getBreakfastIntakeByDay(DateTime day) async =>
-      await _getIntakeByDay(IntakeTypeEntity.breakfast, day);
+  // #139: callers pass [dayStartOffsetHours] when they have the user's
+  // configured boundary; defaulting to 0 keeps every existing caller's
+  // wall-clock-midnight behaviour exactly the same.
+  Future<List<IntakeEntity>> getBreakfastIntakeByDay(
+    DateTime day, {
+    int dayStartOffsetHours = 0,
+  }) async =>
+      await _getIntakeByDay(IntakeTypeEntity.breakfast, day,
+          dayStartOffsetHours: dayStartOffsetHours);
 
-  Future<List<IntakeEntity>> getTodayBreakfastIntake() async =>
-      getBreakfastIntakeByDay(DateTime.now());
+  Future<List<IntakeEntity>> getTodayBreakfastIntake({
+    int dayStartOffsetHours = 0,
+  }) async =>
+      getBreakfastIntakeByDay(DateTime.now(),
+          dayStartOffsetHours: dayStartOffsetHours);
 
-  Future<List<IntakeEntity>> getLunchIntakeByDay(DateTime day) async =>
-      await _getIntakeByDay(IntakeTypeEntity.lunch, day);
+  Future<List<IntakeEntity>> getLunchIntakeByDay(
+    DateTime day, {
+    int dayStartOffsetHours = 0,
+  }) async =>
+      await _getIntakeByDay(IntakeTypeEntity.lunch, day,
+          dayStartOffsetHours: dayStartOffsetHours);
 
-  Future<List<IntakeEntity>> getTodayLunchIntake() async =>
-      await getLunchIntakeByDay(DateTime.now());
+  Future<List<IntakeEntity>> getTodayLunchIntake({
+    int dayStartOffsetHours = 0,
+  }) async =>
+      await getLunchIntakeByDay(DateTime.now(),
+          dayStartOffsetHours: dayStartOffsetHours);
 
-  Future<List<IntakeEntity>> getDinnerIntakeByDay(DateTime day) async =>
-      await _getIntakeByDay(IntakeTypeEntity.dinner, day);
+  Future<List<IntakeEntity>> getDinnerIntakeByDay(
+    DateTime day, {
+    int dayStartOffsetHours = 0,
+  }) async =>
+      await _getIntakeByDay(IntakeTypeEntity.dinner, day,
+          dayStartOffsetHours: dayStartOffsetHours);
 
-  Future<List<IntakeEntity>> getTodayDinnerIntake() async =>
-      await getDinnerIntakeByDay(DateTime.now());
+  Future<List<IntakeEntity>> getTodayDinnerIntake({
+    int dayStartOffsetHours = 0,
+  }) async =>
+      await getDinnerIntakeByDay(DateTime.now(),
+          dayStartOffsetHours: dayStartOffsetHours);
 
-  Future<List<IntakeEntity>> getSnackIntakeByDay(DateTime day) async =>
-      await _getIntakeByDay(IntakeTypeEntity.snack, day);
+  Future<List<IntakeEntity>> getSnackIntakeByDay(
+    DateTime day, {
+    int dayStartOffsetHours = 0,
+  }) async =>
+      await _getIntakeByDay(IntakeTypeEntity.snack, day,
+          dayStartOffsetHours: dayStartOffsetHours);
 
-  Future<List<IntakeEntity>> getTodaySnackIntake() async =>
-      await getSnackIntakeByDay(DateTime.now());
+  Future<List<IntakeEntity>> getTodaySnackIntake({
+    int dayStartOffsetHours = 0,
+  }) async =>
+      await getSnackIntakeByDay(DateTime.now(),
+          dayStartOffsetHours: dayStartOffsetHours);
 
   Future<List<IntakeEntity>> getRecentIntake() async {
     return _intakeRepository.getRecentIntake();

--- a/lib/core/domain/usecase/get_user_activity_usecase.dart
+++ b/lib/core/domain/usecase/get_user_activity_usecase.dart
@@ -6,25 +6,30 @@ class GetUserActivityUsecase {
 
   GetUserActivityUsecase(this._userActivityRepository);
 
-  // #139: callers pass [dayStartOffsetHours] when they have the user's
-  // configured boundary; defaulting to 0 keeps every existing caller's
-  // wall-clock-midnight behaviour exactly the same.
+  // #139: callers pass [dayStartOffsetHours] (and, since the follow-up,
+  // [dayStartOffsetMinutes]) when they have the user's configured boundary.
+  // Both default to 0 so every existing caller keeps wall-clock-midnight
+  // behaviour exactly the same.
   Future<List<UserActivityEntity>> getTodayUserActivity({
     int dayStartOffsetHours = 0,
+    int dayStartOffsetMinutes = 0,
   }) {
     return _userActivityRepository.getAllUserActivityByDate(
       DateTime.now(),
       dayStartOffsetHours: dayStartOffsetHours,
+      dayStartOffsetMinutes: dayStartOffsetMinutes,
     );
   }
 
   Future<List<UserActivityEntity>> getUserActivityByDay(
     DateTime day, {
     int dayStartOffsetHours = 0,
+    int dayStartOffsetMinutes = 0,
   }) {
     return _userActivityRepository.getAllUserActivityByDate(
       day,
       dayStartOffsetHours: dayStartOffsetHours,
+      dayStartOffsetMinutes: dayStartOffsetMinutes,
     );
   }
 

--- a/lib/core/domain/usecase/get_user_activity_usecase.dart
+++ b/lib/core/domain/usecase/get_user_activity_usecase.dart
@@ -6,12 +6,26 @@ class GetUserActivityUsecase {
 
   GetUserActivityUsecase(this._userActivityRepository);
 
-  Future<List<UserActivityEntity>> getTodayUserActivity() {
-    return _userActivityRepository.getAllUserActivityByDate(DateTime.now());
+  // #139: callers pass [dayStartOffsetHours] when they have the user's
+  // configured boundary; defaulting to 0 keeps every existing caller's
+  // wall-clock-midnight behaviour exactly the same.
+  Future<List<UserActivityEntity>> getTodayUserActivity({
+    int dayStartOffsetHours = 0,
+  }) {
+    return _userActivityRepository.getAllUserActivityByDate(
+      DateTime.now(),
+      dayStartOffsetHours: dayStartOffsetHours,
+    );
   }
 
-  Future<List<UserActivityEntity>> getUserActivityByDay(DateTime day) {
-    return _userActivityRepository.getAllUserActivityByDate(day);
+  Future<List<UserActivityEntity>> getUserActivityByDay(
+    DateTime day, {
+    int dayStartOffsetHours = 0,
+  }) {
+    return _userActivityRepository.getAllUserActivityByDate(
+      day,
+      dayStartOffsetHours: dayStartOffsetHours,
+    );
   }
 
   Future<List<UserActivityEntity>> getRecentUserActivity() {

--- a/lib/core/utils/calc/day_boundary_calc.dart
+++ b/lib/core/utils/calc/day_boundary_calc.dart
@@ -3,9 +3,10 @@
 /// Some reporters live by a 04:00-to-04:00 day rather than the wall-clock
 /// 00:00-to-00:00 one — night shifts, late-eaters, anyone for whom a 02:00
 /// snack genuinely belongs to the same day as the evening meal that
-/// preceded it. The user can pick an hour-of-day in Settings → Calculations
-/// to shift the diary's day boundary; an entry logged before that hour
-/// is filed under the previous wall-clock day.
+/// preceded it. The user can pick an hour-of-day (and, since the #139
+/// follow-up, a minute-of-hour) in Settings → Calculations to shift the
+/// diary's day boundary; an entry logged before that time is filed under
+/// the previous wall-clock day.
 ///
 /// The offset only affects which logical day an entry aggregates under.
 /// Stored timestamps remain wall-clock (i.e. `DateTime.now()` at the time
@@ -23,9 +24,8 @@ class DayBoundaryCalc {
   /// users (and freshly upgraded ones with no stored value yet) keep the
   /// original behaviour without surprise.
   static DateTime logicalDayOf(DateTime moment, int? offsetHours) {
-    final hours = _sanitise(offsetHours);
-    final shifted = moment.subtract(Duration(hours: hours));
-    return DateTime(shifted.year, shifted.month, shifted.day);
+    final totalMinutes = _sanitiseHours(offsetHours) * 60;
+    return _logicalDayOfTotalMinutes(moment, totalMinutes);
   }
 
   /// The logical day for "now", given the configured [offsetHours].
@@ -42,9 +42,56 @@ class DayBoundaryCalc {
         dayA.day == dayB.day;
   }
 
-  static int _sanitise(int? offsetHours) {
+  /// Returns the wall-clock midnight of the logical day that [moment]
+  /// belongs to, given a configured offset expressed as a single
+  /// [offsetTotalMinutes] value — i.e. `hours * 60 + minutes`.
+  ///
+  /// This is the form the rest of the app should reach for once it has
+  /// both the hours and minutes companion fields available. The
+  /// hours-only overload above is retained so existing call sites
+  /// remain valid; it simply delegates here with a multiplied value.
+  ///
+  /// Out-of-range values (negative, or ≥ 24 h) are treated as 0 — the
+  /// same defensive behaviour as the hours-only overload.
+  static DateTime logicalDayOfMinutes(DateTime moment, int? offsetTotalMinutes) {
+    return _logicalDayOfTotalMinutes(
+      moment,
+      _sanitiseTotalMinutes(offsetTotalMinutes),
+    );
+  }
+
+  /// The logical day for "now", given the configured [offsetTotalMinutes].
+  static DateTime currentLogicalDayMinutes(int? offsetTotalMinutes) =>
+      logicalDayOfMinutes(DateTime.now(), offsetTotalMinutes);
+
+  /// True when [a] and [b] resolve to the same logical day under
+  /// [offsetTotalMinutes].
+  static bool isSameLogicalDayMinutes(
+    DateTime a,
+    DateTime b,
+    int? offsetTotalMinutes,
+  ) {
+    final dayA = logicalDayOfMinutes(a, offsetTotalMinutes);
+    final dayB = logicalDayOfMinutes(b, offsetTotalMinutes);
+    return dayA.year == dayB.year &&
+        dayA.month == dayB.month &&
+        dayA.day == dayB.day;
+  }
+
+  static DateTime _logicalDayOfTotalMinutes(DateTime moment, int totalMinutes) {
+    final shifted = moment.subtract(Duration(minutes: totalMinutes));
+    return DateTime(shifted.year, shifted.month, shifted.day);
+  }
+
+  static int _sanitiseHours(int? offsetHours) {
     if (offsetHours == null) return 0;
     if (offsetHours < 0 || offsetHours > 23) return 0;
     return offsetHours;
+  }
+
+  static int _sanitiseTotalMinutes(int? offsetTotalMinutes) {
+    if (offsetTotalMinutes == null) return 0;
+    if (offsetTotalMinutes < 0 || offsetTotalMinutes >= 24 * 60) return 0;
+    return offsetTotalMinutes;
   }
 }

--- a/lib/core/utils/calc/day_boundary_calc.dart
+++ b/lib/core/utils/calc/day_boundary_calc.dart
@@ -1,0 +1,50 @@
+/// Helper for the configurable diary day boundary (#139).
+///
+/// Some reporters live by a 04:00-to-04:00 day rather than the wall-clock
+/// 00:00-to-00:00 one — night shifts, late-eaters, anyone for whom a 02:00
+/// snack genuinely belongs to the same day as the evening meal that
+/// preceded it. The user can pick an hour-of-day in Settings → Calculations
+/// to shift the diary's day boundary; an entry logged before that hour
+/// is filed under the previous wall-clock day.
+///
+/// The offset only affects which logical day an entry aggregates under.
+/// Stored timestamps remain wall-clock (i.e. `DateTime.now()` at the time
+/// the entry was created). Notification scheduling has its own timing
+/// logic and is intentionally untouched here.
+class DayBoundaryCalc {
+  /// Returns the wall-clock midnight of the logical day that [moment]
+  /// belongs to, given a configured [offsetHours] in the range 0–23.
+  ///
+  /// With offsetHours = 0 this is equivalent to stripping the time portion
+  /// (the original behaviour). With offsetHours = 4, anything before 04:00
+  /// rolls back to the previous wall-clock day's midnight.
+  ///
+  /// A null or out-of-range [offsetHours] is treated as 0 so existing
+  /// users (and freshly upgraded ones with no stored value yet) keep the
+  /// original behaviour without surprise.
+  static DateTime logicalDayOf(DateTime moment, int? offsetHours) {
+    final hours = _sanitise(offsetHours);
+    final shifted = moment.subtract(Duration(hours: hours));
+    return DateTime(shifted.year, shifted.month, shifted.day);
+  }
+
+  /// The logical day for "now", given the configured [offsetHours].
+  static DateTime currentLogicalDay(int? offsetHours) =>
+      logicalDayOf(DateTime.now(), offsetHours);
+
+  /// True when [a] and [b] resolve to the same logical day under
+  /// [offsetHours].
+  static bool isSameLogicalDay(DateTime a, DateTime b, int? offsetHours) {
+    final dayA = logicalDayOf(a, offsetHours);
+    final dayB = logicalDayOf(b, offsetHours);
+    return dayA.year == dayB.year &&
+        dayA.month == dayB.month &&
+        dayA.day == dayB.day;
+  }
+
+  static int _sanitise(int? offsetHours) {
+    if (offsetHours == null) return 0;
+    if (offsetHours < 0 || offsetHours > 23) return 0;
+    return offsetHours;
+  }
+}

--- a/lib/features/diary/diary_page.dart
+++ b/lib/features/diary/diary_page.dart
@@ -315,9 +315,12 @@ class _DiaryPageState extends State<DiaryPage> with WidgetsBindingObserver {
   }
 
   void _refreshPageOnDayChange() {
-    if (DateUtils.isSameDay(_selectedDate, DateTime.now())) {
-      _calendarDayBloc.add(LoadCalendarDayEvent(_selectedDate));
-      _diaryBloc.add(const LoadDiaryYearEvent());
-    }
+    // #139: refresh unconditionally on resume so any day-boundary
+    // setting change while the app was backgrounded is picked up.
+    // The cost is one extra LoadDiaryYearEvent (already cheap) plus a
+    // single CalendarDay refresh; keeping the original isSameDay check
+    // would miss the offset case entirely.
+    _calendarDayBloc.add(LoadCalendarDayEvent(_selectedDate));
+    _diaryBloc.add(const LoadDiaryYearEvent());
   }
 }

--- a/lib/features/diary/presentation/bloc/calendar_day_bloc.dart
+++ b/lib/features/diary/presentation/bloc/calendar_day_bloc.dart
@@ -67,17 +67,34 @@ class CalendarDayBloc extends Bloc<CalendarDayEvent, CalendarDayState> {
     DateTime day,
     Emitter<CalendarDayState> emit,
   ) async {
+    // #139: when the user has a configured day-start offset, the
+    // intake/activity queries need to know about it so entries logged
+    // before the boundary roll into the previous day's column.
+    final config = await _getConfigUsecase.getConfig();
+    final dayStartOffsetHours = config.dayStartOffsetHours;
+
     final userActivities = await _getUserActivityUsecase.getUserActivityByDay(
       day,
+      dayStartOffsetHours: dayStartOffsetHours,
     );
 
     final breakfastIntakeList = await _getIntakeUsecase.getBreakfastIntakeByDay(
       day,
+      dayStartOffsetHours: dayStartOffsetHours,
     );
 
-    final lunchIntakeList = await _getIntakeUsecase.getLunchIntakeByDay(day);
-    final dinnerIntakeList = await _getIntakeUsecase.getDinnerIntakeByDay(day);
-    final snackIntakeList = await _getIntakeUsecase.getSnackIntakeByDay(day);
+    final lunchIntakeList = await _getIntakeUsecase.getLunchIntakeByDay(
+      day,
+      dayStartOffsetHours: dayStartOffsetHours,
+    );
+    final dinnerIntakeList = await _getIntakeUsecase.getDinnerIntakeByDay(
+      day,
+      dayStartOffsetHours: dayStartOffsetHours,
+    );
+    final snackIntakeList = await _getIntakeUsecase.getSnackIntakeByDay(
+      day,
+      dayStartOffsetHours: dayStartOffsetHours,
+    );
 
     final trackedDayEntity = await _getTrackedDayUsecase.getTrackedDay(day);
     final configData = await _getConfigUsecase.getConfig();
@@ -100,8 +117,6 @@ class CalendarDayBloc extends Bloc<CalendarDayEvent, CalendarDayState> {
     final snackKcalTarget = dailyKcalGoal > 0
         ? configData.targetKcalForMeal(ConfigEntity.mealKeySnack, dailyKcalGoal)
         : 0.0;
-
-    final config = await _getConfigUsecase.getConfig();
 
     emit(
       CalendarDayLoaded(

--- a/lib/features/diary/presentation/bloc/calendar_day_bloc.dart
+++ b/lib/features/diary/presentation/bloc/calendar_day_bloc.dart
@@ -69,31 +69,39 @@ class CalendarDayBloc extends Bloc<CalendarDayEvent, CalendarDayState> {
   ) async {
     // #139: when the user has a configured day-start offset, the
     // intake/activity queries need to know about it so entries logged
-    // before the boundary roll into the previous day's column.
+    // before the boundary roll into the previous day's column. The
+    // follow-up to #139 adds a minutes companion that travels alongside
+    // the hours value through the same call chain.
     final config = await _getConfigUsecase.getConfig();
     final dayStartOffsetHours = config.dayStartOffsetHours;
+    final dayStartOffsetMinutes = config.dayStartOffsetMinutes;
 
     final userActivities = await _getUserActivityUsecase.getUserActivityByDay(
       day,
       dayStartOffsetHours: dayStartOffsetHours,
+      dayStartOffsetMinutes: dayStartOffsetMinutes,
     );
 
     final breakfastIntakeList = await _getIntakeUsecase.getBreakfastIntakeByDay(
       day,
       dayStartOffsetHours: dayStartOffsetHours,
+      dayStartOffsetMinutes: dayStartOffsetMinutes,
     );
 
     final lunchIntakeList = await _getIntakeUsecase.getLunchIntakeByDay(
       day,
       dayStartOffsetHours: dayStartOffsetHours,
+      dayStartOffsetMinutes: dayStartOffsetMinutes,
     );
     final dinnerIntakeList = await _getIntakeUsecase.getDinnerIntakeByDay(
       day,
       dayStartOffsetHours: dayStartOffsetHours,
+      dayStartOffsetMinutes: dayStartOffsetMinutes,
     );
     final snackIntakeList = await _getIntakeUsecase.getSnackIntakeByDay(
       day,
       dayStartOffsetHours: dayStartOffsetHours,
+      dayStartOffsetMinutes: dayStartOffsetMinutes,
     );
 
     final trackedDayEntity = await _getTrackedDayUsecase.getTrackedDay(day);

--- a/lib/features/diary/presentation/bloc/diary_bloc.dart
+++ b/lib/features/diary/presentation/bloc/diary_bloc.dart
@@ -3,6 +3,7 @@ import 'package:flutter_bloc/flutter_bloc.dart';
 import 'package:opennutritracker/core/domain/entity/tracked_day_entity.dart';
 import 'package:opennutritracker/core/domain/usecase/get_config_usecase.dart';
 import 'package:opennutritracker/core/domain/usecase/get_tracked_day_usecase.dart';
+import 'package:opennutritracker/core/utils/calc/day_boundary_calc.dart';
 import 'package:opennutritracker/core/utils/extensions.dart';
 import 'package:opennutritracker/core/utils/locator.dart';
 import 'package:opennutritracker/features/home/presentation/bloc/home_bloc.dart';
@@ -26,7 +27,9 @@ class DiaryBloc extends Bloc<DiaryEvent, DiaryState> {
       final usesImperialUnits = config.usesImperialUnits;
       final showMealMacros = config.showMealMacros;
 
-      currentDay = DateTime.now();
+      // #139: pin currentDay to the user's logical "today" so the
+      // diary calendar's today-marker shifts with the configured boundary.
+      currentDay = DayBoundaryCalc.currentLogicalDay(config.dayStartOffsetHours);
       // #292: Extended to match calendar range (5 years back)
       const yearDuration = Duration(days: 365 * 5);
 

--- a/lib/features/diary/presentation/bloc/diary_bloc.dart
+++ b/lib/features/diary/presentation/bloc/diary_bloc.dart
@@ -29,7 +29,10 @@ class DiaryBloc extends Bloc<DiaryEvent, DiaryState> {
 
       // #139: pin currentDay to the user's logical "today" so the
       // diary calendar's today-marker shifts with the configured boundary.
-      currentDay = DayBoundaryCalc.currentLogicalDay(config.dayStartOffsetHours);
+      // Follow-up: total minutes lets a 04:30 boundary land precisely.
+      currentDay = DayBoundaryCalc.currentLogicalDayMinutes(
+        config.dayStartOffsetTotalMinutes,
+      );
       // #292: Extended to match calendar range (5 years back)
       const yearDuration = Duration(days: 365 * 5);
 

--- a/lib/features/home/home_page.dart
+++ b/lib/features/home/home_page.dart
@@ -438,9 +438,15 @@ class _HomePageState extends State<HomePage> with WidgetsBindingObserver {
   }
 
   /// Refresh page when day changes
+  ///
+  /// #139: HomeBloc.currentDay is the logical "today" (midnight of the
+  /// configured day boundary). Comparing against a fresh logical "today"
+  /// from the same wall clock requires knowing the offset, which we'd
+  /// have to fetch from config asynchronously. Letting LoadItemsEvent
+  /// re-resolve the offset and reload unconditionally on resume is the
+  /// honest cheap path: it costs one config read plus a few Hive scans,
+  /// and it is correct under any boundary setting.
   void _refreshPageOnDayChange() {
-    if (!DateUtils.isSameDay(_homeBloc.currentDay, DateTime.now())) {
-      _homeBloc.add(const LoadItemsEvent());
-    }
+    _homeBloc.add(const LoadItemsEvent());
   }
 }

--- a/lib/features/home/presentation/bloc/home_bloc.dart
+++ b/lib/features/home/presentation/bloc/home_bloc.dart
@@ -17,6 +17,7 @@ import 'package:opennutritracker/core/domain/usecase/get_user_usecase.dart';
 import 'package:opennutritracker/core/domain/usecase/update_intake_usecase.dart';
 import 'package:opennutritracker/core/domain/usecase/update_user_activity_usecase.dart';
 import 'package:opennutritracker/core/utils/calc/calorie_goal_calc.dart';
+import 'package:opennutritracker/core/utils/calc/day_boundary_calc.dart';
 import 'package:opennutritracker/core/utils/calc/macro_calc.dart';
 import 'package:opennutritracker/core/utils/locator.dart';
 import 'package:opennutritracker/features/diary/presentation/bloc/calendar_day_bloc.dart';
@@ -59,32 +60,38 @@ class HomeBloc extends Bloc<HomeEvent, HomeState> {
     on<LoadItemsEvent>((event, emit) async {
       emit(HomeLoadingState());
 
-      currentDay = DateTime.now();
       final configData = await _getConfigUsecase.getConfig();
+      final dayStartOffsetHours = configData.dayStartOffsetHours;
+      // #139: the bloc's "current day" is the logical day, so day-change
+      // detection on app resume respects the user's configured boundary.
+      currentDay = DayBoundaryCalc.currentLogicalDay(dayStartOffsetHours);
       final usesImperialUnits = configData.usesImperialUnits;
       final showDisclaimerDialog = !configData.hasAcceptedDisclaimer;
       final showMealMacros = configData.showMealMacros;
 
-      final breakfastIntakeList =
-          await _getIntakeUsecase.getTodayBreakfastIntake();
+      final breakfastIntakeList = await _getIntakeUsecase
+          .getTodayBreakfastIntake(dayStartOffsetHours: dayStartOffsetHours);
       final totalBreakfastKcal = getTotalKcal(breakfastIntakeList);
       final totalBreakfastCarbs = getTotalCarbs(breakfastIntakeList);
       final totalBreakfastFats = getTotalFats(breakfastIntakeList);
       final totalBreakfastProteins = getTotalProteins(breakfastIntakeList);
 
-      final lunchIntakeList = await _getIntakeUsecase.getTodayLunchIntake();
+      final lunchIntakeList = await _getIntakeUsecase
+          .getTodayLunchIntake(dayStartOffsetHours: dayStartOffsetHours);
       final totalLunchKcal = getTotalKcal(lunchIntakeList);
       final totalLunchCarbs = getTotalCarbs(lunchIntakeList);
       final totalLunchFats = getTotalFats(lunchIntakeList);
       final totalLunchProteins = getTotalProteins(lunchIntakeList);
 
-      final dinnerIntakeList = await _getIntakeUsecase.getTodayDinnerIntake();
+      final dinnerIntakeList = await _getIntakeUsecase
+          .getTodayDinnerIntake(dayStartOffsetHours: dayStartOffsetHours);
       final totalDinnerKcal = getTotalKcal(dinnerIntakeList);
       final totalDinnerCarbs = getTotalCarbs(dinnerIntakeList);
       final totalDinnerFats = getTotalFats(dinnerIntakeList);
       final totalDinnerProteins = getTotalProteins(dinnerIntakeList);
 
-      final snackIntakeList = await _getIntakeUsecase.getTodaySnackIntake();
+      final snackIntakeList = await _getIntakeUsecase
+          .getTodaySnackIntake(dayStartOffsetHours: dayStartOffsetHours);
       final totalSnackKcal = getTotalKcal(snackIntakeList);
       final totalSnackCarbs = getTotalCarbs(snackIntakeList);
       final totalSnackFats = getTotalFats(snackIntakeList);
@@ -107,8 +114,8 @@ class HomeBloc extends Bloc<HomeEvent, HomeState> {
           totalDinnerProteins +
           totalSnackProteins;
 
-      final userActivities =
-          await _getUserActivityUsecase.getTodayUserActivity();
+      final userActivities = await _getUserActivityUsecase
+          .getTodayUserActivity(dayStartOffsetHours: dayStartOffsetHours);
       final totalKcalActivities =
           userActivities.map((activity) => activity.burnedKcal).toList().sum;
 
@@ -206,7 +213,7 @@ class HomeBloc extends Bloc<HomeEvent, HomeState> {
     String intakeId,
     Map<String, dynamic> fields,
   ) async {
-    final dateTime = DateTime.now();
+    final dateTime = await _currentLogicalDay();
     // Get old intake values
     final oldIntakeObject = await _getIntakeUsecase.getIntakeById(intakeId);
     if (oldIntakeObject == null) return;
@@ -248,7 +255,7 @@ class HomeBloc extends Bloc<HomeEvent, HomeState> {
   }
 
   Future<void> deleteIntakeItem(IntakeEntity intakeEntity) async {
-    final dateTime = DateTime.now();
+    final dateTime = await _currentLogicalDay();
     await _deleteIntakeUsecase.deleteIntake(intakeEntity);
     await _addTrackedDayUseCase.removeDayCaloriesTracked(
       dateTime,
@@ -265,7 +272,7 @@ class HomeBloc extends Bloc<HomeEvent, HomeState> {
   }
 
   Future<void> deleteUserActivityItem(UserActivityEntity activityEntity) async {
-    final dateTime = DateTime.now();
+    final dateTime = await _currentLogicalDay();
     await _deleteUserActivityUsecase.deleteUserActivity(activityEntity);
     _addTrackedDayUseCase.reduceDayCalorieGoal(
       dateTime,
@@ -292,7 +299,7 @@ class HomeBloc extends Bloc<HomeEvent, HomeState> {
     UserActivityEntity activityEntity,
     double newDuration,
   ) async {
-    final dateTime = DateTime.now();
+    final dateTime = await _currentLogicalDay();
     final newActivity = await _updateUserActivityUsecase.updateUserActivity(
       activityEntity,
       newDuration,
@@ -322,5 +329,15 @@ class HomeBloc extends Bloc<HomeEvent, HomeState> {
   Future<void> _updateDiaryPage(DateTime day) async {
     locator<DiaryBloc>().add(const LoadDiaryYearEvent());
     locator<CalendarDayBloc>().add(RefreshCalendarDayEvent());
+  }
+
+  /// #139: tracked-day deltas (calories, macros) must land on the
+  /// user's logical "today" — for someone on a 04:00 boundary, a 02:00
+  /// edit still updates yesterday's totals. We resolve the offset on
+  /// each call so the most recent setting wins without needing the
+  /// bloc to cache it explicitly.
+  Future<DateTime> _currentLogicalDay() async {
+    final config = await _getConfigUsecase.getConfig();
+    return DayBoundaryCalc.currentLogicalDay(config.dayStartOffsetHours);
   }
 }

--- a/lib/features/home/presentation/bloc/home_bloc.dart
+++ b/lib/features/home/presentation/bloc/home_bloc.dart
@@ -62,36 +62,50 @@ class HomeBloc extends Bloc<HomeEvent, HomeState> {
 
       final configData = await _getConfigUsecase.getConfig();
       final dayStartOffsetHours = configData.dayStartOffsetHours;
+      final dayStartOffsetMinutes = configData.dayStartOffsetMinutes;
       // #139: the bloc's "current day" is the logical day, so day-change
       // detection on app resume respects the user's configured boundary.
-      currentDay = DayBoundaryCalc.currentLogicalDay(dayStartOffsetHours);
+      // The follow-up to #139 routes the boundary through total minutes
+      // so a 04:30 setting is honoured exactly.
+      currentDay = DayBoundaryCalc.currentLogicalDayMinutes(
+        configData.dayStartOffsetTotalMinutes,
+      );
       final usesImperialUnits = configData.usesImperialUnits;
       final showDisclaimerDialog = !configData.hasAcceptedDisclaimer;
       final showMealMacros = configData.showMealMacros;
 
-      final breakfastIntakeList = await _getIntakeUsecase
-          .getTodayBreakfastIntake(dayStartOffsetHours: dayStartOffsetHours);
+      final breakfastIntakeList =
+          await _getIntakeUsecase.getTodayBreakfastIntake(
+        dayStartOffsetHours: dayStartOffsetHours,
+        dayStartOffsetMinutes: dayStartOffsetMinutes,
+      );
       final totalBreakfastKcal = getTotalKcal(breakfastIntakeList);
       final totalBreakfastCarbs = getTotalCarbs(breakfastIntakeList);
       final totalBreakfastFats = getTotalFats(breakfastIntakeList);
       final totalBreakfastProteins = getTotalProteins(breakfastIntakeList);
 
-      final lunchIntakeList = await _getIntakeUsecase
-          .getTodayLunchIntake(dayStartOffsetHours: dayStartOffsetHours);
+      final lunchIntakeList = await _getIntakeUsecase.getTodayLunchIntake(
+        dayStartOffsetHours: dayStartOffsetHours,
+        dayStartOffsetMinutes: dayStartOffsetMinutes,
+      );
       final totalLunchKcal = getTotalKcal(lunchIntakeList);
       final totalLunchCarbs = getTotalCarbs(lunchIntakeList);
       final totalLunchFats = getTotalFats(lunchIntakeList);
       final totalLunchProteins = getTotalProteins(lunchIntakeList);
 
-      final dinnerIntakeList = await _getIntakeUsecase
-          .getTodayDinnerIntake(dayStartOffsetHours: dayStartOffsetHours);
+      final dinnerIntakeList = await _getIntakeUsecase.getTodayDinnerIntake(
+        dayStartOffsetHours: dayStartOffsetHours,
+        dayStartOffsetMinutes: dayStartOffsetMinutes,
+      );
       final totalDinnerKcal = getTotalKcal(dinnerIntakeList);
       final totalDinnerCarbs = getTotalCarbs(dinnerIntakeList);
       final totalDinnerFats = getTotalFats(dinnerIntakeList);
       final totalDinnerProteins = getTotalProteins(dinnerIntakeList);
 
-      final snackIntakeList = await _getIntakeUsecase
-          .getTodaySnackIntake(dayStartOffsetHours: dayStartOffsetHours);
+      final snackIntakeList = await _getIntakeUsecase.getTodaySnackIntake(
+        dayStartOffsetHours: dayStartOffsetHours,
+        dayStartOffsetMinutes: dayStartOffsetMinutes,
+      );
       final totalSnackKcal = getTotalKcal(snackIntakeList);
       final totalSnackCarbs = getTotalCarbs(snackIntakeList);
       final totalSnackFats = getTotalFats(snackIntakeList);
@@ -114,8 +128,10 @@ class HomeBloc extends Bloc<HomeEvent, HomeState> {
           totalDinnerProteins +
           totalSnackProteins;
 
-      final userActivities = await _getUserActivityUsecase
-          .getTodayUserActivity(dayStartOffsetHours: dayStartOffsetHours);
+      final userActivities = await _getUserActivityUsecase.getTodayUserActivity(
+        dayStartOffsetHours: dayStartOffsetHours,
+        dayStartOffsetMinutes: dayStartOffsetMinutes,
+      );
       final totalKcalActivities =
           userActivities.map((activity) => activity.burnedKcal).toList().sum;
 
@@ -332,12 +348,15 @@ class HomeBloc extends Bloc<HomeEvent, HomeState> {
   }
 
   /// #139: tracked-day deltas (calories, macros) must land on the
-  /// user's logical "today" — for someone on a 04:00 boundary, a 02:00
+  /// user's logical "today" — for someone on a 04:30 boundary, a 02:00
   /// edit still updates yesterday's totals. We resolve the offset on
   /// each call so the most recent setting wins without needing the
-  /// bloc to cache it explicitly.
+  /// bloc to cache it explicitly. The follow-up to #139 reads the
+  /// total-minutes value so the minute component (0-59) is honoured.
   Future<DateTime> _currentLogicalDay() async {
     final config = await _getConfigUsecase.getConfig();
-    return DayBoundaryCalc.currentLogicalDay(config.dayStartOffsetHours);
+    return DayBoundaryCalc.currentLogicalDayMinutes(
+      config.dayStartOffsetTotalMinutes,
+    );
   }
 }

--- a/lib/features/settings/presentation/bloc/settings_bloc.dart
+++ b/lib/features/settings/presentation/bloc/settings_bloc.dart
@@ -66,6 +66,7 @@ class SettingsBloc extends Bloc<SettingsEvent, SettingsState> {
           showMicronutrients: userConfig.showMicronutrients,
           usesKilojoules: userConfig.usesKilojoules,
           caloriesTaperEnabled: userConfig.caloriesTaperEnabled,
+          dayStartOffsetHours: userConfig.dayStartOffsetHours,
         ),
       );
     });
@@ -129,6 +130,16 @@ class SettingsBloc extends Bloc<SettingsEvent, SettingsState> {
 
   Future<void> setDiarySortPreference(String mealKey, int sortIndex) async {
     await _addConfigUsecase.setDiarySortPreference(mealKey, sortIndex);
+  }
+
+  // #139: persist the configurable diary day boundary (0-23).
+  Future<void> setDayStartOffsetHours(int hours) async {
+    await _addConfigUsecase.setConfigDayStartOffsetHours(hours);
+  }
+
+  Future<int> getDayStartOffsetHours() async {
+    final config = await _getConfigUsecase.getConfig();
+    return config.dayStartOffsetHours;
   }
 
   Future<double> getKcalAdjustment() async {

--- a/lib/features/settings/presentation/bloc/settings_bloc.dart
+++ b/lib/features/settings/presentation/bloc/settings_bloc.dart
@@ -67,6 +67,7 @@ class SettingsBloc extends Bloc<SettingsEvent, SettingsState> {
           usesKilojoules: userConfig.usesKilojoules,
           caloriesTaperEnabled: userConfig.caloriesTaperEnabled,
           dayStartOffsetHours: userConfig.dayStartOffsetHours,
+          dayStartOffsetMinutes: userConfig.dayStartOffsetMinutes,
         ),
       );
     });
@@ -140,6 +141,17 @@ class SettingsBloc extends Bloc<SettingsEvent, SettingsState> {
   Future<int> getDayStartOffsetHours() async {
     final config = await _getConfigUsecase.getConfig();
     return config.dayStartOffsetHours;
+  }
+
+  // #139 follow-up: persist the minute component (0-59) of the diary
+  // day boundary so shift workers on 04:30 (or 03:45) can be exact.
+  Future<void> setDayStartOffsetMinutes(int minutes) async {
+    await _addConfigUsecase.setConfigDayStartOffsetMinutes(minutes);
+  }
+
+  Future<int> getDayStartOffsetMinutes() async {
+    final config = await _getConfigUsecase.getConfig();
+    return config.dayStartOffsetMinutes;
   }
 
   Future<double> getKcalAdjustment() async {

--- a/lib/features/settings/presentation/bloc/settings_state.dart
+++ b/lib/features/settings/presentation/bloc/settings_state.dart
@@ -30,6 +30,7 @@ class SettingsLoadedState extends SettingsState {
   final bool showMicronutrients; // #237
   final bool usesKilojoules; // #177
   final bool caloriesTaperEnabled; // #119 follow-up
+  final int dayStartOffsetHours; // #139
 
   const SettingsLoadedState(
     this.versionNumber,
@@ -47,6 +48,7 @@ class SettingsLoadedState extends SettingsState {
     this.showMicronutrients = false,
     this.usesKilojoules = false,
     this.caloriesTaperEnabled = false,
+    this.dayStartOffsetHours = 0,
   });
 
   @override
@@ -66,5 +68,6 @@ class SettingsLoadedState extends SettingsState {
         showMicronutrients,
         usesKilojoules,
         caloriesTaperEnabled,
+        dayStartOffsetHours,
       ];
 }

--- a/lib/features/settings/presentation/bloc/settings_state.dart
+++ b/lib/features/settings/presentation/bloc/settings_state.dart
@@ -31,6 +31,7 @@ class SettingsLoadedState extends SettingsState {
   final bool usesKilojoules; // #177
   final bool caloriesTaperEnabled; // #119 follow-up
   final int dayStartOffsetHours; // #139
+  final int dayStartOffsetMinutes; // #139 follow-up
 
   const SettingsLoadedState(
     this.versionNumber,
@@ -49,6 +50,7 @@ class SettingsLoadedState extends SettingsState {
     this.usesKilojoules = false,
     this.caloriesTaperEnabled = false,
     this.dayStartOffsetHours = 0,
+    this.dayStartOffsetMinutes = 0,
   });
 
   @override
@@ -69,5 +71,6 @@ class SettingsLoadedState extends SettingsState {
         usesKilojoules,
         caloriesTaperEnabled,
         dayStartOffsetHours,
+        dayStartOffsetMinutes,
       ];
 }

--- a/lib/features/settings/presentation/widgets/calculations_dialog.dart
+++ b/lib/features/settings/presentation/widgets/calculations_dialog.dart
@@ -148,6 +148,9 @@ class _CalculationsDialogState extends State<CalculationsDialog> {
       (ConfigEntity.defaultMealKcalSharesPct[ConfigEntity.mealKeySnack]!)
           .toDouble();
 
+  // #139: day-start offset (0-23). 0 = wall-clock midnight rollover.
+  int _dayStartOffsetHours = 0;
+
   UserEntity? _user;
   bool _usesImperialUnits = false;
   // #119 follow-up: opt-in taper that scales the daily kcal deficit
@@ -289,6 +292,9 @@ class _CalculationsDialogState extends State<CalculationsDialog> {
     // every time the dialog opens.
     final today =
         await widget.settingsBloc.getTodayTrackedDay(DateTime.now());
+    // #139: pre-fill the diary day-start hour slider.
+    final dayStartOffsetHours =
+        await widget.settingsBloc.getDayStartOffsetHours();
 
     setState(() {
       _kcalAdjustmentSelection = kcalAdjustment;
@@ -317,6 +323,7 @@ class _CalculationsDialogState extends State<CalculationsDialog> {
       _user = user;
       _usesImperialUnits = usesImperialUnits;
       _caloriesTaperEnabled = caloriesTaperEnabled;
+      _dayStartOffsetHours = dayStartOffsetHours;
     });
     // Seed the controller in whichever unit the user is reading.
     // `mounted` is true here because _initData is awaited inside the
@@ -443,6 +450,7 @@ class _CalculationsDialogState extends State<CalculationsDialog> {
                 _magnesiumGoalMg = null;
                 _vitaminDGoalUg = null;
                 _vitaminB12GoalUg = null;
+                _dayStartOffsetHours = 0; // #139
               });
               _kcalAdjustmentController.text = '0';
               _syncControllersToState();
@@ -1023,6 +1031,45 @@ class _CalculationsDialogState extends State<CalculationsDialog> {
                 decimalStep: true,
               ),
             ),
+            // ── #139: Day-start offset ───────────────────────────────────────
+            const SizedBox(height: 16),
+            Text(
+              S.of(context).settingsDayStartLabel,
+              style: Theme.of(context).textTheme.titleMedium,
+            ),
+            const SizedBox(height: 8),
+            Text(
+              S.of(context).settingsDayStartDescription,
+              style: Theme.of(context).textTheme.bodySmall,
+            ),
+            const SizedBox(height: 8),
+            Row(
+              children: [
+                Expanded(
+                  child: Slider(
+                    min: 0,
+                    max: 23,
+                    divisions: 23,
+                    value: _dayStartOffsetHours.toDouble(),
+                    label: S
+                        .of(context)
+                        .settingsDayStartHourLabel(_dayStartOffsetHours),
+                    onChanged: (value) {
+                      setState(() => _dayStartOffsetHours = value.round());
+                    },
+                  ),
+                ),
+                SizedBox(
+                  width: 56,
+                  child: Text(
+                    S
+                        .of(context)
+                        .settingsDayStartHourLabel(_dayStartOffsetHours),
+                    textAlign: TextAlign.right,
+                  ),
+                ),
+              ],
+            ),
           ],
         ),
       ),
@@ -1454,6 +1501,8 @@ class _CalculationsDialogState extends State<CalculationsDialog> {
       _proteinPctSelection,
       _fatPctSelection,
     );
+    // #139: persist the chosen day-start offset.
+    widget.settingsBloc.setDayStartOffsetHours(_dayStartOffsetHours);
 
     // #150: persist the four meal-share percentages alongside macro goals.
     widget.settingsBloc.setMealKcalSharesPct({

--- a/lib/features/settings/presentation/widgets/calculations_dialog.dart
+++ b/lib/features/settings/presentation/widgets/calculations_dialog.dart
@@ -148,8 +148,11 @@ class _CalculationsDialogState extends State<CalculationsDialog> {
       (ConfigEntity.defaultMealKcalSharesPct[ConfigEntity.mealKeySnack]!)
           .toDouble();
 
-  // #139: day-start offset (0-23). 0 = wall-clock midnight rollover.
+  // #139: day-start offset. Hours (0-23) and minutes (0-59) compose
+  // additively. (0, 0) = wall-clock midnight rollover (the original
+  // behaviour), preserved for everyone who has not touched the setting.
   int _dayStartOffsetHours = 0;
+  int _dayStartOffsetMinutes = 0;
 
   UserEntity? _user;
   bool _usesImperialUnits = false;
@@ -295,6 +298,8 @@ class _CalculationsDialogState extends State<CalculationsDialog> {
     // #139: pre-fill the diary day-start hour slider.
     final dayStartOffsetHours =
         await widget.settingsBloc.getDayStartOffsetHours();
+    final dayStartOffsetMinutes =
+        await widget.settingsBloc.getDayStartOffsetMinutes();
 
     setState(() {
       _kcalAdjustmentSelection = kcalAdjustment;
@@ -324,6 +329,7 @@ class _CalculationsDialogState extends State<CalculationsDialog> {
       _usesImperialUnits = usesImperialUnits;
       _caloriesTaperEnabled = caloriesTaperEnabled;
       _dayStartOffsetHours = dayStartOffsetHours;
+      _dayStartOffsetMinutes = dayStartOffsetMinutes;
     });
     // Seed the controller in whichever unit the user is reading.
     // `mounted` is true here because _initData is awaited inside the
@@ -451,6 +457,7 @@ class _CalculationsDialogState extends State<CalculationsDialog> {
                 _vitaminDGoalUg = null;
                 _vitaminB12GoalUg = null;
                 _dayStartOffsetHours = 0; // #139
+                _dayStartOffsetMinutes = 0; // #139 follow-up
               });
               _kcalAdjustmentController.text = '0';
               _syncControllersToState();
@@ -1043,28 +1050,66 @@ class _CalculationsDialogState extends State<CalculationsDialog> {
               style: Theme.of(context).textTheme.bodySmall,
             ),
             const SizedBox(height: 8),
+            // #139 follow-up: hours slider sits beside a minutes slider so
+            // shift workers on 04:30 / 03:45 can land on the exact boundary
+            // their day actually starts at. A combined HH:MM readout to the
+            // right keeps the pair feeling like one setting rather than two.
             Row(
+              crossAxisAlignment: CrossAxisAlignment.start,
               children: [
                 Expanded(
-                  child: Slider(
-                    min: 0,
-                    max: 23,
-                    divisions: 23,
-                    value: _dayStartOffsetHours.toDouble(),
-                    label: S
-                        .of(context)
-                        .settingsDayStartHourLabel(_dayStartOffsetHours),
-                    onChanged: (value) {
-                      setState(() => _dayStartOffsetHours = value.round());
-                    },
+                  child: Column(
+                    crossAxisAlignment: CrossAxisAlignment.start,
+                    children: [
+                      Text(
+                        S.of(context).settingsDayStartHoursPickerLabel,
+                        style: Theme.of(context).textTheme.bodySmall,
+                      ),
+                      Slider(
+                        min: 0,
+                        max: 23,
+                        divisions: 23,
+                        value: _dayStartOffsetHours.toDouble(),
+                        label: '$_dayStartOffsetHours',
+                        onChanged: (value) {
+                          setState(() => _dayStartOffsetHours = value.round());
+                        },
+                      ),
+                    ],
+                  ),
+                ),
+                const SizedBox(width: 8),
+                Expanded(
+                  child: Column(
+                    crossAxisAlignment: CrossAxisAlignment.start,
+                    children: [
+                      Text(
+                        S.of(context).settingsDayStartMinutesPickerLabel,
+                        style: Theme.of(context).textTheme.bodySmall,
+                      ),
+                      Slider(
+                        min: 0,
+                        max: 59,
+                        divisions: 59,
+                        value: _dayStartOffsetMinutes.toDouble(),
+                        label: _dayStartOffsetMinutes
+                            .toString()
+                            .padLeft(2, '0'),
+                        onChanged: (value) {
+                          setState(
+                              () => _dayStartOffsetMinutes = value.round());
+                        },
+                      ),
+                    ],
                   ),
                 ),
                 SizedBox(
-                  width: 56,
+                  width: 64,
                   child: Text(
-                    S
-                        .of(context)
-                        .settingsDayStartHourLabel(_dayStartOffsetHours),
+                    S.of(context).settingsDayStartTimeLabel(
+                          _dayStartOffsetHours,
+                          _dayStartOffsetMinutes.toString().padLeft(2, '0'),
+                        ),
                     textAlign: TextAlign.right,
                   ),
                 ),
@@ -1501,8 +1546,9 @@ class _CalculationsDialogState extends State<CalculationsDialog> {
       _proteinPctSelection,
       _fatPctSelection,
     );
-    // #139: persist the chosen day-start offset.
+    // #139: persist the chosen day-start offset (hours + minutes).
     widget.settingsBloc.setDayStartOffsetHours(_dayStartOffsetHours);
+    widget.settingsBloc.setDayStartOffsetMinutes(_dayStartOffsetMinutes);
 
     // #150: persist the four meal-share percentages alongside macro goals.
     widget.settingsBloc.setMealKcalSharesPct({

--- a/lib/generated/intl/messages_cs.dart
+++ b/lib/generated/intl/messages_cs.dart
@@ -75,6 +75,8 @@ class MessageLookup extends MessageLookupByLibrary {
 
   static String m24(unit) => "${unit} v jedné porci";
 
+  static String m25(hour) => "${hour}:00";
+
   final messages = _notInlinedMessages(_notInlinedMessages);
   static Map<String, Function> _notInlinedMessages(_) => <String, Function>{
         "activityExample": MessageLookupByLibrary.simpleMessage(
@@ -1092,6 +1094,11 @@ class MessageLookup extends MessageLookupByLibrary {
             "Vyber, které živiny se zobrazí v panelu deníku"),
         "settingsNutrientsHelp": MessageLookupByLibrary.simpleMessage(
             "Zvol, které živiny jsou v denním panelu vidět. Skryté lze kdykoli znovu zapnout."),
+        "settingsDayStartLabel":
+            MessageLookupByLibrary.simpleMessage("Den začíná v"),
+        "settingsDayStartDescription": MessageLookupByLibrary.simpleMessage(
+            "Zvol hodinu, ve které začíná tvůj den. Jídla a aktivity zaznamenané před touto hodinou se počítají k předchozímu dni — hodí se při nočních směnách nebo pozdním jídle."),
+        "settingsDayStartHourLabel": m25,
         "settingsSourceCodeLabel":
             MessageLookupByLibrary.simpleMessage("Zdrojový kód"),
         "settingsSystemLabel": MessageLookupByLibrary.simpleMessage("Systém"),

--- a/lib/generated/intl/messages_cs.dart
+++ b/lib/generated/intl/messages_cs.dart
@@ -77,6 +77,8 @@ class MessageLookup extends MessageLookupByLibrary {
 
   static String m25(hour) => "${hour}:00";
 
+  static String m26(hour, minute) => "${hour}:${minute}";
+
   final messages = _notInlinedMessages(_notInlinedMessages);
   static Map<String, Function> _notInlinedMessages(_) => <String, Function>{
         "activityExample": MessageLookupByLibrary.simpleMessage(
@@ -1099,6 +1101,10 @@ class MessageLookup extends MessageLookupByLibrary {
         "settingsDayStartDescription": MessageLookupByLibrary.simpleMessage(
             "Zvol hodinu, ve které začíná tvůj den. Jídla a aktivity zaznamenané před touto hodinou se počítají k předchozímu dni — hodí se při nočních směnách nebo pozdním jídle."),
         "settingsDayStartHourLabel": m25,
+        "settingsDayStartHoursPickerLabel":
+            MessageLookupByLibrary.simpleMessage("Hodiny"),
+        "settingsDayStartMinutesPickerLabel":
+            MessageLookupByLibrary.simpleMessage("Minuty"),        "settingsDayStartTimeLabel": m26,
         "settingsSourceCodeLabel":
             MessageLookupByLibrary.simpleMessage("Zdrojový kód"),
         "settingsSystemLabel": MessageLookupByLibrary.simpleMessage("Systém"),

--- a/lib/generated/intl/messages_de.dart
+++ b/lib/generated/intl/messages_de.dart
@@ -80,6 +80,8 @@ class MessageLookup extends MessageLookupByLibrary {
 
   static String m25(hour) => "${hour}:00";
 
+  static String m26(hour, minute) => "${hour}:${minute}";
+
   final messages = _notInlinedMessages(_notInlinedMessages);
   static Map<String, Function> _notInlinedMessages(_) => <String, Function>{
         "activityExample": MessageLookupByLibrary.simpleMessage(
@@ -1121,6 +1123,10 @@ class MessageLookup extends MessageLookupByLibrary {
         "settingsDayStartDescription": MessageLookupByLibrary.simpleMessage(
             "Wähle die Stunde, zu der dein Tag beginnt. Mahlzeiten und Aktivitäten, die vor dieser Uhrzeit erfasst werden, zählen zum Vortag — hilfreich bei Nachtschicht oder spätem Essen."),
         "settingsDayStartHourLabel": m25,
+        "settingsDayStartHoursPickerLabel":
+            MessageLookupByLibrary.simpleMessage("Stunden"),
+        "settingsDayStartMinutesPickerLabel":
+            MessageLookupByLibrary.simpleMessage("Minuten"),        "settingsDayStartTimeLabel": m26,
         "settingsSourceCodeLabel":
             MessageLookupByLibrary.simpleMessage("Quellcode"),
         "settingsSystemLabel":

--- a/lib/generated/intl/messages_de.dart
+++ b/lib/generated/intl/messages_de.dart
@@ -78,6 +78,8 @@ class MessageLookup extends MessageLookupByLibrary {
 
   static String m24(unit) => "${unit} pro Portion";
 
+  static String m25(hour) => "${hour}:00";
+
   final messages = _notInlinedMessages(_notInlinedMessages);
   static Map<String, Function> _notInlinedMessages(_) => <String, Function>{
         "activityExample": MessageLookupByLibrary.simpleMessage(
@@ -1114,6 +1116,11 @@ class MessageLookup extends MessageLookupByLibrary {
             "Wähle, welche Nährstoffe im Tagebuch erscheinen"),
         "settingsNutrientsHelp": MessageLookupByLibrary.simpleMessage(
             "Wähle, welche Nährstoffe im Tagespanel sichtbar sind. Ausgeblendete kannst du jederzeit wieder einschalten."),
+        "settingsDayStartLabel":
+            MessageLookupByLibrary.simpleMessage("Tag beginnt um"),
+        "settingsDayStartDescription": MessageLookupByLibrary.simpleMessage(
+            "Wähle die Stunde, zu der dein Tag beginnt. Mahlzeiten und Aktivitäten, die vor dieser Uhrzeit erfasst werden, zählen zum Vortag — hilfreich bei Nachtschicht oder spätem Essen."),
+        "settingsDayStartHourLabel": m25,
         "settingsSourceCodeLabel":
             MessageLookupByLibrary.simpleMessage("Quellcode"),
         "settingsSystemLabel":

--- a/lib/generated/intl/messages_en.dart
+++ b/lib/generated/intl/messages_en.dart
@@ -77,6 +77,8 @@ class MessageLookup extends MessageLookupByLibrary {
 
   static String m24(hour) => "${hour}:00";
 
+  static String m25(hour, minute) => "${hour}:${minute}";
+
   final messages = _notInlinedMessages(_notInlinedMessages);
   static Map<String, Function> _notInlinedMessages(_) => <String, Function>{
         "activityExample": MessageLookupByLibrary.simpleMessage(
@@ -1092,6 +1094,11 @@ class MessageLookup extends MessageLookupByLibrary {
         "settingsDayStartDescription": MessageLookupByLibrary.simpleMessage(
             "Choose the hour at which your day begins. Meals and activities logged before this hour count toward the previous day — useful if you work nights or eat late."),
         "settingsDayStartHourLabel": m24,
+        "settingsDayStartHoursPickerLabel":
+            MessageLookupByLibrary.simpleMessage("Hours"),
+        "settingsDayStartMinutesPickerLabel":
+            MessageLookupByLibrary.simpleMessage("Minutes"),
+        "settingsDayStartTimeLabel": m25,
         "settingsSourceCodeLabel":
             MessageLookupByLibrary.simpleMessage("Source Code"),
         "settingsSystemLabel": MessageLookupByLibrary.simpleMessage("System"),

--- a/lib/generated/intl/messages_en.dart
+++ b/lib/generated/intl/messages_en.dart
@@ -75,6 +75,8 @@ class MessageLookup extends MessageLookupByLibrary {
 
   static String m23(unit) => "${unit} in one serving";
 
+  static String m24(hour) => "${hour}:00";
+
   final messages = _notInlinedMessages(_notInlinedMessages);
   static Map<String, Function> _notInlinedMessages(_) => <String, Function>{
         "activityExample": MessageLookupByLibrary.simpleMessage(
@@ -1085,6 +1087,11 @@ class MessageLookup extends MessageLookupByLibrary {
             "Pick which nutrients appear on the diary panel"),
         "settingsNutrientsHelp": MessageLookupByLibrary.simpleMessage(
             "Choose which nutrients are visible on the daily panel. Hidden ones can be turned back on at any time."),
+        "settingsDayStartLabel":
+            MessageLookupByLibrary.simpleMessage("Day starts at"),
+        "settingsDayStartDescription": MessageLookupByLibrary.simpleMessage(
+            "Choose the hour at which your day begins. Meals and activities logged before this hour count toward the previous day — useful if you work nights or eat late."),
+        "settingsDayStartHourLabel": m24,
         "settingsSourceCodeLabel":
             MessageLookupByLibrary.simpleMessage("Source Code"),
         "settingsSystemLabel": MessageLookupByLibrary.simpleMessage("System"),

--- a/lib/generated/intl/messages_it.dart
+++ b/lib/generated/intl/messages_it.dart
@@ -77,6 +77,8 @@ class MessageLookup extends MessageLookupByLibrary {
 
   static String m25(hour) => "${hour}:00";
 
+  static String m26(hour, minute) => "${hour}:${minute}";
+
   final messages = _notInlinedMessages(_notInlinedMessages);
   static Map<String, Function> _notInlinedMessages(_) => <String, Function>{
         "activityExample": MessageLookupByLibrary.simpleMessage(
@@ -1110,6 +1112,10 @@ class MessageLookup extends MessageLookupByLibrary {
         "settingsDayStartDescription": MessageLookupByLibrary.simpleMessage(
             "Scegli l\'ora in cui inizia la tua giornata. I pasti e le attività registrati prima di questa ora verranno conteggiati nel giorno precedente — utile per chi lavora di notte o mangia tardi."),
         "settingsDayStartHourLabel": m25,
+        "settingsDayStartHoursPickerLabel":
+            MessageLookupByLibrary.simpleMessage("Ore"),
+        "settingsDayStartMinutesPickerLabel":
+            MessageLookupByLibrary.simpleMessage("Minuti"),        "settingsDayStartTimeLabel": m26,
         "settingsSourceCodeLabel":
             MessageLookupByLibrary.simpleMessage("Codice sorgente"),
         "settingsSystemLabel": MessageLookupByLibrary.simpleMessage("Sistema"),

--- a/lib/generated/intl/messages_it.dart
+++ b/lib/generated/intl/messages_it.dart
@@ -75,6 +75,8 @@ class MessageLookup extends MessageLookupByLibrary {
 
   static String m24(unit) => "${unit} per porzione";
 
+  static String m25(hour) => "${hour}:00";
+
   final messages = _notInlinedMessages(_notInlinedMessages);
   static Map<String, Function> _notInlinedMessages(_) => <String, Function>{
         "activityExample": MessageLookupByLibrary.simpleMessage(
@@ -1103,6 +1105,11 @@ class MessageLookup extends MessageLookupByLibrary {
             "Scegli quali nutrienti compaiono nel pannello del diario"),
         "settingsNutrientsHelp": MessageLookupByLibrary.simpleMessage(
             "Scegli quali nutrienti sono visibili nel pannello giornaliero. Quelli nascosti possono essere riattivati in qualsiasi momento."),
+        "settingsDayStartLabel":
+            MessageLookupByLibrary.simpleMessage("Il giorno inizia alle"),
+        "settingsDayStartDescription": MessageLookupByLibrary.simpleMessage(
+            "Scegli l\'ora in cui inizia la tua giornata. I pasti e le attività registrati prima di questa ora verranno conteggiati nel giorno precedente — utile per chi lavora di notte o mangia tardi."),
+        "settingsDayStartHourLabel": m25,
         "settingsSourceCodeLabel":
             MessageLookupByLibrary.simpleMessage("Codice sorgente"),
         "settingsSystemLabel": MessageLookupByLibrary.simpleMessage("Sistema"),

--- a/lib/generated/intl/messages_pl.dart
+++ b/lib/generated/intl/messages_pl.dart
@@ -75,6 +75,8 @@ class MessageLookup extends MessageLookupByLibrary {
 
   static String m24(unit) => "${unit} w jednej porcji";
 
+  static String m25(hour) => "${hour}:00";
+
   final messages = _notInlinedMessages(_notInlinedMessages);
   static Map<String, Function> _notInlinedMessages(_) => <String, Function>{
         "activityExample": MessageLookupByLibrary.simpleMessage(
@@ -1100,6 +1102,11 @@ class MessageLookup extends MessageLookupByLibrary {
             "Wybierz, które składniki pojawiają się w panelu dziennika"),
         "settingsNutrientsHelp": MessageLookupByLibrary.simpleMessage(
             "Wybierz, które składniki są widoczne w panelu dziennym. Ukryte możesz w każdej chwili włączyć ponownie."),
+        "settingsDayStartLabel":
+            MessageLookupByLibrary.simpleMessage("Dzień zaczyna się o"),
+        "settingsDayStartDescription": MessageLookupByLibrary.simpleMessage(
+            "Wybierz godzinę, o której zaczyna się Twój dzień. Posiłki i aktywności zarejestrowane przed tą godziną zaliczają się do poprzedniego dnia — przydatne przy pracy nocnej lub późnym jedzeniu."),
+        "settingsDayStartHourLabel": m25,
         "settingsSourceCodeLabel":
             MessageLookupByLibrary.simpleMessage("Kod źródłowy"),
         "settingsSystemLabel": MessageLookupByLibrary.simpleMessage("System"),

--- a/lib/generated/intl/messages_pl.dart
+++ b/lib/generated/intl/messages_pl.dart
@@ -77,6 +77,8 @@ class MessageLookup extends MessageLookupByLibrary {
 
   static String m25(hour) => "${hour}:00";
 
+  static String m26(hour, minute) => "${hour}:${minute}";
+
   final messages = _notInlinedMessages(_notInlinedMessages);
   static Map<String, Function> _notInlinedMessages(_) => <String, Function>{
         "activityExample": MessageLookupByLibrary.simpleMessage(
@@ -1107,6 +1109,10 @@ class MessageLookup extends MessageLookupByLibrary {
         "settingsDayStartDescription": MessageLookupByLibrary.simpleMessage(
             "Wybierz godzinę, o której zaczyna się Twój dzień. Posiłki i aktywności zarejestrowane przed tą godziną zaliczają się do poprzedniego dnia — przydatne przy pracy nocnej lub późnym jedzeniu."),
         "settingsDayStartHourLabel": m25,
+        "settingsDayStartHoursPickerLabel":
+            MessageLookupByLibrary.simpleMessage("Godziny"),
+        "settingsDayStartMinutesPickerLabel":
+            MessageLookupByLibrary.simpleMessage("Minuty"),        "settingsDayStartTimeLabel": m26,
         "settingsSourceCodeLabel":
             MessageLookupByLibrary.simpleMessage("Kod źródłowy"),
         "settingsSystemLabel": MessageLookupByLibrary.simpleMessage("System"),

--- a/lib/generated/intl/messages_sk.dart
+++ b/lib/generated/intl/messages_sk.dart
@@ -77,6 +77,8 @@ class MessageLookup extends MessageLookupByLibrary {
 
   static String m25(hour) => "${hour}:00";
 
+  static String m26(hour, minute) => "${hour}:${minute}";
+
   final messages = _notInlinedMessages(_notInlinedMessages);
   static Map<String, Function> _notInlinedMessages(_) => <String, Function>{
         "activityExample": MessageLookupByLibrary.simpleMessage(
@@ -1020,6 +1022,11 @@ class MessageLookup extends MessageLookupByLibrary {
         "settingsDayStartDescription": MessageLookupByLibrary.simpleMessage(
             "Vyber hodinu, kedy sa začína tvoj deň. Jedlá a aktivity zaznamenané pred touto hodinou sa počítajú do predchádzajúceho dňa — hodí sa pri nočných smenách alebo neskorom jedle."),
         "settingsDayStartHourLabel": m25,
+        "settingsDayStartHoursPickerLabel":
+            MessageLookupByLibrary.simpleMessage("Hodiny"),
+        "settingsDayStartMinutesPickerLabel":
+            MessageLookupByLibrary.simpleMessage("Minúty"),
+        "settingsDayStartTimeLabel": m26,
         "settingsSourceCodeLabel":
             MessageLookupByLibrary.simpleMessage("Zdrojový kód"),
         "settingsSystemLabel": MessageLookupByLibrary.simpleMessage("Systém"),

--- a/lib/generated/intl/messages_sk.dart
+++ b/lib/generated/intl/messages_sk.dart
@@ -75,6 +75,8 @@ class MessageLookup extends MessageLookupByLibrary {
 
   static String m24(unit) => "${unit} v jednej porcii";
 
+  static String m25(hour) => "${hour}:00";
+
   final messages = _notInlinedMessages(_notInlinedMessages);
   static Map<String, Function> _notInlinedMessages(_) => <String, Function>{
         "activityExample": MessageLookupByLibrary.simpleMessage(
@@ -1013,6 +1015,11 @@ class MessageLookup extends MessageLookupByLibrary {
         "settingsShowMealMacros":
             MessageLookupByLibrary.simpleMessage("Zobraziť makroživiny jedla"),
         "settingsShowMicronutrientsLabel": MessageLookupByLibrary.simpleMessage("Zobraziť mikroživiny"),
+        "settingsDayStartLabel":
+            MessageLookupByLibrary.simpleMessage("Deň začína o"),
+        "settingsDayStartDescription": MessageLookupByLibrary.simpleMessage(
+            "Vyber hodinu, kedy sa začína tvoj deň. Jedlá a aktivity zaznamenané pred touto hodinou sa počítajú do predchádzajúceho dňa — hodí sa pri nočných smenách alebo neskorom jedle."),
+        "settingsDayStartHourLabel": m25,
         "settingsSourceCodeLabel":
             MessageLookupByLibrary.simpleMessage("Zdrojový kód"),
         "settingsSystemLabel": MessageLookupByLibrary.simpleMessage("Systém"),

--- a/lib/generated/intl/messages_tr.dart
+++ b/lib/generated/intl/messages_tr.dart
@@ -77,6 +77,8 @@ class MessageLookup extends MessageLookupByLibrary {
 
   static String m24(unit) => "${unit} porsiyon başına";
 
+  static String m25(hour) => "${hour}:00";
+
   final messages = _notInlinedMessages(_notInlinedMessages);
   static Map<String, Function> _notInlinedMessages(_) => <String, Function>{
         "activityExample": MessageLookupByLibrary.simpleMessage(
@@ -1081,6 +1083,11 @@ class MessageLookup extends MessageLookupByLibrary {
             "Günlük panelinde hangi besinlerin görüneceğini seç"),
         "settingsNutrientsHelp": MessageLookupByLibrary.simpleMessage(
             "Günlük panelde hangi besinlerin görüneceğini seç. Gizlenenler istediğin zaman tekrar açılabilir."),
+        "settingsDayStartLabel":
+            MessageLookupByLibrary.simpleMessage("Gün başlangıcı"),
+        "settingsDayStartDescription": MessageLookupByLibrary.simpleMessage(
+            "Gününün başladığı saati seç. Bu saatten önce kaydedilen öğünler ve aktiviteler önceki güne sayılır — gece çalışanlar veya geç yemek yiyenler için kullanışlıdır."),
+        "settingsDayStartHourLabel": m25,
         "settingsSourceCodeLabel":
             MessageLookupByLibrary.simpleMessage("Kaynak Kodu"),
         "settingsSystemLabel": MessageLookupByLibrary.simpleMessage("Sistem"),

--- a/lib/generated/intl/messages_tr.dart
+++ b/lib/generated/intl/messages_tr.dart
@@ -79,6 +79,8 @@ class MessageLookup extends MessageLookupByLibrary {
 
   static String m25(hour) => "${hour}:00";
 
+  static String m26(hour, minute) => "${hour}:${minute}";
+
   final messages = _notInlinedMessages(_notInlinedMessages);
   static Map<String, Function> _notInlinedMessages(_) => <String, Function>{
         "activityExample": MessageLookupByLibrary.simpleMessage(
@@ -1088,6 +1090,10 @@ class MessageLookup extends MessageLookupByLibrary {
         "settingsDayStartDescription": MessageLookupByLibrary.simpleMessage(
             "Gününün başladığı saati seç. Bu saatten önce kaydedilen öğünler ve aktiviteler önceki güne sayılır — gece çalışanlar veya geç yemek yiyenler için kullanışlıdır."),
         "settingsDayStartHourLabel": m25,
+        "settingsDayStartHoursPickerLabel":
+            MessageLookupByLibrary.simpleMessage("Saat"),
+        "settingsDayStartMinutesPickerLabel":
+            MessageLookupByLibrary.simpleMessage("Dakika"),        "settingsDayStartTimeLabel": m26,
         "settingsSourceCodeLabel":
             MessageLookupByLibrary.simpleMessage("Kaynak Kodu"),
         "settingsSystemLabel": MessageLookupByLibrary.simpleMessage("Sistem"),

--- a/lib/generated/intl/messages_uk.dart
+++ b/lib/generated/intl/messages_uk.dart
@@ -75,6 +75,8 @@ class MessageLookup extends MessageLookupByLibrary {
 
   static String m24(unit) => "${unit} в одній порції";
 
+  static String m25(hour) => "${hour}:00";
+
   final messages = _notInlinedMessages(_notInlinedMessages);
   static Map<String, Function> _notInlinedMessages(_) => <String, Function>{
         "activityExample": MessageLookupByLibrary.simpleMessage(
@@ -1103,6 +1105,11 @@ class MessageLookup extends MessageLookupByLibrary {
             "Обери, які поживні речовини показувати на панелі щоденника"),
         "settingsNutrientsHelp": MessageLookupByLibrary.simpleMessage(
             "Обери, які поживні речовини видимі на щоденній панелі. Приховані можна знову увімкнути будь-коли."),
+        "settingsDayStartLabel":
+            MessageLookupByLibrary.simpleMessage("День починається о"),
+        "settingsDayStartDescription": MessageLookupByLibrary.simpleMessage(
+            "Обери годину, з якої починається твій день. Прийоми їжі та активності, записані до цієї години, зараховуються до попереднього дня — зручно, якщо ти працюєш у нічну зміну або пізно вечеряєш."),
+        "settingsDayStartHourLabel": m25,
         "settingsSourceCodeLabel":
             MessageLookupByLibrary.simpleMessage("Вихідний код"),
         "settingsSystemLabel": MessageLookupByLibrary.simpleMessage("Система"),

--- a/lib/generated/intl/messages_uk.dart
+++ b/lib/generated/intl/messages_uk.dart
@@ -77,6 +77,8 @@ class MessageLookup extends MessageLookupByLibrary {
 
   static String m25(hour) => "${hour}:00";
 
+  static String m26(hour, minute) => "${hour}:${minute}";
+
   final messages = _notInlinedMessages(_notInlinedMessages);
   static Map<String, Function> _notInlinedMessages(_) => <String, Function>{
         "activityExample": MessageLookupByLibrary.simpleMessage(
@@ -1110,6 +1112,10 @@ class MessageLookup extends MessageLookupByLibrary {
         "settingsDayStartDescription": MessageLookupByLibrary.simpleMessage(
             "Обери годину, з якої починається твій день. Прийоми їжі та активності, записані до цієї години, зараховуються до попереднього дня — зручно, якщо ти працюєш у нічну зміну або пізно вечеряєш."),
         "settingsDayStartHourLabel": m25,
+        "settingsDayStartHoursPickerLabel":
+            MessageLookupByLibrary.simpleMessage("Години"),
+        "settingsDayStartMinutesPickerLabel":
+            MessageLookupByLibrary.simpleMessage("Хвилини"),        "settingsDayStartTimeLabel": m26,
         "settingsSourceCodeLabel":
             MessageLookupByLibrary.simpleMessage("Вихідний код"),
         "settingsSystemLabel": MessageLookupByLibrary.simpleMessage("Система"),

--- a/lib/generated/intl/messages_zh.dart
+++ b/lib/generated/intl/messages_zh.dart
@@ -72,6 +72,8 @@ class MessageLookup extends MessageLookupByLibrary {
 
   static String m24(unit) => "每份 ${unit}";
 
+  static String m25(hour) => "${hour}:00";
+
   final messages = _notInlinedMessages(_notInlinedMessages);
   static Map<String, Function> _notInlinedMessages(_) => <String, Function>{
         "activityExample":
@@ -953,6 +955,11 @@ class MessageLookup extends MessageLookupByLibrary {
             MessageLookupByLibrary.simpleMessage("选择在日记面板中显示哪些营养素"),
         "settingsNutrientsHelp":
             MessageLookupByLibrary.simpleMessage("选择每日面板中显示哪些营养素。隐藏的可以随时重新开启。"),
+        "settingsDayStartLabel":
+            MessageLookupByLibrary.simpleMessage("一天开始于"),
+        "settingsDayStartDescription": MessageLookupByLibrary.simpleMessage(
+            "选择一天开始的时刻。在这个时刻之前记录的餐食和活动将计入前一天 —— 适合上夜班或晚餐较晚的用户。"),
+        "settingsDayStartHourLabel": m25,
         "settingsSourceCodeLabel": MessageLookupByLibrary.simpleMessage("源代码"),
         "settingsSystemLabel": MessageLookupByLibrary.simpleMessage("系统"),
         "settingsThemeDarkLabel": MessageLookupByLibrary.simpleMessage("深色"),

--- a/lib/generated/intl/messages_zh.dart
+++ b/lib/generated/intl/messages_zh.dart
@@ -74,6 +74,8 @@ class MessageLookup extends MessageLookupByLibrary {
 
   static String m25(hour) => "${hour}:00";
 
+  static String m26(hour, minute) => "${hour}:${minute}";
+
   final messages = _notInlinedMessages(_notInlinedMessages);
   static Map<String, Function> _notInlinedMessages(_) => <String, Function>{
         "activityExample":
@@ -960,6 +962,10 @@ class MessageLookup extends MessageLookupByLibrary {
         "settingsDayStartDescription": MessageLookupByLibrary.simpleMessage(
             "选择一天开始的时刻。在这个时刻之前记录的餐食和活动将计入前一天 —— 适合上夜班或晚餐较晚的用户。"),
         "settingsDayStartHourLabel": m25,
+        "settingsDayStartHoursPickerLabel":
+            MessageLookupByLibrary.simpleMessage("小时"),
+        "settingsDayStartMinutesPickerLabel":
+            MessageLookupByLibrary.simpleMessage("分钟"),        "settingsDayStartTimeLabel": m26,
         "settingsSourceCodeLabel": MessageLookupByLibrary.simpleMessage("源代码"),
         "settingsSystemLabel": MessageLookupByLibrary.simpleMessage("系统"),
         "settingsThemeDarkLabel": MessageLookupByLibrary.simpleMessage("深色"),

--- a/lib/generated/l10n.dart
+++ b/lib/generated/l10n.dart
@@ -2008,6 +2008,36 @@ class S {
     );
   }
 
+  /// `Hours`
+  String get settingsDayStartHoursPickerLabel {
+    return Intl.message(
+      'Hours',
+      name: 'settingsDayStartHoursPickerLabel',
+      desc: '',
+      args: [],
+    );
+  }
+
+  /// `Minutes`
+  String get settingsDayStartMinutesPickerLabel {
+    return Intl.message(
+      'Minutes',
+      name: 'settingsDayStartMinutesPickerLabel',
+      desc: '',
+      args: [],
+    );
+  }
+
+  /// `{hour}:{minute}`
+  String settingsDayStartTimeLabel(int hour, String minute) {
+    return Intl.message(
+      '$hour:$minute',
+      name: 'settingsDayStartTimeLabel',
+      desc: '',
+      args: [hour, minute],
+    );
+  }
+
   /// `Distance`
   String get settingsDistanceLabel {
     return Intl.message(

--- a/lib/generated/l10n.dart
+++ b/lib/generated/l10n.dart
@@ -1978,6 +1978,35 @@ class S {
     );
   }
 
+  /// `Day starts at`
+  String get settingsDayStartLabel {
+    return Intl.message(
+      'Day starts at',
+      name: 'settingsDayStartLabel',
+      desc: '',
+      args: [],
+    );
+  }
+
+  /// `Choose the hour at which your day begins. Meals and activities logged before this hour count toward the previous day — useful if you work nights or eat late.`
+  String get settingsDayStartDescription {
+    return Intl.message(
+      'Choose the hour at which your day begins. Meals and activities logged before this hour count toward the previous day — useful if you work nights or eat late.',
+      name: 'settingsDayStartDescription',
+      desc: '',
+      args: [],
+    );
+  }
+
+  /// `{hour}:00`
+  String settingsDayStartHourLabel(int hour) {
+    return Intl.message(
+      '$hour:00',
+      name: 'settingsDayStartHourLabel',
+      desc: '',
+      args: [hour],
+    );
+  }
 
   /// `Distance`
   String get settingsDistanceLabel {

--- a/lib/l10n/intl_cs.arb
+++ b/lib/l10n/intl_cs.arb
@@ -706,6 +706,19 @@
       }
     }
   },
+  "settingsDayStartHoursPickerLabel": "Hodiny",
+  "settingsDayStartMinutesPickerLabel": "Minuty",
+  "settingsDayStartTimeLabel": "{hour}:{minute}",
+  "@settingsDayStartTimeLabel": {
+    "placeholders": {
+      "hour": {
+        "type": "int"
+      },
+      "minute": {
+        "type": "String"
+      }
+    }
+  },
   "settingsDisclaimerLabel": "Vzdání se nároku",
   "settingsDistanceLabel": "Vzdálenost",
   "settingsEnergyUnitLabel": "Jednotka energie",

--- a/lib/l10n/intl_cs.arb
+++ b/lib/l10n/intl_cs.arb
@@ -696,6 +696,16 @@
   "settingsCaloriesTaperDescription": "Postupně zmenšuje denní deficit, aby posledních pár kilogramů nepůsobilo jako zeď.",
   "settingsCaloriesTaperLabel": "Upravovat kalorický cíl, jak se blížíte k cílové váze",
   "settingsCustomMealsLabel": "Vlastní jídla",
+  "settingsDayStartLabel": "Den začíná v",
+  "settingsDayStartDescription": "Zvol hodinu, ve které začíná tvůj den. Jídla a aktivity zaznamenané před touto hodinou se počítají k předchozímu dni — hodí se při nočních směnách nebo pozdním jídle.",
+  "settingsDayStartHourLabel": "{hour}:00",
+  "@settingsDayStartHourLabel": {
+    "placeholders": {
+      "hour": {
+        "type": "int"
+      }
+    }
+  },
   "settingsDisclaimerLabel": "Vzdání se nároku",
   "settingsDistanceLabel": "Vzdálenost",
   "settingsEnergyUnitLabel": "Jednotka energie",

--- a/lib/l10n/intl_de.arb
+++ b/lib/l10n/intl_de.arb
@@ -737,6 +737,19 @@
       }
     }
   },
+  "settingsDayStartHoursPickerLabel": "Stunden",
+  "settingsDayStartMinutesPickerLabel": "Minuten",
+  "settingsDayStartTimeLabel": "{hour}:{minute}",
+  "@settingsDayStartTimeLabel": {
+    "placeholders": {
+      "hour": {
+        "type": "int"
+      },
+      "minute": {
+        "type": "String"
+      }
+    }
+  },
   "settingsDisclaimerLabel": "Hinweis",
   "settingsDistanceLabel": "Entfernung",
   "settingsEnergyUnitLabel": "Energieeinheit",

--- a/lib/l10n/intl_de.arb
+++ b/lib/l10n/intl_de.arb
@@ -727,6 +727,16 @@
   "settingsCaloriesTaperDescription": "Reduziert das tägliche Defizit allmählich, damit die letzten Kilos nicht wie eine Wand wirken.",
   "settingsCaloriesTaperLabel": "Kalorienziel anpassen, wenn du dich dem Ziel näherst",
   "settingsCustomMealsLabel": "Eigene Mahlzeiten",
+  "settingsDayStartLabel": "Tag beginnt um",
+  "settingsDayStartDescription": "Wähle die Stunde, zu der dein Tag beginnt. Mahlzeiten und Aktivitäten, die vor dieser Uhrzeit erfasst werden, zählen zum Vortag — hilfreich bei Nachtschicht oder spätem Essen.",
+  "settingsDayStartHourLabel": "{hour}:00",
+  "@settingsDayStartHourLabel": {
+    "placeholders": {
+      "hour": {
+        "type": "int"
+      }
+    }
+  },
   "settingsDisclaimerLabel": "Hinweis",
   "settingsDistanceLabel": "Entfernung",
   "settingsEnergyUnitLabel": "Energieeinheit",

--- a/lib/l10n/intl_en.arb
+++ b/lib/l10n/intl_en.arb
@@ -110,6 +110,13 @@
       }
     }
   },
+  "@settingsDayStartHourLabel": {
+    "placeholders": {
+      "hour": {
+        "type": "int"
+      }
+    }
+  },
   "@settingsNotificationsTimeLabel": {
     "placeholders": {
       "time": {
@@ -727,6 +734,9 @@
   "settingsCaloriesTaperDescription": "Reduces the daily deficit gradually so the last few kg don't feel like a wall.",
   "settingsCaloriesTaperLabel": "Adjust calorie goal as you approach target",
   "settingsCustomMealsLabel": "Custom Meals",
+  "settingsDayStartDescription": "Choose the hour at which your day begins. Meals and activities logged before this hour count toward the previous day — useful if you work nights or eat late.",
+  "settingsDayStartHourLabel": "{hour}:00",
+  "settingsDayStartLabel": "Day starts at",
   "settingsDisclaimerLabel": "Disclaimer",
   "settingsDistanceLabel": "Distance",
   "settingsEnergyUnitLabel": "Energy unit",

--- a/lib/l10n/intl_en.arb
+++ b/lib/l10n/intl_en.arb
@@ -117,6 +117,16 @@
       }
     }
   },
+  "@settingsDayStartTimeLabel": {
+    "placeholders": {
+      "hour": {
+        "type": "int"
+      },
+      "minute": {
+        "type": "String"
+      }
+    }
+  },
   "@settingsNotificationsTimeLabel": {
     "placeholders": {
       "time": {
@@ -736,7 +746,10 @@
   "settingsCustomMealsLabel": "Custom Meals",
   "settingsDayStartDescription": "Choose the hour at which your day begins. Meals and activities logged before this hour count toward the previous day — useful if you work nights or eat late.",
   "settingsDayStartHourLabel": "{hour}:00",
+  "settingsDayStartHoursPickerLabel": "Hours",
   "settingsDayStartLabel": "Day starts at",
+  "settingsDayStartMinutesPickerLabel": "Minutes",
+  "settingsDayStartTimeLabel": "{hour}:{minute}",
   "settingsDisclaimerLabel": "Disclaimer",
   "settingsDistanceLabel": "Distance",
   "settingsEnergyUnitLabel": "Energy unit",

--- a/lib/l10n/intl_it.arb
+++ b/lib/l10n/intl_it.arb
@@ -706,6 +706,19 @@
       }
     }
   },
+  "settingsDayStartHoursPickerLabel": "Ore",
+  "settingsDayStartMinutesPickerLabel": "Minuti",
+  "settingsDayStartTimeLabel": "{hour}:{minute}",
+  "@settingsDayStartTimeLabel": {
+    "placeholders": {
+      "hour": {
+        "type": "int"
+      },
+      "minute": {
+        "type": "String"
+      }
+    }
+  },
   "settingsDisclaimerLabel": "Disclaimer",
   "settingsDistanceLabel": "Distanza",
   "settingsEnergyUnitLabel": "Unità di energia",

--- a/lib/l10n/intl_it.arb
+++ b/lib/l10n/intl_it.arb
@@ -696,6 +696,16 @@
   "settingsCaloriesTaperDescription": "Riduce gradualmente il deficit giornaliero così gli ultimi chili non sembrano un muro.",
   "settingsCaloriesTaperLabel": "Adatta l'obiettivo calorico mentre ti avvicini al tuo peso obiettivo",
   "settingsCustomMealsLabel": "Pasti personalizzati",
+  "settingsDayStartLabel": "Il giorno inizia alle",
+  "settingsDayStartDescription": "Scegli l'ora in cui inizia la tua giornata. I pasti e le attività registrati prima di questa ora verranno conteggiati nel giorno precedente — utile per chi lavora di notte o mangia tardi.",
+  "settingsDayStartHourLabel": "{hour}:00",
+  "@settingsDayStartHourLabel": {
+    "placeholders": {
+      "hour": {
+        "type": "int"
+      }
+    }
+  },
   "settingsDisclaimerLabel": "Disclaimer",
   "settingsDistanceLabel": "Distanza",
   "settingsEnergyUnitLabel": "Unità di energia",

--- a/lib/l10n/intl_pl.arb
+++ b/lib/l10n/intl_pl.arb
@@ -696,6 +696,16 @@
   "settingsCaloriesTaperDescription": "Stopniowo zmniejsza dzienny deficyt, aby ostatnie kilogramy nie wydawały się ścianą.",
   "settingsCaloriesTaperLabel": "Dostosuj cel kaloryczny w miarę zbliżania się do celu",
   "settingsCustomMealsLabel": "Własne posiłki",
+  "settingsDayStartLabel": "Dzień zaczyna się o",
+  "settingsDayStartDescription": "Wybierz godzinę, o której zaczyna się Twój dzień. Posiłki i aktywności zarejestrowane przed tą godziną zaliczają się do poprzedniego dnia — przydatne przy pracy nocnej lub późnym jedzeniu.",
+  "settingsDayStartHourLabel": "{hour}:00",
+  "@settingsDayStartHourLabel": {
+    "placeholders": {
+      "hour": {
+        "type": "int"
+      }
+    }
+  },
   "settingsDisclaimerLabel": "Zastrzeżenie",
   "settingsDistanceLabel": "Odległość",
   "settingsEnergyUnitLabel": "Jednostka energii",

--- a/lib/l10n/intl_pl.arb
+++ b/lib/l10n/intl_pl.arb
@@ -706,6 +706,19 @@
       }
     }
   },
+  "settingsDayStartHoursPickerLabel": "Godziny",
+  "settingsDayStartMinutesPickerLabel": "Minuty",
+  "settingsDayStartTimeLabel": "{hour}:{minute}",
+  "@settingsDayStartTimeLabel": {
+    "placeholders": {
+      "hour": {
+        "type": "int"
+      },
+      "minute": {
+        "type": "String"
+      }
+    }
+  },
   "settingsDisclaimerLabel": "Zastrzeżenie",
   "settingsDistanceLabel": "Odległość",
   "settingsEnergyUnitLabel": "Jednostka energii",

--- a/lib/l10n/intl_sk.arb
+++ b/lib/l10n/intl_sk.arb
@@ -109,6 +109,13 @@
       }
     }
   },
+  "@settingsDayStartHourLabel": {
+    "placeholders": {
+      "hour": {
+        "type": "int"
+      }
+    }
+  },
   "@settingsNotificationsTimeLabel": {
     "placeholders": {
       "time": {
@@ -726,6 +733,9 @@
   "settingsCaloriesTaperDescription": "Postupne znižuje denný kalorický deficit, aby posledné kilá nepôsobili ako stena.",
   "settingsCaloriesTaperLabel": "Upraviť kalorický cieľ s blížením k cieľovej hmotnosti",
   "settingsCustomMealsLabel": "Vlastné jedlá",
+  "settingsDayStartDescription": "Vyber hodinu, kedy sa začína tvoj deň. Jedlá a aktivity zaznamenané pred touto hodinou sa počítajú do predchádzajúceho dňa — hodí sa pri nočných smenách alebo neskorom jedle.",
+  "settingsDayStartHourLabel": "{hour}:00",
+  "settingsDayStartLabel": "Deň začína o",
   "settingsDisclaimerLabel": "Upozornenie",
   "settingsDistanceLabel": "Vzdialenosť",
   "settingsEnergyUnitLabel": "Jednotka energie",

--- a/lib/l10n/intl_sk.arb
+++ b/lib/l10n/intl_sk.arb
@@ -116,6 +116,16 @@
       }
     }
   },
+  "@settingsDayStartTimeLabel": {
+    "placeholders": {
+      "hour": {
+        "type": "int"
+      },
+      "minute": {
+        "type": "String"
+      }
+    }
+  },
   "@settingsNotificationsTimeLabel": {
     "placeholders": {
       "time": {
@@ -735,7 +745,10 @@
   "settingsCustomMealsLabel": "Vlastné jedlá",
   "settingsDayStartDescription": "Vyber hodinu, kedy sa začína tvoj deň. Jedlá a aktivity zaznamenané pred touto hodinou sa počítajú do predchádzajúceho dňa — hodí sa pri nočných smenách alebo neskorom jedle.",
   "settingsDayStartHourLabel": "{hour}:00",
+  "settingsDayStartHoursPickerLabel": "Hodiny",
   "settingsDayStartLabel": "Deň začína o",
+  "settingsDayStartMinutesPickerLabel": "Minúty",
+  "settingsDayStartTimeLabel": "{hour}:{minute}",
   "settingsDisclaimerLabel": "Upozornenie",
   "settingsDistanceLabel": "Vzdialenosť",
   "settingsEnergyUnitLabel": "Jednotka energie",

--- a/lib/l10n/intl_tr.arb
+++ b/lib/l10n/intl_tr.arb
@@ -727,6 +727,16 @@
   "settingsCaloriesTaperDescription": "Günlük açığı kademeli olarak azaltır, böylece son birkaç kilo bir duvar gibi hissettirmez.",
   "settingsCaloriesTaperLabel": "Hedefine yaklaştıkça kalori hedefini ayarla",
   "settingsCustomMealsLabel": "Özel Yemekler",
+  "settingsDayStartLabel": "Gün başlangıcı",
+  "settingsDayStartDescription": "Gününün başladığı saati seç. Bu saatten önce kaydedilen öğünler ve aktiviteler önceki güne sayılır — gece çalışanlar veya geç yemek yiyenler için kullanışlıdır.",
+  "settingsDayStartHourLabel": "{hour}:00",
+  "@settingsDayStartHourLabel": {
+    "placeholders": {
+      "hour": {
+        "type": "int"
+      }
+    }
+  },
   "settingsDisclaimerLabel": "Sorumluluk Reddi",
   "settingsDistanceLabel": "Mesafe",
   "settingsEnergyUnitLabel": "Enerji birimi",

--- a/lib/l10n/intl_tr.arb
+++ b/lib/l10n/intl_tr.arb
@@ -737,6 +737,19 @@
       }
     }
   },
+  "settingsDayStartHoursPickerLabel": "Saat",
+  "settingsDayStartMinutesPickerLabel": "Dakika",
+  "settingsDayStartTimeLabel": "{hour}:{minute}",
+  "@settingsDayStartTimeLabel": {
+    "placeholders": {
+      "hour": {
+        "type": "int"
+      },
+      "minute": {
+        "type": "String"
+      }
+    }
+  },
   "settingsDisclaimerLabel": "Sorumluluk Reddi",
   "settingsDistanceLabel": "Mesafe",
   "settingsEnergyUnitLabel": "Enerji birimi",

--- a/lib/l10n/intl_uk.arb
+++ b/lib/l10n/intl_uk.arb
@@ -696,6 +696,16 @@
   "settingsCaloriesTaperDescription": "Поступово зменшує щоденний дефіцит, щоб останні кілограми не здавалися стіною.",
   "settingsCaloriesTaperLabel": "Коригувати калорійну ціль у міру наближення до цілі",
   "settingsCustomMealsLabel": "Власні страви",
+  "settingsDayStartLabel": "День починається о",
+  "settingsDayStartDescription": "Обери годину, з якої починається твій день. Прийоми їжі та активності, записані до цієї години, зараховуються до попереднього дня — зручно, якщо ти працюєш у нічну зміну або пізно вечеряєш.",
+  "settingsDayStartHourLabel": "{hour}:00",
+  "@settingsDayStartHourLabel": {
+    "placeholders": {
+      "hour": {
+        "type": "int"
+      }
+    }
+  },
   "settingsDisclaimerLabel": "Відмова від відповідальності",
   "settingsDistanceLabel": "Відстань",
   "settingsEnergyUnitLabel": "Одиниця енергії",

--- a/lib/l10n/intl_uk.arb
+++ b/lib/l10n/intl_uk.arb
@@ -706,6 +706,19 @@
       }
     }
   },
+  "settingsDayStartHoursPickerLabel": "Години",
+  "settingsDayStartMinutesPickerLabel": "Хвилини",
+  "settingsDayStartTimeLabel": "{hour}:{minute}",
+  "@settingsDayStartTimeLabel": {
+    "placeholders": {
+      "hour": {
+        "type": "int"
+      },
+      "minute": {
+        "type": "String"
+      }
+    }
+  },
   "settingsDisclaimerLabel": "Відмова від відповідальності",
   "settingsDistanceLabel": "Відстань",
   "settingsEnergyUnitLabel": "Одиниця енергії",

--- a/lib/l10n/intl_zh.arb
+++ b/lib/l10n/intl_zh.arb
@@ -707,6 +707,19 @@
       }
     }
   },
+  "settingsDayStartHoursPickerLabel": "小时",
+  "settingsDayStartMinutesPickerLabel": "分钟",
+  "settingsDayStartTimeLabel": "{hour}:{minute}",
+  "@settingsDayStartTimeLabel": {
+    "placeholders": {
+      "hour": {
+        "type": "int"
+      },
+      "minute": {
+        "type": "String"
+      }
+    }
+  },
   "settingsDisclaimerLabel": "免责声明",
   "settingsDistanceLabel": "距离",
   "settingsEnergyUnitLabel": "能量单位",

--- a/lib/l10n/intl_zh.arb
+++ b/lib/l10n/intl_zh.arb
@@ -697,6 +697,16 @@
   "settingsCaloriesTaperDescription": "逐渐减小每日热量缺口，让最后几公斤不再像一堵墙。",
   "settingsCaloriesTaperLabel": "接近目标时调整卡路里目标",
   "settingsCustomMealsLabel": "自定义餐食",
+  "settingsDayStartLabel": "一天开始于",
+  "settingsDayStartDescription": "选择一天开始的时刻。在这个时刻之前记录的餐食和活动将计入前一天 —— 适合上夜班或晚餐较晚的用户。",
+  "settingsDayStartHourLabel": "{hour}:00",
+  "@settingsDayStartHourLabel": {
+    "placeholders": {
+      "hour": {
+        "type": "int"
+      }
+    }
+  },
   "settingsDisclaimerLabel": "免责声明",
   "settingsDistanceLabel": "距离",
   "settingsEnergyUnitLabel": "能量单位",

--- a/test/unit_test/day_boundary_calc_test.dart
+++ b/test/unit_test/day_boundary_calc_test.dart
@@ -1,0 +1,144 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:opennutritracker/core/utils/calc/day_boundary_calc.dart';
+
+void main() {
+  group('DayBoundaryCalc.logicalDayOf', () {
+    test('offset 0: midnight-exact rounds to the same wall-clock day', () {
+      // The original behaviour, kept intact for everyone who has not
+      // touched the new setting. A meal logged at 00:00:00 on Jan 15
+      // belongs to Jan 15.
+      final moment = DateTime(2024, 1, 15, 0, 0, 0);
+      final logical = DayBoundaryCalc.logicalDayOf(moment, 0);
+      expect(logical, DateTime(2024, 1, 15));
+    });
+
+    test('offset 0: late evening still rolls under today', () {
+      // 23:59 with no offset is still today — this is the normal case
+      // for anyone who has not set a custom boundary.
+      final moment = DateTime(2024, 1, 15, 23, 59);
+      final logical = DayBoundaryCalc.logicalDayOf(moment, 0);
+      expect(logical, DateTime(2024, 1, 15));
+    });
+
+    test('offset 4: 01:00 resolves to the previous day', () {
+      // The use case from the issue: a 01:00 snack while the user is
+      // still up from the night before should file under yesterday's
+      // diary, not the day that has technically just begun.
+      final moment = DateTime(2024, 1, 15, 1, 0);
+      final logical = DayBoundaryCalc.logicalDayOf(moment, 4);
+      expect(logical, DateTime(2024, 1, 14));
+    });
+
+    test('offset 4: 05:00 resolves to today', () {
+      // Once you cross the configured day boundary, you are firmly in
+      // the new day. 05:00 with a 04:00 boundary is one hour into today.
+      final moment = DateTime(2024, 1, 15, 5, 0);
+      final logical = DayBoundaryCalc.logicalDayOf(moment, 4);
+      expect(logical, DateTime(2024, 1, 15));
+    });
+
+    test('offset 4: 04:00 exact is the start of today (not the end of '
+        'yesterday)', () {
+      // The boundary itself is inclusive of the new day, so a 04:00
+      // entry counts toward today.
+      final moment = DateTime(2024, 1, 15, 4, 0);
+      final logical = DayBoundaryCalc.logicalDayOf(moment, 4);
+      expect(logical, DateTime(2024, 1, 15));
+    });
+
+    test('offset 4: 03:59 is the last minute of yesterday', () {
+      final moment = DateTime(2024, 1, 15, 3, 59);
+      final logical = DayBoundaryCalc.logicalDayOf(moment, 4);
+      expect(logical, DateTime(2024, 1, 14));
+    });
+
+    test('mid-day entry stays in today for offsets at or below the hour', () {
+      // A 14:00 entry resolves to today as long as the user's
+      // configured boundary has already passed; at offset 12 we are
+      // two hours into today, at offset 14 we would be on the cusp.
+      final moment = DateTime(2024, 1, 15, 14, 0);
+      for (final offset in [0, 1, 4, 8, 12]) {
+        expect(
+          DayBoundaryCalc.logicalDayOf(moment, offset),
+          DateTime(2024, 1, 15),
+          reason: 'offset=$offset',
+        );
+      }
+      // At offset 15 or higher, 14:00 has not yet reached today's
+      // boundary, so it still belongs to yesterday.
+      expect(
+        DayBoundaryCalc.logicalDayOf(moment, 15),
+        DateTime(2024, 1, 14),
+      );
+    });
+
+    test('offset 23: only the 23:00-23:59 window stays in today', () {
+      // The extreme case: most of the calendar day belongs to "yesterday"
+      // from the user's perspective. This is unusual but supported.
+      expect(
+        DayBoundaryCalc.logicalDayOf(DateTime(2024, 1, 15, 22, 59), 23),
+        DateTime(2024, 1, 14),
+      );
+      expect(
+        DayBoundaryCalc.logicalDayOf(DateTime(2024, 1, 15, 23, 0), 23),
+        DateTime(2024, 1, 15),
+      );
+    });
+
+    test('null offset behaves as 0 (no boundary configured yet)', () {
+      // Fresh installs and existing users have no stored offset; null
+      // should keep them on wall-clock midnight.
+      final moment = DateTime(2024, 1, 15, 2, 0);
+      expect(
+        DayBoundaryCalc.logicalDayOf(moment, null),
+        DateTime(2024, 1, 15),
+      );
+    });
+
+    test('out-of-range offsets clamp to 0', () {
+      // Defensive: a corrupt or hand-edited Hive value should not push
+      // the diary into an impossible state. Anything outside 0-23 is
+      // treated as the default.
+      final moment = DateTime(2024, 1, 15, 2, 0);
+      expect(
+        DayBoundaryCalc.logicalDayOf(moment, -1),
+        DateTime(2024, 1, 15),
+      );
+      expect(
+        DayBoundaryCalc.logicalDayOf(moment, 24),
+        DateTime(2024, 1, 15),
+      );
+      expect(
+        DayBoundaryCalc.logicalDayOf(moment, 999),
+        DateTime(2024, 1, 15),
+      );
+    });
+  });
+
+  group('DayBoundaryCalc.isSameLogicalDay', () {
+    test('offset 0: behaves like wall-clock day equality', () {
+      // A regression check — with no offset, the helper should be a
+      // drop-in replacement for DateUtils.isSameDay.
+      final a = DateTime(2024, 1, 15, 9, 0);
+      final b = DateTime(2024, 1, 15, 23, 30);
+      final c = DateTime(2024, 1, 16, 0, 30);
+      expect(DayBoundaryCalc.isSameLogicalDay(a, b, 0), isTrue);
+      expect(DayBoundaryCalc.isSameLogicalDay(a, c, 0), isFalse);
+    });
+
+    test('offset 4: a 02:00 snack matches the prior evening meal', () {
+      // The exact scenario from #139 — a meal logged at 19:00 on Jan 14
+      // and a snack logged at 02:00 on Jan 15 are the same logical day
+      // under a 4-hour boundary.
+      final dinner = DateTime(2024, 1, 14, 19, 0);
+      final snack = DateTime(2024, 1, 15, 2, 0);
+      expect(DayBoundaryCalc.isSameLogicalDay(dinner, snack, 4), isTrue);
+    });
+
+    test('offset 4: an entry just after the boundary is a new day', () {
+      final lateLog = DateTime(2024, 1, 15, 3, 30);
+      final earlyLog = DateTime(2024, 1, 15, 5, 30);
+      expect(DayBoundaryCalc.isSameLogicalDay(lateLog, earlyLog, 4), isFalse);
+    });
+  });
+}

--- a/test/unit_test/day_boundary_calc_test.dart
+++ b/test/unit_test/day_boundary_calc_test.dart
@@ -141,4 +141,107 @@ void main() {
       expect(DayBoundaryCalc.isSameLogicalDay(lateLog, earlyLog, 4), isFalse);
     });
   });
+
+  group('DayBoundaryCalc.logicalDayOfMinutes (hour + minute companion)', () {
+    // #139 follow-up: shift workers on 04:30 / 03:45 want their day to
+    // actually start at that time. The total-minutes form lets the
+    // hours and minutes fields compose without losing precision.
+    test('4 hours + 0 minutes = 240 minutes total, same as offset-4 hours', () {
+      // The composition contract: a clean 4-hour boundary expressed as
+      // total minutes should resolve identically to the hour-only path.
+      final moment = DateTime(2024, 1, 15, 1, 0);
+      expect(
+        DayBoundaryCalc.logicalDayOfMinutes(moment, 4 * 60),
+        DayBoundaryCalc.logicalDayOf(moment, 4),
+      );
+      expect(
+        DayBoundaryCalc.logicalDayOfMinutes(moment, 240),
+        DateTime(2024, 1, 14),
+      );
+    });
+
+    test('4 hours + 30 minutes = 270 minutes, snack at 04:15 is yesterday', () {
+      // 04:30 is the new day, so 04:15 still belongs to the day before.
+      // This is the exact scenario the follow-up exists to support.
+      final snack = DateTime(2024, 1, 15, 4, 15);
+      expect(
+        DayBoundaryCalc.logicalDayOfMinutes(snack, 4 * 60 + 30),
+        DateTime(2024, 1, 14),
+      );
+      // One minute past the boundary lands in today.
+      final justAfter = DateTime(2024, 1, 15, 4, 31);
+      expect(
+        DayBoundaryCalc.logicalDayOfMinutes(justAfter, 4 * 60 + 30),
+        DateTime(2024, 1, 15),
+      );
+    });
+
+    test('0 hours + 15 minutes = 15 minutes, 00:10 rolls back', () {
+      // A small minute-only offset is unusual but supported — a 00:15
+      // boundary means anything before 00:15 is still yesterday.
+      final lateNight = DateTime(2024, 1, 15, 0, 10);
+      expect(
+        DayBoundaryCalc.logicalDayOfMinutes(lateNight, 15),
+        DateTime(2024, 1, 14),
+      );
+      final justAfter = DateTime(2024, 1, 15, 0, 20);
+      expect(
+        DayBoundaryCalc.logicalDayOfMinutes(justAfter, 15),
+        DateTime(2024, 1, 15),
+      );
+    });
+
+    test('total minutes out of range falls back to 0', () {
+      // Defensive: negative or ≥ 24h values are a sign of corruption,
+      // and we'd rather show wall-clock midnight than an impossible day.
+      final moment = DateTime(2024, 1, 15, 2, 0);
+      expect(
+        DayBoundaryCalc.logicalDayOfMinutes(moment, -1),
+        DateTime(2024, 1, 15),
+      );
+      expect(
+        DayBoundaryCalc.logicalDayOfMinutes(moment, 24 * 60),
+        DateTime(2024, 1, 15),
+      );
+      expect(
+        DayBoundaryCalc.logicalDayOfMinutes(moment, null),
+        DateTime(2024, 1, 15),
+      );
+    });
+
+    test('isSameLogicalDayMinutes: 04:30 boundary groups 04:00 with previous '
+        'evening', () {
+      // The use case from the follow-up review: a hospitality worker
+      // finishing at 04:00 wants that wind-down period filed with the
+      // shift's evening meal, not the new day.
+      final dinner = DateTime(2024, 1, 14, 21, 0);
+      final wrapUp = DateTime(2024, 1, 15, 4, 0);
+      expect(
+        DayBoundaryCalc.isSameLogicalDayMinutes(dinner, wrapUp, 4 * 60 + 30),
+        isTrue,
+      );
+    });
+  });
+
+  group('ConfigEntity-level clamping (via the minutes companion)', () {
+    // The actual clamping happens at the entity boundary, but the
+    // data-source code path also defends itself. This documents the
+    // expected behaviour at the call-site level: a stored 99-minute
+    // value should not be able to produce a > 23:59 total offset.
+    test('clamped minute=99 inside data-source path resolves as 59', () {
+      // The data sources apply `.clamp(0, 59)` to the minute parameter
+      // before composing the total. With hours=4 and minutes=99, the
+      // effective offset is 4*60 + 59 = 299 minutes, not 4*60 + 99.
+      const hours = 4;
+      const rawMinutes = 99;
+      final clampedTotal = hours * 60 + rawMinutes.clamp(0, 59);
+      expect(clampedTotal, 299);
+      // And 04:30 still rolls back to yesterday under this offset.
+      final moment = DateTime(2024, 1, 15, 4, 30);
+      expect(
+        DayBoundaryCalc.logicalDayOfMinutes(moment, clampedTotal),
+        DateTime(2024, 1, 14),
+      );
+    });
+  });
 }


### PR DESCRIPTION
Closes #139.

Adds a configurable diary day-start time in Settings (default still midnight) so users on shift work or different schedules can have late-evening entries roll back to the previous day's totals. Includes a Simple form mode for custom meals (which lets the user type macros for one serving directly without per-100 scaffolding) and the kJ display option, both pulled along from develop's adjacent work.

Synced with current `origin/develop` (Tier A + Tier B all merged). Slovak translations added for every new ARB key on this branch. `flutter analyze` clean; `just check_intl` clean.

## Test plan

- [ ] Build a debug APK on this branch, install, walk the affected flow on device
- [ ] Confirm existing features still behave as before (no regressions in the surrounding screens)
