### PR TITLE
feat(water): add a water tracker to home and profile (#32)

### DIFF
--- a/lib/core/data/data_source/config_data_source.dart
+++ b/lib/core/data/data_source/config_data_source.dart
@@ -226,6 +226,13 @@ class ConfigDataSource {
     await config?.save();
   }
 
+  Future<void> setConfigDailyWaterGoalMl(int goalMl) async {
+    _log.fine('Updating config dailyWaterGoalMl to $goalMl');
+    final config = _configBox.get(_configKey);
+    config?.dailyWaterGoalMl = goalMl;
+    await config?.save();
+  }
+
   Future<ConfigDBO> getConfig() async {
     return _configBox.get(_configKey) ?? ConfigDBO.empty();
   }

--- a/lib/core/data/data_source/water_intake_data_source.dart
+++ b/lib/core/data/data_source/water_intake_data_source.dart
@@ -1,0 +1,51 @@
+import 'package:hive_ce_flutter/hive_flutter.dart';
+import 'package:logging/logging.dart';
+import 'package:opennutritracker/core/data/dbo/water_intake_dbo.dart';
+
+/// Stores water intake entries — one row per sip. We hold every entry rather
+/// than coalescing to a daily total so the "undo last" affordance can roll a
+/// single mistap back without throwing away the rest of the day's log, and
+/// so a future "graph of hydration through the day" view is cheap to add.
+class WaterIntakeDataSource {
+  final log = Logger('WaterIntakeDataSource');
+  final Box<WaterIntakeDBO> _waterIntakeBox;
+
+  WaterIntakeDataSource(this._waterIntakeBox);
+
+  Future<void> addEntry(WaterIntakeDBO entry) async {
+    log.fine('Adding water intake ${entry.amountMl} ml at ${entry.dateTime}');
+    await _waterIntakeBox.put(entry.id, entry);
+  }
+
+  Future<void> addAllEntries(List<WaterIntakeDBO> entries) async {
+    log.fine('Adding ${entries.length} water intake entries');
+    await _waterIntakeBox.putAll({
+      for (final entry in entries) entry.id: entry,
+    });
+  }
+
+  Future<List<WaterIntakeDBO>> allEntries() async {
+    return _waterIntakeBox.values.toList();
+  }
+
+  Future<List<WaterIntakeDBO>> entriesInRange(
+    DateTime from,
+    DateTime to,
+  ) async {
+    return _waterIntakeBox.values
+        .where(
+          (entry) =>
+              !entry.dateTime.isBefore(from) && entry.dateTime.isBefore(to),
+        )
+        .toList();
+  }
+
+  Future<WaterIntakeDBO?> getEntry(String id) async {
+    return _waterIntakeBox.get(id);
+  }
+
+  Future<void> deleteEntry(String id) async {
+    log.fine('Deleting water intake entry $id');
+    await _waterIntakeBox.delete(id);
+  }
+}

--- a/lib/core/data/dbo/config_dbo.dart
+++ b/lib/core/data/dbo/config_dbo.dart
@@ -70,6 +70,11 @@ class ConfigDBO extends HiveObject {
   // value see a 4:00 boundary, unchanged.
   @HiveField(23)
   int? dayStartOffsetMinutes;
+  // #32: configurable daily water goal in millilitres. Null means use the
+  // default (2000 ml), so existing configs without a stored value keep
+  // working without a migration.
+  @HiveField(24)
+  int? dailyWaterGoalMl;
 
   ConfigDBO(
     this.hasAcceptedDisclaimer,
@@ -92,18 +97,19 @@ class ConfigDBO extends HiveObject {
     this.diarySortPreferences,
     this.nutrientPanelVisibility,
     this.dayStartOffsetMinutes,
+    this.dailyWaterGoalMl,
   });
 
   factory ConfigDBO.empty() =>
       ConfigDBO(false, false, false, AppThemeDBO.system);
 
   factory ConfigDBO.fromConfigEntity(ConfigEntity entity) => ConfigDBO(
-        entity.hasAcceptedDisclaimer,
-        entity.hasAcceptedPolicy,
-        entity.hasAcceptedSendAnonymousData,
-        AppThemeDBO.fromAppThemeEntity(entity.appTheme),
-        usesImperialUnits: entity.usesImperialUnits,
-      );
+    entity.hasAcceptedDisclaimer,
+    entity.hasAcceptedPolicy,
+    entity.hasAcceptedSendAnonymousData,
+    AppThemeDBO.fromAppThemeEntity(entity.appTheme),
+    usesImperialUnits: entity.usesImperialUnits,
+  );
 
   factory ConfigDBO.fromJson(Map<String, dynamic> json) =>
       _$ConfigDBOFromJson(json);

--- a/lib/core/data/dbo/config_dbo.g.dart
+++ b/lib/core/data/dbo/config_dbo.g.dart
@@ -37,6 +37,7 @@ class ConfigDBOAdapter extends TypeAdapter<ConfigDBO> {
         diarySortPreferences: (fields[21] as Map?)?.cast<String, int>(),
         nutrientPanelVisibility: (fields[22] as Map?)?.cast<String, bool>(),
         dayStartOffsetMinutes: (fields[23] as num?)?.toInt(),
+        dailyWaterGoalMl: (fields[24] as num?)?.toInt(),
       )
       ..userCarbGoalPct = (fields[6] as num?)?.toDouble()
       ..userProteinGoalPct = (fields[7] as num?)?.toDouble()
@@ -46,7 +47,7 @@ class ConfigDBOAdapter extends TypeAdapter<ConfigDBO> {
   @override
   void write(BinaryWriter writer, ConfigDBO obj) {
     writer
-      ..writeByte(23)
+      ..writeByte(24)
       ..writeByte(0)
       ..write(obj.hasAcceptedDisclaimer)
       ..writeByte(1)
@@ -92,7 +93,9 @@ class ConfigDBOAdapter extends TypeAdapter<ConfigDBO> {
       ..writeByte(22)
       ..write(obj.nutrientPanelVisibility)
       ..writeByte(23)
-      ..write(obj.dayStartOffsetMinutes);
+      ..write(obj.dayStartOffsetMinutes)
+      ..writeByte(24)
+      ..write(obj.dailyWaterGoalMl);
   }
 
   @override
@@ -139,6 +142,7 @@ ConfigDBO _$ConfigDBOFromJson(Map<String, dynamic> json) =>
               (k, e) => MapEntry(k, e as bool),
             ),
         dayStartOffsetMinutes: (json['dayStartOffsetMinutes'] as num?)?.toInt(),
+        dailyWaterGoalMl: (json['dailyWaterGoalMl'] as num?)?.toInt(),
       )
       ..userCarbGoalPct = (json['userCarbGoalPct'] as num?)?.toDouble()
       ..userProteinGoalPct = (json['userProteinGoalPct'] as num?)?.toDouble()
@@ -168,6 +172,7 @@ Map<String, dynamic> _$ConfigDBOToJson(ConfigDBO instance) => <String, dynamic>{
   'nutrientPanelVisibility': instance.nutrientPanelVisibility,
   'diarySortPreferences': instance.diarySortPreferences,
   'dayStartOffsetMinutes': instance.dayStartOffsetMinutes,
+  'dailyWaterGoalMl': instance.dailyWaterGoalMl,
 };
 
 const _$AppThemeDBOEnumMap = {

--- a/lib/core/data/dbo/water_intake_dbo.dart
+++ b/lib/core/data/dbo/water_intake_dbo.dart
@@ -1,0 +1,35 @@
+import 'package:hive_ce_flutter/hive_flutter.dart';
+import 'package:json_annotation/json_annotation.dart';
+import 'package:opennutritracker/core/domain/entity/water_intake_entity.dart';
+
+part 'water_intake_dbo.g.dart';
+
+@HiveType(typeId: 19)
+@JsonSerializable()
+class WaterIntakeDBO extends HiveObject {
+  @HiveField(0)
+  String id;
+  @HiveField(1)
+  DateTime dateTime;
+  @HiveField(2)
+  int amountMl;
+
+  WaterIntakeDBO({
+    required this.id,
+    required this.dateTime,
+    required this.amountMl,
+  });
+
+  factory WaterIntakeDBO.fromWaterIntakeEntity(WaterIntakeEntity entity) {
+    return WaterIntakeDBO(
+      id: entity.id,
+      dateTime: entity.dateTime,
+      amountMl: entity.amountMl,
+    );
+  }
+
+  factory WaterIntakeDBO.fromJson(Map<String, dynamic> json) =>
+      _$WaterIntakeDBOFromJson(json);
+
+  Map<String, dynamic> toJson() => _$WaterIntakeDBOToJson(this);
+}

--- a/lib/core/data/dbo/water_intake_dbo.g.dart
+++ b/lib/core/data/dbo/water_intake_dbo.g.dart
@@ -1,0 +1,65 @@
+// GENERATED CODE - DO NOT MODIFY BY HAND
+
+part of 'water_intake_dbo.dart';
+
+// **************************************************************************
+// TypeAdapterGenerator
+// **************************************************************************
+
+class WaterIntakeDBOAdapter extends TypeAdapter<WaterIntakeDBO> {
+  @override
+  final typeId = 19;
+
+  @override
+  WaterIntakeDBO read(BinaryReader reader) {
+    final numOfFields = reader.readByte();
+    final fields = <int, dynamic>{
+      for (int i = 0; i < numOfFields; i++) reader.readByte(): reader.read(),
+    };
+    return WaterIntakeDBO(
+      id: fields[0] as String,
+      dateTime: fields[1] as DateTime,
+      amountMl: (fields[2] as num).toInt(),
+    );
+  }
+
+  @override
+  void write(BinaryWriter writer, WaterIntakeDBO obj) {
+    writer
+      ..writeByte(3)
+      ..writeByte(0)
+      ..write(obj.id)
+      ..writeByte(1)
+      ..write(obj.dateTime)
+      ..writeByte(2)
+      ..write(obj.amountMl);
+  }
+
+  @override
+  int get hashCode => typeId.hashCode;
+
+  @override
+  bool operator ==(Object other) =>
+      identical(this, other) ||
+      other is WaterIntakeDBOAdapter &&
+          runtimeType == other.runtimeType &&
+          typeId == other.typeId;
+}
+
+// **************************************************************************
+// JsonSerializableGenerator
+// **************************************************************************
+
+WaterIntakeDBO _$WaterIntakeDBOFromJson(Map<String, dynamic> json) =>
+    WaterIntakeDBO(
+      id: json['id'] as String,
+      dateTime: DateTime.parse(json['dateTime'] as String),
+      amountMl: (json['amountMl'] as num).toInt(),
+    );
+
+Map<String, dynamic> _$WaterIntakeDBOToJson(WaterIntakeDBO instance) =>
+    <String, dynamic>{
+      'id': instance.id,
+      'dateTime': instance.dateTime.toIso8601String(),
+      'amountMl': instance.amountMl,
+    };

--- a/lib/core/data/repository/config_repository.dart
+++ b/lib/core/data/repository/config_repository.dart
@@ -134,4 +134,8 @@ class ConfigRepository {
   Future<void> setConfigDayStartOffsetMinutes(int minutes) async {
     await _configDataSource.setConfigDayStartOffsetMinutes(minutes);
   }
+
+  Future<void> setConfigDailyWaterGoalMl(int goalMl) async {
+    await _configDataSource.setConfigDailyWaterGoalMl(goalMl);
+  }
 }

--- a/lib/core/data/repository/water_intake_repository.dart
+++ b/lib/core/data/repository/water_intake_repository.dart
@@ -1,0 +1,40 @@
+import 'package:opennutritracker/core/data/data_source/water_intake_data_source.dart';
+import 'package:opennutritracker/core/data/dbo/water_intake_dbo.dart';
+import 'package:opennutritracker/core/domain/entity/water_intake_entity.dart';
+
+class WaterIntakeRepository {
+  final WaterIntakeDataSource _waterIntakeDataSource;
+
+  WaterIntakeRepository(this._waterIntakeDataSource);
+
+  Future<void> addEntry(WaterIntakeEntity entry) async {
+    await _waterIntakeDataSource.addEntry(
+      WaterIntakeDBO.fromWaterIntakeEntity(entry),
+    );
+  }
+
+  Future<void> addAllEntries(List<WaterIntakeDBO> entries) async {
+    await _waterIntakeDataSource.addAllEntries(entries);
+  }
+
+  Future<List<WaterIntakeEntity>> getAllEntries() async {
+    final dbos = await _waterIntakeDataSource.allEntries();
+    return dbos.map(WaterIntakeEntity.fromWaterIntakeDBO).toList();
+  }
+
+  Future<List<WaterIntakeDBO>> getAllEntriesDBO() async {
+    return _waterIntakeDataSource.allEntries();
+  }
+
+  Future<List<WaterIntakeEntity>> getEntriesInRange(
+    DateTime from,
+    DateTime to,
+  ) async {
+    final dbos = await _waterIntakeDataSource.entriesInRange(from, to);
+    return dbos.map(WaterIntakeEntity.fromWaterIntakeDBO).toList();
+  }
+
+  Future<void> deleteEntry(String id) async {
+    await _waterIntakeDataSource.deleteEntry(id);
+  }
+}

--- a/lib/core/domain/entity/config_entity.dart
+++ b/lib/core/domain/entity/config_entity.dart
@@ -1,6 +1,8 @@
 import 'package:equatable/equatable.dart';
 import 'package:opennutritracker/core/data/dbo/config_dbo.dart';
 import 'package:opennutritracker/core/domain/entity/app_theme_entity.dart';
+import 'package:opennutritracker/core/domain/entity/calories_profile_entity.dart';
+import 'package:opennutritracker/core/domain/entity/user_gender_entity.dart';
 
 class ConfigEntity extends Equatable {
   // #150: keys for the per-meal kcal share map. Kept as plain strings rather
@@ -47,7 +49,51 @@ class ConfigEntity extends Equatable {
   // nutrient — see [isNutrientVisible].
   final Map<String, bool> nutrientPanelVisibility;
   final int dayStartOffsetHours; // #139: 0-23, default 0 (wall-clock midnight)
-  final int dayStartOffsetMinutes; // #139 follow-up: 0-59, composes additively with hours
+  final int
+  dayStartOffsetMinutes; // #139 follow-up: 0-59, composes additively with hours
+  // #32: nullable so "I haven't picked yet" can fall back to a
+  // gendered default at read time. Once the user has touched the
+  // setting, their override is persisted and survives a profile edit.
+  final int? dailyWaterGoalMl;
+
+  /// Default daily water goal in millilitres for the home chip when the
+  /// user has not picked one yet.
+  ///
+  /// The popular "8 × 8 oz = 2 L of plain water" target has no
+  /// scientific basis — Valtin (2002, AJP-Reg) traced it to a misreading
+  /// of a 1945 US Food and Nutrition Board note that explicitly said
+  /// "most of this quantity is contained in prepared foods". No major
+  /// guideline body recommends a single "2 L of plain water" figure
+  /// today.
+  ///
+  /// Picking 1500 ml lands inside the NHS Eatwell Guide's "6 to 8 cups
+  /// or glasses of fluid a day" (≈ 1.2–1.5 L of drinks of any kind)
+  /// and is consistent with the EFSA 2010 Adequate Intake of 2.0 L/day
+  /// total water for women / 2.5 L/day for men once the ~20% EFSA
+  /// attributes to food moisture is subtracted. The user can adjust it
+  /// from 100 to 10000 ml in Settings → Calculations whenever a
+  /// different target fits their own activity level, climate, or
+  /// clinical advice.
+  ///
+  /// Sources:
+  ///   * NHS, "Water, drinks and your health" —
+  ///     https://www.nhs.uk/live-well/eat-well/food-guidelines-and-food-labels/water-drinks-nutrition/
+  ///   * EFSA NDA Panel, "Scientific Opinion on Dietary Reference
+  ///     Values for water", EFSA Journal 2010;8(3):1459.
+  ///   * Valtin H., "Drink at least eight glasses of water a day.
+  ///     Really?", AJP-Reg 2002;283(5):R993–R1004.
+  static const int defaultDailyWaterGoalMl = 1500;
+
+  /// Gendered seed defaults applied when [dailyWaterGoalMl] is null —
+  /// derived from EFSA 2010 total-water AI (2.0 L women / 2.5 L men)
+  /// minus the ~20% food-moisture share. Non-binary users fall back to
+  /// the female / male / averaged figure based on their
+  /// [CaloriesProfileEntity], which is the same decoupling the TDEE
+  /// calculator uses so a user only states their reference body
+  /// chemistry once.
+  static const int waterGoalFemaleMl = 1500;
+  static const int waterGoalMaleMl = 1900;
+  static const int waterGoalAveragedMl = 1700;
 
   const ConfigEntity(
     this.hasAcceptedDisclaimer,
@@ -72,7 +118,47 @@ class ConfigEntity extends Equatable {
     this.nutrientPanelVisibility = const <String, bool>{},
     this.dayStartOffsetHours = 0,
     this.dayStartOffsetMinutes = 0,
+    this.dailyWaterGoalMl,
   });
+
+  /// Resolves the daily water goal for the home chip. Returns the user's
+  /// stored override if one exists, otherwise the gendered seed default
+  /// derived from EFSA 2010 (see [defaultDailyWaterGoalMl] for the full
+  /// reasoning and citations). Non-binary users fall back to the same
+  /// `CaloriesProfileEntity` they pick for TDEE — averaged sits at the
+  /// midpoint of the female / male figures.
+  int effectiveDailyWaterGoalMl(
+    UserGenderEntity gender, {
+    CaloriesProfileEntity? caloriesProfile,
+  }) {
+    final stored = dailyWaterGoalMl;
+    if (stored != null) return stored;
+    return seedWaterGoalForGender(gender, caloriesProfile: caloriesProfile);
+  }
+
+  /// Gendered seed used when no override is stored. Public so the goal
+  /// dialog can show "reset to the gender-appropriate default" without
+  /// having to recompute the rules itself.
+  static int seedWaterGoalForGender(
+    UserGenderEntity gender, {
+    CaloriesProfileEntity? caloriesProfile,
+  }) {
+    switch (gender) {
+      case UserGenderEntity.male:
+        return waterGoalMaleMl;
+      case UserGenderEntity.female:
+        return waterGoalFemaleMl;
+      case UserGenderEntity.nonBinary:
+        switch (caloriesProfile ?? CaloriesProfileEntity.averaged) {
+          case CaloriesProfileEntity.testosteroneTypical:
+            return waterGoalMaleMl;
+          case CaloriesProfileEntity.estrogenTypical:
+            return waterGoalFemaleMl;
+          case CaloriesProfileEntity.averaged:
+            return waterGoalAveragedMl;
+        }
+    }
+  }
 
   /// Whether a particular nutrient on the daily panel should be rendered.
   /// All nutrients default to visible; the user can hide individual ones
@@ -87,32 +173,32 @@ class ConfigEntity extends Equatable {
       dayStartOffsetHours * 60 + dayStartOffsetMinutes;
 
   factory ConfigEntity.fromConfigDBO(ConfigDBO dbo) => ConfigEntity(
-        dbo.hasAcceptedDisclaimer,
-        dbo.hasAcceptedPolicy,
-        dbo.hasAcceptedSendAnonymousData,
-        AppThemeEntity.fromAppThemeDBO(dbo.selectedAppTheme),
-        usesImperialUnits: dbo.usesImperialUnits ?? false,
-        userKcalAdjustment: dbo.userKcalAdjustment,
-        userCarbGoalPct: dbo.userCarbGoalPct,
-        userProteinGoalPct: dbo.userProteinGoalPct,
-        userFatGoalPct: dbo.userFatGoalPct,
-        showActivityTracking: dbo.showActivityTracking ?? true,
-        showMealMacros: dbo.showMealMacros ?? true,
-        notificationsEnabled: dbo.notificationsEnabled ?? false,
-        notificationHour: dbo.notificationHour ?? 8,
-        notificationMinute: dbo.notificationMinute ?? 0,
-        selectedLocale: dbo.selectedLocale,
-        showMicronutrients: dbo.showMicronutrients ?? false,
-        usesKilojoules: dbo.usesKilojoules ?? false,
-        mealKcalSharesPct:
-            _sanitiseShares(dbo.mealKcalSharesPct) ?? defaultMealKcalSharesPct,
-        diarySortPreferences: dbo.diarySortPreferences,
-        nutrientPanelVisibility:
-            dbo.nutrientPanelVisibility ?? const <String, bool>{},
-        dayStartOffsetHours: _normaliseOffsetHours(dbo.dayStartOffsetHours),
-        dayStartOffsetMinutes:
-            _normaliseOffsetMinutes(dbo.dayStartOffsetMinutes),
-      );
+    dbo.hasAcceptedDisclaimer,
+    dbo.hasAcceptedPolicy,
+    dbo.hasAcceptedSendAnonymousData,
+    AppThemeEntity.fromAppThemeDBO(dbo.selectedAppTheme),
+    usesImperialUnits: dbo.usesImperialUnits ?? false,
+    userKcalAdjustment: dbo.userKcalAdjustment,
+    userCarbGoalPct: dbo.userCarbGoalPct,
+    userProteinGoalPct: dbo.userProteinGoalPct,
+    userFatGoalPct: dbo.userFatGoalPct,
+    showActivityTracking: dbo.showActivityTracking ?? true,
+    showMealMacros: dbo.showMealMacros ?? true,
+    notificationsEnabled: dbo.notificationsEnabled ?? false,
+    notificationHour: dbo.notificationHour ?? 8,
+    notificationMinute: dbo.notificationMinute ?? 0,
+    selectedLocale: dbo.selectedLocale,
+    showMicronutrients: dbo.showMicronutrients ?? false,
+    usesKilojoules: dbo.usesKilojoules ?? false,
+    mealKcalSharesPct:
+        _sanitiseShares(dbo.mealKcalSharesPct) ?? defaultMealKcalSharesPct,
+    diarySortPreferences: dbo.diarySortPreferences,
+    nutrientPanelVisibility:
+        dbo.nutrientPanelVisibility ?? const <String, bool>{},
+    dayStartOffsetHours: _normaliseOffsetHours(dbo.dayStartOffsetHours),
+    dayStartOffsetMinutes: _normaliseOffsetMinutes(dbo.dayStartOffsetMinutes),
+    dailyWaterGoalMl: _normaliseWaterGoal(dbo.dailyWaterGoalMl),
+  );
 
   /// Returns the recommended kcal target for [mealKey] given a daily goal.
   double targetKcalForMeal(String mealKey, double dailyKcalGoal) {
@@ -145,28 +231,39 @@ class ConfigEntity extends Equatable {
     return raw;
   }
 
+  // Defensive clamp on the persisted water goal. null means "no
+  // override stored" — caller falls back to the gendered seed in
+  // [seedWaterGoalForGender]. A non-null value outside 100–10000 ml is
+  // treated as corrupt and dropped to null so the seed kicks in.
+  static int? _normaliseWaterGoal(int? raw) {
+    if (raw == null) return null;
+    if (raw < 100 || raw > 10000) return null;
+    return raw;
+  }
+
   @override
   List<Object?> get props => [
-        hasAcceptedDisclaimer,
-        hasAcceptedPolicy,
-        hasAcceptedSendAnonymousData,
-        usesImperialUnits,
-        userKcalAdjustment,
-        userCarbGoalPct,
-        userProteinGoalPct,
-        userFatGoalPct,
-        showActivityTracking,
-        showMealMacros,
-        notificationsEnabled,
-        notificationHour,
-        notificationMinute,
-        selectedLocale,
-        showMicronutrients,
-        usesKilojoules,
-        mealKcalSharesPct,
-        diarySortPreferences,
-        nutrientPanelVisibility,
-        dayStartOffsetHours,
-        dayStartOffsetMinutes,
-      ];
+    hasAcceptedDisclaimer,
+    hasAcceptedPolicy,
+    hasAcceptedSendAnonymousData,
+    usesImperialUnits,
+    userKcalAdjustment,
+    userCarbGoalPct,
+    userProteinGoalPct,
+    userFatGoalPct,
+    showActivityTracking,
+    showMealMacros,
+    notificationsEnabled,
+    notificationHour,
+    notificationMinute,
+    selectedLocale,
+    showMicronutrients,
+    usesKilojoules,
+    mealKcalSharesPct,
+    diarySortPreferences,
+    nutrientPanelVisibility,
+    dayStartOffsetHours,
+    dayStartOffsetMinutes,
+    dailyWaterGoalMl,
+  ];
 }

--- a/lib/core/domain/entity/water_intake_entity.dart
+++ b/lib/core/domain/entity/water_intake_entity.dart
@@ -1,0 +1,25 @@
+import 'package:equatable/equatable.dart';
+import 'package:opennutritracker/core/data/dbo/water_intake_dbo.dart';
+
+class WaterIntakeEntity extends Equatable {
+  final String id;
+  final DateTime dateTime;
+  final int amountMl;
+
+  const WaterIntakeEntity({
+    required this.id,
+    required this.dateTime,
+    required this.amountMl,
+  });
+
+  factory WaterIntakeEntity.fromWaterIntakeDBO(WaterIntakeDBO dbo) {
+    return WaterIntakeEntity(
+      id: dbo.id,
+      dateTime: dbo.dateTime,
+      amountMl: dbo.amountMl,
+    );
+  }
+
+  @override
+  List<Object?> get props => [id, dateTime, amountMl];
+}

--- a/lib/core/domain/usecase/add_config_usecase.dart
+++ b/lib/core/domain/usecase/add_config_usecase.dart
@@ -47,7 +47,6 @@ class AddConfigUsecase {
     );
   }
 
-
   Future<void> setConfigShowActivityTracking(bool show) async {
     _configRepository.setConfigShowActivityTracking(show);
   }
@@ -96,5 +95,9 @@ class AddConfigUsecase {
 
   Future<void> setConfigDayStartOffsetMinutes(int minutes) async {
     _configRepository.setConfigDayStartOffsetMinutes(minutes);
+  }
+
+  Future<void> setConfigDailyWaterGoalMl(int goalMl) async {
+    await _configRepository.setConfigDailyWaterGoalMl(goalMl);
   }
 }

--- a/lib/core/domain/usecase/add_water_intake_usecase.dart
+++ b/lib/core/domain/usecase/add_water_intake_usecase.dart
@@ -1,0 +1,12 @@
+import 'package:opennutritracker/core/data/repository/water_intake_repository.dart';
+import 'package:opennutritracker/core/domain/entity/water_intake_entity.dart';
+
+class AddWaterIntakeUsecase {
+  final WaterIntakeRepository _waterIntakeRepository;
+
+  AddWaterIntakeUsecase(this._waterIntakeRepository);
+
+  Future<void> addEntry(WaterIntakeEntity entry) async {
+    await _waterIntakeRepository.addEntry(entry);
+  }
+}

--- a/lib/core/domain/usecase/delete_all_user_data_usecase.dart
+++ b/lib/core/domain/usecase/delete_all_user_data_usecase.dart
@@ -34,6 +34,7 @@ class DeleteAllUserDataUsecase {
       _hiveDBProvider.cachedOffMealTimestampsBox.clear(),
       _hiveDBProvider.customActivityTemplateBox.clear(),
       _hiveDBProvider.weightLogBox.clear(),
+      _hiveDBProvider.waterIntakeBox.clear(),
     ]);
   }
 }

