### PR TITLE
feat(onboarding): capture target weight on the current-weight screen

### DIFF
--- a/lib/features/onboarding/domain/entity/user_data_mask_entity.dart
+++ b/lib/features/onboarding/domain/entity/user_data_mask_entity.dart
@@ -16,6 +16,12 @@ class UserDataMaskEntity {
   UserActivitySelectionEntity? activity;
   UserGoalSelectionEntity? goal;
 
+  /// Optional weight the user is working towards. Captured on the same
+  /// onboarding screen as the current weight so new users don't have to
+  /// dig into Profile after first-run to set it. Stored in kilograms
+  /// regardless of the display unit the user picked.
+  double? targetWeight;
+
   bool acceptDataCollection = false;
 
   bool usesImperialUnits = false;
@@ -28,6 +34,7 @@ class UserDataMaskEntity {
     this.weight,
     this.activity,
     this.goal,
+    this.targetWeight,
     this.acceptDataCollection = false,
     this.usesImperialUnits = false,
   });
@@ -108,6 +115,7 @@ class UserDataMaskEntity {
       pal: userPal,
       caloriesProfile:
           userGender == UserGenderEntity.nonBinary ? caloriesProfile : null,
+      targetWeightKg: targetWeight,
     );
   }
 }

--- a/lib/features/onboarding/onboarding_screen.dart
+++ b/lib/features/onboarding/onboarding_screen.dart
@@ -142,6 +142,7 @@ class _OnboardingScreenState extends State<OnboardingScreen> {
             setButtonContent: _setSecondPageData,
             initialHeightCm: selection.height,
             initialWeightKg: selection.weight,
+            initialTargetWeightKg: selection.targetWeight,
             initialUsesImperial: selection.usesImperialUnits,
           ),
           footer: HighlightButton(
@@ -243,11 +244,13 @@ class _OnboardingScreenState extends State<OnboardingScreen> {
     bool active,
     double? selectedHeight,
     double? selectedWeight,
+    double? selectedTargetWeight,
     bool usesImperial,
   ) {
     setState(() {
       _onboardingBloc.userSelection.height = selectedHeight;
       _onboardingBloc.userSelection.weight = selectedWeight;
+      _onboardingBloc.userSelection.targetWeight = selectedTargetWeight;
       _onboardingBloc.userSelection.usesImperialUnits = usesImperial;
 
       _secondPageButtonActive = active;

--- a/lib/features/onboarding/presentation/widgets/onboarding_second_page_body.dart
+++ b/lib/features/onboarding/presentation/widgets/onboarding_second_page_body.dart
@@ -9,6 +9,7 @@ class OnboardingSecondPageBody extends StatefulWidget {
     bool active,
     double? selectedHeight,
     double? selectedWeight,
+    double? selectedTargetWeight,
     bool usesImperialUnits,
   ) setButtonContent;
 
@@ -21,6 +22,11 @@ class OnboardingSecondPageBody extends StatefulWidget {
   /// userSelection model). The widget converts to pounds for display when
   /// [initialUsesImperial] is true.
   final double? initialWeightKg;
+
+  /// Optional already-stored target weight (#119) in kilograms — set when
+  /// the user has navigated back to this page after entering one. Same
+  /// metric/imperial convention as [initialWeightKg].
+  final double? initialTargetWeightKg;
   final bool initialUsesImperial;
 
   const OnboardingSecondPageBody({
@@ -28,6 +34,7 @@ class OnboardingSecondPageBody extends StatefulWidget {
     required this.setButtonContent,
     this.initialHeightCm,
     this.initialWeightKg,
+    this.initialTargetWeightKg,
     this.initialUsesImperial = false,
   });
 
@@ -39,16 +46,23 @@ class OnboardingSecondPageBody extends StatefulWidget {
 class _OnboardingSecondPageBodyState extends State<OnboardingSecondPageBody> {
   final _heightFormKey = GlobalKey<FormState>();
   final _weightFormKey = GlobalKey<FormState>();
+  final _targetWeightFormKey = GlobalKey<FormState>();
   final _heightFocusNode = FocusNode();
   final _weightFocusNode = FocusNode();
+  final _targetWeightFocusNode = FocusNode();
   final _heightController = TextEditingController();
   final _weightController = TextEditingController();
+  final _targetWeightController = TextEditingController();
   late final List<bool> _isUnitSelected = [
     !widget.initialUsesImperial,
     widget.initialUsesImperial,
   ];
   double? _parsedHeight;
   double? _parsedWeight;
+  // Target weight is optional. Null means "user hasn't set one"; the
+  // onboarding flow stays valid either way. Only populated when the
+  // input parses to a sensible kg value.
+  double? _parsedTargetWeight;
 
   bool get _isImperialSelected => _isUnitSelected[1];
 
@@ -77,6 +91,14 @@ class _OnboardingSecondPageBodyState extends State<OnboardingSecondPageBody> {
       _parsedWeight = initialWeightKg;
       _weightController.text = _formatRestoredNumber(displayWeight);
     }
+    final initialTargetWeightKg = widget.initialTargetWeightKg;
+    if (initialTargetWeightKg != null) {
+      final displayTarget = widget.initialUsesImperial
+          ? UnitCalc.kgToLbs(initialTargetWeightKg)
+          : initialTargetWeightKg;
+      _parsedTargetWeight = initialTargetWeightKg;
+      _targetWeightController.text = _formatRestoredNumber(displayTarget);
+    }
   }
 
   /// Trim a restored value to one decimal place when needed, and drop the
@@ -92,19 +114,26 @@ class _OnboardingSecondPageBodyState extends State<OnboardingSecondPageBody> {
   void dispose() {
     _heightFocusNode.dispose();
     _weightFocusNode.dispose();
+    _targetWeightFocusNode.dispose();
     _heightController.dispose();
     _weightController.dispose();
+    _targetWeightController.dispose();
     super.dispose();
   }
 
   @override
   Widget build(BuildContext context) {
-    return SizedBox(
-      width: double.infinity,
-      child: Column(
-        mainAxisAlignment: MainAxisAlignment.start,
-        crossAxisAlignment: CrossAxisAlignment.start,
-        children: [
+    // Wrapped in a SingleChildScrollView so the extra target-weight
+    // section (#119 follow-up) doesn't overflow on short screens or in
+    // the widget tests, which pump straight into a Scaffold body
+    // without any outer scrollable.
+    return SingleChildScrollView(
+      child: SizedBox(
+        width: double.infinity,
+        child: Column(
+          mainAxisAlignment: MainAxisAlignment.start,
+          crossAxisAlignment: CrossAxisAlignment.start,
+          children: [
           Text(
             S.of(context).heightLabel,
             style: Theme.of(context).textTheme.headlineSmall,
@@ -215,7 +244,7 @@ class _OnboardingSecondPageBodyState extends State<OnboardingSecondPageBody> {
                   }
                 },
                 onFieldSubmitted: (_) {
-                  FocusScope.of(context).unfocus();
+                  FocusScope.of(context).requestFocus(_targetWeightFocusNode);
                 },
                 validator: validateWeight,
                 decoration: InputDecoration(
@@ -252,6 +281,7 @@ class _OnboardingSecondPageBodyState extends State<OnboardingSecondPageBody> {
                     _isUnitSelected[i] = i == index;
                   }
                   _weightFormKey.currentState!.validate();
+                  _targetWeightFormKey.currentState?.validate();
                   checkCorrectInput();
                 });
               },
@@ -267,7 +297,70 @@ class _OnboardingSecondPageBodyState extends State<OnboardingSecondPageBody> {
               ],
             ),
           ),
-        ],
+          const SizedBox(height: 32.0),
+          // Target weight (#119) on the same screen as the current
+          // weight so a new user can set it once in onboarding instead
+          // of having to find Profile after first-run. Optional: leaving
+          // it blank keeps the user without a target and is valid.
+          Text(
+            S.of(context).profileTargetWeightLabel,
+            style: Theme.of(context).textTheme.headlineSmall,
+          ),
+          Text(
+            S.of(context).onboardingTargetWeightSubtitle,
+            style: Theme.of(context).textTheme.titleMedium,
+          ),
+          const SizedBox(height: 16.0),
+          Form(
+            key: _targetWeightFormKey,
+            child: Semantics(
+              identifier: 'onboarding-target-weight-field',
+              child: TextFormField(
+                controller: _targetWeightController,
+                focusNode: _targetWeightFocusNode,
+                onChanged: (text) {
+                  if (text.trim().isEmpty) {
+                    _parsedTargetWeight = null;
+                    checkCorrectInput();
+                    return;
+                  }
+                  if (_targetWeightFormKey.currentState!.validate()) {
+                    _parsedTargetWeight = ValueValidator.parseWeightInKg(
+                      double.tryParse(text.replaceAll(',', '.')),
+                      isImperial: _isImperialSelected,
+                    );
+                  } else {
+                    _parsedTargetWeight = null;
+                  }
+                  checkCorrectInput();
+                },
+                onFieldSubmitted: (_) {
+                  FocusScope.of(context).unfocus();
+                },
+                validator: validateOptionalTargetWeight,
+                decoration: InputDecoration(
+                  labelText: _isImperialSelected
+                      ? S.of(context).lbsLabel
+                      : S.of(context).kgLabel,
+                  hintText: S.of(context).onboardingTargetWeightHintOptional,
+                  filled: true,
+                  border: OutlineInputBorder(
+                    borderRadius: BorderRadius.circular(10),
+                  ),
+                ),
+                keyboardType:
+                    const TextInputType.numberWithOptions(decimal: true),
+                textInputAction: TextInputAction.done,
+                inputFormatters: [
+                  FilteringTextInputFormatter.allow(
+                    RegExp(r'^\d+([.,]\d{0,1})?$'),
+                  ),
+                ],
+              ),
+            ),
+          ),
+          ],
+        ),
       ),
     );
   }
@@ -296,14 +389,43 @@ class _OnboardingSecondPageBodyState extends State<OnboardingSecondPageBody> {
     return null;
   }
 
+  /// Target weight is opt-in, so an empty field is valid. When the user
+  /// has typed something we reuse the regular weight validator to keep
+  /// the bounds consistent.
+  String? validateOptionalTargetWeight(String? value) {
+    if (value == null || value.trim().isEmpty) return null;
+    return validateWeight(value);
+  }
+
   void checkCorrectInput() {
     final isHeightValid = _heightFormKey.currentState?.validate() ?? false;
     final isWeightValid = _weightFormKey.currentState?.validate() ?? false;
+    // Target weight is optional. Block proceed only when the user has
+    // typed something invalid; an empty field is fine.
+    final targetText = _targetWeightController.text.trim();
+    final isTargetValid = targetText.isEmpty ||
+        (_targetWeightFormKey.currentState?.validate() ?? false);
 
-    if (isHeightValid && isWeightValid && _parsedHeight != null && _parsedWeight != null) {
-      widget.setButtonContent(true, _parsedHeight, _parsedWeight, _isImperialSelected);
+    if (isHeightValid &&
+        isWeightValid &&
+        isTargetValid &&
+        _parsedHeight != null &&
+        _parsedWeight != null) {
+      widget.setButtonContent(
+        true,
+        _parsedHeight,
+        _parsedWeight,
+        _parsedTargetWeight,
+        _isImperialSelected,
+      );
     } else {
-      widget.setButtonContent(false, null, null, _isImperialSelected);
+      widget.setButtonContent(
+        false,
+        null,
+        null,
+        null,
+        _isImperialSelected,
+      );
     }
   }
 }

--- a/lib/generated/intl/messages_cs.dart
+++ b/lib/generated/intl/messages_cs.dart
@@ -456,6 +456,10 @@ class MessageLookup extends MessageLookupByLibrary {
             MessageLookupByLibrary.simpleMessage("např. 132"),
         "onboardingWeightQuestionSubtitle":
             MessageLookupByLibrary.simpleMessage("Jaká je Vaše hmotnost?"),
+        "onboardingTargetWeightSubtitle":
+            MessageLookupByLibrary.simpleMessage("Máš hmotnost, ke které směřuješ? Pole můžeš nechat prázdné nebo ho později změnit v Profilu."),
+        "onboardingTargetWeightHintOptional":
+            MessageLookupByLibrary.simpleMessage("Volitelné"),
         "onboardingWelcomeLabel":
             MessageLookupByLibrary.simpleMessage("Vítejte v"),
         "onboardingWrongHeightLabel":

--- a/lib/generated/intl/messages_de.dart
+++ b/lib/generated/intl/messages_de.dart
@@ -474,6 +474,11 @@ class MessageLookup extends MessageLookupByLibrary {
         "onboardingWeightQuestionSubtitle":
             MessageLookupByLibrary.simpleMessage(
                 "Wie viel wiegen Sie derzeit?"),
+        "onboardingTargetWeightSubtitle":
+            MessageLookupByLibrary.simpleMessage(
+                "Gibt es ein Gewicht, auf das du hinarbeitest? Du kannst das Feld leer lassen oder es später im Profil ändern."),
+        "onboardingTargetWeightHintOptional":
+            MessageLookupByLibrary.simpleMessage("Optional"),
         "onboardingWelcomeLabel":
             MessageLookupByLibrary.simpleMessage("Willkommen bei"),
         "onboardingWrongHeightLabel": MessageLookupByLibrary.simpleMessage(

--- a/lib/generated/intl/messages_en.dart
+++ b/lib/generated/intl/messages_en.dart
@@ -428,6 +428,10 @@ class MessageLookup extends MessageLookupByLibrary {
             MessageLookupByLibrary.simpleMessage("e.g. 132"),
         "onboardingWeightQuestionSubtitle":
             MessageLookupByLibrary.simpleMessage("Whats your current weight?"),
+        "onboardingTargetWeightSubtitle":
+            MessageLookupByLibrary.simpleMessage("Is there a weight you\'re working towards? You can leave this blank or change it later in Profile."),
+        "onboardingTargetWeightHintOptional":
+            MessageLookupByLibrary.simpleMessage("Optional"),
         "onboardingWelcomeLabel":
             MessageLookupByLibrary.simpleMessage("Welcome to"),
         "onboardingWrongHeightLabel":

--- a/lib/generated/intl/messages_it.dart
+++ b/lib/generated/intl/messages_it.dart
@@ -464,6 +464,10 @@ class MessageLookup extends MessageLookupByLibrary {
             MessageLookupByLibrary.simpleMessage("es. 132"),
         "onboardingWeightQuestionSubtitle":
             MessageLookupByLibrary.simpleMessage("Qual è il tuo peso attuale?"),
+        "onboardingTargetWeightSubtitle":
+            MessageLookupByLibrary.simpleMessage("C\'è un peso che vuoi raggiungere? Puoi lasciare vuoto o modificarlo più tardi dal Profilo."),
+        "onboardingTargetWeightHintOptional":
+            MessageLookupByLibrary.simpleMessage("Facoltativo"),
         "onboardingWelcomeLabel":
             MessageLookupByLibrary.simpleMessage("Benvenuto in"),
         "onboardingWrongHeightLabel": MessageLookupByLibrary.simpleMessage(

--- a/lib/generated/intl/messages_pl.dart
+++ b/lib/generated/intl/messages_pl.dart
@@ -465,6 +465,11 @@ class MessageLookup extends MessageLookupByLibrary {
         "onboardingWeightQuestionSubtitle":
             MessageLookupByLibrary.simpleMessage(
                 "Jaka jest Twoja aktualna waga?"),
+        "onboardingTargetWeightSubtitle":
+            MessageLookupByLibrary.simpleMessage(
+                "Czy masz wagę, do której dążysz? Możesz zostawić to pole puste lub zmienić je później w Profilu."),
+        "onboardingTargetWeightHintOptional":
+            MessageLookupByLibrary.simpleMessage("Opcjonalnie"),
         "onboardingWelcomeLabel":
             MessageLookupByLibrary.simpleMessage("Witaj w"),
         "onboardingWrongHeightLabel":

--- a/lib/generated/intl/messages_sk.dart
+++ b/lib/generated/intl/messages_sk.dart
@@ -457,6 +457,10 @@ class MessageLookup extends MessageLookupByLibrary {
             MessageLookupByLibrary.simpleMessage("napr. 132"),
         "onboardingWeightQuestionSubtitle":
             MessageLookupByLibrary.simpleMessage("Aká je vaša aktuálna hmotnosť?"),
+        "onboardingTargetWeightSubtitle":
+            MessageLookupByLibrary.simpleMessage("Máš hmotnosť, ku ktorej smeruješ? Pole môžeš nechať prázdne alebo ho neskôr zmeniť v Profile."),
+        "onboardingTargetWeightHintOptional":
+            MessageLookupByLibrary.simpleMessage("Voliteľné"),
         "onboardingWelcomeLabel":
             MessageLookupByLibrary.simpleMessage("Víta vás"),
         "onboardingWrongHeightLabel":

--- a/lib/generated/intl/messages_tr.dart
+++ b/lib/generated/intl/messages_tr.dart
@@ -462,6 +462,10 @@ class MessageLookup extends MessageLookupByLibrary {
             MessageLookupByLibrary.simpleMessage("ör. 132"),
         "onboardingWeightQuestionSubtitle":
             MessageLookupByLibrary.simpleMessage("Mevcut kilonuz nedir?"),
+        "onboardingTargetWeightSubtitle":
+            MessageLookupByLibrary.simpleMessage("Ulaşmak istediğin bir kilo var mı? Bu alanı boş bırakabilir veya daha sonra Profil\'den değiştirebilirsin."),
+        "onboardingTargetWeightHintOptional":
+            MessageLookupByLibrary.simpleMessage("İsteğe bağlı"),
         "onboardingWelcomeLabel":
             MessageLookupByLibrary.simpleMessage("Hoş geldiniz"),
         "onboardingWrongHeightLabel":

--- a/lib/generated/intl/messages_uk.dart
+++ b/lib/generated/intl/messages_uk.dart
@@ -462,6 +462,10 @@ class MessageLookup extends MessageLookupByLibrary {
             MessageLookupByLibrary.simpleMessage("наприклад, 132"),
         "onboardingWeightQuestionSubtitle":
             MessageLookupByLibrary.simpleMessage("Яка ваша поточна вага?"),
+        "onboardingTargetWeightSubtitle":
+            MessageLookupByLibrary.simpleMessage("Чи є вага, до якої ти прагнеш? Це поле можна залишити порожнім або змінити пізніше у Профілі."),
+        "onboardingTargetWeightHintOptional":
+            MessageLookupByLibrary.simpleMessage("Необов\'язково"),
         "onboardingWelcomeLabel":
             MessageLookupByLibrary.simpleMessage("Ласкаво просимо до"),
         "onboardingWrongHeightLabel":

--- a/lib/generated/intl/messages_zh.dart
+++ b/lib/generated/intl/messages_zh.dart
@@ -422,6 +422,10 @@ class MessageLookup extends MessageLookupByLibrary {
             MessageLookupByLibrary.simpleMessage("例如：132"),
         "onboardingWeightQuestionSubtitle":
             MessageLookupByLibrary.simpleMessage("您当前的体重是多少？"),
+        "onboardingTargetWeightSubtitle":
+            MessageLookupByLibrary.simpleMessage("你有想要达到的目标体重吗？可以留空，也可以稍后在“个人资料”中修改。"),
+        "onboardingTargetWeightHintOptional":
+            MessageLookupByLibrary.simpleMessage("可选"),
         "onboardingWelcomeLabel": MessageLookupByLibrary.simpleMessage("欢迎使用"),
         "onboardingWrongHeightLabel":
             MessageLookupByLibrary.simpleMessage("请输入正确的身高"),

--- a/lib/generated/l10n.dart
+++ b/lib/generated/l10n.dart
@@ -1090,6 +1090,26 @@ class S {
     );
   }
 
+  /// `Is there a weight you're working towards? You can leave this blank or change it later in Profile.`
+  String get onboardingTargetWeightSubtitle {
+    return Intl.message(
+      'Is there a weight you\'re working towards? You can leave this blank or change it later in Profile.',
+      name: 'onboardingTargetWeightSubtitle',
+      desc: '',
+      args: [],
+    );
+  }
+
+  /// `Optional`
+  String get onboardingTargetWeightHintOptional {
+    return Intl.message(
+      'Optional',
+      name: 'onboardingTargetWeightHintOptional',
+      desc: '',
+      args: [],
+    );
+  }
+
   /// `Enter correct height`
   String get onboardingWrongHeightLabel {
     return Intl.message(

--- a/lib/l10n/intl_cs.arb
+++ b/lib/l10n/intl_cs.arb
@@ -330,6 +330,8 @@
   "onboardingWeightExampleHintKg": "např. 60",
   "onboardingWeightExampleHintLbs": "např. 132",
   "onboardingWeightQuestionSubtitle": "Jaká je Vaše hmotnost?",
+  "onboardingTargetWeightSubtitle": "Máš hmotnost, ke které směřuješ? Pole můžeš nechat prázdné nebo ho později změnit v Profilu.",
+  "onboardingTargetWeightHintOptional": "Volitelné",
   "onboardingWelcomeLabel": "Vítejte v",
   "onboardingWrongHeightLabel": "Zadejte správnou výšku",
   "onboardingWrongWeightLabel": "Zadejte správnou hmotnost",

--- a/lib/l10n/intl_de.arb
+++ b/lib/l10n/intl_de.arb
@@ -361,6 +361,8 @@
   "onboardingWeightExampleHintKg": "z. B. 60",
   "onboardingWeightExampleHintLbs": "z. B. 132",
   "onboardingWeightQuestionSubtitle": "Wie viel wiegen Sie derzeit?",
+  "onboardingTargetWeightSubtitle": "Gibt es ein Gewicht, auf das du hinarbeitest? Du kannst das Feld leer lassen oder es später im Profil ändern.",
+  "onboardingTargetWeightHintOptional": "Optional",
   "onboardingWelcomeLabel": "Willkommen bei",
   "onboardingWrongHeightLabel": "Geben Sie eine korrekte Größe ein",
   "onboardingWrongWeightLabel": "Geben Sie ein korrekte Gewicht ein",

--- a/lib/l10n/intl_en.arb
+++ b/lib/l10n/intl_en.arb
@@ -371,6 +371,8 @@
   "onboardingWeightExampleHintKg": "e.g. 60",
   "onboardingWeightExampleHintLbs": "e.g. 132",
   "onboardingWeightQuestionSubtitle": "Whats your current weight?",
+  "onboardingTargetWeightSubtitle": "Is there a weight you're working towards? You can leave this blank or change it later in Profile.",
+  "onboardingTargetWeightHintOptional": "Optional",
   "onboardingWelcomeLabel": "Welcome to",
   "onboardingWrongHeightLabel": "Enter correct height",
   "onboardingWrongWeightLabel": "Enter correct weight",

--- a/lib/l10n/intl_it.arb
+++ b/lib/l10n/intl_it.arb
@@ -330,6 +330,8 @@
   "onboardingWeightExampleHintKg": "es. 60",
   "onboardingWeightExampleHintLbs": "es. 132",
   "onboardingWeightQuestionSubtitle": "Qual è il tuo peso attuale?",
+  "onboardingTargetWeightSubtitle": "C'è un peso che vuoi raggiungere? Puoi lasciare vuoto o modificarlo più tardi dal Profilo.",
+  "onboardingTargetWeightHintOptional": "Facoltativo",
   "onboardingWelcomeLabel": "Benvenuto in",
   "onboardingWrongHeightLabel": "Inserisci un'altezza corretta",
   "onboardingWrongWeightLabel": "Inserisci un peso corretto",

--- a/lib/l10n/intl_pl.arb
+++ b/lib/l10n/intl_pl.arb
@@ -330,6 +330,8 @@
   "onboardingWeightExampleHintKg": "np. 60",
   "onboardingWeightExampleHintLbs": "np. 132",
   "onboardingWeightQuestionSubtitle": "Jaka jest Twoja aktualna waga?",
+  "onboardingTargetWeightSubtitle": "Czy masz wagę, do której dążysz? Możesz zostawić to pole puste lub zmienić je później w Profilu.",
+  "onboardingTargetWeightHintOptional": "Opcjonalnie",
   "onboardingWelcomeLabel": "Witaj w",
   "onboardingWrongHeightLabel": "Wprowadź poprawny wzrost",
   "onboardingWrongWeightLabel": "Wprowadź poprawną wagę",

--- a/lib/l10n/intl_sk.arb
+++ b/lib/l10n/intl_sk.arb
@@ -370,6 +370,8 @@
   "onboardingWeightExampleHintKg": "napr. 60",
   "onboardingWeightExampleHintLbs": "napr. 132",
   "onboardingWeightQuestionSubtitle": "Aká je vaša aktuálna hmotnosť?",
+  "onboardingTargetWeightSubtitle": "Máš hmotnosť, ku ktorej smeruješ? Pole môžeš nechať prázdne alebo ho neskôr zmeniť v Profile.",
+  "onboardingTargetWeightHintOptional": "Voliteľné",
   "onboardingWelcomeLabel": "Víta vás",
   "onboardingWrongHeightLabel": "Zadajte správnu výšku",
   "onboardingWrongWeightLabel": "Zadajte správnu hmotnosť",

--- a/lib/l10n/intl_tr.arb
+++ b/lib/l10n/intl_tr.arb
@@ -361,6 +361,8 @@
   "onboardingWeightExampleHintKg": "ör. 60",
   "onboardingWeightExampleHintLbs": "ör. 132",
   "onboardingWeightQuestionSubtitle": "Mevcut kilonuz nedir?",
+  "onboardingTargetWeightSubtitle": "Ulaşmak istediğin bir kilo var mı? Bu alanı boş bırakabilir veya daha sonra Profil'den değiştirebilirsin.",
+  "onboardingTargetWeightHintOptional": "İsteğe bağlı",
   "onboardingWelcomeLabel": "Hoş geldiniz",
   "onboardingWrongHeightLabel": "Doğru boy girin",
   "onboardingWrongWeightLabel": "Doğru kilo girin",

--- a/lib/l10n/intl_uk.arb
+++ b/lib/l10n/intl_uk.arb
@@ -330,6 +330,8 @@
   "onboardingWeightExampleHintKg": "наприклад, 60",
   "onboardingWeightExampleHintLbs": "наприклад, 132",
   "onboardingWeightQuestionSubtitle": "Яка ваша поточна вага?",
+  "onboardingTargetWeightSubtitle": "Чи є вага, до якої ти прагнеш? Це поле можна залишити порожнім або змінити пізніше у Профілі.",
+  "onboardingTargetWeightHintOptional": "Необов'язково",
   "onboardingWelcomeLabel": "Ласкаво просимо до",
   "onboardingWrongHeightLabel": "Введіть коректний зріст",
   "onboardingWrongWeightLabel": "Введіть коректну вагу",

--- a/lib/l10n/intl_zh.arb
+++ b/lib/l10n/intl_zh.arb
@@ -331,6 +331,8 @@
   "onboardingWeightExampleHintKg": "例如：60",
   "onboardingWeightExampleHintLbs": "例如：132",
   "onboardingWeightQuestionSubtitle": "您当前的体重是多少？",
+  "onboardingTargetWeightSubtitle": "你有想要达到的目标体重吗？可以留空，也可以稍后在“个人资料”中修改。",
+  "onboardingTargetWeightHintOptional": "可选",
   "onboardingWelcomeLabel": "欢迎使用",
   "onboardingWrongHeightLabel": "请输入正确的身高",
   "onboardingWrongWeightLabel": "请输入正确的体重",

--- a/test/features/onboarding/presentation/widgets/onboarding_second_page_body_test.dart
+++ b/test/features/onboarding/presentation/widgets/onboarding_second_page_body_test.dart
@@ -11,7 +11,7 @@ void main() {
       ],
       home: Scaffold(
         body: OnboardingSecondPageBody(
-          setButtonContent: (_, _, _, _) {},
+          setButtonContent: (_, _, _, _, _) {},
         ),
       ),
     ));
@@ -31,7 +31,7 @@ void main() {
       ],
       home: Scaffold(
         body: OnboardingSecondPageBody(
-          setButtonContent: (_, _, _, _) {},
+          setButtonContent: (_, _, _, _, _) {},
         ),
       ),
     ));
@@ -62,7 +62,7 @@ void main() {
       ],
       home: Scaffold(
         body: OnboardingSecondPageBody(
-          setButtonContent: (_, _, _, _) {},
+          setButtonContent: (_, _, _, _, _) {},
         ),
       ),
     ));
@@ -93,7 +93,7 @@ void main() {
       ],
       home: Scaffold(
         body: OnboardingSecondPageBody(
-          setButtonContent: (_, _, _, _) {},
+          setButtonContent: (_, _, _, _, _) {},
         ),
       ),
     ));
@@ -127,7 +127,7 @@ void main() {
       ],
       home: Scaffold(
         body: OnboardingSecondPageBody(
-          setButtonContent: (_, _, _, _) {},
+          setButtonContent: (_, _, _, _, _) {},
         ),
       ),
     ));
@@ -158,7 +158,7 @@ void main() {
       ],
       home: Scaffold(
         body: OnboardingSecondPageBody(
-          setButtonContent: (_, _, _, _) {},
+          setButtonContent: (_, _, _, _, _) {},
         ),
       ),
     ));
@@ -174,7 +174,7 @@ void main() {
     await tester.enterText(heightField, '6.7');
     await tester.pump();
 
-    final weightField = find.byType(TextFormField).last;
+    final weightField = find.byType(TextFormField).at(1);
     await tester.enterText(weightField, '150');
     await tester.pump();
 
@@ -194,7 +194,7 @@ void main() {
       ],
       home: Scaffold(
         body: OnboardingSecondPageBody(
-          setButtonContent: (_, _, _, _) {},
+          setButtonContent: (_, _, _, _, _) {},
         ),
       ),
     ));
@@ -210,7 +210,7 @@ void main() {
     await tester.enterText(heightField, '6.7');
     await tester.pump();
 
-    final weightField = find.byType(TextFormField).last;
+    final weightField = find.byType(TextFormField).at(1);
     await tester.enterText(weightField, '150');
     await tester.pump();
 
@@ -233,16 +233,16 @@ void main() {
       localizationsDelegates: const [S.delegate],
       home: Scaffold(
         body: OnboardingSecondPageBody(
-          setButtonContent: (_, _, _, _) {},
+          setButtonContent: (_, _, _, _, _) {},
         ),
       ),
     ));
 
-    final weightField = find.byType(TextFormField).last;
+    final weightField = find.byType(TextFormField).at(1);
     await tester.enterText(weightField, '65.5');
     await tester.pump();
 
-    final weightForm = find.byType(Form).last;
+    final weightForm = find.byType(Form).at(1);
     final isValid = tester.state<FormState>(weightForm).validate();
     await tester.pump();
 
@@ -259,16 +259,16 @@ void main() {
       localizationsDelegates: const [S.delegate],
       home: Scaffold(
         body: OnboardingSecondPageBody(
-          setButtonContent: (_, _, _, _) {},
+          setButtonContent: (_, _, _, _, _) {},
         ),
       ),
     ));
 
-    final weightField = find.byType(TextFormField).last;
+    final weightField = find.byType(TextFormField).at(1);
     await tester.enterText(weightField, '65,5');
     await tester.pump();
 
-    final weightForm = find.byType(Form).last;
+    final weightForm = find.byType(Form).at(1);
     final isValid = tester.state<FormState>(weightForm).validate();
     await tester.pump();
 
@@ -283,16 +283,16 @@ void main() {
       localizationsDelegates: const [S.delegate],
       home: Scaffold(
         body: OnboardingSecondPageBody(
-          setButtonContent: (_, _, _, _) {},
+          setButtonContent: (_, _, _, _, _) {},
         ),
       ),
     ));
 
-    final weightField = find.byType(TextFormField).last;
+    final weightField = find.byType(TextFormField).at(1);
     await tester.enterText(weightField, '0');
     await tester.pump();
 
-    final weightForm = find.byType(Form).last;
+    final weightForm = find.byType(Form).at(1);
     tester.state<FormState>(weightForm).validate();
     await tester.pump();
 

--- a/test/features/onboarding/presentation/widgets/onboarding_state_restoration_test.dart
+++ b/test/features/onboarding/presentation/widgets/onboarding_state_restoration_test.dart
@@ -83,7 +83,7 @@ void main() {
     testWidgets('metric: shows the stored cm/kg values in the text fields',
         (tester) async {
       await tester.pumpWidget(wrap(OnboardingSecondPageBody(
-        setButtonContent: (_, _, _, _) {},
+        setButtonContent: (_, _, _, _, _) {},
         initialHeightCm: 178,
         initialWeightKg: 72.5,
       )));
@@ -96,7 +96,7 @@ void main() {
     testWidgets('imperial: stored cm/kg are converted to ft/lbs for display',
         (tester) async {
       await tester.pumpWidget(wrap(OnboardingSecondPageBody(
-        setButtonContent: (_, _, _, _) {},
+        setButtonContent: (_, _, _, _, _) {},
         initialHeightCm: 180,
         initialWeightKg: 80,
         initialUsesImperial: true,
@@ -180,7 +180,7 @@ void main() {
     testWidgets('second page: text fields empty when no initial values given',
         (tester) async {
       await tester.pumpWidget(wrap(OnboardingSecondPageBody(
-        setButtonContent: (_, _, _, _) {},
+        setButtonContent: (_, _, _, _, _) {},
       )));
       await tester.pumpAndSettle();
 

--- a/tools/adb/walk-onboarding.sh
+++ b/tools/adb/walk-onboarding.sh
@@ -36,10 +36,18 @@ walk_onboarding() {
   _tap_text 'OK' || _tap_text 'Ok' || _tap_text 'ok' || return 1; sleep 0.8
   tap_id 'onboarding-button' || return 1; sleep 1
 
-  echo "  page 2 — height + weight"
+  echo "  page 2 — height + weight + optional target weight"
   wait_for_id 'onboarding-height-field' 10 || return 1
   enter_text_at 'onboarding-height-field' '170' || return 1; sleep 0.3
   enter_text_at 'onboarding-weight-field' '65'  || return 1; sleep 0.3
+  press_back; sleep 0.5  # dismiss keyboard before scrolling
+  # Target weight (#119) sits below the fold on shorter devices because
+  # the page now scrolls. Swipe the content up so the field is visible
+  # before tapping into it. The walker types an example value so the
+  # verifier exercises the full happy path; leaving the field blank is
+  # also a valid path through onboarding.
+  adb -s "$DEVICE" shell input swipe 540 1600 540 800 300; sleep 0.4
+  enter_text_at 'onboarding-target-weight-field' '63' || return 1; sleep 0.3
   press_back; sleep 0.5  # dismiss keyboard so NEXT button is reachable
   tap_id 'onboarding-button' || return 1; sleep 1
 


### PR DESCRIPTION
Builds on #406 (target weight) and #400 (weight history). The target weight field is now offered during onboarding, on the same screen where the user enters their current weight, so a new user doesn't have to discover the Profile setting after first-run to set one.

## What changed

- **Onboarding page 2** grows an optional target-weight section below the existing current-weight section. Same kg/lbs unit toggle, same input validation reused as `validateOptionalTargetWeight` (empty is valid; non-empty must parse as a weight). Leaving the field blank is a valid path — the user proceeds without a target, matching the Profile-side behaviour.
- **UserDataMaskEntity** carries the new `targetWeight` field through onboarding and writes it onto `UserEntity.targetWeightKg` in `toUserEntity()`.
- **Scroll wrapper.** The page body now sits inside a `SingleChildScrollView` so the extra row doesn't overflow on shorter screens or inside the widget tests, which pump straight into a bare Scaffold body.
- **ADB walker** (`tools/adb/walk-onboarding.sh`) swipes the page up before tapping the target field so the verifier can reach it on devices where it ends up below the fold. The walker fills the field with an example value (63) so the happy path is exercised end-to-end on every branch run.
- **Localisation.** `onboardingTargetWeightSubtitle` ("Is there a weight you're working towards? You can leave this blank or change it later in Profile.") and `onboardingTargetWeightHintOptional` ("Optional") added across all eight locale ARBs plus the matching `messages_*.dart` entries and `l10n.dart` getters. The existing `profileTargetWeightLabel` is reused as the section heading so the language stays consistent with Profile.

`flutter analyze` clean; `flutter test` all green (existing onboarding widget tests updated for the new 5-arg `setButtonContent` signature). Walked end-to-end on a Pixel 6 Pro via `tools/adb/walk-onboarding.sh`.

## Test plan

- [x] Build a debug APK, install, walk onboarding
- [x] Page 2: confirm the target-weight section appears below the current-weight section, with the same kg/lbs unit toggle
- [x] Leave target blank → NEXT remains enabled, complete onboarding, confirm Profile → Target weight reads "Not set"
- [x] Set a target weight → complete onboarding, confirm Profile → Target weight shows the value
- [x] Toggle to imperial mid-flow → both weight and target switch unit, both parse back to kg correctly
- [x] Navigate back from page 3 to page 2 → previously entered target value is restored