### PR TITLE
fix(diary): remove redundant macro text row under the progress circles

### DIFF
--- a/lib/features/diary/presentation/widgets/day_info_widget.dart
+++ b/lib/features/diary/presentation/widgets/day_info_widget.dart
@@ -137,20 +137,6 @@ class DayInfoWidget extends StatelessWidget {
                           totalFatsGoal: trackedDay.fatGoal ?? 0.0,
                           totalProteinsGoal: trackedDay.proteinGoal ?? 0.0,
                         ),
-                        const SizedBox(height: 4.0),
-                        Text(
-                          _getMacroTrackedDisplayString(trackedDay),
-                          maxLines: 2,
-                          overflow: TextOverflow.ellipsis,
-                          style: Theme.of(context)
-                              .textTheme
-                              .bodyMedium
-                              ?.copyWith(
-                                color: Theme.of(
-                                  context,
-                                ).colorScheme.onSurface.withValues(alpha: 0.7),
-                              ),
-                        ),
                       ],
                     ),
                   )
@@ -261,21 +247,6 @@ class DayInfoWidget extends StatelessWidget {
     final actualKcal = _allIntakes.fold(0.0, (sum, i) => sum + i.totalKcal);
     final caloriesTracked = actualKcal < 0 ? 0 : actualKcal.toInt();
     return '$caloriesTracked/${trackedDay.calorieGoal.toInt()} kcal';
-  }
-
-  String _getMacroTrackedDisplayString(TrackedDayEntity trackedDay) {
-    final carbsTracked =
-        _allIntakes.fold(0.0, (sum, i) => sum + i.totalCarbsGram).floor();
-    final fatTracked =
-        _allIntakes.fold(0.0, (sum, i) => sum + i.totalFatsGram).floor();
-    final proteinTracked =
-        _allIntakes.fold(0.0, (sum, i) => sum + i.totalProteinsGram).floor();
-
-    final carbsGoal = trackedDay.carbsGoal?.floor().toString() ?? '?';
-    final fatGoal = trackedDay.fatGoal?.floor().toString() ?? '?';
-    final proteinGoal = trackedDay.proteinGoal?.floor().toString() ?? '?';
-
-    return 'Carbs: $carbsTracked/${carbsGoal}g, Fat: $fatTracked/${fatGoal}g, Protein: $proteinTracked/${proteinGoal}g';
   }
 
   void showCopyOrDeleteIntakeDialog(


### PR DESCRIPTION
Follow-up to [#397](https://github.com/simonoppowa/OpenNutriTracker/pull/397) (diary progress circles) and [#404](https://github.com/simonoppowa/OpenNutriTracker/pull/404) (daily nutrient panel).

After both of those landed on develop, the Diary day view ended up rendering carbs / fat / protein twice — once as the `MacroNutrientsView` rings (which #397 promoted to a shared widget and reused below the day's calorie summary), and once as a small `Carbs: X/Yg, Fat: …, Protein: …` text row immediately underneath. The two showed the same numbers in two visual idioms, which made the section feel busier than it is and quietly contradicted the at-a-glance reason for the circles in the first place.

This PR removes the redundant text row, along with the now-orphan `_getMacroTrackedDisplayString` helper that fed it. The circles stay (still the primary read), and the daily nutrient panel from #404 sits underneath them as it did before.

## Test plan

- [x] `flutter analyze` — clean
- [x] Open the Diary, tap a day with logged intake — confirm only one set of macro values is visible (the circles), and the text row beneath them is gone
- [x] Tested on Pixel 6 Pro / Android 16