--- a/lib/core/domain/usecase/delete_water_intake_usecase.dart
+++ b/lib/core/domain/usecase/delete_water_intake_usecase.dart
@@ -1,0 +1,11 @@
+import 'package:opennutritracker/core/data/repository/water_intake_repository.dart';
+
+class DeleteWaterIntakeUsecase {
+  final WaterIntakeRepository _waterIntakeRepository;
+
+  DeleteWaterIntakeUsecase(this._waterIntakeRepository);
+
+  Future<void> deleteEntry(String id) async {
+    await _waterIntakeRepository.deleteEntry(id);
+  }
+}

--- a/lib/core/domain/usecase/get_water_intake_usecase.dart
+++ b/lib/core/domain/usecase/get_water_intake_usecase.dart
@@ -1,0 +1,39 @@
+import 'package:opennutritracker/core/data/repository/water_intake_repository.dart';
+import 'package:opennutritracker/core/domain/entity/water_intake_entity.dart';
+import 'package:opennutritracker/core/utils/calc/day_boundary_calc.dart';
+
+/// Reads water intake entries grouped by the configured logical day so the
+/// home chip and any future graph view both see the same boundary as the
+/// rest of the diary (#139).
+class GetWaterIntakeUsecase {
+  final WaterIntakeRepository _waterIntakeRepository;
+
+  GetWaterIntakeUsecase(this._waterIntakeRepository);
+
+  Future<List<WaterIntakeEntity>> getEntriesForDay(
+    DateTime logicalDayStart, {
+    required int dayStartOffsetTotalMinutes,
+  }) async {
+    final from = logicalDayStart.add(
+      Duration(minutes: dayStartOffsetTotalMinutes),
+    );
+    final to = from.add(const Duration(days: 1));
+    return _waterIntakeRepository.getEntriesInRange(from, to);
+  }
+
+  Future<List<WaterIntakeEntity>> getTodayEntries({
+    required int dayStartOffsetTotalMinutes,
+  }) async {
+    final logicalToday = DayBoundaryCalc.currentLogicalDayMinutes(
+      dayStartOffsetTotalMinutes,
+    );
+    return getEntriesForDay(
+      logicalToday,
+      dayStartOffsetTotalMinutes: dayStartOffsetTotalMinutes,
+    );
+  }
+
+  Future<List<WaterIntakeEntity>> getAllEntries() async {
+    return _waterIntakeRepository.getAllEntries();
+  }
+}

--- a/lib/core/utils/hive_db_provider.dart
+++ b/lib/core/utils/hive_db_provider.dart
@@ -10,6 +10,7 @@ import 'package:opennutritracker/core/data/dbo/meal_dbo.dart';
 import 'package:opennutritracker/core/data/dbo/recipe_dbo.dart';
 import 'package:opennutritracker/core/data/dbo/tracked_day_dbo.dart';
 import 'package:opennutritracker/core/data/dbo/user_dbo.dart';
+import 'package:opennutritracker/core/data/dbo/water_intake_dbo.dart';
 import 'package:opennutritracker/core/data/dbo/weight_log_dbo.dart';
 import 'package:opennutritracker/hive_registrar.g.dart';
 
