### PR TITLE
Support serving size in custom-food CSV and JSON import

### DIFF
--- a/lib/core/utils/csv_meal_importer.dart
+++ b/lib/core/utils/csv_meal_importer.dart
@@ -29,6 +29,7 @@ class CsvMealImporter {
   static const _kSugars = 'sugars_per_100g';
   static const _kSatFat = 'saturated_fat_per_100g';
   static const _kFiber = 'fiber_per_100g';
+  static const _kServingSize = 'serving_size';
 
   /// Column order in the sample CSV (also used by the column-name table in
   /// the UI / docs).
@@ -43,6 +44,7 @@ class CsvMealImporter {
     _kSugars,
     _kSatFat,
     _kFiber,
+    _kServingSize,
   ];
 
   static const requiredColumns = <String>{_kName, _kKcal};
@@ -113,6 +115,21 @@ class CsvMealImporter {
         continue;
       }
 
+      // Optional `serving_size` (issues #420 / #421): when present, becomes
+      // the meal's per-serving quantity in grams, which `meal_detail_screen`
+      // reads via `hasServingValues` to default the logged amount to 1
+      // serving instead of 100 g.
+      final servingRaw = row[_kServingSize];
+      double? servingQuantity;
+      if (servingRaw != null && servingRaw.isNotEmpty) {
+        final parsed = CsvRowParser.parseDoubleOrNull(servingRaw);
+        if (parsed == null || parsed <= 0) {
+          errors.add('Row $rowNum: serving_size must be a positive number');
+          continue;
+        }
+        servingQuantity = parsed;
+      }
+
       meals.add(
         MealEntity(
           // Leave the code null when no barcode was supplied so
@@ -124,9 +141,11 @@ class CsvMealImporter {
           url: null,
           mealQuantity: '100',
           mealUnit: 'g',
-          servingQuantity: null,
+          servingQuantity: servingQuantity,
           servingUnit: 'g',
-          servingSize: '100 g',
+          servingSize: servingQuantity != null
+              ? '${_formatNumber(servingQuantity)} g'
+              : '100 g',
           nutriments: MealNutrimentsEntity(
             energyKcal100: kcal,
             carbohydrates100: CsvRowParser.parseDoubleOrNull(row[_kCarbs]),
@@ -145,12 +164,23 @@ class CsvMealImporter {
   }
 
   /// Sample CSV text shipped with the app. Includes the header row plus a
-  /// couple of plausible rows so the user can see the expected shape.
+  /// couple of plausible rows so the user can see the expected shape — the
+  /// banana row demonstrates a serving size (one medium banana ~118 g) and
+  /// the milk row shows a sensible glass (240 ml expressed as 240 g, since
+  /// the importer is gram-only today).
   static String sampleCsv() {
     final header = orderedColumns.join(',');
     return '$header\n'
-        'Banana,,,89,22.8,0.3,1.1,12.2,0.1,2.6\n'
-        'Whole Milk 3.25%,Acme Dairy,1234567890123,61,4.8,3.3,3.2,5.1,1.9,0\n';
+        'Banana,,,89,22.8,0.3,1.1,12.2,0.1,2.6,118\n'
+        'Whole Milk 3.25%,Acme Dairy,1234567890123,61,4.8,3.3,3.2,5.1,1.9,0,240\n';
   }
 
+  /// Render `n` as a compact decimal: no trailing `.0` for whole numbers,
+  /// trimmed trailing zeros otherwise. So `118.0` becomes `118` and
+  /// `62.5` stays `62.5`. Keeps the user-visible servingSize string ("118 g")
+  /// readable.
+  static String _formatNumber(double n) {
+    if (n == n.truncateToDouble()) return n.toInt().toString();
+    return n.toString();
+  }
 }

--- a/lib/core/utils/json_meal_importer.dart
+++ b/lib/core/utils/json_meal_importer.dart
@@ -36,7 +36,9 @@ class JsonImportResult {
 ///   "mealType": "snack",   // optional, default "snack"
 ///   "amount": 100,         // optional, default 100
 ///   "unit": "g",           // optional, default "g"
-///   "date": "2026-05-13"   // optional, default today
+///   "date": "2026-05-13",  // optional, default today
+///   "serving_size": 100    // optional — when set, the saved custom meal
+///                          // defaults to 1 serving on re-log
 /// }
 /// ```
 ///
@@ -61,6 +63,7 @@ class JsonMealImporter {
   static const _kAmount = 'amount';
   static const _kUnit = 'unit';
   static const _kDate = 'date';
+  static const _kServingSize = 'serving_size';
 
   static const _requiredKeys = <String>[_kName, _kKcal, _kProtein, _kCarbs, _kFat];
 
@@ -97,7 +100,8 @@ class JsonMealImporter {
     "protein": 7.0,
     "carbs": 12.0,
     "fat": 16.0,
-    "mealType": "lunch"
+    "mealType": "lunch",
+    "serving_size": 250
   }
 ]
 ''';
@@ -207,6 +211,21 @@ class JsonMealImporter {
           ? entry[_kUnit].toString().trim()
           : 'g';
 
+      // Optional serving_size: independent of `amount`. `amount` is what
+      // was logged this time; `serving_size` describes what a serving
+      // *generally* is, and once the meal is saved as a custom food the
+      // meal-detail screen uses it to default re-logged quantities to
+      // 1 serving instead of 100 g.
+      double? servingQuantity;
+      if (entry.containsKey(_kServingSize) && entry[_kServingSize] != null) {
+        final parsed = _asDouble(entry[_kServingSize]);
+        if (parsed == null || parsed <= 0) {
+          errors.add('Entry $entryNum: serving_size must be a positive number');
+          continue;
+        }
+        servingQuantity = parsed;
+      }
+
       DateTime date;
       final dateRaw = entry[_kDate]?.toString().trim();
       if (dateRaw == null || dateRaw.isEmpty) {
@@ -245,9 +264,11 @@ class JsonMealImporter {
         url: null,
         mealQuantity: amount.toString(),
         mealUnit: unit,
-        servingQuantity: null,
+        servingQuantity: servingQuantity,
         servingUnit: unit,
-        servingSize: '$amount $unit',
+        servingSize: servingQuantity != null
+            ? '${_formatNumber(servingQuantity)} $unit'
+            : '$amount $unit',
         nutriments: nutriments,
         source: MealSourceEntity.custom,
       );
@@ -276,6 +297,11 @@ class JsonMealImporter {
       return double.tryParse(trimmed.replaceAll(',', '.'));
     }
     return null;
+  }
+
+  static String _formatNumber(double n) {
+    if (n == n.truncateToDouble()) return n.toInt().toString();
+    return n.toString();
   }
 
   static IntakeTypeEntity? _parseMealType(String raw) {

--- a/lib/generated/intl/messages_cs.dart
+++ b/lib/generated/intl/messages_cs.dart
@@ -45,7 +45,7 @@ class MessageLookup extends MessageLookupByLibrary {
 
   static String m11(time) => "Čas připomínky: ${time}";
 
-  static String m12(count) => "Importováno ${count} jídel z CSV souboru.";
+  static String m12(count) => "Importováno ${count} jídel.";
 
   static String m13(imported, skipped) =>
       "Importováno ${imported} jídel; ${skipped} řádků přeskočeno kvůli neplatným datům.";

--- a/lib/generated/intl/messages_de.dart
+++ b/lib/generated/intl/messages_de.dart
@@ -47,8 +47,7 @@ class MessageLookup extends MessageLookupByLibrary {
 
   static String m11(time) => "Erinnerungszeit: ${time}";
 
-  static String m12(count) =>
-      "${count} Mahlzeit(en) aus der CSV-Datei importiert.";
+  static String m12(count) => "${count} Mahlzeit(en) importiert.";
 
   static String m13(imported, skipped) =>
       "${imported} Mahlzeit(en) importiert; ${skipped} Zeile(n) wegen ungültiger Daten übersprungen.";

--- a/lib/generated/intl/messages_en.dart
+++ b/lib/generated/intl/messages_en.dart
@@ -47,8 +47,7 @@ class MessageLookup extends MessageLookupByLibrary {
 
   static String m11(time) => "Reminder time: ${time}";
 
-  static String m12(count) =>
-      "Imported ${count} meal(s) from the CSV file.";
+  static String m12(count) => "Imported ${count} meal(s).";
 
   static String m13(imported, skipped) =>
       "Imported ${imported} meal(s); ${skipped} row(s) were skipped due to invalid data.";

--- a/lib/generated/intl/messages_it.dart
+++ b/lib/generated/intl/messages_it.dart
@@ -45,7 +45,7 @@ class MessageLookup extends MessageLookupByLibrary {
 
   static String m11(time) => "Orario promemoria: ${time}";
 
-  static String m12(count) => "Importati ${count} pasti dal file CSV.";
+  static String m12(count) => "Importati ${count} pasti.";
 
   static String m13(imported, skipped) =>
       "Importati ${imported} pasti; ${skipped} righe ignorate per dati non validi.";

--- a/lib/generated/intl/messages_pl.dart
+++ b/lib/generated/intl/messages_pl.dart
@@ -44,8 +44,7 @@ class MessageLookup extends MessageLookupByLibrary {
 
   static String m11(time) => "Czas przypomnienia: ${time}";
 
-  static String m12(count) =>
-      "Zaimportowano ${count} posiłk(ów) z pliku CSV.";
+  static String m12(count) => "Zaimportowano ${count} posiłk(ów).";
 
   static String m13(imported, skipped) =>
       "Zaimportowano ${imported} posiłk(ów); pominięto ${skipped} wiersz(y) z powodu nieprawidłowych danych.";

--- a/lib/generated/intl/messages_sk.dart
+++ b/lib/generated/intl/messages_sk.dart
@@ -45,7 +45,7 @@ class MessageLookup extends MessageLookupByLibrary {
 
   static String m11(time) => "Čas pripomienky: ${time}";
 
-  static String m12(count) => "Z CSV súboru bolo importovaných ${count} jedál.";
+  static String m12(count) => "Importovaných ${count} jedál.";
 
   static String m13(imported, skipped) =>
       "Importovaných ${imported} jedál; ${skipped} riadkov bolo preskočených pre neplatné údaje.";

--- a/lib/generated/intl/messages_tr.dart
+++ b/lib/generated/intl/messages_tr.dart
@@ -47,7 +47,7 @@ class MessageLookup extends MessageLookupByLibrary {
 
   static String m11(time) => "Hatırlatma zamanı: ${time}";
 
-  static String m12(count) => "CSV dosyasından ${count} öğün içe aktarıldı.";
+  static String m12(count) => "${count} öğün içe aktarıldı.";
 
   static String m13(imported, skipped) =>
       "${imported} öğün içe aktarıldı; geçersiz veri nedeniyle ${skipped} satır atlandı.";

--- a/lib/generated/intl/messages_uk.dart
+++ b/lib/generated/intl/messages_uk.dart
@@ -45,7 +45,7 @@ class MessageLookup extends MessageLookupByLibrary {
 
   static String m11(time) => "Час нагадування: ${time}";
 
-  static String m12(count) => "З CSV файлу імпортовано ${count} страв.";
+  static String m12(count) => "Імпортовано ${count} страв.";
 
   static String m13(imported, skipped) =>
       "Імпортовано ${imported} страв; ${skipped} рядків пропущено через неправильні дані.";

--- a/lib/generated/intl/messages_zh.dart
+++ b/lib/generated/intl/messages_zh.dart
@@ -43,7 +43,7 @@ class MessageLookup extends MessageLookupByLibrary {
 
   static String m11(time) => "提醒时间：${time}";
 
-  static String m12(count) => "已从 CSV 文件导入 ${count} 项餐食。";
+  static String m12(count) => "已导入 ${count} 项餐食。";
 
   static String m13(imported, skipped) =>
       "已导入 ${imported} 项餐食；因数据无效跳过 ${skipped} 行。";

--- a/lib/generated/l10n.dart
+++ b/lib/generated/l10n.dart
@@ -2449,7 +2449,7 @@ class S {
 
   String csvImportSuccessLabel(int count) {
     return Intl.message(
-      'Imported $count meal(s) from the CSV file.',
+      'Imported $count meal(s).',
       name: 'csvImportSuccessLabel',
       desc: '',
       args: [count],

--- a/lib/l10n/intl_cs.arb
+++ b/lib/l10n/intl_cs.arb
@@ -164,7 +164,7 @@
   "csvImportContributeOffPrefix": "Máte čárový kód? Přispějte produktem do Open Food Facts:",
   "csvImportErrorLabel": "Nelze přečíst CSV soubor. Zkontrolujte formát a zkuste znovu.",
   "csvImportPartialLabel": "Importováno {imported} jídel; {skipped} řádků přeskočeno kvůli neplatným datům.",
-  "csvImportSuccessLabel": "Importováno {count} jídel z CSV souboru.",
+  "csvImportSuccessLabel": "Importováno {count} jídel.",
   "customActivityDescription": "Zadejte spálené kalorie přímo, pro tréninky, které nejsou na seznamu, nebo hodnoty z fitness náramku",
   "customActivityDescriptionKj": "Zadejte spálené kilojouly přímo, pro tréninky, které nejsou na seznamu, nebo hodnoty z fitness náramku",
   "customActivityKcalHint": "např. 250",

--- a/lib/l10n/intl_de.arb
+++ b/lib/l10n/intl_de.arb
@@ -195,7 +195,7 @@
   "csvImportContributeOffPrefix": "Barcode dabei? Trag das Produkt zu Open Food Facts bei:",
   "csvImportErrorLabel": "CSV-Datei konnte nicht gelesen werden. Format prüfen und erneut versuchen.",
   "csvImportPartialLabel": "{imported} Mahlzeit(en) importiert; {skipped} Zeile(n) wegen ungültiger Daten übersprungen.",
-  "csvImportSuccessLabel": "{count} Mahlzeit(en) aus der CSV-Datei importiert.",
+  "csvImportSuccessLabel": "{count} Mahlzeit(en) importiert.",
   "customActivityDescription": "Trage verbrannte Kalorien direkt ein – für Trainings, die nicht in der Liste sind, oder Werte aus einem Fitnesstracker",
   "customActivityDescriptionKj": "Trage verbrannte Kilojoule direkt ein – für Trainings, die nicht in der Liste sind, oder Werte aus einem Fitnesstracker",
   "customActivityKcalHint": "z. B. 250",

--- a/lib/l10n/intl_en.arb
+++ b/lib/l10n/intl_en.arb
@@ -229,7 +229,7 @@
   "csvImportContributeOffPrefix": "Have a barcode? Help everyone by contributing the product to Open Food Facts:",
   "csvImportErrorLabel": "Could not read CSV file. Check the format and try again.",
   "csvImportPartialLabel": "Imported {imported} meal(s); {skipped} row(s) were skipped due to invalid data.",
-  "csvImportSuccessLabel": "Imported {count} meal(s) from the CSV file.",
+  "csvImportSuccessLabel": "Imported {count} meal(s).",
   "customActivityDescription": "Enter calories burned directly, for workouts that aren't in the list or readings from a fitness tracker",
   "customActivityDescriptionKj": "Enter kilojoules burned directly, for workouts that aren't in the list or readings from a fitness tracker",
   "customActivityKcalHint": "e.g. 250",

--- a/lib/l10n/intl_it.arb
+++ b/lib/l10n/intl_it.arb
@@ -164,7 +164,7 @@
   "csvImportContributeOffPrefix": "Hai un codice a barre? Contribuisci il prodotto a Open Food Facts:",
   "csvImportErrorLabel": "Impossibile leggere il file CSV. Controlla il formato e riprova.",
   "csvImportPartialLabel": "Importati {imported} pasti; {skipped} righe ignorate per dati non validi.",
-  "csvImportSuccessLabel": "Importati {count} pasti dal file CSV.",
+  "csvImportSuccessLabel": "Importati {count} pasti.",
   "customActivityDescription": "Inserisci direttamente le calorie bruciate, per allenamenti non in elenco o letture da un fitness tracker",
   "customActivityDescriptionKj": "Inserisci direttamente i kilojoule bruciati, per allenamenti non in elenco o letture da un fitness tracker",
   "customActivityKcalHint": "es. 250",

--- a/lib/l10n/intl_pl.arb
+++ b/lib/l10n/intl_pl.arb
@@ -164,7 +164,7 @@
   "csvImportContributeOffPrefix": "Masz kod kreskowy? Dodaj produkt do Open Food Facts:",
   "csvImportErrorLabel": "Nie można odczytać pliku CSV. Sprawdź format i spróbuj ponownie.",
   "csvImportPartialLabel": "Zaimportowano {imported} posiłk(ów); pominięto {skipped} wiersz(y) z powodu nieprawidłowych danych.",
-  "csvImportSuccessLabel": "Zaimportowano {count} posiłk(ów) z pliku CSV.",
+  "csvImportSuccessLabel": "Zaimportowano {count} posiłk(ów).",
   "customActivityDescription": "Wprowadź spalone kalorie bezpośrednio – dla treningów spoza listy lub odczytów z opaski fitness",
   "customActivityDescriptionKj": "Wprowadź spalone kilodżule bezpośrednio – dla treningów spoza listy lub odczytów z opaski fitness",
   "customActivityKcalHint": "np. 250",

--- a/lib/l10n/intl_sk.arb
+++ b/lib/l10n/intl_sk.arb
@@ -211,7 +211,7 @@
   "csvImportContributeOffPrefix": "Máte čiarový kód? Pomôžte všetkým a prispejte produktom do Open Food Facts:",
   "csvImportErrorLabel": "CSV súbor sa nepodarilo prečítať. Skontrolujte formát a skúste to znova.",
   "csvImportPartialLabel": "Importovaných {imported} jedál; {skipped} riadkov bolo preskočených pre neplatné údaje.",
-  "csvImportSuccessLabel": "Z CSV súboru bolo importovaných {count} jedál.",
+  "csvImportSuccessLabel": "Importovaných {count} jedál.",
   "customActivityDescription": "Zadajte spálené kalórie priamo, pre tréningy ktoré nie sú v zozname, alebo údaje z fitness náramku",
   "customActivityDescriptionKj": "Zadajte spálené kilojouly priamo, pre tréningy ktoré nie sú v zozname, alebo údaje z fitness náramku",
   "customActivityKcalHint": "napr. 250",

--- a/lib/l10n/intl_tr.arb
+++ b/lib/l10n/intl_tr.arb
@@ -195,7 +195,7 @@
   "csvImportContributeOffPrefix": "Barkod var mı? Ürünü Open Food Facts'e katkıda bulunun:",
   "csvImportErrorLabel": "CSV dosyası okunamadı. Biçimi kontrol edin ve tekrar deneyin.",
   "csvImportPartialLabel": "{imported} öğün içe aktarıldı; geçersiz veri nedeniyle {skipped} satır atlandı.",
-  "csvImportSuccessLabel": "CSV dosyasından {count} öğün içe aktarıldı.",
+  "csvImportSuccessLabel": "{count} öğün içe aktarıldı.",
   "customActivityDescription": "Listede olmayan antrenmanlar veya bir fitness takip cihazından okumalar için yakılan kaloriyi doğrudan girin",
   "customActivityDescriptionKj": "Listede olmayan antrenmanlar veya bir fitness takip cihazından okumalar için yakılan kilojulleri doğrudan girin",
   "customActivityKcalHint": "örn. 250",

--- a/lib/l10n/intl_uk.arb
+++ b/lib/l10n/intl_uk.arb
@@ -164,7 +164,7 @@
   "csvImportContributeOffPrefix": "Маєте штрих-код? Додайте продукт до Open Food Facts:",
   "csvImportErrorLabel": "Не вдалося прочитати CSV файл. Перевірте формат і спробуйте знову.",
   "csvImportPartialLabel": "Імпортовано {imported} страв; {skipped} рядків пропущено через неправильні дані.",
-  "csvImportSuccessLabel": "З CSV файлу імпортовано {count} страв.",
+  "csvImportSuccessLabel": "Імпортовано {count} страв.",
   "customActivityDescription": "Введіть спалені калорії безпосередньо — для тренувань, яких немає у списку, або показників із фітнес-трекера",
   "customActivityDescriptionKj": "Введіть спалені кілоджоулі безпосередньо — для тренувань, яких немає у списку, або показників із фітнес-трекера",
   "customActivityKcalHint": "напр. 250",

--- a/lib/l10n/intl_zh.arb
+++ b/lib/l10n/intl_zh.arb
@@ -165,7 +165,7 @@
   "csvImportContributeOffPrefix": "有条形码？请把产品贡献到 Open Food Facts：",
   "csvImportErrorLabel": "无法读取 CSV 文件。请检查格式后重试。",
   "csvImportPartialLabel": "已导入 {imported} 项餐食；因数据无效跳过 {skipped} 行。",
-  "csvImportSuccessLabel": "已从 CSV 文件导入 {count} 项餐食。",
+  "csvImportSuccessLabel": "已导入 {count} 项餐食。",
   "customActivityDescription": "直接输入消耗的卡路里，适用于列表中没有的训练或来自健身追踪器的读数",
   "customActivityDescriptionKj": "直接输入消耗的千焦，适用于列表中没有的训练或来自健身追踪器的读数",
   "customActivityKcalHint": "例如 250",

--- a/test/unit_test/csv_meal_importer_test.dart
+++ b/test/unit_test/csv_meal_importer_test.dart
@@ -207,5 +207,65 @@ void main() {
       expect(result.meals[0].name, 'Banana');
       expect(result.meals[1].name, 'Whole Milk 3.25%');
     });
+
+    test('serving_size populates servingQuantity and hasServingValues', () {
+      // Issue #420 / #421: when present, the meal-detail screen uses
+      // `hasServingValues` to default the logged amount to 1 serving
+      // instead of 100 g.
+      const csv = 'name,kcal_per_100g,serving_size\nBanana,89,118';
+
+      final result = CsvMealImporter.parse(csv);
+
+      expect(result.errors, isEmpty);
+      final meal = result.meals.single;
+      expect(meal.servingQuantity, 118);
+      expect(meal.servingSize, '118 g');
+      expect(meal.hasServingValues, isTrue);
+    });
+
+    test('decimal serving_size like 62.5 is preserved', () {
+      const csv = 'name,kcal_per_100g,serving_size\nProtein Bar,400,62.5';
+
+      final result = CsvMealImporter.parse(csv);
+
+      expect(result.errors, isEmpty);
+      final meal = result.meals.single;
+      expect(meal.servingQuantity, 62.5);
+      expect(meal.servingSize, '62.5 g');
+    });
+
+    test('blank serving_size leaves servingQuantity null', () {
+      const csv = 'name,kcal_per_100g,serving_size\nApple,52,\nBanana,89,';
+
+      final result = CsvMealImporter.parse(csv);
+
+      expect(result.errors, isEmpty);
+      expect(result.meals.every((m) => m.servingQuantity == null), isTrue);
+    });
+
+    test('non-positive serving_size is rejected with a row error', () {
+      const csv = 'name,kcal_per_100g,serving_size\nApple,52,-1\nBanana,89,0';
+
+      final result = CsvMealImporter.parse(csv);
+
+      expect(result.meals, isEmpty);
+      expect(result.errors, hasLength(2));
+      expect(result.errors[0], contains('serving_size'));
+      expect(result.errors[1], contains('serving_size'));
+    });
+
+    test('old CSV without serving_size column still parses (backward-compat)', () {
+      // The header set predating issue #420. Importers in the wild that
+      // omit the new column must keep working.
+      const csv = 'name,brands,barcode,kcal_per_100g,carbs_per_100g,'
+          'fat_per_100g,protein_per_100g,sugars_per_100g,'
+          'saturated_fat_per_100g,fiber_per_100g\n'
+          'Banana,,,89,22.8,0.3,1.1,12.2,0.1,2.6';
+
+      final result = CsvMealImporter.parse(csv);
+
+      expect(result.errors, isEmpty);
+      expect(result.meals.single.servingQuantity, isNull);
+    });
   });
 }

--- a/test/unit_test/json_meal_importer_test.dart
+++ b/test/unit_test/json_meal_importer_test.dart
@@ -147,6 +147,53 @@ void main() {
       expect(intake.totalKcal, closeTo(200, 0.001));
       expect(intake.totalProteinsGram, closeTo(10, 0.001));
     });
+
+    test('serving_size populates servingQuantity on the saved meal', () {
+      // Issue #420 / #421: a saved custom meal with serving values set
+      // makes meal-detail default re-logged quantities to 1 serving.
+      const json = '{"name":"Banana","kcal":89,"protein":1.1,"carbs":22.8,'
+          '"fat":0.3,"amount":100,"unit":"g","serving_size":118}';
+
+      final result = JsonMealImporter.parse(json, now: fixedNow);
+
+      expect(result.errors, isEmpty);
+      final meal = result.intakes.single.meal;
+      expect(meal.servingQuantity, 118);
+      expect(meal.servingSize, '118 g');
+      expect(meal.hasServingValues, isTrue);
+    });
+
+    test('serving_size omitted leaves servingQuantity null', () {
+      const json = '{"name":"Apple","kcal":52,"protein":0.3,"carbs":14,'
+          '"fat":0.2}';
+
+      final result = JsonMealImporter.parse(json, now: fixedNow);
+
+      expect(result.errors, isEmpty);
+      expect(result.intakes.single.meal.servingQuantity, isNull);
+    });
+
+    test('non-positive serving_size is rejected', () {
+      const json = '{"name":"Apple","kcal":52,"protein":0.3,"carbs":14,'
+          '"fat":0.2,"serving_size":0}';
+
+      final result = JsonMealImporter.parse(json, now: fixedNow);
+
+      expect(result.intakes, isEmpty);
+      expect(result.errors.single, contains('serving_size'));
+    });
+
+    test('decimal serving_size like 62.5 is preserved', () {
+      const json = '{"name":"Protein Bar","kcal":400,"protein":20,"carbs":35,'
+          '"fat":15,"serving_size":62.5}';
+
+      final result = JsonMealImporter.parse(json, now: fixedNow);
+
+      expect(result.errors, isEmpty);
+      final meal = result.intakes.single.meal;
+      expect(meal.servingQuantity, 62.5);
+      expect(meal.servingSize, '62.5 g');
+    });
   });
 
   group('JsonMealImporter.sampleJson', () {


### PR DESCRIPTION
Two related issues from the same place: people who know what a serving of their food actually looks like had no way to record it on import, and the saved meal then opened at 100 g every time they re-logged it. This PR closes both.

Closes #420, closes #421.

## What changed

Both the CSV and the JSON importers gain an optional `serving_size` field. When it is set, the saved custom meal carries it through to `MealEntity.servingQuantity`, and the meal-detail screen's existing `hasServingValues` path picks it up so re-logged quantities default to 1 serving instead of the blanket 100 g.

The CSV path adds one column appended to the existing header set, so anyone whose tooling emits the old shape keeps importing without a change. The sample CSV bundled with the app now has realistic per-row servings (Banana 118 g, Whole Milk 240 g) so the field is discoverable from the download button.

The JSON path adds a matching `serving_size` field on each entry. It is kept deliberately distinct from `amount`: `amount` is what was logged this time, `serving_size` is what a serving generally is. Collapsing the two would let a one-off 250 g bowl of porridge permanently rewrite the saved meal's per-serving baseline, which is the wrong shape for the user who pastes the same recipe back next week.

Both importers reject a present-but-non-positive value with a per-row or per-entry error, so the user knows exactly which input to fix.

## A small label fix that came out in testing

While walking the JSON path on a real device, the success message read "Imported 3 meal(s) from the CSV file." even when the import was a JSON paste, because the dialog reused `csvImportSuccessLabel` for both formats. I reworded that key to "Imported {count} meal(s)." across all nine locales (en, de, cs, it, pl, sk, tr, uk, zh) and updated the generated message files to match. It is a small thing, but the wrong format name in a success row is the sort of detail that makes a user wonder whether the import really did the right thing.

## Recipes already work

While verifying, I checked that imported recipes get the same per-serving default behaviour. They do, via the existing `recipe_servings` and `recipe_total_weight_g` columns. `RecipeEntity.toMealEntity` (`lib/core/domain/entity/recipe_entity.dart:96`) derives `servingQuantity = totalWeightG / servingsCount` when servings is set, so a saved recipe with those fields populated already opens at 1 serving when re-logged. No new field was needed on the recipe importer side.

## Verification

- `just test` — 540 tests pass, including 9 new ones covering present, absent, decimal, negative, and back-compat cases for both importers.
- `fvm flutter analyze` — clean.
- ADB walk on a real Android device: imported the sample CSV (2 meals) and the sample JSON (3 meals), then logged the saved Banana. The meal-detail screen opened at 1 × 118 g for 105 kcal, exactly as intended, instead of the previous 100 g / 89 kcal default. The JSON tab now reads "Imported 3 meal(s)." rather than "from the CSV file."
- Recipes: imported the sample recipes CSV and logged Vanilla Cake. It opened at 1 × 8 servings (68.75 g per serving, 196 kcal), confirming the existing recipe-serving path is unaffected.

## Files of interest for review

- `lib/core/utils/csv_meal_importer.dart` — new column, parse and validation, sample text.
- `lib/core/utils/json_meal_importer.dart` — new field, parse and validation, sample text.
- `test/unit_test/csv_meal_importer_test.dart` and `test/unit_test/json_meal_importer_test.dart` — the new cases.
- ARB and generated message files for the label rewording.