### PR TITLE
ci: drop per-job timeout-minutes from default workflow

### DIFF
--- a/.github/workflows/default_workflow.yml
+++ b/.github/workflows/default_workflow.yml
@@ -20,7 +20,6 @@ on:
 jobs:
   linux-checks:
     runs-on: ubuntu-latest
-    timeout-minutes: 30
     permissions:
       contents: read
     steps:
@@ -100,7 +99,6 @@ jobs:
   # otherwise the macOS minutes aren't worth burning.
   ios-podfile-lock-guard:
     runs-on: macos-latest
-    timeout-minutes: 20
     if: github.event_name == 'pull_request'
     permissions:
       contents: read
@@ -174,7 +172,6 @@ jobs:
 
   ios-build:
     runs-on: macos-latest
-    timeout-minutes: 45
     permissions:
       contents: write
     steps:
@@ -263,7 +260,6 @@ jobs:
 
   ios-integration-tests:
     runs-on: macos-latest
-    timeout-minutes: 45
     permissions:
       contents: read
     steps:
@@ -334,7 +330,6 @@ jobs:
 
   android-build:
     runs-on: ubuntu-latest
-    timeout-minutes: 30
     permissions:
       contents: read
     steps:
@@ -395,7 +390,6 @@ jobs:
 
   android-integration-tests:
     runs-on: ubuntu-latest
-    timeout-minutes: 60
     permissions:
       contents: read
     steps:


### PR DESCRIPTION
## What changed

Removed the explicit `timeout-minutes` entries from every job in `.github/workflows/default_workflow.yml`:

| Job | Was |
|---|---|
| linux-checks | 30 min |
| ios-podfile-lock-guard | 20 min |
| ios-build | 45 min |
| ios-integration-tests | 45 min |
| android-build | 30 min |
| final ubuntu job | 60 min |

## Why

The GitHub-hosted runners we use are modest, and runs that were genuinely going to finish have sometimes brushed up against these per-job caps and been marked as failures. Without the explicit setting, jobs fall back to GitHub Actions' default six-hour ceiling — that is plenty of room for a slow run while keeping the runaway-job safety net in place.

## Test plan

- [ ] Workflow re-runs without timing out on the affected jobs
- [ ] No other behaviour changes (only the `timeout-minutes:` lines were removed)