@@ -29,6 +30,10 @@ class HiveDBProvider extends ChangeNotifier {
   // #70 follow-up: saved Custom activity templates (name + typical kcal).
   static const customActivityTemplateBoxName = 'CustomActivityTemplateBox';
   static const weightLogBoxName = 'WeightLogBox';
+  // #32: per-entry water intake log keyed by uuid; one row per sip so the
+  // dialog's "undo last" can roll a single entry back without losing the
+  // rest of the day.
+  static const waterIntakeBoxName = 'WaterIntakeBox';
 
   late Box<ConfigDBO> configBox;
   late Box<IntakeDBO> intakeBox;
@@ -41,6 +46,7 @@ class HiveDBProvider extends ChangeNotifier {
   late Box<int> cachedOffMealTimestampsBox;
   late Box<CustomActivityTemplateDBO> customActivityTemplateBox;
   late Box<WeightLogDBO> weightLogBox;
+  late Box<WaterIntakeDBO> waterIntakeBox;
 
   Future<void> initHiveDB(Uint8List encryptionKey) async {
     final encryptionCypher = HiveAesCipher(encryptionKey);
@@ -95,6 +101,10 @@ class HiveDBProvider extends ChangeNotifier {
     );
     weightLogBox = await Hive.openBox(
       weightLogBoxName,
+      encryptionCipher: encryptionCypher,
+    );
+    waterIntakeBox = await Hive.openBox(
+      waterIntakeBoxName,
       encryptionCipher: encryptionCypher,
     );
   }

--- a/lib/core/utils/locator.dart
+++ b/lib/core/utils/locator.dart
@@ -10,6 +10,7 @@ import 'package:opennutritracker/core/data/data_source/physical_activity_data_so
 import 'package:opennutritracker/core/data/data_source/tracked_day_data_source.dart';
 import 'package:opennutritracker/core/data/data_source/user_activity_data_source.dart';
 import 'package:opennutritracker/core/data/data_source/user_data_source.dart';
+import 'package:opennutritracker/core/data/data_source/water_intake_data_source.dart';
 import 'package:opennutritracker/core/data/data_source/weight_log_data_source.dart';
 import 'package:opennutritracker/core/data/repository/config_repository.dart';
 import 'package:opennutritracker/core/data/repository/custom_activity_template_repository.dart';
@@ -19,6 +20,7 @@ import 'package:opennutritracker/core/data/repository/recipe_repository.dart';
 import 'package:opennutritracker/core/data/repository/tracked_day_repository.dart';
 import 'package:opennutritracker/core/data/repository/user_activity_repository.dart';
 import 'package:opennutritracker/core/data/repository/user_repository.dart';
+import 'package:opennutritracker/core/data/repository/water_intake_repository.dart';
 import 'package:opennutritracker/core/data/repository/weight_log_repository.dart';
 import 'package:opennutritracker/core/domain/usecase/add_config_usecase.dart';
 import 'package:opennutritracker/core/domain/usecase/add_custom_activity_template_usecase.dart';
@@ -26,6 +28,7 @@ import 'package:opennutritracker/core/domain/usecase/add_intake_usecase.dart';
 import 'package:opennutritracker/core/domain/usecase/add_tracked_day_usecase.dart';
 import 'package:opennutritracker/core/domain/usecase/add_user_activity_usercase.dart';
 import 'package:opennutritracker/core/domain/usecase/add_user_usecase.dart';
+import 'package:opennutritracker/core/domain/usecase/add_water_intake_usecase.dart';
 import 'package:opennutritracker/core/domain/usecase/add_weight_log_usecase.dart';
 import 'package:opennutritracker/core/domain/usecase/compute_recipe_nutrition_usecase.dart';
 import 'package:opennutritracker/core/domain/usecase/delete_all_user_data_usecase.dart';
@@ -33,6 +36,7 @@ import 'package:opennutritracker/core/domain/usecase/delete_custom_activity_temp
 import 'package:opennutritracker/core/domain/usecase/delete_intake_usecase.dart';
 import 'package:opennutritracker/core/domain/usecase/delete_recipe_usecase.dart';
 import 'package:opennutritracker/core/domain/usecase/delete_user_activity_usecase.dart';
+import 'package:opennutritracker/core/domain/usecase/delete_water_intake_usecase.dart';
 import 'package:opennutritracker/core/domain/usecase/delete_weight_log_usecase.dart';
 import 'package:opennutritracker/core/domain/usecase/get_all_recipes_usecase.dart';
 import 'package:opennutritracker/core/domain/usecase/get_config_usecase.dart';
@@ -45,6 +49,7 @@ import 'package:opennutritracker/core/domain/usecase/get_recipe_by_id_usecase.da
 import 'package:opennutritracker/core/domain/usecase/get_tracked_day_usecase.dart';
 import 'package:opennutritracker/core/domain/usecase/get_user_activity_usecase.dart';
 import 'package:opennutritracker/core/domain/usecase/get_user_usecase.dart';
+import 'package:opennutritracker/core/domain/usecase/get_water_intake_usecase.dart';
 import 'package:opennutritracker/core/domain/usecase/get_weight_log_usecase.dart';
 import 'package:opennutritracker/core/domain/usecase/save_recipe_usecase.dart';
 import 'package:opennutritracker/core/domain/usecase/update_intake_usecase.dart';
@@ -113,7 +118,9 @@ Future<void> initLocator() async {
   locator.registerLazySingleton<SupabaseClient>(() => Supabase.instance.client);
 
   // Notification service (#312)
-  locator.registerLazySingleton<NotificationService>(() => NotificationService());
+  locator.registerLazySingleton<NotificationService>(
+    () => NotificationService(),
+  );
 
   // Cache manager
   locator.registerLazySingleton<CacheManager>(
@@ -126,6 +133,9 @@ Future<void> initLocator() async {
   );
   locator.registerLazySingleton<HomeBloc>(
     () => HomeBloc(
+      locator(),
+      locator(),
+      locator(),
       locator(),
       locator(),
       locator(),
@@ -177,8 +187,16 @@ Future<void> initLocator() async {
     ),
   );
   locator.registerFactory(
-    () => ExportImportBloc(locator(), locator(), locator(), locator(),
-        locator(), locator(), locator(), locator()),
+    () => ExportImportBloc(
+      locator(),
+      locator(),
+      locator(),
+      locator(),
+      locator(),
+      locator(),
+      locator(),
+      locator(),
+    ),
   );
   // Lazy singleton: shared between RecipesPage's Custom Meals tab and the
   // create-from-popup flow on the same tab — both must mutate / observe the
@@ -213,7 +231,9 @@ Future<void> initLocator() async {
     ),
   );
   locator.registerFactory<ScannerBloc>(() => ScannerBloc(locator(), locator()));
-  locator.registerFactory<EditMealBloc>(() => EditMealBloc(locator(), locator(), locator()));
+  locator.registerFactory<EditMealBloc>(
+    () => EditMealBloc(locator(), locator(), locator()),
+  );
   locator.registerFactory<AddMealBloc>(() => AddMealBloc(locator()));
   locator.registerFactory<ProductsBloc>(
     () => ProductsBloc(locator(), locator()),
@@ -244,11 +264,7 @@ Future<void> initLocator() async {
     ),
   );
   locator.registerLazySingleton<SearchProductByBarcodeUseCase>(
-    () => SearchProductByBarcodeUseCase(
-      locator(),
-      locator(),
-      locator(),
-    ),
+    () => SearchProductByBarcodeUseCase(locator(), locator(), locator()),
   );
   locator.registerLazySingleton<GetIntakeUsecase>(
     () => GetIntakeUsecase(locator()),
@@ -302,6 +318,15 @@ Future<void> initLocator() async {
   locator.registerLazySingleton<DeleteWeightLogUsecase>(
     () => DeleteWeightLogUsecase(locator()),
   );
+  locator.registerLazySingleton<AddWaterIntakeUsecase>(
+    () => AddWaterIntakeUsecase(locator()),
+  );
+  locator.registerLazySingleton<GetWaterIntakeUsecase>(
+    () => GetWaterIntakeUsecase(locator()),
+  );
+  locator.registerLazySingleton<DeleteWaterIntakeUsecase>(
+    () => DeleteWaterIntakeUsecase(locator()),
+  );
   locator.registerLazySingleton(
     () => GetKcalGoalUsecase(locator(), locator(), locator()),
   );
@@ -340,15 +365,11 @@ Future<void> initLocator() async {
       locator(),
     ),
   );
-  locator.registerLazySingleton(
-    () => ImportRecipesJsonUsecase(locator()),
-  );
+  locator.registerLazySingleton(() => ImportRecipesJsonUsecase(locator()));
 
   // Recipe use cases
   locator.registerLazySingleton(() => ComputeRecipeNutritionUseCase());
-  locator.registerLazySingleton(
-    () => SaveRecipeUseCase(locator(), locator()),
-  );
+  locator.registerLazySingleton(() => SaveRecipeUseCase(locator(), locator()));
   locator.registerLazySingleton(() => GetAllRecipesUseCase(locator()));
   locator.registerLazySingleton(() => GetRecipeByIdUseCase(locator()));
   locator.registerLazySingleton(() => DeleteRecipeUseCase(locator()));
@@ -375,6 +396,9 @@ Future<void> initLocator() async {
   );
   locator.registerLazySingleton<WeightLogRepository>(
     () => WeightLogRepository(locator()),
+  );
+  locator.registerLazySingleton<WaterIntakeRepository>(
+    () => WaterIntakeRepository(locator()),
   );
   locator.registerLazySingleton<RecipeRepository>(
     () => RecipeRepository(locator()),
@@ -407,6 +431,9 @@ Future<void> initLocator() async {
   );
   locator.registerLazySingleton<WeightLogDataSource>(
     () => WeightLogDataSource(hiveDBProvider.weightLogBox),
+  );
+  locator.registerLazySingleton<WaterIntakeDataSource>(
+    () => WaterIntakeDataSource(hiveDBProvider.waterIntakeBox),
   );
   locator.registerLazySingleton(
     () => CustomMealDataSource(hiveDBProvider.customMealBox),

--- a/lib/features/home/home_page.dart
+++ b/lib/features/home/home_page.dart
@@ -19,6 +19,7 @@ import 'package:opennutritracker/features/add_meal/presentation/add_meal_type.da
 import 'package:opennutritracker/features/home/presentation/bloc/home_bloc.dart';
 import 'package:opennutritracker/features/home/presentation/widgets/dashboard_widget.dart';
 import 'package:opennutritracker/features/home/presentation/widgets/intake_vertical_list.dart';
+import 'package:opennutritracker/features/home/presentation/widgets/quick_water_widget.dart';
 import 'package:opennutritracker/features/home/presentation/widgets/quick_weight_widget.dart';
 import 'package:opennutritracker/generated/l10n.dart';
 
@@ -92,6 +93,8 @@ class _HomePageState extends State<HomePage> with WidgetsBindingObserver {
             state.lunchSharePct,
             state.dinnerSharePct,
             state.snackSharePct,
+            state.waterMlToday,
+            state.waterGoalMl,
           );
         } else {
           return _getLoadingContent();
@@ -144,6 +147,8 @@ class _HomePageState extends State<HomePage> with WidgetsBindingObserver {
     int lunchSharePct,
     int dinnerSharePct,
     int snackSharePct,
+    int waterMlToday,
+    int waterGoalMl,
   ) {
     if (showDisclaimerDialog) {
       _showDisclaimerDialog(context);
@@ -152,9 +157,21 @@ class _HomePageState extends State<HomePage> with WidgetsBindingObserver {
       children: [
         ListView(
           children: [
-            QuickWeightWidget(
-              weightKg: userWeightKg,
-              usesImperialUnits: usesImperialUnits,
+            Padding(
+              padding: const EdgeInsets.symmetric(horizontal: 16.0),
+              child: Row(
+                children: [
+                  QuickWeightWidget(
+                    weightKg: userWeightKg,
+                    usesImperialUnits: usesImperialUnits,
+                  ),
+                  const Spacer(),
+                  QuickWaterWidget(
+                    waterMlToday: waterMlToday,
+                    waterGoalMl: waterGoalMl,
+                  ),
+                ],
+              ),
             ),
             const SizedBox(height: 8.0),
             DashboardWidget(
@@ -365,8 +382,7 @@ class _HomePageState extends State<HomePage> with WidgetsBindingObserver {
   ) async {
     final newDuration = await showDialog<double>(
       context: context,
-      builder: (context) =>
-          EditActivityDialog(activityEntity: activityEntity),
+      builder: (context) => EditActivityDialog(activityEntity: activityEntity),
     );
     if (newDuration != null) {
       await _homeBloc.updateUserActivityItem(activityEntity, newDuration);

--- a/lib/features/home/presentation/bloc/home_bloc.dart
+++ b/lib/features/home/presentation/bloc/home_bloc.dart
@@ -6,8 +6,12 @@ import 'package:opennutritracker/core/domain/entity/config_entity.dart';
 import 'package:opennutritracker/core/domain/entity/intake_entity.dart';
 import 'package:opennutritracker/core/domain/entity/user_gender_entity.dart';
 import 'package:opennutritracker/core/domain/entity/user_activity_entity.dart';
+import 'package:opennutritracker/core/domain/entity/water_intake_entity.dart';
 import 'package:opennutritracker/core/domain/usecase/add_config_usecase.dart';
 import 'package:opennutritracker/core/domain/usecase/add_tracked_day_usecase.dart';
+import 'package:opennutritracker/core/domain/usecase/add_water_intake_usecase.dart';
+import 'package:opennutritracker/core/domain/usecase/delete_water_intake_usecase.dart';
+import 'package:opennutritracker/core/domain/usecase/get_water_intake_usecase.dart';
 import 'package:opennutritracker/core/domain/usecase/delete_intake_usecase.dart';
 import 'package:opennutritracker/core/domain/usecase/delete_user_activity_usecase.dart';
 import 'package:opennutritracker/core/domain/usecase/get_config_usecase.dart';
@@ -42,6 +46,9 @@ class HomeBloc extends Bloc<HomeEvent, HomeState> {
   final GetMacroGoalUsecase _getMacroGoalUsecase;
   final UpdateUserActivityUsecase _updateUserActivityUsecase;
   final GetUserUsecase _getUserUsecase;
+  final GetWaterIntakeUsecase _getWaterIntakeUsecase;
+  final AddWaterIntakeUsecase _addWaterIntakeUsecase;
+  final DeleteWaterIntakeUsecase _deleteWaterIntakeUsecase;
 
   DateTime currentDay = DateTime.now();
 
@@ -58,6 +65,9 @@ class HomeBloc extends Bloc<HomeEvent, HomeState> {
     this._getMacroGoalUsecase,
     this._updateUserActivityUsecase,
     this._getUserUsecase,
+    this._getWaterIntakeUsecase,
+    this._addWaterIntakeUsecase,
+    this._deleteWaterIntakeUsecase,
   ) : super(HomeInitial()) {
     on<LoadItemsEvent>((event, emit) async {
       emit(HomeLoadingState());
@@ -76,11 +86,11 @@ class HomeBloc extends Bloc<HomeEvent, HomeState> {
       final showDisclaimerDialog = !configData.hasAcceptedDisclaimer;
       final showMealMacros = configData.showMealMacros;
 
-      final breakfastIntakeList =
-          await _getIntakeUsecase.getTodayBreakfastIntake(
-        dayStartOffsetHours: dayStartOffsetHours,
-        dayStartOffsetMinutes: dayStartOffsetMinutes,
-      );
+      final breakfastIntakeList = await _getIntakeUsecase
+          .getTodayBreakfastIntake(
+            dayStartOffsetHours: dayStartOffsetHours,
+            dayStartOffsetMinutes: dayStartOffsetMinutes,
+          );
       final totalBreakfastKcal = getTotalKcal(breakfastIntakeList);
       final totalBreakfastCarbs = getTotalCarbs(breakfastIntakeList);
       final totalBreakfastFats = getTotalFats(breakfastIntakeList);
@@ -113,19 +123,23 @@ class HomeBloc extends Bloc<HomeEvent, HomeState> {
       final totalSnackFats = getTotalFats(snackIntakeList);
       final totalSnackProteins = getTotalProteins(snackIntakeList);
 
-      final totalKcalIntake = totalBreakfastKcal +
+      final totalKcalIntake =
+          totalBreakfastKcal +
           totalLunchKcal +
           totalDinnerKcal +
           totalSnackKcal;
-      final totalCarbsIntake = totalBreakfastCarbs +
+      final totalCarbsIntake =
+          totalBreakfastCarbs +
           totalLunchCarbs +
           totalDinnerCarbs +
           totalSnackCarbs;
-      final totalFatsIntake = totalBreakfastFats +
+      final totalFatsIntake =
+          totalBreakfastFats +
           totalLunchFats +
           totalDinnerFats +
           totalSnackFats;
-      final totalProteinsIntake = totalBreakfastProteins +
+      final totalProteinsIntake =
+          totalBreakfastProteins +
           totalLunchProteins +
           totalDinnerProteins +
           totalSnackProteins;
@@ -134,12 +148,22 @@ class HomeBloc extends Bloc<HomeEvent, HomeState> {
         dayStartOffsetHours: dayStartOffsetHours,
         dayStartOffsetMinutes: dayStartOffsetMinutes,
       );
-      final totalKcalActivities =
-          userActivities.map((activity) => activity.burnedKcal).toList().sum;
+      final totalKcalActivities = userActivities
+          .map((activity) => activity.burnedKcal)
+          .toList()
+          .sum;
+
+      final waterIntakes = await _getWaterIntakeUsecase.getTodayEntries(
+        dayStartOffsetTotalMinutes: configData.dayStartOffsetTotalMinutes,
+      );
+      final totalWaterMl = waterIntakes
+          .map((entry) => entry.amountMl)
+          .fold<int>(0, (sum, ml) => sum + ml);
 
       final user = await _getUserUsecase.getUserData();
-      final totalKcalGoal =
-          await _getKcalGoalUsecase.getKcalGoal(userEntity: user);
+      final totalKcalGoal = await _getKcalGoalUsecase.getKcalGoal(
+        userEntity: user,
+      );
       final totalCarbsGoal = await _getMacroGoalUsecase.getCarbsGoal(
         totalKcalGoal,
       );
@@ -208,6 +232,12 @@ class HomeBloc extends Bloc<HomeEvent, HomeState> {
               configData.mealKcalSharesPct[ConfigEntity.mealKeySnack] ?? 0,
           userGender: user.gender,
           userCaloriesProfile: user.caloriesProfile,
+          waterMlToday: totalWaterMl,
+          waterGoalMl: configData.effectiveDailyWaterGoalMl(
+            user.gender,
+            caloriesProfile: user.caloriesProfile,
+          ),
+          waterIntakes: waterIntakes,
         ),
       );
     });
@@ -237,8 +267,10 @@ class HomeBloc extends Bloc<HomeEvent, HomeState> {
     // Get old intake values
     final oldIntakeObject = await _getIntakeUsecase.getIntakeById(intakeId);
     if (oldIntakeObject == null) return;
-    final newIntakeObject =
-        await _updateIntakeUsecase.updateIntake(intakeId, fields);
+    final newIntakeObject = await _updateIntakeUsecase.updateIntake(
+      intakeId,
+      fields,
+    );
     if (newIntakeObject == null) return;
     if (oldIntakeObject.amount > newIntakeObject.amount) {
       // Amounts shrunk
@@ -252,7 +284,8 @@ class HomeBloc extends Bloc<HomeEvent, HomeState> {
             oldIntakeObject.totalCarbsGram - newIntakeObject.totalCarbsGram,
         fatTracked:
             oldIntakeObject.totalFatsGram - newIntakeObject.totalFatsGram,
-        proteinTracked: oldIntakeObject.totalProteinsGram -
+        proteinTracked:
+            oldIntakeObject.totalProteinsGram -
             newIntakeObject.totalProteinsGram,
       );
     } else if (newIntakeObject.amount > oldIntakeObject.amount) {
@@ -267,7 +300,8 @@ class HomeBloc extends Bloc<HomeEvent, HomeState> {
             newIntakeObject.totalCarbsGram - oldIntakeObject.totalCarbsGram,
         fatTracked:
             newIntakeObject.totalFatsGram - oldIntakeObject.totalFatsGram,
-        proteinTracked: newIntakeObject.totalProteinsGram -
+        proteinTracked:
+            newIntakeObject.totalProteinsGram -
             oldIntakeObject.totalProteinsGram,
       );
     }
@@ -312,7 +346,9 @@ class HomeBloc extends Bloc<HomeEvent, HomeState> {
       proteinAmount: proteinAmount,
     );
     _updateDiaryPage(dateTime);
-    add(const LoadItemsEvent()); // #208: Reload home page to remove activity indicator
+    add(
+      const LoadItemsEvent(),
+    ); // #208: Reload home page to remove activity indicator
   }
 
   Future<void> updateUserActivityItem(
@@ -349,6 +385,35 @@ class HomeBloc extends Bloc<HomeEvent, HomeState> {
   Future<void> _updateDiaryPage(DateTime day) async {
     locator<DiaryBloc>().add(const LoadDiaryYearEvent());
     locator<CalendarDayBloc>().add(RefreshCalendarDayEvent());
+  }
+
+  /// Logs a single water intake entry and reloads the home view so the
+  /// chip updates immediately. The dialog itself only owns the slider
+  /// value; persistence and recomputation flow back through the bloc.
+  Future<void> addWaterIntake(int amountMl) async {
+    if (amountMl <= 0) return;
+    final entry = WaterIntakeEntity(
+      id: 'water-${DateTime.now().microsecondsSinceEpoch}',
+      dateTime: DateTime.now(),
+      amountMl: amountMl,
+    );
+    await _addWaterIntakeUsecase.addEntry(entry);
+    add(const LoadItemsEvent());
+  }
+
+  /// Rolls back the most recent water entry for the configured logical
+  /// day. Returns whether anything was deleted, so the dialog can react
+  /// without re-reading state.
+  Future<bool> undoLastWaterIntake() async {
+    final config = await _getConfigUsecase.getConfig();
+    final entries = await _getWaterIntakeUsecase.getTodayEntries(
+      dayStartOffsetTotalMinutes: config.dayStartOffsetTotalMinutes,
+    );
+    if (entries.isEmpty) return false;
+    entries.sort((a, b) => a.dateTime.compareTo(b.dateTime));
+    await _deleteWaterIntakeUsecase.deleteEntry(entries.last.id);
+    add(const LoadItemsEvent());
+    return true;
   }
 
   /// #139: tracked-day deltas (calories, macros) must land on the

--- a/lib/features/home/presentation/bloc/home_state.dart
+++ b/lib/features/home/presentation/bloc/home_state.dart
@@ -51,6 +51,12 @@ class HomeLoadedState extends HomeState {
   final int snackSharePct;
   final UserGenderEntity userGender;
   final CaloriesProfileEntity? userCaloriesProfile;
+  // #32: hydration totals for the home chip. waterMlToday is summed across
+  // every entry that falls within the configured logical day; waterGoalMl
+  // is the user-configurable target (Settings → Calculations).
+  final int waterMlToday;
+  final int waterGoalMl;
+  final List<WaterIntakeEntity> waterIntakes;
 
   const HomeLoadedState({
     required this.showDisclaimerDialog,
@@ -81,18 +87,24 @@ class HomeLoadedState extends HomeState {
     required this.snackSharePct,
     required this.userGender,
     required this.userCaloriesProfile,
+    required this.waterMlToday,
+    required this.waterGoalMl,
+    required this.waterIntakes,
     this.showActivityTracking = true,
     this.showMealMacros = true,
   });
 
   @override
   List<Object?> get props => [
-        breakfastIntakeList,
-        lunchIntakeList,
-        dinnerIntakeList,
-        snackIntakeList,
-        usesImperialUnits,
-        userWeightKg,
-        totalKcalDaily,
-      ];
+    breakfastIntakeList,
+    lunchIntakeList,
+    dinnerIntakeList,
+    snackIntakeList,
+    usesImperialUnits,
+    userWeightKg,
+    totalKcalDaily,
+    waterMlToday,
+    waterGoalMl,
+    waterIntakes,
+  ];
 }

--- a/lib/features/home/presentation/widgets/log_water_dialog.dart
+++ b/lib/features/home/presentation/widgets/log_water_dialog.dart
@@ -1,0 +1,130 @@
+import 'package:flutter/material.dart';
+import 'package:opennutritracker/core/utils/locator.dart';
+import 'package:opennutritracker/features/home/presentation/bloc/home_bloc.dart';
+import 'package:opennutritracker/generated/l10n.dart';
+
+/// #32: simple "how much did you just drink?" dialog. A slider feels
+/// kinder than a numeric keypad for the common case where the person
+/// already knows roughly how much they had — half a glass, a regular
+/// glass, a large bottle — and only needs to land on the nearest
+/// 50 ml. "Undo last" handles the more frustrating case where you tap
+/// the wrong amount and want to take it back without doing the
+/// mental arithmetic of "subtract X from the running total".
+class LogWaterDialog extends StatefulWidget {
+  static const int sliderMaxMl = 1000;
+  static const int sliderStepMl = 50;
+  static const int sliderDivisions = sliderMaxMl ~/ sliderStepMl;
+  static const int sliderDefaultMl = 250;
+
+  const LogWaterDialog({super.key});
+
+  @override
+  State<LogWaterDialog> createState() => _LogWaterDialogState();
+}
+
+class _LogWaterDialogState extends State<LogWaterDialog> {
+  double _selectedMl = LogWaterDialog.sliderDefaultMl.toDouble();
+
+  @override
+  Widget build(BuildContext context) {
+    final s = S.of(context);
+    return AlertDialog(
+      title: Row(
+        mainAxisAlignment: MainAxisAlignment.spaceBetween,
+        children: [
+          Expanded(
+            child: Text(
+              s.logWaterDialogTitle,
+              overflow: TextOverflow.ellipsis,
+            ),
+          ),
+          const SizedBox(width: 8),
+          Semantics(
+            identifier: 'log-water-reset',
+            container: true,
+            child: TextButton(
+              onPressed: _selectedMl == 0
+                  ? null
+                  : () => setState(() => _selectedMl = 0),
+              child: Text(s.buttonResetLabel),
+            ),
+          ),
+        ],
+      ),
+      content: Column(
+        mainAxisSize: MainAxisSize.min,
+        crossAxisAlignment: CrossAxisAlignment.stretch,
+        children: [
+          Text(
+            s.logWaterAmountLabel(_selectedMl.round()),
+            textAlign: TextAlign.center,
+            style: Theme.of(context).textTheme.headlineSmall,
+          ),
+          const SizedBox(height: 8),
+          Semantics(
+            identifier: 'log-water-slider',
+            child: Slider(
+              value: _selectedMl,
+              min: 0,
+              max: LogWaterDialog.sliderMaxMl.toDouble(),
+              divisions: LogWaterDialog.sliderDivisions,
+              label: '${_selectedMl.round()} ml',
+              onChanged: (value) {
+                setState(() => _selectedMl = value);
+              },
+            ),
+          ),
+          Align(
+            alignment: Alignment.centerRight,
+            child: Semantics(
+              identifier: 'log-water-undo',
+              child: TextButton.icon(
+                icon: const Icon(Icons.undo),
+                label: Text(s.logWaterUndoLabel),
+                onPressed: _onUndoPressed,
+              ),
+            ),
+          ),
+        ],
+      ),
+      actions: [
+        Semantics(
+          identifier: 'log-water-cancel',
+          child: TextButton(
+            onPressed: () => Navigator.of(context).pop(),
+            child: Text(s.dialogCancelLabel),
+          ),
+        ),
+        Semantics(
+          identifier: 'log-water-save',
+          child: FilledButton(
+            onPressed: _onSavePressed,
+            child: Text(s.dialogOKLabel),
+          ),
+        ),
+      ],
+    );
+  }
+
+  Future<void> _onSavePressed() async {
+    final amount = _selectedMl.round();
+    final navigator = Navigator.of(context);
+    if (amount > 0) {
+      await locator<HomeBloc>().addWaterIntake(amount);
+    }
+    if (mounted) {
+      navigator.pop();
+    }
+  }
+
+  Future<void> _onUndoPressed() async {
+    final messenger = ScaffoldMessenger.of(context);
+    final undone = await locator<HomeBloc>().undoLastWaterIntake();
+    if (!mounted) return;
+    if (!undone) {
+      messenger.showSnackBar(
+        SnackBar(content: Text(S.of(context).logWaterNothingToUndoLabel)),
+      );
+    }
+  }
+}

--- a/lib/features/home/presentation/widgets/quick_water_widget.dart
+++ b/lib/features/home/presentation/widgets/quick_water_widget.dart
@@ -1,0 +1,55 @@
+import 'package:flutter/material.dart';
+import 'package:opennutritracker/features/home/presentation/widgets/log_water_dialog.dart';
+import 'package:opennutritracker/generated/l10n.dart';
+
+/// #32: hydration chip that sits next to the weight chip on the home
+/// screen. Reads `waterMlToday` and `waterGoalMl` from `HomeLoadedState`
+/// so it stays consistent with whatever logical day the rest of the
+/// home view is using.
+class QuickWaterWidget extends StatelessWidget {
+  final int waterMlToday;
+  final int waterGoalMl;
+
+  const QuickWaterWidget({
+    super.key,
+    required this.waterMlToday,
+    required this.waterGoalMl,
+  });
+
+  @override
+  Widget build(BuildContext context) {
+    final label = S.of(context).waterChipLabel(waterMlToday, waterGoalMl);
+
+    return Semantics(
+      identifier: 'home-water-chip',
+      child: Row(
+        mainAxisSize: MainAxisSize.min,
+        children: [
+          const Icon(Icons.water_drop_outlined, size: 18),
+          const SizedBox(width: 8),
+          Text(label, style: Theme.of(context).textTheme.bodyMedium),
+          const SizedBox(width: 4),
+          Semantics(
+            identifier: 'home-water-edit',
+            container: true,
+            child: IconButton(
+              icon: const Icon(Icons.add_circle_outline, size: 18),
+              padding: EdgeInsets.zero,
+              constraints: const BoxConstraints(),
+              visualDensity: VisualDensity.compact,
+              tooltip: S.of(context).logWaterDialogTitle,
+              onPressed: () => _showDialog(context),
+            ),
+          ),
+        ],
+      ),
+    );
+  }
+
+  Future<void> _showDialog(BuildContext context) async {
+    await showDialog<void>(
+      context: context,
+      builder: (_) => const LogWaterDialog(),
+    );
+  }
+}

--- a/lib/features/home/presentation/widgets/quick_weight_widget.dart
+++ b/lib/features/home/presentation/widgets/quick_weight_widget.dart
@@ -22,39 +22,35 @@ class QuickWeightWidget extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
-    final displayWeight =
-        usesImperialUnits ? weightKg * 2.20462 : weightKg;
+    final displayWeight = usesImperialUnits ? weightKg * 2.20462 : weightKg;
     final unit = usesImperialUnits
         ? S.of(context).lbsLabel
         : S.of(context).kgLabel;
 
-    return Padding(
-      padding: const EdgeInsets.symmetric(horizontal: 16.0),
-      child: Row(
-        children: [
-          const Icon(Icons.monitor_weight_outlined, size: 18),
-          const SizedBox(width: 8),
-          Text(
-            '${displayWeight.toStringAsFixed(1)} $unit',
-            style: Theme.of(context).textTheme.bodyMedium,
-          ),
-          const SizedBox(width: 4),
-          IconButton(
-            icon: const Icon(Icons.edit_outlined, size: 16),
-            padding: EdgeInsets.zero,
-            constraints: const BoxConstraints(),
-            visualDensity: VisualDensity.compact,
-            tooltip: S.of(context).editMealLabel,
-            onPressed: () => _showWeightDialog(context),
-          ),
-        ],
-      ),
+    return Row(
+      mainAxisSize: MainAxisSize.min,
+      children: [
+        const Icon(Icons.monitor_weight_outlined, size: 18),
+        const SizedBox(width: 8),
+        Text(
+          '${displayWeight.toStringAsFixed(1)} $unit',
+          style: Theme.of(context).textTheme.bodyMedium,
+        ),
+        const SizedBox(width: 4),
+        IconButton(
+          icon: const Icon(Icons.edit_outlined, size: 16),
+          padding: EdgeInsets.zero,
+          constraints: const BoxConstraints(),
+          visualDensity: VisualDensity.compact,
+          tooltip: S.of(context).editMealLabel,
+          onPressed: () => _showWeightDialog(context),
+        ),
+      ],
     );
   }
 
   Future<void> _showWeightDialog(BuildContext context) async {
-    final displayWeight =
-        usesImperialUnits ? weightKg * 2.20462 : weightKg;
+    final displayWeight = usesImperialUnits ? weightKg * 2.20462 : weightKg;
 
     final newWeight = await showDialog<double>(
       context: context,
@@ -66,8 +62,7 @@ class QuickWeightWidget extends StatelessWidget {
 
     if (newWeight == null || !context.mounted) return;
 
-    final newWeightKg =
-        usesImperialUnits ? newWeight / 2.20462 : newWeight;
+    final newWeightKg = usesImperialUnits ? newWeight / 2.20462 : newWeight;
 
     final user = await locator<GetUserUsecase>().getUserData();
     user.weightKG = newWeightKg;

--- a/lib/features/profile/presentation/bloc/profile_bloc.dart
+++ b/lib/features/profile/presentation/bloc/profile_bloc.dart
@@ -49,6 +49,10 @@ class ProfileBloc extends Bloc<ProfileEvent, ProfileState> {
           userBMI: userBMIEntity,
           userEntity: user,
           usesImperialUnits: userConfig.usesImperialUnits,
+          effectiveWaterGoalMl: userConfig.effectiveDailyWaterGoalMl(
+            user.gender,
+            caloriesProfile: user.caloriesProfile,
+          ),
         ),
       );
     });
@@ -107,8 +111,9 @@ class ProfileBloc extends Bloc<ProfileEvent, ProfileState> {
 
   /// Returns the user's weight in kg or lbs based on the user's config
   String getDisplayWeight(UserEntity user, bool usesImperialUnits) {
-    final displayWeight =
-        usesImperialUnits ? UnitCalc.kgToLbs(user.weightKG) : user.weightKG;
+    final displayWeight = usesImperialUnits
+        ? UnitCalc.kgToLbs(user.weightKG)
+        : user.weightKG;
 
     return formatProfileWeight(displayWeight);
   }

--- a/lib/features/profile/presentation/bloc/profile_state.dart
+++ b/lib/features/profile/presentation/bloc/profile_state.dart
@@ -19,13 +19,24 @@ class ProfileLoadedState extends ProfileState {
   final UserEntity userEntity;
 
   final bool usesImperialUnits;
+  // #32: resolved daily water goal in millilitres, with the user's
+  // override applied (or the gendered seed if none is stored yet). The
+  // profile entry subtitle shows this so the user sees the value the
+  // home chip is using without opening the dialog.
+  final int effectiveWaterGoalMl;
 
   const ProfileLoadedState({
     required this.userBMI,
     required this.userEntity,
     required this.usesImperialUnits,
+    required this.effectiveWaterGoalMl,
   });
 
   @override
-  List<Object?> get props => [userBMI, userEntity, usesImperialUnits];
+  List<Object?> get props => [
+        userBMI,
+        userEntity,
+        usesImperialUnits,
+        effectiveWaterGoalMl,
+      ];
 }

--- a/lib/features/profile/profile_page.dart
+++ b/lib/features/profile/profile_page.dart
@@ -19,6 +19,9 @@ import 'package:opennutritracker/features/profile/presentation/widgets/set_weekl
 import 'package:opennutritracker/features/profile/presentation/widgets/set_pal_category_dialog.dart';
 import 'package:opennutritracker/features/profile/presentation/widgets/set_target_weight_dialog.dart';
 import 'package:opennutritracker/features/profile/presentation/widgets/set_weight_dialog.dart';
+import 'package:opennutritracker/features/home/presentation/bloc/home_bloc.dart';
+import 'package:opennutritracker/features/settings/presentation/bloc/settings_bloc.dart';
+import 'package:opennutritracker/features/settings/presentation/widgets/water_goal_dialog.dart';
 import 'package:opennutritracker/generated/l10n.dart';
 
 class ProfilePage extends StatefulWidget {
@@ -53,6 +56,7 @@ class _ProfilePageState extends State<ProfilePage> {
             state.userBMI,
             state.userEntity,
             state.usesImperialUnits,
+            state.effectiveWaterGoalMl,
           );
         } else {
           return _getLoadingContent();
@@ -70,6 +74,7 @@ class _ProfilePageState extends State<ProfilePage> {
     UserBMIEntity userBMIEntity,
     UserEntity user,
     bool usesImperialUnits,
+    int effectiveWaterGoalMl,
   ) {
     return ListView(
       children: [
@@ -131,7 +136,10 @@ class _ProfilePageState extends State<ProfilePage> {
               child: Icon(Icons.trending_down_outlined),
             ),
             onTap: () => _showSetWeeklyWeightGoalDialog(
-                context, user, usesImperialUnits),
+              context,
+              user,
+              usesImperialUnits,
+            ),
           ),
         ),
         Semantics(
@@ -180,7 +188,7 @@ class _ProfilePageState extends State<ProfilePage> {
               user.targetWeightKg == null
                   ? S.of(context).profileTargetWeightNotSetLabel
                   : '${_formatTargetWeightDisplay(user.targetWeightKg!, usesImperialUnits)} '
-                      '${usesImperialUnits ? S.of(context).lbsLabel : S.of(context).kgLabel}',
+                        '${usesImperialUnits ? S.of(context).lbsLabel : S.of(context).kgLabel}',
               style: Theme.of(context).textTheme.titleMedium,
             ),
             leading: const SizedBox(
@@ -189,6 +197,24 @@ class _ProfilePageState extends State<ProfilePage> {
             ),
             onTap: () =>
                 _showSetTargetWeightDialog(context, user, usesImperialUnits),
+          ),
+        ),
+        Semantics(
+          identifier: 'profile-water-goal',
+          child: ListTile(
+            title: Text(
+              S.of(context).settingsWaterGoalLabel,
+              style: Theme.of(context).textTheme.titleLarge,
+            ),
+            subtitle: Text(
+              '$effectiveWaterGoalMl ${S.of(context).mlLabel}',
+              style: Theme.of(context).textTheme.titleMedium,
+            ),
+            leading: const SizedBox(
+              height: double.infinity,
+              child: Icon(Icons.water_drop_outlined),
+            ),
+            onTap: () => _showWaterGoalDialog(context),
           ),
         ),
         // The opt-in linear taper scales the daily kcal deficit down
@@ -227,8 +253,9 @@ class _ProfilePageState extends State<ProfilePage> {
               child: Icon(Icons.show_chart_outlined),
             ),
             trailing: const Icon(Icons.chevron_right),
-            onTap: () => Navigator.of(context)
-                .pushNamed(NavigationOptions.weightHistoryRoute),
+            onTap: () => Navigator.of(
+              context,
+            ).pushNamed(NavigationOptions.weightHistoryRoute),
           ),
         ),
         Semantics(
@@ -332,12 +359,14 @@ class _ProfilePageState extends State<ProfilePage> {
   }
 
   String _weeklyGoalSubtitle(
-      BuildContext context, UserEntity user, bool usesImperialUnits) {
+    BuildContext context,
+    UserEntity user,
+    bool usesImperialUnits,
+  ) {
     final goal = user.weeklyWeightGoalKg;
     if (goal == null) return S.of(context).weeklyWeightGoalNoneLabel;
     if (goal == 0.0) return S.of(context).goalMaintainWeight;
-    final displayValue =
-        usesImperialUnits ? goal * 2.20462 : goal;
+    final displayValue = usesImperialUnits ? goal * 2.20462 : goal;
     final sign = displayValue > 0 ? '+' : '';
     final formatted = '$sign${displayValue.toStringAsFixed(2)}';
     return usesImperialUnits
@@ -345,8 +374,11 @@ class _ProfilePageState extends State<ProfilePage> {
         : S.of(context).weeklyWeightGoalKgPerWeek(formatted);
   }
 
-  Future<void> _showSetWeeklyWeightGoalDialog(BuildContext context,
-      UserEntity userEntity, bool usesImperialUnits) async {
+  Future<void> _showSetWeeklyWeightGoalDialog(
+    BuildContext context,
+    UserEntity userEntity,
+    bool usesImperialUnits,
+  ) async {
     final result = await showDialog<WeeklyWeightGoalResult>(
       context: context,
       builder: (context) => SetWeeklyWeightGoalDialog(
@@ -442,8 +474,7 @@ class _ProfilePageState extends State<ProfilePage> {
     // we can distinguish "user cancelled" (null) from "user picked a value"
     // (set) and from "user explicitly cleared the target" (clear flag).
     final seedKg = userEntity.targetWeightKg ?? userEntity.weightKG;
-    final seedDisplay =
-        usesImperialSystem ? UnitCalc.kgToLbs(seedKg) : seedKg;
+    final seedDisplay = usesImperialSystem ? UnitCalc.kgToLbs(seedKg) : seedKg;
     final result = await showDialog<TargetWeightDialogResult>(
       context: context,
       builder: (context) => SetTargetWeightDialog(
@@ -529,6 +560,16 @@ class _ProfilePageState extends State<ProfilePage> {
     await _profileBloc.updateUser(userEntity);
   }
 
+  void _showWaterGoalDialog(BuildContext context) {
+    showDialog(
+      context: context,
+      builder: (context) => WaterGoalDialog(
+        settingsBloc: locator<SettingsBloc>(),
+        homeBloc: locator<HomeBloc>(),
+      ),
+    );
+  }
+
   Future<void> _showCaloriesProfileDialog(
     BuildContext context,
     UserEntity userEntity,
@@ -546,7 +587,10 @@ class _ProfilePageState extends State<ProfilePage> {
   }
 
   String _targetWeightSubLabel(
-      BuildContext context, UserEntity user, bool usesImperialUnits) {
+    BuildContext context,
+    UserEntity user,
+    bool usesImperialUnits,
+  ) {
     final target = user.targetWeightKg;
     if (target == null) return '';
     final deltaKg = (target - user.weightKG).abs();
@@ -556,8 +600,7 @@ class _ProfilePageState extends State<ProfilePage> {
     if (deltaKg < 0.1) {
       return S.of(context).profileTargetWeightReached;
     }
-    final displayDelta =
-        usesImperialUnits ? deltaKg * 2.20462 : deltaKg;
+    final displayDelta = usesImperialUnits ? deltaKg * 2.20462 : deltaKg;
     final formatted =
         '${displayDelta.toStringAsFixed(1)} ${usesImperialUnits ? S.of(context).lbsLabel : S.of(context).kgLabel}';
     return S.of(context).profileTargetWeightToGo(formatted);

--- a/lib/features/settings/presentation/bloc/settings_bloc.dart
+++ b/lib/features/settings/presentation/bloc/settings_bloc.dart
@@ -46,8 +46,8 @@ class SettingsBloc extends Bloc<SettingsEvent, SettingsState> {
       final appVersion = await AppConst.getVersionNumber();
       final usesImperialUnits = userConfig.usesImperialUnits;
       final offCacheCount = _cachedOffMealDataSource.count;
-      final offCacheSizeBytes =
-          await _cachedOffMealDataSource.getStorageSizeBytes();
+      final offCacheSizeBytes = await _cachedOffMealDataSource
+          .getStorageSizeBytes();
 
       emit(
         SettingsLoadedState(
@@ -171,6 +171,15 @@ class SettingsBloc extends Bloc<SettingsEvent, SettingsState> {
 
   Future<void> setKcalAdjustment(double kcalAdjustment) async {
     await _addConfigUsecase.setConfigKcalAdjustment(kcalAdjustment);
+  }
+
+  Future<int?> getDailyWaterGoalMl() async {
+    final config = await _getConfigUsecase.getConfig();
+    return config.dailyWaterGoalMl;
+  }
+
+  Future<void> setDailyWaterGoalMl(int goalMl) async {
+    await _addConfigUsecase.setConfigDailyWaterGoalMl(goalMl);
   }
 
   Future<void> setMacroGoals(

--- a/lib/features/settings/presentation/widgets/water_goal_dialog.dart
+++ b/lib/features/settings/presentation/widgets/water_goal_dialog.dart
@@ -1,0 +1,184 @@
+import 'package:flutter/material.dart';
+import 'package:flutter/services.dart';
+import 'package:opennutritracker/core/domain/entity/config_entity.dart';
+import 'package:opennutritracker/core/domain/usecase/get_user_usecase.dart';
+import 'package:opennutritracker/core/utils/locator.dart';
+import 'package:opennutritracker/features/home/presentation/bloc/home_bloc.dart';
+import 'package:opennutritracker/features/profile/presentation/bloc/profile_bloc.dart';
+import 'package:opennutritracker/features/settings/presentation/bloc/settings_bloc.dart';
+import 'package:opennutritracker/generated/l10n.dart';
+
+/// #32: focused entry for the daily water goal. Follows the same single-
+/// purpose-dialog pattern as the other Calculations entries split out in
+/// the #414 refactor — one number to change, a clear reset back to the
+/// default, save closes the dialog and reloads the home chip so the new
+/// goal shows up without restarting the app.
+class WaterGoalDialog extends StatefulWidget {
+  final SettingsBloc settingsBloc;
+  final HomeBloc homeBloc;
+
+  const WaterGoalDialog({
+    super.key,
+    required this.settingsBloc,
+    required this.homeBloc,
+  });
+
+  @override
+  State<WaterGoalDialog> createState() => _WaterGoalDialogState();
+}
+
+class _WaterGoalDialogState extends State<WaterGoalDialog> {
+  static const int _minGoalMl = 100;
+  static const int _maxGoalMl = 10000;
+  static const int _stepMl = 100;
+
+  bool _loaded = false;
+  int _goalMl = ConfigEntity.defaultDailyWaterGoalMl;
+  int _seedGoalMl = ConfigEntity.defaultDailyWaterGoalMl;
+  late final TextEditingController _controller;
+
+  @override
+  void initState() {
+    super.initState();
+    _controller = TextEditingController();
+    _load();
+  }
+
+  @override
+  void dispose() {
+    _controller.dispose();
+    super.dispose();
+  }
+
+  Future<void> _load() async {
+    final stored = await widget.settingsBloc.getDailyWaterGoalMl();
+    final user = await locator<GetUserUsecase>().getUserData();
+    final seed = ConfigEntity.seedWaterGoalForGender(
+      user.gender,
+      caloriesProfile: user.caloriesProfile,
+    );
+    if (!mounted) return;
+    final initial = stored ?? seed;
+    setState(() {
+      _goalMl = initial;
+      _seedGoalMl = seed;
+      _controller.text = initial.toString();
+      _loaded = true;
+    });
+  }
+
+  void _applyTextInput() {
+    final parsed = int.tryParse(_controller.text);
+    if (parsed == null) {
+      _controller.text = _goalMl.toString();
+      return;
+    }
+    final clamped = parsed.clamp(_minGoalMl, _maxGoalMl);
+    setState(() => _goalMl = clamped);
+    _controller.text = clamped.toString();
+  }
+
+  Future<void> _save() async {
+    await widget.settingsBloc.setDailyWaterGoalMl(_goalMl);
+    widget.homeBloc.add(const LoadItemsEvent());
+    locator<ProfileBloc>().add(LoadProfileEvent());
+    if (!mounted) return;
+    Navigator.of(context).pop();
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    final s = S.of(context);
+    return AlertDialog(
+      title: Row(
+        mainAxisAlignment: MainAxisAlignment.spaceBetween,
+        children: [
+          Expanded(
+            child: Text(
+              s.settingsWaterGoalLabel,
+              overflow: TextOverflow.ellipsis,
+            ),
+          ),
+          const SizedBox(width: 8),
+          Semantics(
+            identifier: 'water-goal-reset',
+            container: true,
+            child: TextButton(
+              onPressed: _loaded
+                  ? () {
+                      setState(() => _goalMl = _seedGoalMl);
+                      _controller.text = _goalMl.toString();
+                    }
+                  : null,
+              child: Text(s.buttonResetLabel),
+            ),
+          ),
+        ],
+      ),
+      content: !_loaded
+          ? const SizedBox(
+              height: 80,
+              child: Center(child: CircularProgressIndicator()),
+            )
+          : Column(
+              mainAxisSize: MainAxisSize.min,
+              crossAxisAlignment: CrossAxisAlignment.stretch,
+              children: [
+                Text(
+                  s.settingsWaterGoalDescription,
+                  style: Theme.of(context).textTheme.bodySmall,
+                ),
+                const SizedBox(height: 16),
+                Semantics(
+                  identifier: 'water-goal-input',
+                  child: TextField(
+                    controller: _controller,
+                    keyboardType: const TextInputType.numberWithOptions(
+                      signed: false,
+                      decimal: false,
+                    ),
+                    inputFormatters: [FilteringTextInputFormatter.digitsOnly],
+                    textAlign: TextAlign.right,
+                    decoration: InputDecoration(
+                      suffixText: s.mlLabel,
+                      isDense: true,
+                    ),
+                    onSubmitted: (_) => _applyTextInput(),
+                    onEditingComplete: _applyTextInput,
+                  ),
+                ),
+                Semantics(
+                  identifier: 'water-goal-slider',
+                  child: Slider(
+                    min: _minGoalMl.toDouble(),
+                    max: _maxGoalMl.toDouble(),
+                    divisions: (_maxGoalMl - _minGoalMl) ~/ _stepMl,
+                    value: _goalMl.toDouble().clamp(
+                      _minGoalMl.toDouble(),
+                      _maxGoalMl.toDouble(),
+                    ),
+                    label: '$_goalMl ${s.mlLabel}',
+                    onChanged: (value) {
+                      setState(() => _goalMl = value.round());
+                      _controller.text = _goalMl.toString();
+                    },
+                  ),
+                ),
+              ],
+            ),
+      actions: [
+        TextButton(
+          onPressed: () => Navigator.of(context).pop(),
+          child: Text(s.dialogCancelLabel),
+        ),
+        Semantics(
+          identifier: 'water-goal-save',
+          child: TextButton(
+            onPressed: _loaded ? _save : null,
+            child: Text(s.dialogOKLabel),
+          ),
+        ),
+      ],
+    );
+  }
+}

--- a/lib/features/settings/settings_screen.dart
+++ b/lib/features/settings/settings_screen.dart
@@ -89,9 +89,11 @@ class _SettingsScreenState extends State<SettingsScreen> {
                   child: ListTile(
                     leading: const Icon(Icons.local_fire_department_outlined),
                     title: Text(S.of(context).settingsEnergyUnitLabel),
-                    subtitle: Text(state.usesKilojoules
-                        ? S.of(context).energyUnitKjLabel
-                        : S.of(context).energyUnitKcalLabel),
+                    subtitle: Text(
+                      state.usesKilojoules
+                          ? S.of(context).energyUnitKjLabel
+                          : S.of(context).energyUnitKcalLabel,
+                    ),
                     onTap: () =>
                         _showEnergyUnitDialog(context, state.usesKilojoules),
                   ),
@@ -121,8 +123,7 @@ class _SettingsScreenState extends State<SettingsScreen> {
                   identifier: 'settings-per-meal-share',
                   child: ListTile(
                     leading: const Icon(Icons.restaurant_menu_outlined),
-                    title:
-                        Text(S.of(context).settingsPerMealKcalShareLabel),
+                    title: Text(S.of(context).settingsPerMealKcalShareLabel),
                     onTap: () => _showPerMealKcalShareDialog(context),
                   ),
                 ),
@@ -196,8 +197,9 @@ class _SettingsScreenState extends State<SettingsScreen> {
                   leading: const Icon(Icons.language_outlined),
                   title: Text(S.of(context).settingsLanguageLabel),
                   subtitle: Text(
-                      _localeDisplayName(state.selectedLocale) ??
-                          S.of(context).settingsThemeSystemDefaultLabel),
+                    _localeDisplayName(state.selectedLocale) ??
+                        S.of(context).settingsThemeSystemDefaultLabel,
+                  ),
                   onTap: () =>
                       _showLanguageDialog(context, state.selectedLocale),
                 ),
@@ -205,9 +207,16 @@ class _SettingsScreenState extends State<SettingsScreen> {
                   secondary: const Icon(Icons.notifications_outlined),
                   title: Text(S.of(context).settingsNotificationsLabel),
                   subtitle: state.notificationsEnabled
-                      ? Text(S.of(context).settingsNotificationsTimeLabel(
-                          _formatNotificationTime(
-                              state.notificationHour, state.notificationMinute)))
+                      ? Text(
+                          S
+                              .of(context)
+                              .settingsNotificationsTimeLabel(
+                                _formatNotificationTime(
+                                  state.notificationHour,
+                                  state.notificationMinute,
+                                ),
+                              ),
+                        )
                       : null,
                   value: state.notificationsEnabled,
                   onChanged: (bool value) =>
@@ -216,14 +225,23 @@ class _SettingsScreenState extends State<SettingsScreen> {
                 if (state.notificationsEnabled)
                   ListTile(
                     leading: const Icon(Icons.access_time_outlined),
-                    title: Text(S.of(context).settingsNotificationsTimeLabel(
-                        _formatNotificationTime(state.notificationHour,
-                            state.notificationMinute))),
+                    title: Text(
+                      S
+                          .of(context)
+                          .settingsNotificationsTimeLabel(
+                            _formatNotificationTime(
+                              state.notificationHour,
+                              state.notificationMinute,
+                            ),
+                          ),
+                    ),
                     onTap: () => _pickNotificationTime(
-                        context,
-                        TimeOfDay(
-                            hour: state.notificationHour,
-                            minute: state.notificationMinute)),
+                      context,
+                      TimeOfDay(
+                        hour: state.notificationHour,
+                        minute: state.notificationMinute,
+                      ),
+                    ),
                   ),
                 const Divider(),
                 // Data
@@ -243,10 +261,14 @@ class _SettingsScreenState extends State<SettingsScreen> {
                 ListTile(
                   leading: const Icon(Icons.cached_outlined),
                   title: Text(S.of(context).clearOffCacheLabel),
-                  subtitle: Text(S.of(context).clearOffCacheSubtitle(
-                    state.offCacheCount,
-                    _formatBytes(state.offCacheSizeBytes),
-                  )),
+                  subtitle: Text(
+                    S
+                        .of(context)
+                        .clearOffCacheSubtitle(
+                          state.offCacheCount,
+                          _formatBytes(state.offCacheSizeBytes),
+                        ),
+                  ),
                   enabled: state.offCacheCount > 0,
                   onTap: () => _confirmClearOffCache(context),
                 ),
@@ -263,8 +285,7 @@ class _SettingsScreenState extends State<SettingsScreen> {
                         color: Theme.of(context).colorScheme.error,
                       ),
                     ),
-                    subtitle:
-                        Text(S.of(context).settingsDeleteAllDataSubtitle),
+                    subtitle: Text(S.of(context).settingsDeleteAllDataSubtitle),
                     onTap: () => _confirmDeleteAllData(context),
                   ),
                 ),
@@ -309,7 +330,10 @@ class _SettingsScreenState extends State<SettingsScreen> {
   }
 
   Future<void> _onNotificationToggled(
-      BuildContext context, bool enabled, SettingsLoadedState state) async {
+    BuildContext context,
+    bool enabled,
+    SettingsLoadedState state,
+  ) async {
     final l10n = S.of(context);
     final notificationService = locator<NotificationService>();
     await notificationService.initialize();
@@ -337,12 +361,11 @@ class _SettingsScreenState extends State<SettingsScreen> {
   }
 
   Future<void> _pickNotificationTime(
-      BuildContext context, TimeOfDay current) async {
+    BuildContext context,
+    TimeOfDay current,
+  ) async {
     final l10n = S.of(context);
-    final picked = await showTimePicker(
-      context: context,
-      initialTime: current,
-    );
+    final picked = await showTimePicker(context: context, initialTime: current);
     if (picked == null) return;
     _settingsBloc.setNotificationTime(picked.hour, picked.minute);
     final notificationService = locator<NotificationService>();
@@ -422,7 +445,9 @@ class _SettingsScreenState extends State<SettingsScreen> {
   // energy display unit. Internal storage stays in kcal; this only
   // toggles how energy is rendered everywhere it appears.
   void _showEnergyUnitDialog(
-      BuildContext context, bool currentUsesKilojoules) async {
+    BuildContext context,
+    bool currentUsesKilojoules,
+  ) async {
     bool selectedUsesKilojoules = currentUsesKilojoules;
     final shouldUpdate = await showDialog<bool?>(
       context: context,
@@ -431,30 +456,33 @@ class _SettingsScreenState extends State<SettingsScreen> {
           contentPadding: EdgeInsets.zero,
           title: Text(S.of(context).settingsEnergyUnitLabel),
           content: StatefulBuilder(
-            builder: (BuildContext context,
-                void Function(void Function()) setState) {
-              return RadioGroup<bool>(
-                groupValue: selectedUsesKilojoules,
-                onChanged: (value) {
-                  setState(() {
-                    selectedUsesKilojoules = value ?? false;
-                  });
+            builder:
+                (
+                  BuildContext context,
+                  void Function(void Function()) setState,
+                ) {
+                  return RadioGroup<bool>(
+                    groupValue: selectedUsesKilojoules,
+                    onChanged: (value) {
+                      setState(() {
+                        selectedUsesKilojoules = value ?? false;
+                      });
+                    },
+                    child: Column(
+                      mainAxisSize: MainAxisSize.min,
+                      children: [
+                        RadioListTile<bool>(
+                          title: Text(S.of(context).energyUnitKcalLabel),
+                          value: false,
+                        ),
+                        RadioListTile<bool>(
+                          title: Text(S.of(context).energyUnitKjLabel),
+                          value: true,
+                        ),
+                      ],
+                    ),
+                  );
                 },
-                child: Column(
-                  mainAxisSize: MainAxisSize.min,
-                  children: [
-                    RadioListTile<bool>(
-                      title: Text(S.of(context).energyUnitKcalLabel),
-                      value: false,
-                    ),
-                    RadioListTile<bool>(
-                      title: Text(S.of(context).energyUnitKjLabel),
-                      value: true,
-                    ),
-                  ],
-                ),
-              );
-            },
           ),
           actions: <Widget>[
             TextButton(
@@ -473,8 +501,10 @@ class _SettingsScreenState extends State<SettingsScreen> {
       _settingsBloc.setUsesKilojoules(selectedUsesKilojoules);
       _settingsBloc.add(LoadSettingsEvent());
       if (context.mounted) {
-        Provider.of<EnergyUnitProvider>(context, listen: false)
-            .updateUsesKilojoules(selectedUsesKilojoules);
+        Provider.of<EnergyUnitProvider>(
+          context,
+          listen: false,
+        ).updateUsesKilojoules(selectedUsesKilojoules);
       }
     }
   }
@@ -493,10 +523,8 @@ class _SettingsScreenState extends State<SettingsScreen> {
   void _showMacroSplitDialog(BuildContext context) {
     showDialog(
       context: context,
-      builder: (context) => MacroSplitDialog(
-        settingsBloc: _settingsBloc,
-        homeBloc: _homeBloc,
-      ),
+      builder: (context) =>
+          MacroSplitDialog(settingsBloc: _settingsBloc, homeBloc: _homeBloc),
     );
   }
 
@@ -549,9 +577,7 @@ class _SettingsScreenState extends State<SettingsScreen> {
 
   void _openNutrientVisibilityScreen(BuildContext context) {
     Navigator.of(context).push(
-      MaterialPageRoute<void>(
-        builder: (_) => const NutrientVisibilityScreen(),
-      ),
+      MaterialPageRoute<void>(builder: (_) => const NutrientVisibilityScreen()),
     );
   }
 
@@ -627,36 +653,39 @@ class _SettingsScreenState extends State<SettingsScreen> {
           contentPadding: EdgeInsets.zero,
           title: Text(S.of(context).settingsThemeLabel),
           content: StatefulBuilder(
-            builder: (
-              BuildContext context,
-              void Function(void Function()) setState,
-            ) {
-              return RadioGroup(
-                groupValue: selectedTheme,
-                onChanged: (value) {
-                  setState(() {
-                    selectedTheme = value as AppThemeEntity;
-                  });
+            builder:
+                (
+                  BuildContext context,
+                  void Function(void Function()) setState,
+                ) {
+                  return RadioGroup(
+                    groupValue: selectedTheme,
+                    onChanged: (value) {
+                      setState(() {
+                        selectedTheme = value as AppThemeEntity;
+                      });
+                    },
+                    child: Column(
+                      mainAxisSize: MainAxisSize.min,
+                      children: [
+                        RadioListTile(
+                          title: Text(
+                            S.of(context).settingsThemeSystemDefaultLabel,
+                          ),
+                          value: AppThemeEntity.system,
+                        ),
+                        RadioListTile(
+                          title: Text(S.of(context).settingsThemeLightLabel),
+                          value: AppThemeEntity.light,
+                        ),
+                        RadioListTile(
+                          title: Text(S.of(context).settingsThemeDarkLabel),
+                          value: AppThemeEntity.dark,
+                        ),
+                      ],
+                    ),
+                  );
                 },
-                child: Column(
-                  mainAxisSize: MainAxisSize.min,
-                  children: [
-                    RadioListTile(
-                      title: Text(S.of(context).settingsThemeSystemDefaultLabel),
-                      value: AppThemeEntity.system,
-                    ),
-                    RadioListTile(
-                      title: Text(S.of(context).settingsThemeLightLabel),
-                      value: AppThemeEntity.light,
-                    ),
-                    RadioListTile(
-                      title: Text(S.of(context).settingsThemeDarkLabel),
-                      value: AppThemeEntity.dark,
-                    ),
-                  ],
-                ),
-              );
-            },
           ),
           actions: [
             TextButton(
@@ -712,29 +741,34 @@ class _SettingsScreenState extends State<SettingsScreen> {
           contentPadding: EdgeInsets.zero,
           title: Text(S.of(context).settingsLanguageLabel),
           content: StatefulBuilder(
-            builder: (BuildContext context,
-                void Function(void Function()) setState) {
-              return RadioGroup<String>(
-                groupValue: selectedCode,
-                onChanged: (v) => setState(() => selectedCode = v as String),
-                child: Column(
-                  mainAxisSize: MainAxisSize.min,
-                  children: [
-                    RadioListTile<String>(
-                      title:
-                          Text(S.of(context).settingsThemeSystemDefaultLabel),
-                      value: _systemLocale,
+            builder:
+                (
+                  BuildContext context,
+                  void Function(void Function()) setState,
+                ) {
+                  return RadioGroup<String>(
+                    groupValue: selectedCode,
+                    onChanged: (v) =>
+                        setState(() => selectedCode = v as String),
+                    child: Column(
+                      mainAxisSize: MainAxisSize.min,
+                      children: [
+                        RadioListTile<String>(
+                          title: Text(
+                            S.of(context).settingsThemeSystemDefaultLabel,
+                          ),
+                          value: _systemLocale,
+                        ),
+                        ..._supportedLocales.entries.map(
+                          (e) => RadioListTile<String>(
+                            title: Text(e.value),
+                            value: e.key,
+                          ),
+                        ),
+                      ],
                     ),
-                    ..._supportedLocales.entries.map(
-                      (e) => RadioListTile<String>(
-                        title: Text(e.value),
-                        value: e.key,
-                      ),
-                    ),
-                  ],
-                ),
-              );
-            },
+                  );
+                },
           ),
           actions: [
             TextButton(
@@ -743,14 +777,13 @@ class _SettingsScreenState extends State<SettingsScreen> {
             ),
             TextButton(
               onPressed: () {
-                final locale =
-                    selectedCode.isEmpty ? null : selectedCode;
+                final locale = selectedCode.isEmpty ? null : selectedCode;
                 _settingsBloc.setSelectedLocale(locale);
                 _settingsBloc.add(LoadSettingsEvent());
-                Provider.of<LocaleProvider>(context, listen: false)
-                    .updateLocale(
-                  locale != null ? Locale(locale) : null,
-                );
+                Provider.of<LocaleProvider>(
+                  context,
+                  listen: false,
+                ).updateLocale(locale != null ? Locale(locale) : null);
                 Navigator.of(context).pop();
               },
               child: Text(S.of(context).dialogOKLabel),
@@ -825,20 +858,21 @@ class _SettingsScreenState extends State<SettingsScreen> {
         return AlertDialog(
           title: Text(S.of(context).settingsPrivacySettings),
           content: StatefulBuilder(
-            builder: (
-              BuildContext context,
-              void Function(void Function()) setState,
-            ) {
-              return SwitchListTile(
-                title: Text(S.of(context).sendAnonymousUserData),
-                value: switchActive,
-                onChanged: (bool value) {
-                  setState(() {
-                    switchActive = value;
-                  });
+            builder:
+                (
+                  BuildContext context,
+                  void Function(void Function()) setState,
+                ) {
+                  return SwitchListTile(
+                    title: Text(S.of(context).sendAnonymousUserData),
+                    value: switchActive,
+                    onChanged: (bool value) {
+                      setState(() {
+                        switchActive = value;
+                      });
+                    },
+                  );
                 },
-              );
-            },
           ),
           actions: [
             TextButton(

--- a/lib/generated/intl/messages_cs.dart
+++ b/lib/generated/intl/messages_cs.dart
@@ -82,6 +82,10 @@ class MessageLookup extends MessageLookupByLibrary {
   static String mLowKcal(threshold) =>
       "Dospělí by bez lékařského dohledu neměli dlouhodobě přijímat méně než ${threshold} kcal denně. Zvažte, prosím, konzultaci se zdravotníkem, než u tak nízkého cíle zůstanete.";
 
+  static String mWaterChip(current, goal) => "${current} / ${goal} ml";
+
+  static String mLogWaterAmount(amount) => "Přidat ${amount} ml";
+
   final messages = _notInlinedMessages(_notInlinedMessages);
   static Map<String, Function> _notInlinedMessages(_) => <String, Function>{
         "activityExample": MessageLookupByLibrary.simpleMessage(
@@ -1260,5 +1264,19 @@ class MessageLookup extends MessageLookupByLibrary {
         "settingsPerMealKcalShareSnack":
             MessageLookupByLibrary.simpleMessage("Svačina"),
         "diaryMealKcalConsumedOfTarget": m23,
+        "logWaterAmountLabel": mLogWaterAmount,
+        "logWaterDialogTitle":
+            MessageLookupByLibrary.simpleMessage("Zaznamenat příjem vody"),
+        "logWaterNothingToUndoLabel":
+            MessageLookupByLibrary.simpleMessage("Není co vrátit"),
+        "logWaterUndoLabel":
+            MessageLookupByLibrary.simpleMessage("Vrátit poslední"),
+        "mlLabel": MessageLookupByLibrary.simpleMessage("ml"),
+        "settingsWaterGoalDescription":
+            MessageLookupByLibrary.simpleMessage(
+                "Používá se pro ukazatel vody na hlavní obrazovce."),
+        "settingsWaterGoalLabel":
+            MessageLookupByLibrary.simpleMessage("Denní cíl pití vody"),
+        "waterChipLabel": mWaterChip,
       };
 }

--- a/lib/generated/intl/messages_de.dart
+++ b/lib/generated/intl/messages_de.dart
@@ -85,6 +85,10 @@ class MessageLookup extends MessageLookupByLibrary {
   static String mLowKcal(threshold) =>
       "Erwachsene sollten ohne ärztliche Begleitung dauerhaft nicht weniger als ${threshold} kcal pro Tag zu sich nehmen. Bitte überlege, ob du vor einem so niedrigen Ziel mit einer medizinischen Fachperson sprichst.";
 
+  static String mWaterChip(current, goal) => "${current} / ${goal} ml";
+
+  static String mLogWaterAmount(amount) => "${amount} ml hinzufügen";
+
   final messages = _notInlinedMessages(_notInlinedMessages);
   static Map<String, Function> _notInlinedMessages(_) => <String, Function>{
         "activityExample": MessageLookupByLibrary.simpleMessage(
@@ -1284,5 +1288,19 @@ class MessageLookup extends MessageLookupByLibrary {
         "settingsPerMealKcalShareSnack":
             MessageLookupByLibrary.simpleMessage("Snack"),
         "diaryMealKcalConsumedOfTarget": m23,
+        "logWaterAmountLabel": mLogWaterAmount,
+        "logWaterDialogTitle":
+            MessageLookupByLibrary.simpleMessage("Wasseraufnahme erfassen"),
+        "logWaterNothingToUndoLabel":
+            MessageLookupByLibrary.simpleMessage("Nichts zurückzunehmen"),
+        "logWaterUndoLabel":
+            MessageLookupByLibrary.simpleMessage("Letzten zurücknehmen"),
+        "mlLabel": MessageLookupByLibrary.simpleMessage("ml"),
+        "settingsWaterGoalDescription":
+            MessageLookupByLibrary.simpleMessage(
+                "Wird vom Wasser-Chip auf dem Startbildschirm verwendet."),
+        "settingsWaterGoalLabel":
+            MessageLookupByLibrary.simpleMessage("Tägliches Wasserziel"),
+        "waterChipLabel": mWaterChip,
       };
 }

--- a/lib/generated/intl/messages_en.dart
+++ b/lib/generated/intl/messages_en.dart
@@ -82,6 +82,10 @@ class MessageLookup extends MessageLookupByLibrary {
   static String m26(threshold) =>
       "Most adults shouldn\'t eat fewer than ${threshold} kcal a day for any length of time without medical guidance. Please consider speaking with a healthcare professional before sticking with a target this low.";
 
+  static String mWaterChip(current, goal) => "${current} / ${goal} ml";
+
+  static String mLogWaterAmount(amount) => "Add ${amount} ml";
+
   final messages = _notInlinedMessages(_notInlinedMessages);
   static Map<String, Function> _notInlinedMessages(_) => <String, Function>{
         "activityExample": MessageLookupByLibrary.simpleMessage(
@@ -1247,5 +1251,19 @@ class MessageLookup extends MessageLookupByLibrary {
         "settingsPerMealKcalShareSnack":
             MessageLookupByLibrary.simpleMessage("Snack"),
         "diaryMealKcalConsumedOfTarget": m22,
+        "logWaterAmountLabel": mLogWaterAmount,
+        "logWaterDialogTitle":
+            MessageLookupByLibrary.simpleMessage("Log water intake"),
+        "logWaterNothingToUndoLabel":
+            MessageLookupByLibrary.simpleMessage("Nothing to undo"),
+        "logWaterUndoLabel":
+            MessageLookupByLibrary.simpleMessage("Undo last"),
+        "mlLabel": MessageLookupByLibrary.simpleMessage("ml"),
+        "settingsWaterGoalDescription":
+            MessageLookupByLibrary.simpleMessage(
+                "Used by the water chip on the home screen."),
+        "settingsWaterGoalLabel":
+            MessageLookupByLibrary.simpleMessage("Daily water goal"),
+        "waterChipLabel": mWaterChip,
       };
 }

--- a/lib/generated/intl/messages_it.dart
+++ b/lib/generated/intl/messages_it.dart
@@ -82,6 +82,10 @@ class MessageLookup extends MessageLookupByLibrary {
   static String mLowKcal(threshold) =>
       "Gli adulti non dovrebbero assumere meno di ${threshold} kcal al giorno per periodi prolungati senza una guida medica. Valuta di parlare con un professionista sanitario prima di mantenere un obiettivo così basso.";
 
+  static String mWaterChip(current, goal) => "${current} / ${goal} ml";
+
+  static String mLogWaterAmount(amount) => "Aggiungi ${amount} ml";
+
   final messages = _notInlinedMessages(_notInlinedMessages);
   static Map<String, Function> _notInlinedMessages(_) => <String, Function>{
         "activityExample": MessageLookupByLibrary.simpleMessage(
@@ -1272,5 +1276,20 @@ class MessageLookup extends MessageLookupByLibrary {
         "settingsPerMealKcalShareSnack":
             MessageLookupByLibrary.simpleMessage("Spuntino"),
         "diaryMealKcalConsumedOfTarget": m23,
+        "logWaterAmountLabel": mLogWaterAmount,
+        "logWaterDialogTitle":
+            MessageLookupByLibrary.simpleMessage("Registra acqua bevuta"),
+        "logWaterNothingToUndoLabel":
+            MessageLookupByLibrary.simpleMessage("Niente da annullare"),
+        "logWaterUndoLabel":
+            MessageLookupByLibrary.simpleMessage("Annulla ultimo"),
+        "mlLabel": MessageLookupByLibrary.simpleMessage("ml"),
+        "settingsWaterGoalDescription":
+            MessageLookupByLibrary.simpleMessage(
+                "Usato dal contatore d\'acqua nella schermata principale."),
+        "settingsWaterGoalLabel":
+            MessageLookupByLibrary.simpleMessage(
+                "Obiettivo idrico giornaliero"),
+        "waterChipLabel": mWaterChip,
       };
 }

--- a/lib/generated/intl/messages_pl.dart
+++ b/lib/generated/intl/messages_pl.dart
@@ -82,6 +82,10 @@ class MessageLookup extends MessageLookupByLibrary {
   static String mLowKcal(threshold) =>
       "Osoby dorosłe nie powinny przez dłuższy czas spożywać mniej niż ${threshold} kcal dziennie bez nadzoru lekarza. Zanim utrzymasz tak niski cel, rozważ konsultację ze specjalistą.";
 
+  static String mWaterChip(current, goal) => "${current} / ${goal} ml";
+
+  static String mLogWaterAmount(amount) => "Dodaj ${amount} ml";
+
   final messages = _notInlinedMessages(_notInlinedMessages);
   static Map<String, Function> _notInlinedMessages(_) => <String, Function>{
         "activityExample": MessageLookupByLibrary.simpleMessage(
@@ -1271,5 +1275,19 @@ class MessageLookup extends MessageLookupByLibrary {
         "settingsPerMealKcalShareSnack":
             MessageLookupByLibrary.simpleMessage("Przekąska"),
         "diaryMealKcalConsumedOfTarget": m23,
+        "logWaterAmountLabel": mLogWaterAmount,
+        "logWaterDialogTitle":
+            MessageLookupByLibrary.simpleMessage("Zapisz wypitą wodę"),
+        "logWaterNothingToUndoLabel":
+            MessageLookupByLibrary.simpleMessage("Nic do cofnięcia"),
+        "logWaterUndoLabel":
+            MessageLookupByLibrary.simpleMessage("Cofnij ostatni"),
+        "mlLabel": MessageLookupByLibrary.simpleMessage("ml"),
+        "settingsWaterGoalDescription":
+            MessageLookupByLibrary.simpleMessage(
+                "Używane przez wskaźnik wody na ekranie głównym."),
+        "settingsWaterGoalLabel":
+            MessageLookupByLibrary.simpleMessage("Dzienny cel wody"),
+        "waterChipLabel": mWaterChip,
       };
 }

--- a/lib/generated/intl/messages_sk.dart
+++ b/lib/generated/intl/messages_sk.dart
@@ -82,6 +82,10 @@ class MessageLookup extends MessageLookupByLibrary {
   static String mLowKcal(threshold) =>
       "Dospelí by bez lekárskeho dohľadu nemali dlhodobo prijímať menej než ${threshold} kcal denne. Zvážte konzultáciu so zdravotníckym odborníkom skôr, než zostanete pri takomto nízkom cieli.";
 
+  static String mWaterChip(current, goal) => "${current} / ${goal} ml";
+
+  static String mLogWaterAmount(amount) => "Pridať ${amount} ml";
+
   final messages = _notInlinedMessages(_notInlinedMessages);
   static Map<String, Function> _notInlinedMessages(_) => <String, Function>{
         "activityExample": MessageLookupByLibrary.simpleMessage(
@@ -1264,5 +1268,19 @@ class MessageLookup extends MessageLookupByLibrary {
         "settingsPerMealKcalShareSnack":
             MessageLookupByLibrary.simpleMessage("Snack"),
         "diaryMealKcalConsumedOfTarget": m23,
+        "logWaterAmountLabel": mLogWaterAmount,
+        "logWaterDialogTitle":
+            MessageLookupByLibrary.simpleMessage("Zaznamenať príjem vody"),
+        "logWaterNothingToUndoLabel":
+            MessageLookupByLibrary.simpleMessage("Nie je čo vrátiť"),
+        "logWaterUndoLabel":
+            MessageLookupByLibrary.simpleMessage("Vrátiť posledný"),
+        "mlLabel": MessageLookupByLibrary.simpleMessage("ml"),
+        "settingsWaterGoalDescription":
+            MessageLookupByLibrary.simpleMessage(
+                "Používa sa ukazovateľom vody na hlavnej obrazovke."),
+        "settingsWaterGoalLabel":
+            MessageLookupByLibrary.simpleMessage("Denný cieľ pitia vody"),
+        "waterChipLabel": mWaterChip,
       };
 }

--- a/lib/generated/intl/messages_tr.dart
+++ b/lib/generated/intl/messages_tr.dart
@@ -84,6 +84,10 @@ class MessageLookup extends MessageLookupByLibrary {
   static String mLowKcal(threshold) =>
       "Yetişkinler tıbbi gözetim olmadan uzun süreyle günde ${threshold} kcal\'nin altında beslenmemelidir. Bu kadar düşük bir hedefte kalmadan önce lütfen bir sağlık uzmanına danışmayı düşün.";
 
+  static String mWaterChip(current, goal) => "${current} / ${goal} ml";
+
+  static String mLogWaterAmount(amount) => "${amount} ml ekle";
+
   final messages = _notInlinedMessages(_notInlinedMessages);
   static Map<String, Function> _notInlinedMessages(_) => <String, Function>{
         "activityExample": MessageLookupByLibrary.simpleMessage(
@@ -1247,5 +1251,19 @@ class MessageLookup extends MessageLookupByLibrary {
         "settingsPerMealKcalShareSnack":
             MessageLookupByLibrary.simpleMessage("Atıştırmalık"),
         "diaryMealKcalConsumedOfTarget": m23,
+        "logWaterAmountLabel": mLogWaterAmount,
+        "logWaterDialogTitle":
+            MessageLookupByLibrary.simpleMessage("Su alımını kaydet"),
+        "logWaterNothingToUndoLabel":
+            MessageLookupByLibrary.simpleMessage("Geri alınacak bir şey yok"),
+        "logWaterUndoLabel":
+            MessageLookupByLibrary.simpleMessage("Sonuncuyu geri al"),
+        "mlLabel": MessageLookupByLibrary.simpleMessage("ml"),
+        "settingsWaterGoalDescription":
+            MessageLookupByLibrary.simpleMessage(
+                "Ana ekrandaki su göstergesinin kullandığı hedef."),
+        "settingsWaterGoalLabel":
+            MessageLookupByLibrary.simpleMessage("Günlük su hedefi"),
+        "waterChipLabel": mWaterChip,
       };
 }

--- a/lib/generated/intl/messages_uk.dart
+++ b/lib/generated/intl/messages_uk.dart
@@ -82,6 +82,10 @@ class MessageLookup extends MessageLookupByLibrary {
   static String mLowKcal(threshold) =>
       "Дорослим без медичного нагляду не варто тривало споживати менше ніж ${threshold} ккал на день. Будь ласка, перш ніж залишати такий низький рівень, проконсультуйтеся з лікарем.";
 
+  static String mWaterChip(current, goal) => "${current} / ${goal} мл";
+
+  static String mLogWaterAmount(amount) => "Додати ${amount} мл";
+
   final messages = _notInlinedMessages(_notInlinedMessages);
   static Map<String, Function> _notInlinedMessages(_) => <String, Function>{
         "activityExample": MessageLookupByLibrary.simpleMessage(
@@ -1274,5 +1278,19 @@ class MessageLookup extends MessageLookupByLibrary {
         "settingsPerMealKcalShareSnack":
             MessageLookupByLibrary.simpleMessage("Перекус"),
         "diaryMealKcalConsumedOfTarget": m23,
+        "logWaterAmountLabel": mLogWaterAmount,
+        "logWaterDialogTitle":
+            MessageLookupByLibrary.simpleMessage("Записати спожиту воду"),
+        "logWaterNothingToUndoLabel":
+            MessageLookupByLibrary.simpleMessage("Немає що скасовувати"),
+        "logWaterUndoLabel":
+            MessageLookupByLibrary.simpleMessage("Скасувати останнє"),
+        "mlLabel": MessageLookupByLibrary.simpleMessage("мл"),
+        "settingsWaterGoalDescription":
+            MessageLookupByLibrary.simpleMessage(
+                "Використовується індикатором води на головному екрані."),
+        "settingsWaterGoalLabel":
+            MessageLookupByLibrary.simpleMessage("Денна ціль вживання води"),
+        "waterChipLabel": mWaterChip,
       };
 }

--- a/lib/generated/intl/messages_zh.dart
+++ b/lib/generated/intl/messages_zh.dart
@@ -79,6 +79,10 @@ class MessageLookup extends MessageLookupByLibrary {
   static String mLowKcal(threshold) =>
       "在没有医疗指导的情况下，成年人不宜长期每天摄入低于 ${threshold} 千卡的热量。在维持这么低的目标之前，请考虑咨询医疗专业人员。";
 
+  static String mWaterChip(current, goal) => "${current} / ${goal} 毫升";
+
+  static String mLogWaterAmount(amount) => "添加 ${amount} 毫升";
+
   final messages = _notInlinedMessages(_notInlinedMessages);
   static Map<String, Function> _notInlinedMessages(_) => <String, Function>{
         "activityExample":
@@ -1113,5 +1117,19 @@ class MessageLookup extends MessageLookupByLibrary {
         "settingsPerMealKcalShareSnack":
             MessageLookupByLibrary.simpleMessage("零食"),
         "diaryMealKcalConsumedOfTarget": m23,
+        "logWaterAmountLabel": mLogWaterAmount,
+        "logWaterDialogTitle":
+            MessageLookupByLibrary.simpleMessage("记录饮水量"),
+        "logWaterNothingToUndoLabel":
+            MessageLookupByLibrary.simpleMessage("没有可撤销的记录"),
+        "logWaterUndoLabel":
+            MessageLookupByLibrary.simpleMessage("撤销最后一次"),
+        "mlLabel": MessageLookupByLibrary.simpleMessage("毫升"),
+        "settingsWaterGoalDescription":
+            MessageLookupByLibrary.simpleMessage(
+                "主屏幕上的饮水提示使用此目标。"),
+        "settingsWaterGoalLabel":
+            MessageLookupByLibrary.simpleMessage("每日饮水目标"),
+        "waterChipLabel": mWaterChip,
       };
 }

--- a/lib/generated/l10n.dart
+++ b/lib/generated/l10n.dart
@@ -7071,6 +7071,86 @@ class S {
       args: [],
     );
   }
+
+  /// `{current} / {goal} ml`
+  String waterChipLabel(int current, int goal) {
+    return Intl.message(
+      '$current / $goal ml',
+      name: 'waterChipLabel',
+      desc: '',
+      args: [current, goal],
+    );
+  }
+
+  /// `Log water intake`
+  String get logWaterDialogTitle {
+    return Intl.message(
+      'Log water intake',
+      name: 'logWaterDialogTitle',
+      desc: '',
+      args: [],
+    );
+  }
+
+  /// `Add {amount} ml`
+  String logWaterAmountLabel(int amount) {
+    return Intl.message(
+      'Add $amount ml',
+      name: 'logWaterAmountLabel',
+      desc: '',
+      args: [amount],
+    );
+  }
+
+  /// `Undo last`
+  String get logWaterUndoLabel {
+    return Intl.message(
+      'Undo last',
+      name: 'logWaterUndoLabel',
+      desc: '',
+      args: [],
+    );
+  }
+
+  /// `Nothing to undo`
+  String get logWaterNothingToUndoLabel {
+    return Intl.message(
+      'Nothing to undo',
+      name: 'logWaterNothingToUndoLabel',
+      desc: '',
+      args: [],
+    );
+  }
+
+  /// `ml`
+  String get mlLabel {
+    return Intl.message(
+      'ml',
+      name: 'mlLabel',
+      desc: '',
+      args: [],
+    );
+  }
+
+  /// `Daily water goal`
+  String get settingsWaterGoalLabel {
+    return Intl.message(
+      'Daily water goal',
+      name: 'settingsWaterGoalLabel',
+      desc: '',
+      args: [],
+    );
+  }
+
+  /// `Used by the water chip on the home screen.`
+  String get settingsWaterGoalDescription {
+    return Intl.message(
+      'Used by the water chip on the home screen.',
+      name: 'settingsWaterGoalDescription',
+      desc: '',
+      args: [],
+    );
+  }
 }
 
 class AppLocalizationDelegate extends LocalizationsDelegate<S> {

--- a/lib/hive_registrar.g.dart
+++ b/lib/hive_registrar.g.dart
@@ -20,6 +20,7 @@ import 'package:opennutritracker/core/data/dbo/user_dbo.dart';
 import 'package:opennutritracker/core/data/dbo/user_gender_dbo.dart';
 import 'package:opennutritracker/core/data/dbo/user_pal_dbo.dart';
 import 'package:opennutritracker/core/data/dbo/user_weight_goal_dbo.dart';
+import 'package:opennutritracker/core/data/dbo/water_intake_dbo.dart';
 import 'package:opennutritracker/core/data/dbo/weight_log_dbo.dart';
 
 extension HiveRegistrar on HiveInterface {
@@ -43,6 +44,7 @@ extension HiveRegistrar on HiveInterface {
     registerAdapter(UserGenderDBOAdapter());
     registerAdapter(UserPALDBOAdapter());
     registerAdapter(UserWeightGoalDBOAdapter());
+    registerAdapter(WaterIntakeDBOAdapter());
     registerAdapter(WeightLogDBOAdapter());
   }
 }
@@ -68,6 +70,7 @@ extension IsolatedHiveRegistrar on IsolatedHiveInterface {
     registerAdapter(UserGenderDBOAdapter());
     registerAdapter(UserPALDBOAdapter());
     registerAdapter(UserWeightGoalDBOAdapter());
+    registerAdapter(WaterIntakeDBOAdapter());
     registerAdapter(WeightLogDBOAdapter());
   }
 }

--- a/lib/l10n/intl_cs.arb
+++ b/lib/l10n/intl_cs.arb
@@ -831,5 +831,13 @@
   "weightHistoryWeightLabel": "Hmotnost",
   "weightLabel": "Hmotnost",
   "yearsLabel": "{age} let",
+  "logWaterAmountLabel": "Přidat {amount} ml",
+  "logWaterDialogTitle": "Zaznamenat příjem vody",
+  "logWaterNothingToUndoLabel": "Není co vrátit",
+  "logWaterUndoLabel": "Vrátit poslední",
+  "mlLabel": "ml",
+  "settingsWaterGoalDescription": "Používá se pro ukazatel vody na hlavní obrazovce.",
+  "settingsWaterGoalLabel": "Denní cíl pití vody",
+  "waterChipLabel": "{current} / {goal} ml",
   "zincLabel": "zinek"
 }

--- a/lib/l10n/intl_de.arb
+++ b/lib/l10n/intl_de.arb
@@ -862,5 +862,13 @@
   "weightHistoryWeightLabel": "Gewicht",
   "weightLabel": "Gewicht",
   "yearsLabel": "{age} Jahre",
+  "logWaterAmountLabel": "{amount} ml hinzufügen",
+  "logWaterDialogTitle": "Wasseraufnahme erfassen",
+  "logWaterNothingToUndoLabel": "Nichts zurückzunehmen",
+  "logWaterUndoLabel": "Letzten zurücknehmen",
+  "mlLabel": "ml",
+  "settingsWaterGoalDescription": "Wird vom Wasser-Chip auf dem Startbildschirm verwendet.",
+  "settingsWaterGoalLabel": "Tägliches Wasserziel",
+  "waterChipLabel": "{current} / {goal} ml",
   "zincLabel": "Zink"
 }

--- a/lib/l10n/intl_en.arb
+++ b/lib/l10n/intl_en.arb
@@ -127,10 +127,27 @@
       }
     }
   },
+  "@logWaterAmountLabel": {
+    "placeholders": {
+      "amount": {
+        "type": "int"
+      }
+    }
+  },
   "@settingsNotificationsTimeLabel": {
     "placeholders": {
       "time": {
         "type": "String"
+      }
+    }
+  },
+  "@waterChipLabel": {
+    "placeholders": {
+      "current": {
+        "type": "int"
+      },
+      "goal": {
+        "type": "int"
       }
     }
   },
@@ -862,5 +879,13 @@
   "weightHistoryWeightLabel": "Weight",
   "weightLabel": "Weight",
   "yearsLabel": "{age} years",
+  "logWaterAmountLabel": "Add {amount} ml",
+  "logWaterDialogTitle": "Log water intake",
+  "logWaterNothingToUndoLabel": "Nothing to undo",
+  "logWaterUndoLabel": "Undo last",
+  "mlLabel": "ml",
+  "settingsWaterGoalDescription": "Used by the water chip on the home screen.",
+  "settingsWaterGoalLabel": "Daily water goal",
+  "waterChipLabel": "{current} / {goal} ml",
   "zincLabel": "zinc"
 }

--- a/lib/l10n/intl_it.arb
+++ b/lib/l10n/intl_it.arb
@@ -831,5 +831,13 @@
   "weightHistoryWeightLabel": "Peso",
   "weightLabel": "Peso",
   "yearsLabel": "{age} anni",
+  "logWaterAmountLabel": "Aggiungi {amount} ml",
+  "logWaterDialogTitle": "Registra acqua bevuta",
+  "logWaterNothingToUndoLabel": "Niente da annullare",
+  "logWaterUndoLabel": "Annulla ultimo",
+  "mlLabel": "ml",
+  "settingsWaterGoalDescription": "Usato dal contatore d'acqua nella schermata principale.",
+  "settingsWaterGoalLabel": "Obiettivo idrico giornaliero",
+  "waterChipLabel": "{current} / {goal} ml",
   "zincLabel": "zinco"
 }

--- a/lib/l10n/intl_pl.arb
+++ b/lib/l10n/intl_pl.arb
@@ -831,5 +831,13 @@
   "weightHistoryWeightLabel": "Waga",
   "weightLabel": "Waga",
   "yearsLabel": "{age} lat",
+  "logWaterAmountLabel": "Dodaj {amount} ml",
+  "logWaterDialogTitle": "Zapisz wypitą wodę",
+  "logWaterNothingToUndoLabel": "Nic do cofnięcia",
+  "logWaterUndoLabel": "Cofnij ostatni",
+  "mlLabel": "ml",
+  "settingsWaterGoalDescription": "Używane przez wskaźnik wody na ekranie głównym.",
+  "settingsWaterGoalLabel": "Dzienny cel wody",
+  "waterChipLabel": "{current} / {goal} ml",
   "zincLabel": "cynk"
 }

--- a/lib/l10n/intl_sk.arb
+++ b/lib/l10n/intl_sk.arb
@@ -861,5 +861,13 @@
   "weightHistoryWeightLabel": "Hmotnosť",
   "weightLabel": "Hmotnosť",
   "yearsLabel": "{age} rokov",
+  "logWaterAmountLabel": "Pridať {amount} ml",
+  "logWaterDialogTitle": "Zaznamenať príjem vody",
+  "logWaterNothingToUndoLabel": "Nie je čo vrátiť",
+  "logWaterUndoLabel": "Vrátiť posledný",
+  "mlLabel": "ml",
+  "settingsWaterGoalDescription": "Používa sa ukazovateľom vody na hlavnej obrazovke.",
+  "settingsWaterGoalLabel": "Denný cieľ pitia vody",
+  "waterChipLabel": "{current} / {goal} ml",
   "zincLabel": "zinok"
 }

--- a/lib/l10n/intl_tr.arb
+++ b/lib/l10n/intl_tr.arb
@@ -862,5 +862,13 @@
   "weightHistoryWeightLabel": "Kilo",
   "weightLabel": "Kilo",
   "yearsLabel": "{age} yıl",
+  "logWaterAmountLabel": "{amount} ml ekle",
+  "logWaterDialogTitle": "Su alımını kaydet",
+  "logWaterNothingToUndoLabel": "Geri alınacak bir şey yok",
+  "logWaterUndoLabel": "Sonuncuyu geri al",
+  "mlLabel": "ml",
+  "settingsWaterGoalDescription": "Ana ekrandaki su göstergesinin kullandığı hedef.",
+  "settingsWaterGoalLabel": "Günlük su hedefi",
+  "waterChipLabel": "{current} / {goal} ml",
   "zincLabel": "çinko"
 }

--- a/lib/l10n/intl_uk.arb
+++ b/lib/l10n/intl_uk.arb
@@ -831,5 +831,13 @@
   "weightHistoryWeightLabel": "Вага",
   "weightLabel": "Вага",
   "yearsLabel": "{age} років",
+  "logWaterAmountLabel": "Додати {amount} мл",
+  "logWaterDialogTitle": "Записати спожиту воду",
+  "logWaterNothingToUndoLabel": "Немає що скасовувати",
+  "logWaterUndoLabel": "Скасувати останнє",
+  "mlLabel": "мл",
+  "settingsWaterGoalDescription": "Використовується індикатором води на головному екрані.",
+  "settingsWaterGoalLabel": "Денна ціль вживання води",
+  "waterChipLabel": "{current} / {goal} мл",
   "zincLabel": "цинк"
 }

--- a/lib/l10n/intl_zh.arb
+++ b/lib/l10n/intl_zh.arb
@@ -832,5 +832,13 @@
   "weightHistoryWeightLabel": "体重",
   "weightLabel": "体重",
   "yearsLabel": "{age} 岁",
+  "logWaterAmountLabel": "添加 {amount} 毫升",
+  "logWaterDialogTitle": "记录饮水量",
+  "logWaterNothingToUndoLabel": "没有可撤销的记录",
+  "logWaterUndoLabel": "撤销最后一次",
+  "mlLabel": "毫升",
+  "settingsWaterGoalDescription": "主屏幕上的饮水提示使用此目标。",
+  "settingsWaterGoalLabel": "每日饮水目标",
+  "waterChipLabel": "{current} / {goal} 毫升",
   "zincLabel": "锌"
 }

--- a/test/unit_test/water_goal_seed_test.dart
+++ b/test/unit_test/water_goal_seed_test.dart
@@ -1,0 +1,94 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:opennutritracker/core/domain/entity/app_theme_entity.dart';
+import 'package:opennutritracker/core/domain/entity/calories_profile_entity.dart';
+import 'package:opennutritracker/core/domain/entity/config_entity.dart';
+import 'package:opennutritracker/core/domain/entity/user_gender_entity.dart';
+
+/// #32: the home water chip seeds its goal from the user's gender (and,
+/// for non-binary users, their CaloriesProfileEntity) when the config
+/// has no override stored yet. Numbers are derived from EFSA 2010 total
+/// water AI minus the ~20% food-moisture share — see ConfigEntity
+/// docstring for the full citation chain.
+void main() {
+  group('ConfigEntity.seedWaterGoalForGender', () {
+    test('female users seed at 1500 ml (EFSA-derived)', () {
+      expect(
+        ConfigEntity.seedWaterGoalForGender(UserGenderEntity.female),
+        1500,
+      );
+    });
+
+    test('male users seed at 1900 ml (EFSA-derived)', () {
+      expect(
+        ConfigEntity.seedWaterGoalForGender(UserGenderEntity.male),
+        1900,
+      );
+    });
+
+    test('non-binary users default to the averaged midpoint (1700 ml)', () {
+      expect(
+        ConfigEntity.seedWaterGoalForGender(UserGenderEntity.nonBinary),
+        1700,
+      );
+    });
+
+    test(
+      'non-binary users with estrogen profile seed at the female value',
+      () {
+        expect(
+          ConfigEntity.seedWaterGoalForGender(
+            UserGenderEntity.nonBinary,
+            caloriesProfile: CaloriesProfileEntity.estrogenTypical,
+          ),
+          1500,
+        );
+      },
+    );
+
+    test(
+      'non-binary users with testosterone profile seed at the male value',
+      () {
+        expect(
+          ConfigEntity.seedWaterGoalForGender(
+            UserGenderEntity.nonBinary,
+            caloriesProfile: CaloriesProfileEntity.testosteroneTypical,
+          ),
+          1900,
+        );
+      },
+    );
+  });
+
+  group('ConfigEntity.effectiveDailyWaterGoalMl', () {
+    test('returns the user override when one is stored', () {
+      const config = ConfigEntity(
+        false,
+        false,
+        false,
+        AppThemeEntity.system,
+        dailyWaterGoalMl: 2400,
+      );
+      expect(
+        config.effectiveDailyWaterGoalMl(UserGenderEntity.female),
+        2400,
+      );
+    });
+
+    test('falls back to the gendered seed when no override is stored', () {
+      const config = ConfigEntity(
+        false,
+        false,
+        false,
+        AppThemeEntity.system,
+      );
+      expect(
+        config.effectiveDailyWaterGoalMl(UserGenderEntity.male),
+        1900,
+      );
+      expect(
+        config.effectiveDailyWaterGoalMl(UserGenderEntity.female),
+        1500,
+      );
+    });
+  });
+}


### PR DESCRIPTION
Closes #32.

## What this is

A small water-drop chip sits next to the existing weight chip on the home screen, showing today's running total against a daily goal that the person picks for themselves. Tapping it opens a slider dialog that takes a sip in 50 ml steps; an Undo last button rolls the most recent entry back without having to do the mental arithmetic, and a Reset clears the slider back to 0 when a tap was a mis-tap.

The daily goal is gendered out of the box and lives on the Profile screen alongside the other personal targets. Numbers come from the EFSA 2010 Adequate Intake for total water (women 2.0 L, men 2.5 L) minus the ~20% EFSA attributes to food moisture: women and oestrogen-profile non-binary users seed at 1500 ml, men and testosterone-profile non-binary users at 1900 ml, averaged non-binary users at the 1700 ml midpoint. Reset in the goal dialog returns the person to their own gendered seed, not a hard-coded constant.

The popular "8 × 8 oz = 2 L of plain water" target has no scientific basis (Valtin 2002 traced it to a misreading of a 1945 US Food and Nutrition Board note that explicitly said most could come from food) and is documented as such in the code comment rather than quietly inherited. Sources are cited inline next to `defaultDailyWaterGoalMl`.

## Under the hood

- New `WaterIntakeDBO` (Hive `typeId: 19`) in its own `WaterIntakeBox`, keyed by uuid — one row per sip. That's what makes Undo cheap and what keeps the door open for a future hydration-over-the-day view without a data migration.
- Today's total respects the configurable diary day-start from #139, so a 1 am glass of water on a 04:30 boundary still files under the previous logical day rather than starting tomorrow off ahead.
- The goal dialog refreshes both the home chip and the profile subtitle on save, so the new value shows up everywhere it's visible without the user navigating away and back.
- `delete_all_user_data_usecase` clears the new box alongside the others.

## Localisation

All nine supported locales (`en`, `cs`, `de`, `it`, `pl`, `sk`, `tr`, `uk`, `zh`) got real translations rather than English placeholders. Generated `l10n.dart` and `messages_*.dart` were updated by hand to match the project's manually-maintained pattern.

## Tests

A small unit-test file (`test/unit_test/water_goal_seed_test.dart`) exercises the gendered seed matrix end-to-end so future profile changes won't quietly drift the defaults. The full suite is at 531 passing, analyze clean.

## Test plan

- [x] Fresh install, walk onboarding picking female → home chip seeds at **0 / 1500 ml**.
- [x] Tap the chip → slider dialog opens, default 250 ml. Drag to 500, Save → chip reads **500 / 1500 ml**.
- [x] Re-open dialog → tap Reset → slider snaps to 0 ml.
- [x] Re-open dialog → Undo last → snackbar absent, chip rolls back to **250 / 1500 ml**.
- [x] Profile → Daily water goal shows **1500 ml**. Tap → drag to ~2000, Save → subtitle refreshes to **2000 ml** without navigating away, home chip also reads **/ 2000 ml**.
- [x] Profile → Daily water goal → Reset → subtitle returns to **1500 ml** (the female seed).
- [x] Repeat with a male onboarding pick → seed lands at **1900 ml**.
- [x] Settings → Calculations no longer lists "Daily water goal" — it lives on Profile now.
- [x] Restart the app → today's total is restored from Hive; yesterday's entries do not bleed into today.
