### PR TITLE
feat(custom-foods): merge duplicate custom foods with successor selection

### DIFF
--- a/lib/core/data/data_source/intake_data_source.dart
+++ b/lib/core/data/data_source/intake_data_source.dart
@@ -119,4 +119,37 @@ class IntakeDataSource {
   Future<List<IntakeDBO>> getCustomMealIntakes() async {
     return _intakeBox.values.where((dbo) => dbo.meal.source == MealSourceDBO.custom).toList();
   }
+
+  /// Replace the denormalised [MealDBO] snapshot on every intake whose
+  /// `(meal.code ?? meal.name)` matches [fromMealKey] *and* whose meal source
+  /// is custom. Used by the custom-meal merge flow: callers compute the
+  /// kcal/macro deltas before invoking this and apply them to TrackedDay
+  /// totals separately.
+  ///
+  /// Returns the list of `(oldIntake, newIntake)` pairs that were rewritten,
+  /// so the caller can recompute totals from the diff.
+  Future<List<(IntakeDBO, IntakeDBO)>> remapCustomMealOnIntakes({
+    required String fromMealKey,
+    required MealDBO toMeal,
+  }) async {
+    final rewrites = <(IntakeDBO, IntakeDBO)>[];
+    final entries = _intakeBox.toMap().entries.toList();
+    for (final entry in entries) {
+      final dbo = entry.value;
+      if (dbo.meal.source != MealSourceDBO.custom) continue;
+      final key = dbo.meal.code ?? dbo.meal.name;
+      if (key != fromMealKey) continue;
+      final updated = IntakeDBO(
+        id: dbo.id,
+        unit: dbo.unit,
+        amount: dbo.amount,
+        type: dbo.type,
+        meal: toMeal,
+        dateTime: dbo.dateTime,
+      );
+      await _intakeBox.put(entry.key, updated);
+      rewrites.add((dbo, updated));
+    }
+    return rewrites;
+  }
 }

--- a/lib/core/data/repository/intake_repository.dart
+++ b/lib/core/data/repository/intake_repository.dart
@@ -1,6 +1,7 @@
 import 'package:opennutritracker/core/data/data_source/intake_data_source.dart';
 import 'package:opennutritracker/core/data/dbo/intake_dbo.dart';
 import 'package:opennutritracker/core/data/dbo/intake_type_dbo.dart';
+import 'package:opennutritracker/core/data/dbo/meal_dbo.dart';
 import 'package:opennutritracker/core/domain/entity/intake_entity.dart';
 import 'package:opennutritracker/core/domain/entity/intake_type_entity.dart';
 
@@ -69,5 +70,25 @@ class IntakeRepository {
   Future<List<IntakeEntity>> getCustomMealIntakes() async {
     final dboList = await _intakeDataSource.getCustomMealIntakes();
     return dboList.map(IntakeEntity.fromIntakeDBO).toList();
+  }
+
+  /// Rewrites every custom-meal intake whose key (code-or-name) matches
+  /// [fromMealKey] to instead snapshot [toMeal]. Returns the rewritten
+  /// before/after pairs so the caller can reconcile TrackedDay totals from
+  /// the macro diff per intake.
+  Future<List<(IntakeEntity, IntakeEntity)>> remapCustomMealOnIntakes({
+    required String fromMealKey,
+    required MealDBO toMeal,
+  }) async {
+    final rewrites = await _intakeDataSource.remapCustomMealOnIntakes(
+      fromMealKey: fromMealKey,
+      toMeal: toMeal,
+    );
+    return rewrites
+        .map((pair) => (
+              IntakeEntity.fromIntakeDBO(pair.$1),
+              IntakeEntity.fromIntakeDBO(pair.$2),
+            ))
+        .toList();
   }
 }

--- a/lib/core/domain/usecase/merge_custom_meals_usecase.dart
+++ b/lib/core/domain/usecase/merge_custom_meals_usecase.dart
@@ -1,0 +1,101 @@
+import 'package:opennutritracker/core/data/data_source/custom_meal_data_source.dart';
+import 'package:opennutritracker/core/data/repository/intake_repository.dart';
+import 'package:opennutritracker/core/domain/usecase/add_tracked_day_usecase.dart';
+
+/// Result of a merge: how many past diary entries were rewritten so the
+/// caller can show a friendly confirmation to the person who triggered it.
+class MergeCustomMealsResult {
+  final int rewrittenIntakeCount;
+  final String winnerDisplayName;
+
+  const MergeCustomMealsResult({
+    required this.rewrittenIntakeCount,
+    required this.winnerDisplayName,
+  });
+}
+
+/// Folds two duplicate custom meals into one. The non-successor ("loser")
+/// is removed from the saved-meals list, and every diary entry that was
+/// logged from the loser is rewritten so that it reads as the successor
+/// going forward. TrackedDay calorie/macro totals are reconciled from the
+/// per-intake before/after diff so charts stay accurate.
+///
+/// Only operates on custom meals (`MealSourceDBO.custom`). Recipes and
+/// OFF/FDC entries are out of scope by design.
+class MergeCustomMealsUseCase {
+  final CustomMealDataSource _customMealDataSource;
+  final IntakeRepository _intakeRepository;
+  final AddTrackedDayUsecase _addTrackedDayUsecase;
+
+  MergeCustomMealsUseCase(
+    this._customMealDataSource,
+    this._intakeRepository,
+    this._addTrackedDayUsecase,
+  );
+
+  /// [loserKey] / [winnerKey] are the dedup keys used everywhere else in
+  /// the custom-meal layer (`meal.code ?? meal.name`).
+  Future<MergeCustomMealsResult> merge({
+    required String loserKey,
+    required String winnerKey,
+  }) async {
+    if (loserKey == winnerKey) {
+      return const MergeCustomMealsResult(
+        rewrittenIntakeCount: 0,
+        winnerDisplayName: '',
+      );
+    }
+
+    final all = _customMealDataSource.getAllCustomMeals();
+    final winner = all.firstWhere(
+      (m) => (m.code ?? m.name) == winnerKey,
+      orElse: () => throw StateError('Winner custom meal not found'),
+    );
+    // The winner is the survivor; we snapshot its current MealDBO onto
+    // every loser intake so they continue to read as the successor.
+    final rewrites = await _intakeRepository.remapCustomMealOnIntakes(
+      fromMealKey: loserKey,
+      toMeal: winner,
+    );
+
+    // Reconcile TrackedDay totals from the macro diff per intake. If the two
+    // meals had identical nutrition this is a no-op; if they differed, the
+    // diary stays consistent with the winner going forward.
+    for (final pair in rewrites) {
+      final before = pair.$1;
+      final after = pair.$2;
+      final kcalDelta = after.totalKcal - before.totalKcal;
+      final carbsDelta = after.totalCarbsGram - before.totalCarbsGram;
+      final fatDelta = after.totalFatsGram - before.totalFatsGram;
+      final proteinDelta = after.totalProteinsGram - before.totalProteinsGram;
+      if (kcalDelta != 0) {
+        if (kcalDelta > 0) {
+          await _addTrackedDayUsecase.addDayCaloriesTracked(
+            after.dateTime,
+            kcalDelta,
+          );
+        } else {
+          await _addTrackedDayUsecase.removeDayCaloriesTracked(
+            after.dateTime,
+            -kcalDelta,
+          );
+        }
+      }
+      if (carbsDelta != 0 || fatDelta != 0 || proteinDelta != 0) {
+        await _addTrackedDayUsecase.addDayMacrosTracked(
+          after.dateTime,
+          carbsTracked: carbsDelta,
+          fatTracked: fatDelta,
+          proteinTracked: proteinDelta,
+        );
+      }
+    }
+
+    await _customMealDataSource.deleteCustomMeal(loserKey);
+
+    return MergeCustomMealsResult(
+      rewrittenIntakeCount: rewrites.length,
+      winnerDisplayName: winner.name ?? winner.code ?? winnerKey,
+    );
+  }
+}

--- a/lib/core/utils/locator.dart
+++ b/lib/core/utils/locator.dart
@@ -35,6 +35,7 @@ import 'package:opennutritracker/core/domain/usecase/delete_all_user_data_usecas
 import 'package:opennutritracker/core/domain/usecase/delete_custom_activity_template_usecase.dart';
 import 'package:opennutritracker/core/domain/usecase/delete_intake_usecase.dart';
 import 'package:opennutritracker/core/domain/usecase/delete_recipe_usecase.dart';
+import 'package:opennutritracker/core/domain/usecase/merge_custom_meals_usecase.dart';
 import 'package:opennutritracker/core/domain/usecase/delete_user_activity_usecase.dart';
 import 'package:opennutritracker/core/domain/usecase/delete_water_intake_usecase.dart';
 import 'package:opennutritracker/core/domain/usecase/delete_weight_log_usecase.dart';
@@ -202,7 +203,13 @@ Future<void> initLocator() async {
   // create-from-popup flow on the same tab — both must mutate / observe the
   // same instance so the list refreshes after a new entry is created.
   locator.registerLazySingleton<CustomMealsBloc>(
-    () => CustomMealsBloc(locator(), locator(), locator(), locator()),
+    () => CustomMealsBloc(
+      locator(),
+      locator(),
+      locator(),
+      locator(),
+      locator(),
+    ),
   );
 
   locator.registerFactory<ActivitiesBloc>(() => ActivitiesBloc(locator()));
@@ -373,6 +380,9 @@ Future<void> initLocator() async {
   locator.registerLazySingleton(() => GetAllRecipesUseCase(locator()));
   locator.registerLazySingleton(() => GetRecipeByIdUseCase(locator()));
   locator.registerLazySingleton(() => DeleteRecipeUseCase(locator()));
+  locator.registerLazySingleton(
+    () => MergeCustomMealsUseCase(locator(), locator(), locator()),
+  );
 
   // Repositories
   locator.registerLazySingleton(() => ConfigRepository(locator()));

--- a/lib/features/recipes/presentation/widgets/custom_meals_tab.dart
+++ b/lib/features/recipes/presentation/widgets/custom_meals_tab.dart
@@ -17,9 +17,27 @@ class CustomMealsTab extends StatelessWidget {
 
   const CustomMealsTab({super.key, required this.usesImperialUnits});
 
+  static String _keyFor(MealEntity meal) => meal.code ?? meal.name ?? '';
+
   @override
   Widget build(BuildContext context) {
-    return BlocBuilder<CustomMealsBloc, CustomMealsState>(
+    return BlocConsumer<CustomMealsBloc, CustomMealsState>(
+      listenWhen: (prev, curr) => curr is CustomMealsMergedState,
+      listener: (context, state) {
+        if (state is CustomMealsMergedState) {
+          final s = S.of(context);
+          ScaffoldMessenger.of(context).showSnackBar(
+            SnackBar(
+              content: Text(
+                s.customMealsMergeSuccessSnackbar(
+                  state.rewrittenIntakeCount,
+                  state.winnerDisplayName,
+                ),
+              ),
+            ),
+          );
+        }
+      },
       builder: (context, state) {
         if (state is CustomMealsLoadingState ||
             state is CustomMealsInitial) {
@@ -41,14 +59,41 @@ class CustomMealsTab extends StatelessWidget {
             itemCount: state.meals.length,
             itemBuilder: (context, index) {
               final meal = state.meals[index];
+              final canMerge = state.meals.length >= 2;
               return ListTile(
                 leading: _MealLeadingThumbnail(meal: meal),
                 title: Text(meal.name ?? ''),
                 subtitle: meal.brands != null ? Text(meal.brands!) : null,
                 onTap: () => _openEditMeal(context, meal),
-                trailing: IconButton(
-                  icon: const Icon(Icons.delete_outline),
-                  onPressed: () => _confirmDelete(context, meal),
+                trailing: Row(
+                  mainAxisSize: MainAxisSize.min,
+                  children: [
+                    if (canMerge)
+                      Semantics(
+                        identifier: 'custom-foods-merge-open',
+                        child: PopupMenuButton<String>(
+                          icon: const Icon(Icons.more_vert),
+                          tooltip: S.of(context).customMealsRowMoreTooltip,
+                          onSelected: (value) {
+                            if (value == 'merge') {
+                              _startMerge(context, meal, state.meals);
+                            }
+                          },
+                          itemBuilder: (ctx) => [
+                            PopupMenuItem<String>(
+                              value: 'merge',
+                              child: Text(
+                                S.of(context).customMealsMergeAction,
+                              ),
+                            ),
+                          ],
+                        ),
+                      ),
+                    IconButton(
+                      icon: const Icon(Icons.delete_outline),
+                      onPressed: () => _confirmDelete(context, meal),
+                    ),
+                  ],
                 ),
               );
             },
@@ -96,6 +141,162 @@ class CustomMealsTab extends StatelessWidget {
     if (confirmed == true) {
       bloc.add(DeleteCustomMealEvent(meal.code ?? meal.name ?? ''));
     }
+  }
+
+  /// Two-step flow: pick the partner to merge with, then choose which of
+  /// the two stays as the survivor. The row the menu was opened from is
+  /// pre-selected as the survivor so the default behaviour matches the
+  /// gesture (you tapped the "good" entry, then picked the duplicate).
+  Future<void> _startMerge(
+    BuildContext context,
+    MealEntity tappedFrom,
+    List<MealEntity> allMeals,
+  ) async {
+    final bloc = context.read<CustomMealsBloc>();
+    final candidates = allMeals
+        .where((m) => _keyFor(m) != _keyFor(tappedFrom))
+        .toList();
+    if (candidates.isEmpty) return;
+
+    final partner = await showModalBottomSheet<MealEntity>(
+      context: context,
+      builder: (ctx) {
+        return Semantics(
+          identifier: 'custom-foods-merge-picker',
+          child: SafeArea(
+            child: Column(
+              mainAxisSize: MainAxisSize.min,
+              children: [
+                Padding(
+                  padding: const EdgeInsets.fromLTRB(16, 16, 16, 8),
+                  child: Text(
+                    S.of(context).customMealsMergePickerTitle,
+                    style: Theme.of(context).textTheme.titleMedium,
+                  ),
+                ),
+                Flexible(
+                  child: ListView.builder(
+                    shrinkWrap: true,
+                    itemCount: candidates.length,
+                    itemBuilder: (ctx2, i) {
+                      final m = candidates[i];
+                      return ListTile(
+                        leading: _MealLeadingThumbnail(meal: m),
+                        title: Text(m.name ?? ''),
+                        subtitle: m.brands != null ? Text(m.brands!) : null,
+                        onTap: () => Navigator.of(ctx).pop(m),
+                      );
+                    },
+                  ),
+                ),
+              ],
+            ),
+          ),
+        );
+      },
+    );
+    if (partner == null || !context.mounted) return;
+
+    final winner = await _chooseSurvivor(context, tappedFrom, partner);
+    if (winner == null || !context.mounted) return;
+    final loser = _keyFor(winner) == _keyFor(tappedFrom) ? partner : tappedFrom;
+
+    final confirmed = await _confirmMerge(context, loser: loser, winner: winner);
+    if (confirmed != true) return;
+
+    bloc.add(
+      MergeCustomMealsEvent(
+        loserKey: _keyFor(loser),
+        winnerKey: _keyFor(winner),
+      ),
+    );
+  }
+
+  Future<MealEntity?> _chooseSurvivor(
+    BuildContext context,
+    MealEntity a,
+    MealEntity b,
+  ) async {
+    MealEntity selected = a;
+    return showDialog<MealEntity>(
+      context: context,
+      builder: (ctx) {
+        return StatefulBuilder(
+          builder: (ctx2, setState) => AlertDialog(
+            title: Text(S.of(context).customMealsMergeChooseSurvivorTitle),
+            content: Column(
+              mainAxisSize: MainAxisSize.min,
+              children: [
+                Semantics(
+                  identifier: 'custom-foods-merge-successor-a',
+                  child: RadioListTile<MealEntity>(
+                    title: Text(a.name ?? ''),
+                    value: a,
+                    groupValue: selected,
+                    onChanged: (v) => setState(() => selected = v ?? a),
+                  ),
+                ),
+                Semantics(
+                  identifier: 'custom-foods-merge-successor-b',
+                  child: RadioListTile<MealEntity>(
+                    title: Text(b.name ?? ''),
+                    value: b,
+                    groupValue: selected,
+                    onChanged: (v) => setState(() => selected = v ?? b),
+                  ),
+                ),
+              ],
+            ),
+            actions: [
+              Semantics(
+                identifier: 'custom-foods-merge-cancel',
+                child: TextButton(
+                  onPressed: () => Navigator.of(ctx).pop(),
+                  child: Text(S.of(context).dialogCancelLabel),
+                ),
+              ),
+              Semantics(
+                identifier: 'custom-foods-merge-confirm',
+                child: FilledButton(
+                  onPressed: () => Navigator.of(ctx).pop(selected),
+                  child: Text(S.of(context).customMealsMergeContinueAction),
+                ),
+              ),
+            ],
+          ),
+        );
+      },
+    );
+  }
+
+  Future<bool?> _confirmMerge(
+    BuildContext context, {
+    required MealEntity loser,
+    required MealEntity winner,
+  }) {
+    final s = S.of(context);
+    return showDialog<bool>(
+      context: context,
+      builder: (ctx) => AlertDialog(
+        title: Text(s.customMealsMergeConfirmTitle),
+        content: Text(
+          s.customMealsMergeConfirmContent(
+            loser.name ?? '',
+            winner.name ?? '',
+          ),
+        ),
+        actions: [
+          TextButton(
+            onPressed: () => Navigator.of(ctx).pop(false),
+            child: Text(s.dialogCancelLabel),
+          ),
+          FilledButton(
+            onPressed: () => Navigator.of(ctx).pop(true),
+            child: Text(s.customMealsMergeConfirmAction),
+          ),
+        ],
+      ),
+    );
   }
 }
 

--- a/lib/features/recipes/presentation/widgets/custom_meals_tab.dart
+++ b/lib/features/recipes/presentation/widgets/custom_meals_tab.dart
@@ -228,28 +228,32 @@ class CustomMealsTab extends StatelessWidget {
         return StatefulBuilder(
           builder: (ctx2, setState) => AlertDialog(
             title: Text(S.of(context).customMealsMergeChooseSurvivorTitle),
-            content: Column(
-              mainAxisSize: MainAxisSize.min,
-              children: [
-                Semantics(
-                  identifier: 'custom-foods-merge-successor-a',
-                  child: RadioListTile<MealEntity>(
-                    title: Text(a.name ?? ''),
-                    value: a,
-                    groupValue: selected,
-                    onChanged: (v) => setState(() => selected = v ?? a),
+            // Flutter 3.32 deprecated the per-tile `groupValue` / `onChanged`
+            // pattern in favour of a single `RadioGroup` ancestor that owns
+            // the selected value and the change callback. The tiles now
+            // just declare their `value`.
+            content: RadioGroup<MealEntity>(
+              groupValue: selected,
+              onChanged: (v) => setState(() => selected = v ?? selected),
+              child: Column(
+                mainAxisSize: MainAxisSize.min,
+                children: [
+                  Semantics(
+                    identifier: 'custom-foods-merge-successor-a',
+                    child: RadioListTile<MealEntity>(
+                      title: Text(a.name ?? ''),
+                      value: a,
+                    ),
                   ),
-                ),
-                Semantics(
-                  identifier: 'custom-foods-merge-successor-b',
-                  child: RadioListTile<MealEntity>(
-                    title: Text(b.name ?? ''),
-                    value: b,
-                    groupValue: selected,
-                    onChanged: (v) => setState(() => selected = v ?? b),
+                  Semantics(
+                    identifier: 'custom-foods-merge-successor-b',
+                    child: RadioListTile<MealEntity>(
+                      title: Text(b.name ?? ''),
+                      value: b,
+                    ),
                   ),
-                ),
-              ],
+                ],
+              ),
             ),
             actions: [
               Semantics(

--- a/lib/features/recipes/presentation/widgets/custom_meals_tab.dart
+++ b/lib/features/recipes/presentation/widgets/custom_meals_tab.dart
@@ -29,10 +29,14 @@ class CustomMealsTab extends StatelessWidget {
           ScaffoldMessenger.of(context).showSnackBar(
             SnackBar(
               content: Text(
-                s.customMealsMergeSuccessSnackbar(
-                  state.rewrittenIntakeCount,
-                  state.winnerDisplayName,
-                ),
+                state.rewrittenIntakeCount == 1
+                    ? s.customMealsMergeSuccessSnackbarOne(
+                        state.winnerDisplayName,
+                      )
+                    : s.customMealsMergeSuccessSnackbarOther(
+                        state.rewrittenIntakeCount,
+                        state.winnerDisplayName,
+                      ),
               ),
             ),
           );

--- a/lib/features/settings/presentation/bloc/custom_meals_bloc.dart
+++ b/lib/features/settings/presentation/bloc/custom_meals_bloc.dart
@@ -4,6 +4,7 @@ import 'package:opennutritracker/core/data/data_source/custom_meal_data_source.d
 import 'package:opennutritracker/core/domain/usecase/add_tracked_day_usecase.dart';
 import 'package:opennutritracker/core/domain/usecase/delete_intake_usecase.dart';
 import 'package:opennutritracker/core/domain/usecase/get_intake_usecase.dart';
+import 'package:opennutritracker/core/domain/usecase/merge_custom_meals_usecase.dart';
 import 'package:opennutritracker/features/add_meal/domain/entity/meal_entity.dart';
 
 part 'custom_meals_event.dart';
@@ -16,12 +17,14 @@ class CustomMealsBloc extends Bloc<CustomMealsEvent, CustomMealsState> {
   final GetIntakeUsecase _getIntakeUsecase;
   final DeleteIntakeUsecase _deleteIntakeUsecase;
   final AddTrackedDayUsecase _addTrackedDayUsecase;
+  final MergeCustomMealsUseCase _mergeCustomMealsUseCase;
 
   CustomMealsBloc(
     this._customMealDataSource,
     this._getIntakeUsecase,
     this._deleteIntakeUsecase,
     this._addTrackedDayUsecase,
+    this._mergeCustomMealsUseCase,
   ) : super(CustomMealsInitial()) {
     on<LoadCustomMealsEvent>((event, emit) async {
       emit(CustomMealsLoadingState());
@@ -62,6 +65,30 @@ class CustomMealsBloc extends Bloc<CustomMealsEvent, CustomMealsState> {
           );
         }
         add(LoadCustomMealsEvent());
+      } catch (error) {
+        log.severe(error);
+        emit(CustomMealsFailedState());
+      }
+    });
+
+    on<MergeCustomMealsEvent>((event, emit) async {
+      emit(CustomMealsLoadingState());
+      try {
+        final result = await _mergeCustomMealsUseCase.merge(
+          loserKey: event.loserKey,
+          winnerKey: event.winnerKey,
+        );
+        final meals = _customMealDataSource
+            .getAllCustomMeals()
+            .map(MealEntity.fromMealDBO)
+            .toList();
+        emit(
+          CustomMealsMergedState(
+            meals: meals,
+            rewrittenIntakeCount: result.rewrittenIntakeCount,
+            winnerDisplayName: result.winnerDisplayName,
+          ),
+        );
       } catch (error) {
         log.severe(error);
         emit(CustomMealsFailedState());

--- a/lib/features/settings/presentation/bloc/custom_meals_event.dart
+++ b/lib/features/settings/presentation/bloc/custom_meals_event.dart
@@ -9,3 +9,12 @@ class DeleteCustomMealEvent extends CustomMealsEvent {
 
   DeleteCustomMealEvent(this.mealKey);
 }
+
+/// Folds [loserKey]'s diary entries into [winnerKey] and drops the loser
+/// from the saved-meals list. Both keys are `meal.code ?? meal.name`.
+class MergeCustomMealsEvent extends CustomMealsEvent {
+  final String loserKey;
+  final String winnerKey;
+
+  MergeCustomMealsEvent({required this.loserKey, required this.winnerKey});
+}

--- a/lib/features/settings/presentation/bloc/custom_meals_state.dart
+++ b/lib/features/settings/presentation/bloc/custom_meals_state.dart
@@ -13,3 +13,18 @@ class CustomMealsLoadedState extends CustomMealsState {
 }
 
 class CustomMealsFailedState extends CustomMealsState {}
+
+/// Emitted after a successful merge so the UI can surface a snackbar
+/// referencing the survivor and the count of rewritten diary entries.
+/// Extends [CustomMealsLoadedState] so existing list-rendering code keeps
+/// working without a new branch in the BlocBuilder.
+class CustomMealsMergedState extends CustomMealsLoadedState {
+  final int rewrittenIntakeCount;
+  final String winnerDisplayName;
+
+  CustomMealsMergedState({
+    required super.meals,
+    required this.rewrittenIntakeCount,
+    required this.winnerDisplayName,
+  });
+}

--- a/lib/generated/intl/messages_cs.dart
+++ b/lib/generated/intl/messages_cs.dart
@@ -92,6 +92,7 @@ class MessageLookup extends MessageLookupByLibrary {
   static String mMergeSuccess(count, winner) =>
       "Sloučeno — ${winner} má nyní ${count} záznamů.";
   static String mDriRef(value) => "ref. ${value}";
+  static String mMergeOneCs(winner) => "Sloučeno — ${winner} má nyní 1 záznam.";
 
   final messages = _notInlinedMessages(_notInlinedMessages);
   static Map<String, Function> _notInlinedMessages(_) => <String, Function>{
@@ -229,7 +230,8 @@ class MessageLookup extends MessageLookupByLibrary {
         "customMealsMergeConfirmContent": mMergeConfirm,
         "customMealsMergeConfirmAction":
             MessageLookupByLibrary.simpleMessage("Sloučit"),
-        "customMealsMergeSuccessSnackbar": mMergeSuccess,
+                "customMealsMergeSuccessSnackbarOne": mMergeOneCs,
+        "customMealsMergeSuccessSnackbarOther": mMergeSuccess,
         "dailyKcalAdjustmentLabel": MessageLookupByLibrary.simpleMessage(
             "Úprava denního kalorického příjmu:"),
         "dailyKjAdjustmentLabel":

--- a/lib/generated/intl/messages_cs.dart
+++ b/lib/generated/intl/messages_cs.dart
@@ -86,6 +86,12 @@ class MessageLookup extends MessageLookupByLibrary {
 
   static String mLogWaterAmount(amount) => "Přidat ${amount} ml";
 
+  static String mMergeConfirm(loser, winner) =>
+      "Tímto se všechny záznamy zapsané s ${loser} nahradí, aby se zobrazovaly jako ${winner}, a ${loser} bude odstraněna z vašich vlastních potravin. Tuto akci nelze vrátit zpět.";
+
+  static String mMergeSuccess(count, winner) =>
+      "Sloučeno — ${winner} má nyní ${count} záznamů.";
+
   final messages = _notInlinedMessages(_notInlinedMessages);
   static Map<String, Function> _notInlinedMessages(_) => <String, Function>{
         "activityExample": MessageLookupByLibrary.simpleMessage(
@@ -207,6 +213,22 @@ class MessageLookup extends MessageLookupByLibrary {
             MessageLookupByLibrary.simpleMessage("Smazat vlastní jídlo?"),
         "customMealsEmptyLabel": MessageLookupByLibrary.simpleMessage(
             "Zatím žádná vlastní jídla uložena."),
+        "customMealsRowMoreTooltip":
+            MessageLookupByLibrary.simpleMessage("Další akce"),
+        "customMealsMergeAction": MessageLookupByLibrary.simpleMessage(
+            "Sloučit s jinou vlastní potravinou"),
+        "customMealsMergePickerTitle": MessageLookupByLibrary.simpleMessage(
+            "Vyberte vlastní potravinu pro sloučení"),
+        "customMealsMergeChooseSurvivorTitle":
+            MessageLookupByLibrary.simpleMessage("Která zůstane?"),
+        "customMealsMergeContinueAction":
+            MessageLookupByLibrary.simpleMessage("Pokračovat"),
+        "customMealsMergeConfirmTitle": MessageLookupByLibrary.simpleMessage(
+            "Sloučit vlastní potraviny?"),
+        "customMealsMergeConfirmContent": mMergeConfirm,
+        "customMealsMergeConfirmAction":
+            MessageLookupByLibrary.simpleMessage("Sloučit"),
+        "customMealsMergeSuccessSnackbar": mMergeSuccess,
         "dailyKcalAdjustmentLabel": MessageLookupByLibrary.simpleMessage(
             "Úprava denního kalorického příjmu:"),
         "dailyKjAdjustmentLabel":

--- a/lib/generated/intl/messages_de.dart
+++ b/lib/generated/intl/messages_de.dart
@@ -88,6 +88,12 @@ class MessageLookup extends MessageLookupByLibrary {
 
   static String mLogWaterAmount(amount) => "${amount} ml hinzufügen";
 
+  static String mMergeConfirm(loser, winner) =>
+      "Dadurch werden alle Einträge, die mit ${loser} protokolliert wurden, ersetzt, sodass sie ${winner} anzeigen. Außerdem wird ${loser} aus deinen eigenen Mahlzeiten entfernt. Das kann nicht rückgängig gemacht werden.";
+
+  static String mMergeSuccess(count, winner) =>
+      "Zusammengeführt — ${winner} hat jetzt ${count} protokollierte Einträge.";
+
   final messages = _notInlinedMessages(_notInlinedMessages);
   static Map<String, Function> _notInlinedMessages(_) => <String, Function>{
         "activityExample": MessageLookupByLibrary.simpleMessage(
@@ -212,6 +218,22 @@ class MessageLookup extends MessageLookupByLibrary {
             MessageLookupByLibrary.simpleMessage("Eigene Mahlzeit löschen?"),
         "customMealsEmptyLabel": MessageLookupByLibrary.simpleMessage(
             "Noch keine eigenen Mahlzeiten gespeichert."),
+        "customMealsRowMoreTooltip":
+            MessageLookupByLibrary.simpleMessage("Weitere Aktionen"),
+        "customMealsMergeAction": MessageLookupByLibrary.simpleMessage(
+            "Mit einer anderen eigenen Mahlzeit zusammenführen"),
+        "customMealsMergePickerTitle": MessageLookupByLibrary.simpleMessage(
+            "Wähle die eigene Mahlzeit zum Zusammenführen"),
+        "customMealsMergeChooseSurvivorTitle":
+            MessageLookupByLibrary.simpleMessage("Welche bleibt?"),
+        "customMealsMergeContinueAction":
+            MessageLookupByLibrary.simpleMessage("Weiter"),
+        "customMealsMergeConfirmTitle": MessageLookupByLibrary.simpleMessage(
+            "Eigene Mahlzeiten zusammenführen?"),
+        "customMealsMergeConfirmContent": mMergeConfirm,
+        "customMealsMergeConfirmAction":
+            MessageLookupByLibrary.simpleMessage("Zusammenführen"),
+        "customMealsMergeSuccessSnackbar": mMergeSuccess,
         "dailyKcalAdjustmentLabel":
             MessageLookupByLibrary.simpleMessage("Tägliche kcal-Anpassung:"),
         "dailyKjAdjustmentLabel":

--- a/lib/generated/intl/messages_de.dart
+++ b/lib/generated/intl/messages_de.dart
@@ -94,6 +94,7 @@ class MessageLookup extends MessageLookupByLibrary {
   static String mMergeSuccess(count, winner) =>
       "Zusammengeführt — ${winner} hat jetzt ${count} protokollierte Einträge.";
   static String mDriRef(value) => "Ref. ${value}";
+  static String mMergeOneDe(winner) => "Zusammengeführt — ${winner} hat jetzt 1 Eintrag.";
 
   final messages = _notInlinedMessages(_notInlinedMessages);
   static Map<String, Function> _notInlinedMessages(_) => <String, Function>{
@@ -234,7 +235,8 @@ class MessageLookup extends MessageLookupByLibrary {
         "customMealsMergeConfirmContent": mMergeConfirm,
         "customMealsMergeConfirmAction":
             MessageLookupByLibrary.simpleMessage("Zusammenführen"),
-        "customMealsMergeSuccessSnackbar": mMergeSuccess,
+                "customMealsMergeSuccessSnackbarOne": mMergeOneDe,
+        "customMealsMergeSuccessSnackbarOther": mMergeSuccess,
         "dailyKcalAdjustmentLabel":
             MessageLookupByLibrary.simpleMessage("Tägliche kcal-Anpassung:"),
         "dailyKjAdjustmentLabel":

--- a/lib/generated/intl/messages_en.dart
+++ b/lib/generated/intl/messages_en.dart
@@ -91,6 +91,7 @@ class MessageLookup extends MessageLookupByLibrary {
   static String mMergeSuccess(count, winner) =>
       "Merged — ${winner} now has ${count} logged entries.";
   static String mDriRef(value) => "ref ${value}";
+  static String mMergeOneEn(winner) => "Merged — ${winner} now has 1 logged entry.";
 
   final messages = _notInlinedMessages(_notInlinedMessages);
   static Map<String, Function> _notInlinedMessages(_) => <String, Function>{
@@ -322,7 +323,8 @@ class MessageLookup extends MessageLookupByLibrary {
         "customMealsMergeConfirmContent": mMergeConfirm,
         "customMealsMergeConfirmAction":
             MessageLookupByLibrary.simpleMessage("Merge"),
-        "customMealsMergeSuccessSnackbar": mMergeSuccess,
+                "customMealsMergeSuccessSnackbarOne": mMergeOneEn,
+        "customMealsMergeSuccessSnackbarOther": mMergeSuccess,
         "ironLabel": MessageLookupByLibrary.simpleMessage("iron"),
         "magnesiumLabel": MessageLookupByLibrary.simpleMessage("magnesium"),
         "micronutrientsLabel": MessageLookupByLibrary.simpleMessage("Micronutrients"),

--- a/lib/generated/intl/messages_en.dart
+++ b/lib/generated/intl/messages_en.dart
@@ -85,6 +85,12 @@ class MessageLookup extends MessageLookupByLibrary {
 
   static String mLogWaterAmount(amount) => "Add ${amount} ml";
 
+  static String mMergeConfirm(loser, winner) =>
+      "This will replace all entries logged with ${loser} so they show ${winner} instead, and remove ${loser} from your custom foods. This can\'t be undone.";
+
+  static String mMergeSuccess(count, winner) =>
+      "Merged — ${winner} now has ${count} logged entries.";
+
   final messages = _notInlinedMessages(_notInlinedMessages);
   static Map<String, Function> _notInlinedMessages(_) => <String, Function>{
         "activityExample": MessageLookupByLibrary.simpleMessage(
@@ -293,6 +299,22 @@ class MessageLookup extends MessageLookupByLibrary {
             MessageLookupByLibrary.simpleMessage("Delete custom meal?"),
         "customMealsEmptyLabel":
             MessageLookupByLibrary.simpleMessage("No custom meals saved yet."),
+        "customMealsRowMoreTooltip":
+            MessageLookupByLibrary.simpleMessage("More actions"),
+        "customMealsMergeAction": MessageLookupByLibrary.simpleMessage(
+            "Merge with another custom food"),
+        "customMealsMergePickerTitle": MessageLookupByLibrary.simpleMessage(
+            "Pick the custom food to merge with"),
+        "customMealsMergeChooseSurvivorTitle":
+            MessageLookupByLibrary.simpleMessage("Which one stays?"),
+        "customMealsMergeContinueAction":
+            MessageLookupByLibrary.simpleMessage("Continue"),
+        "customMealsMergeConfirmTitle":
+            MessageLookupByLibrary.simpleMessage("Merge custom foods?"),
+        "customMealsMergeConfirmContent": mMergeConfirm,
+        "customMealsMergeConfirmAction":
+            MessageLookupByLibrary.simpleMessage("Merge"),
+        "customMealsMergeSuccessSnackbar": mMergeSuccess,
         "ironLabel": MessageLookupByLibrary.simpleMessage("iron"),
         "magnesiumLabel": MessageLookupByLibrary.simpleMessage("magnesium"),
         "micronutrientsLabel": MessageLookupByLibrary.simpleMessage("Micronutrients"),

--- a/lib/generated/intl/messages_it.dart
+++ b/lib/generated/intl/messages_it.dart
@@ -92,6 +92,7 @@ class MessageLookup extends MessageLookupByLibrary {
   static String mMergeSuccess(count, winner) =>
       "Uniti — ${winner} ora ha ${count} voci registrate.";
   static String mDriRef(value) => "rif. ${value}";
+  static String mMergeOneIt(winner) => "Unito — ${winner} ora ha 1 voce registrata.";
 
   final messages = _notInlinedMessages(_notInlinedMessages);
   static Map<String, Function> _notInlinedMessages(_) => <String, Function>{
@@ -232,7 +233,8 @@ class MessageLookup extends MessageLookupByLibrary {
         "customMealsMergeConfirmContent": mMergeConfirm,
         "customMealsMergeConfirmAction":
             MessageLookupByLibrary.simpleMessage("Unisci"),
-        "customMealsMergeSuccessSnackbar": mMergeSuccess,
+                "customMealsMergeSuccessSnackbarOne": mMergeOneIt,
+        "customMealsMergeSuccessSnackbarOther": mMergeSuccess,
         "dailyKcalAdjustmentLabel": MessageLookupByLibrary.simpleMessage(
             "Regolazione kcal giornaliere:"),
         "dailyKjAdjustmentLabel":

--- a/lib/generated/intl/messages_it.dart
+++ b/lib/generated/intl/messages_it.dart
@@ -86,6 +86,12 @@ class MessageLookup extends MessageLookupByLibrary {
 
   static String mLogWaterAmount(amount) => "Aggiungi ${amount} ml";
 
+  static String mMergeConfirm(loser, winner) =>
+      "Tutte le voci registrate con ${loser} verranno sostituite e mostrate come ${winner}, e ${loser} sarà rimosso dai tuoi alimenti personalizzati. Questa operazione non può essere annullata.";
+
+  static String mMergeSuccess(count, winner) =>
+      "Uniti — ${winner} ora ha ${count} voci registrate.";
+
   final messages = _notInlinedMessages(_notInlinedMessages);
   static Map<String, Function> _notInlinedMessages(_) => <String, Function>{
         "activityExample": MessageLookupByLibrary.simpleMessage(
@@ -210,6 +216,22 @@ class MessageLookup extends MessageLookupByLibrary {
             "Eliminare il pasto personalizzato?"),
         "customMealsEmptyLabel": MessageLookupByLibrary.simpleMessage(
             "Nessun pasto personalizzato salvato."),
+        "customMealsRowMoreTooltip":
+            MessageLookupByLibrary.simpleMessage("Altre azioni"),
+        "customMealsMergeAction": MessageLookupByLibrary.simpleMessage(
+            "Unisci a un altro alimento personalizzato"),
+        "customMealsMergePickerTitle": MessageLookupByLibrary.simpleMessage(
+            "Scegli l\'alimento personalizzato da unire"),
+        "customMealsMergeChooseSurvivorTitle":
+            MessageLookupByLibrary.simpleMessage("Quale rimane?"),
+        "customMealsMergeContinueAction":
+            MessageLookupByLibrary.simpleMessage("Continua"),
+        "customMealsMergeConfirmTitle": MessageLookupByLibrary.simpleMessage(
+            "Unire gli alimenti personalizzati?"),
+        "customMealsMergeConfirmContent": mMergeConfirm,
+        "customMealsMergeConfirmAction":
+            MessageLookupByLibrary.simpleMessage("Unisci"),
+        "customMealsMergeSuccessSnackbar": mMergeSuccess,
         "dailyKcalAdjustmentLabel": MessageLookupByLibrary.simpleMessage(
             "Regolazione kcal giornaliere:"),
         "dailyKjAdjustmentLabel":

--- a/lib/generated/intl/messages_pl.dart
+++ b/lib/generated/intl/messages_pl.dart
@@ -91,6 +91,7 @@ class MessageLookup extends MessageLookupByLibrary {
   static String mMergeSuccess(count, winner) =>
       "Połączono — ${winner} ma teraz ${count} zarejestrowanych wpisów.";
   static String mDriRef(value) => "ref. ${value}";
+  static String mMergeOnePl(winner) => "Połączono — ${winner} ma teraz 1 wpis.";
 
   final messages = _notInlinedMessages(_notInlinedMessages);
   static Map<String, Function> _notInlinedMessages(_) => <String, Function>{
@@ -229,7 +230,8 @@ class MessageLookup extends MessageLookupByLibrary {
         "customMealsMergeConfirmContent": mMergeConfirm,
         "customMealsMergeConfirmAction":
             MessageLookupByLibrary.simpleMessage("Połącz"),
-        "customMealsMergeSuccessSnackbar": mMergeSuccess,
+                "customMealsMergeSuccessSnackbarOne": mMergeOnePl,
+        "customMealsMergeSuccessSnackbarOther": mMergeSuccess,
         "dailyKcalAdjustmentLabel":
             MessageLookupByLibrary.simpleMessage("Dzienna korekta Kcal:"),
         "dailyKjAdjustmentLabel":

--- a/lib/generated/intl/messages_pl.dart
+++ b/lib/generated/intl/messages_pl.dart
@@ -85,6 +85,12 @@ class MessageLookup extends MessageLookupByLibrary {
 
   static String mLogWaterAmount(amount) => "Dodaj ${amount} ml";
 
+  static String mMergeConfirm(loser, winner) =>
+      "Spowoduje to zastąpienie wszystkich wpisów zarejestrowanych z ${loser}, tak by pokazywały ${winner}, oraz usunie ${loser} z Twoich własnych produktów. Tej operacji nie można cofnąć.";
+
+  static String mMergeSuccess(count, winner) =>
+      "Połączono — ${winner} ma teraz ${count} zarejestrowanych wpisów.";
+
   final messages = _notInlinedMessages(_notInlinedMessages);
   static Map<String, Function> _notInlinedMessages(_) => <String, Function>{
         "activityExample": MessageLookupByLibrary.simpleMessage(
@@ -207,6 +213,22 @@ class MessageLookup extends MessageLookupByLibrary {
             MessageLookupByLibrary.simpleMessage("Usunąć własny posiłek?"),
         "customMealsEmptyLabel": MessageLookupByLibrary.simpleMessage(
             "Brak zapisanych własnych posiłków."),
+        "customMealsRowMoreTooltip":
+            MessageLookupByLibrary.simpleMessage("Więcej akcji"),
+        "customMealsMergeAction": MessageLookupByLibrary.simpleMessage(
+            "Połącz z innym własnym produktem"),
+        "customMealsMergePickerTitle": MessageLookupByLibrary.simpleMessage(
+            "Wybierz własny produkt do połączenia"),
+        "customMealsMergeChooseSurvivorTitle":
+            MessageLookupByLibrary.simpleMessage("Który zostaje?"),
+        "customMealsMergeContinueAction":
+            MessageLookupByLibrary.simpleMessage("Kontynuuj"),
+        "customMealsMergeConfirmTitle":
+            MessageLookupByLibrary.simpleMessage("Połączyć własne produkty?"),
+        "customMealsMergeConfirmContent": mMergeConfirm,
+        "customMealsMergeConfirmAction":
+            MessageLookupByLibrary.simpleMessage("Połącz"),
+        "customMealsMergeSuccessSnackbar": mMergeSuccess,
         "dailyKcalAdjustmentLabel":
             MessageLookupByLibrary.simpleMessage("Dzienna korekta Kcal:"),
         "dailyKjAdjustmentLabel":

--- a/lib/generated/intl/messages_sk.dart
+++ b/lib/generated/intl/messages_sk.dart
@@ -86,6 +86,12 @@ class MessageLookup extends MessageLookupByLibrary {
 
   static String mLogWaterAmount(amount) => "Pridať ${amount} ml";
 
+  static String mMergeConfirm(loser, winner) =>
+      "Tým sa všetky záznamy zapísané s ${loser} nahradia, aby zobrazovali ${winner}, a ${loser} bude odstránené z vašich vlastných jedál. Túto akciu nemožno vrátiť späť.";
+
+  static String mMergeSuccess(count, winner) =>
+      "Zlúčené — ${winner} má teraz ${count} zaznamenaných záznamov.";
+
   final messages = _notInlinedMessages(_notInlinedMessages);
   static Map<String, Function> _notInlinedMessages(_) => <String, Function>{
         "activityExample": MessageLookupByLibrary.simpleMessage(
@@ -215,6 +221,22 @@ class MessageLookup extends MessageLookupByLibrary {
             MessageLookupByLibrary.simpleMessage("Zmazať vlastné jedlo?"),
         "customMealsEmptyLabel": MessageLookupByLibrary.simpleMessage(
             "Zatiaľ nie sú uložené žiadne vlastné jedlá."),
+        "customMealsRowMoreTooltip":
+            MessageLookupByLibrary.simpleMessage("Ďalšie akcie"),
+        "customMealsMergeAction": MessageLookupByLibrary.simpleMessage(
+            "Zlúčiť s iným vlastným jedlom"),
+        "customMealsMergePickerTitle": MessageLookupByLibrary.simpleMessage(
+            "Vyberte vlastné jedlo na zlúčenie"),
+        "customMealsMergeChooseSurvivorTitle":
+            MessageLookupByLibrary.simpleMessage("Ktoré ostane?"),
+        "customMealsMergeContinueAction":
+            MessageLookupByLibrary.simpleMessage("Pokračovať"),
+        "customMealsMergeConfirmTitle":
+            MessageLookupByLibrary.simpleMessage("Zlúčiť vlastné jedlá?"),
+        "customMealsMergeConfirmContent": mMergeConfirm,
+        "customMealsMergeConfirmAction":
+            MessageLookupByLibrary.simpleMessage("Zlúčiť"),
+        "customMealsMergeSuccessSnackbar": mMergeSuccess,
         "dailyKcalAdjustmentLabel": MessageLookupByLibrary.simpleMessage(
             "Denná úprava kcal:"),
         "dailyKjAdjustmentLabel":

--- a/lib/generated/intl/messages_sk.dart
+++ b/lib/generated/intl/messages_sk.dart
@@ -92,6 +92,7 @@ class MessageLookup extends MessageLookupByLibrary {
   static String mMergeSuccess(count, winner) =>
       "Zlúčené — ${winner} má teraz ${count} zaznamenaných záznamov.";
   static String mDriRef(value) => "ref. ${value}";
+  static String mMergeOneSk(winner) => "Zlúčené — ${winner} má teraz 1 záznam.";
 
   final messages = _notInlinedMessages(_notInlinedMessages);
   static Map<String, Function> _notInlinedMessages(_) => <String, Function>{
@@ -237,7 +238,8 @@ class MessageLookup extends MessageLookupByLibrary {
         "customMealsMergeConfirmContent": mMergeConfirm,
         "customMealsMergeConfirmAction":
             MessageLookupByLibrary.simpleMessage("Zlúčiť"),
-        "customMealsMergeSuccessSnackbar": mMergeSuccess,
+                "customMealsMergeSuccessSnackbarOne": mMergeOneSk,
+        "customMealsMergeSuccessSnackbarOther": mMergeSuccess,
         "dailyKcalAdjustmentLabel": MessageLookupByLibrary.simpleMessage(
             "Denná úprava kcal:"),
         "dailyKjAdjustmentLabel":

--- a/lib/generated/intl/messages_tr.dart
+++ b/lib/generated/intl/messages_tr.dart
@@ -88,6 +88,12 @@ class MessageLookup extends MessageLookupByLibrary {
 
   static String mLogWaterAmount(amount) => "${amount} ml ekle";
 
+  static String mMergeConfirm(loser, winner) =>
+      "Bu işlem, ${loser} ile kaydedilen tüm girdileri değiştirip ${winner} olarak gösterir ve ${loser} özel yiyeceklerinden kaldırılır. Bu işlem geri alınamaz.";
+
+  static String mMergeSuccess(count, winner) =>
+      "Birleştirildi — ${winner} artık ${count} kayıtlı girdiye sahip.";
+
   final messages = _notInlinedMessages(_notInlinedMessages);
   static Map<String, Function> _notInlinedMessages(_) => <String, Function>{
         "activityExample": MessageLookupByLibrary.simpleMessage(
@@ -210,6 +216,22 @@ class MessageLookup extends MessageLookupByLibrary {
             MessageLookupByLibrary.simpleMessage("Özel yemek silinsin mi?"),
         "customMealsEmptyLabel": MessageLookupByLibrary.simpleMessage(
             "Henüz özel yemek kaydedilmedi."),
+        "customMealsRowMoreTooltip":
+            MessageLookupByLibrary.simpleMessage("Diğer eylemler"),
+        "customMealsMergeAction": MessageLookupByLibrary.simpleMessage(
+            "Başka bir özel yiyecekle birleştir"),
+        "customMealsMergePickerTitle": MessageLookupByLibrary.simpleMessage(
+            "Birleştirilecek özel yiyeceği seç"),
+        "customMealsMergeChooseSurvivorTitle":
+            MessageLookupByLibrary.simpleMessage("Hangisi kalsın?"),
+        "customMealsMergeContinueAction":
+            MessageLookupByLibrary.simpleMessage("Devam et"),
+        "customMealsMergeConfirmTitle": MessageLookupByLibrary.simpleMessage(
+            "Özel yiyecekler birleştirilsin mi?"),
+        "customMealsMergeConfirmContent": mMergeConfirm,
+        "customMealsMergeConfirmAction":
+            MessageLookupByLibrary.simpleMessage("Birleştir"),
+        "customMealsMergeSuccessSnackbar": mMergeSuccess,
         "dailyKcalAdjustmentLabel":
             MessageLookupByLibrary.simpleMessage("Günlük Kcal ayarı:"),
         "dailyKjAdjustmentLabel":

--- a/lib/generated/intl/messages_tr.dart
+++ b/lib/generated/intl/messages_tr.dart
@@ -94,6 +94,7 @@ class MessageLookup extends MessageLookupByLibrary {
   static String mMergeSuccess(count, winner) =>
       "Birleştirildi — ${winner} artık ${count} kayıtlı girdiye sahip.";
   static String mDriRef(value) => "ref. ${value}";
+  static String mMergeOneTr(winner) => "Birleştirildi — ${winner} artık 1 kayda sahip.";
 
   final messages = _notInlinedMessages(_notInlinedMessages);
   static Map<String, Function> _notInlinedMessages(_) => <String, Function>{
@@ -232,7 +233,8 @@ class MessageLookup extends MessageLookupByLibrary {
         "customMealsMergeConfirmContent": mMergeConfirm,
         "customMealsMergeConfirmAction":
             MessageLookupByLibrary.simpleMessage("Birleştir"),
-        "customMealsMergeSuccessSnackbar": mMergeSuccess,
+                "customMealsMergeSuccessSnackbarOne": mMergeOneTr,
+        "customMealsMergeSuccessSnackbarOther": mMergeSuccess,
         "dailyKcalAdjustmentLabel":
             MessageLookupByLibrary.simpleMessage("Günlük Kcal ayarı:"),
         "dailyKjAdjustmentLabel":

--- a/lib/generated/intl/messages_uk.dart
+++ b/lib/generated/intl/messages_uk.dart
@@ -86,6 +86,12 @@ class MessageLookup extends MessageLookupByLibrary {
 
   static String mLogWaterAmount(amount) => "Додати ${amount} мл";
 
+  static String mMergeConfirm(loser, winner) =>
+      "Це замінить усі записи, додані з ${loser}, щоб вони показували ${winner}, і видалить ${loser} з ваших власних страв. Цю дію не можна скасувати.";
+
+  static String mMergeSuccess(count, winner) =>
+      "Об’єднано — ${winner} тепер має ${count} записів.";
+
   final messages = _notInlinedMessages(_notInlinedMessages);
   static Map<String, Function> _notInlinedMessages(_) => <String, Function>{
         "activityExample": MessageLookupByLibrary.simpleMessage(
@@ -208,6 +214,22 @@ class MessageLookup extends MessageLookupByLibrary {
             MessageLookupByLibrary.simpleMessage("Видалити власну страву?"),
         "customMealsEmptyLabel": MessageLookupByLibrary.simpleMessage(
             "Ще немає збережених власних страв."),
+        "customMealsRowMoreTooltip":
+            MessageLookupByLibrary.simpleMessage("Більше дій"),
+        "customMealsMergeAction": MessageLookupByLibrary.simpleMessage(
+            "Об’єднати з іншою власною стравою"),
+        "customMealsMergePickerTitle": MessageLookupByLibrary.simpleMessage(
+            "Виберіть власну страву для об’єднання"),
+        "customMealsMergeChooseSurvivorTitle":
+            MessageLookupByLibrary.simpleMessage("Яка залишається?"),
+        "customMealsMergeContinueAction":
+            MessageLookupByLibrary.simpleMessage("Продовжити"),
+        "customMealsMergeConfirmTitle":
+            MessageLookupByLibrary.simpleMessage("Об’єднати власні страви?"),
+        "customMealsMergeConfirmContent": mMergeConfirm,
+        "customMealsMergeConfirmAction":
+            MessageLookupByLibrary.simpleMessage("Об’єднати"),
+        "customMealsMergeSuccessSnackbar": mMergeSuccess,
         "dailyKcalAdjustmentLabel":
             MessageLookupByLibrary.simpleMessage("Щоденна корекція калорій:"),
         "dailyKjAdjustmentLabel":

--- a/lib/generated/intl/messages_uk.dart
+++ b/lib/generated/intl/messages_uk.dart
@@ -92,6 +92,7 @@ class MessageLookup extends MessageLookupByLibrary {
   static String mMergeSuccess(count, winner) =>
       "Об’єднано — ${winner} тепер має ${count} записів.";
   static String mDriRef(value) => "орієнт. ${value}";
+  static String mMergeOneUk(winner) => "Об'єднано — ${winner} тепер має 1 запис.";
 
   final messages = _notInlinedMessages(_notInlinedMessages);
   static Map<String, Function> _notInlinedMessages(_) => <String, Function>{
@@ -230,7 +231,8 @@ class MessageLookup extends MessageLookupByLibrary {
         "customMealsMergeConfirmContent": mMergeConfirm,
         "customMealsMergeConfirmAction":
             MessageLookupByLibrary.simpleMessage("Об’єднати"),
-        "customMealsMergeSuccessSnackbar": mMergeSuccess,
+                "customMealsMergeSuccessSnackbarOne": mMergeOneUk,
+        "customMealsMergeSuccessSnackbarOther": mMergeSuccess,
         "dailyKcalAdjustmentLabel":
             MessageLookupByLibrary.simpleMessage("Щоденна корекція калорій:"),
         "dailyKjAdjustmentLabel":

--- a/lib/generated/intl/messages_zh.dart
+++ b/lib/generated/intl/messages_zh.dart
@@ -83,6 +83,12 @@ class MessageLookup extends MessageLookupByLibrary {
 
   static String mLogWaterAmount(amount) => "添加 ${amount} 毫升";
 
+  static String mMergeConfirm(loser, winner) =>
+      "这会把所有用 ${loser} 记录的条目改为显示 ${winner}，并把 ${loser} 从你的自定义食物中移除。此操作无法撤销。";
+
+  static String mMergeSuccess(count, winner) =>
+      "已合并 — ${winner} 现在有 ${count} 条记录。";
+
   final messages = _notInlinedMessages(_notInlinedMessages);
   static Map<String, Function> _notInlinedMessages(_) => <String, Function>{
         "activityExample":
@@ -198,6 +204,22 @@ class MessageLookup extends MessageLookupByLibrary {
             MessageLookupByLibrary.simpleMessage("删除自定义餐食？"),
         "customMealsEmptyLabel":
             MessageLookupByLibrary.simpleMessage("尚未保存自定义餐食。"),
+        "customMealsRowMoreTooltip":
+            MessageLookupByLibrary.simpleMessage("更多操作"),
+        "customMealsMergeAction":
+            MessageLookupByLibrary.simpleMessage("与另一项自定义食物合并"),
+        "customMealsMergePickerTitle":
+            MessageLookupByLibrary.simpleMessage("选择要合并的自定义食物"),
+        "customMealsMergeChooseSurvivorTitle":
+            MessageLookupByLibrary.simpleMessage("保留哪一项？"),
+        "customMealsMergeContinueAction":
+            MessageLookupByLibrary.simpleMessage("继续"),
+        "customMealsMergeConfirmTitle":
+            MessageLookupByLibrary.simpleMessage("合并自定义食物？"),
+        "customMealsMergeConfirmContent": mMergeConfirm,
+        "customMealsMergeConfirmAction":
+            MessageLookupByLibrary.simpleMessage("合并"),
+        "customMealsMergeSuccessSnackbar": mMergeSuccess,
         "dailyKcalAdjustmentLabel":
             MessageLookupByLibrary.simpleMessage("每日卡路里调整："),
         "dailyKjAdjustmentLabel":

--- a/lib/generated/intl/messages_zh.dart
+++ b/lib/generated/intl/messages_zh.dart
@@ -89,6 +89,7 @@ class MessageLookup extends MessageLookupByLibrary {
   static String mMergeSuccess(count, winner) =>
       "已合并 — ${winner} 现在有 ${count} 条记录。";
   static String mDriRef(value) => "参考 ${value}";
+  static String mMergeOneZh(winner) => "已合并 — ${winner} 现在有 1 条记录。";
 
   final messages = _notInlinedMessages(_notInlinedMessages);
   static Map<String, Function> _notInlinedMessages(_) => <String, Function>{
@@ -220,7 +221,8 @@ class MessageLookup extends MessageLookupByLibrary {
         "customMealsMergeConfirmContent": mMergeConfirm,
         "customMealsMergeConfirmAction":
             MessageLookupByLibrary.simpleMessage("合并"),
-        "customMealsMergeSuccessSnackbar": mMergeSuccess,
+                "customMealsMergeSuccessSnackbarOne": mMergeOneZh,
+        "customMealsMergeSuccessSnackbarOther": mMergeSuccess,
         "dailyKcalAdjustmentLabel":
             MessageLookupByLibrary.simpleMessage("每日卡路里调整："),
         "dailyKjAdjustmentLabel":

--- a/lib/generated/l10n.dart
+++ b/lib/generated/l10n.dart
@@ -7482,11 +7482,21 @@ class S {
     );
   }
 
+  /// `Merged — {winner} now has 1 logged entry.`
+  String customMealsMergeSuccessSnackbarOne(String winner) {
+    return Intl.message(
+      'Merged — $winner now has 1 logged entry.',
+      name: 'customMealsMergeSuccessSnackbarOne',
+      desc: '',
+      args: [winner],
+    );
+  }
+
   /// `Merged — {winner} now has {count} logged entries.`
-  String customMealsMergeSuccessSnackbar(int count, String winner) {
+  String customMealsMergeSuccessSnackbarOther(int count, String winner) {
     return Intl.message(
       'Merged — $winner now has $count logged entries.',
-      name: 'customMealsMergeSuccessSnackbar',
+      name: 'customMealsMergeSuccessSnackbarOther',
       desc: '',
       args: [count, winner],
     );

--- a/lib/generated/l10n.dart
+++ b/lib/generated/l10n.dart
@@ -7151,6 +7151,96 @@ class S {
       args: [],
     );
   }
+
+  /// `More actions`
+  String get customMealsRowMoreTooltip {
+    return Intl.message(
+      'More actions',
+      name: 'customMealsRowMoreTooltip',
+      desc: '',
+      args: [],
+    );
+  }
+
+  /// `Merge with another custom food`
+  String get customMealsMergeAction {
+    return Intl.message(
+      'Merge with another custom food',
+      name: 'customMealsMergeAction',
+      desc: '',
+      args: [],
+    );
+  }
+
+  /// `Pick the custom food to merge with`
+  String get customMealsMergePickerTitle {
+    return Intl.message(
+      'Pick the custom food to merge with',
+      name: 'customMealsMergePickerTitle',
+      desc: '',
+      args: [],
+    );
+  }
+
+  /// `Which one stays?`
+  String get customMealsMergeChooseSurvivorTitle {
+    return Intl.message(
+      'Which one stays?',
+      name: 'customMealsMergeChooseSurvivorTitle',
+      desc: '',
+      args: [],
+    );
+  }
+
+  /// `Continue`
+  String get customMealsMergeContinueAction {
+    return Intl.message(
+      'Continue',
+      name: 'customMealsMergeContinueAction',
+      desc: '',
+      args: [],
+    );
+  }
+
+  /// `Merge custom foods?`
+  String get customMealsMergeConfirmTitle {
+    return Intl.message(
+      'Merge custom foods?',
+      name: 'customMealsMergeConfirmTitle',
+      desc: '',
+      args: [],
+    );
+  }
+
+  /// `This will replace all entries logged with {loser} so they show {winner} instead, and remove {loser} from your custom foods. This can't be undone.`
+  String customMealsMergeConfirmContent(String loser, String winner) {
+    return Intl.message(
+      "This will replace all entries logged with $loser so they show $winner instead, and remove $loser from your custom foods. This can't be undone.",
+      name: 'customMealsMergeConfirmContent',
+      desc: '',
+      args: [loser, winner],
+    );
+  }
+
+  /// `Merge`
+  String get customMealsMergeConfirmAction {
+    return Intl.message(
+      'Merge',
+      name: 'customMealsMergeConfirmAction',
+      desc: '',
+      args: [],
+    );
+  }
+
+  /// `Merged — {winner} now has {count} logged entries.`
+  String customMealsMergeSuccessSnackbar(int count, String winner) {
+    return Intl.message(
+      'Merged — $winner now has $count logged entries.',
+      name: 'customMealsMergeSuccessSnackbar',
+      desc: '',
+      args: [count, winner],
+    );
+  }
 }
 
 class AppLocalizationDelegate extends LocalizationsDelegate<S> {

--- a/lib/l10n/intl_cs.arb
+++ b/lib/l10n/intl_cs.arb
@@ -887,8 +887,12 @@
     }
   },
   "customMealsMergeConfirmAction": "Sloučit",
-  "customMealsMergeSuccessSnackbar": "Sloučeno — {winner} má nyní {count} záznamů.",
-  "@customMealsMergeSuccessSnackbar": {
+  "customMealsMergeSuccessSnackbarOne": "Sloučeno — {winner} má nyní 1 záznam.",
+  "@customMealsMergeSuccessSnackbarOne": {
+    "placeholders": { "winner": { "type": "String" } }
+  },
+  "customMealsMergeSuccessSnackbarOther": "Sloučeno — {winner} má nyní {count} záznamů.",
+  "@customMealsMergeSuccessSnackbarOther": {
     "placeholders": {
       "count": { "type": "int" },
       "winner": { "type": "String" }

--- a/lib/l10n/intl_cs.arb
+++ b/lib/l10n/intl_cs.arb
@@ -839,5 +839,26 @@
   "settingsWaterGoalDescription": "Používá se pro ukazatel vody na hlavní obrazovce.",
   "settingsWaterGoalLabel": "Denní cíl pití vody",
   "waterChipLabel": "{current} / {goal} ml",
-  "zincLabel": "zinek"
+  "zincLabel": "zinek",
+  "customMealsRowMoreTooltip": "Další akce",
+  "customMealsMergeAction": "Sloučit s jinou vlastní potravinou",
+  "customMealsMergePickerTitle": "Vyberte vlastní potravinu pro sloučení",
+  "customMealsMergeChooseSurvivorTitle": "Která zůstane?",
+  "customMealsMergeContinueAction": "Pokračovat",
+  "customMealsMergeConfirmTitle": "Sloučit vlastní potraviny?",
+  "customMealsMergeConfirmContent": "Tímto se všechny záznamy zapsané s {loser} nahradí, aby se zobrazovaly jako {winner}, a {loser} bude odstraněna z vašich vlastních potravin. Tuto akci nelze vrátit zpět.",
+  "@customMealsMergeConfirmContent": {
+    "placeholders": {
+      "loser": { "type": "String" },
+      "winner": { "type": "String" }
+    }
+  },
+  "customMealsMergeConfirmAction": "Sloučit",
+  "customMealsMergeSuccessSnackbar": "Sloučeno — {winner} má nyní {count} záznamů.",
+  "@customMealsMergeSuccessSnackbar": {
+    "placeholders": {
+      "count": { "type": "int" },
+      "winner": { "type": "String" }
+    }
+  }
 }

--- a/lib/l10n/intl_de.arb
+++ b/lib/l10n/intl_de.arb
@@ -870,5 +870,26 @@
   "settingsWaterGoalDescription": "Wird vom Wasser-Chip auf dem Startbildschirm verwendet.",
   "settingsWaterGoalLabel": "Tägliches Wasserziel",
   "waterChipLabel": "{current} / {goal} ml",
-  "zincLabel": "Zink"
+  "zincLabel": "Zink",
+  "customMealsRowMoreTooltip": "Weitere Aktionen",
+  "customMealsMergeAction": "Mit einer anderen eigenen Mahlzeit zusammenführen",
+  "customMealsMergePickerTitle": "Wähle die eigene Mahlzeit zum Zusammenführen",
+  "customMealsMergeChooseSurvivorTitle": "Welche bleibt?",
+  "customMealsMergeContinueAction": "Weiter",
+  "customMealsMergeConfirmTitle": "Eigene Mahlzeiten zusammenführen?",
+  "customMealsMergeConfirmContent": "Dadurch werden alle Einträge, die mit {loser} protokolliert wurden, ersetzt, sodass sie {winner} anzeigen. Außerdem wird {loser} aus deinen eigenen Mahlzeiten entfernt. Das kann nicht rückgängig gemacht werden.",
+  "@customMealsMergeConfirmContent": {
+    "placeholders": {
+      "loser": { "type": "String" },
+      "winner": { "type": "String" }
+    }
+  },
+  "customMealsMergeConfirmAction": "Zusammenführen",
+  "customMealsMergeSuccessSnackbar": "Zusammengeführt — {winner} hat jetzt {count} protokollierte Einträge.",
+  "@customMealsMergeSuccessSnackbar": {
+    "placeholders": {
+      "count": { "type": "int" },
+      "winner": { "type": "String" }
+    }
+  }
 }

--- a/lib/l10n/intl_de.arb
+++ b/lib/l10n/intl_de.arb
@@ -918,8 +918,12 @@
     }
   },
   "customMealsMergeConfirmAction": "Zusammenführen",
-  "customMealsMergeSuccessSnackbar": "Zusammengeführt — {winner} hat jetzt {count} protokollierte Einträge.",
-  "@customMealsMergeSuccessSnackbar": {
+  "customMealsMergeSuccessSnackbarOne": "Zusammengeführt — {winner} hat jetzt 1 Eintrag.",
+  "@customMealsMergeSuccessSnackbarOne": {
+    "placeholders": { "winner": { "type": "String" } }
+  },
+  "customMealsMergeSuccessSnackbarOther": "Zusammengeführt — {winner} hat jetzt {count} Einträge.",
+  "@customMealsMergeSuccessSnackbarOther": {
     "placeholders": {
       "count": { "type": "int" },
       "winner": { "type": "String" }

--- a/lib/l10n/intl_en.arb
+++ b/lib/l10n/intl_en.arb
@@ -887,5 +887,26 @@
   "settingsWaterGoalDescription": "Used by the water chip on the home screen.",
   "settingsWaterGoalLabel": "Daily water goal",
   "waterChipLabel": "{current} / {goal} ml",
-  "zincLabel": "zinc"
+  "zincLabel": "zinc",
+  "customMealsRowMoreTooltip": "More actions",
+  "customMealsMergeAction": "Merge with another custom food",
+  "customMealsMergePickerTitle": "Pick the custom food to merge with",
+  "customMealsMergeChooseSurvivorTitle": "Which one stays?",
+  "customMealsMergeContinueAction": "Continue",
+  "customMealsMergeConfirmTitle": "Merge custom foods?",
+  "customMealsMergeConfirmContent": "This will replace all entries logged with {loser} so they show {winner} instead, and remove {loser} from your custom foods. This can't be undone.",
+  "@customMealsMergeConfirmContent": {
+    "placeholders": {
+      "loser": { "type": "String" },
+      "winner": { "type": "String" }
+    }
+  },
+  "customMealsMergeConfirmAction": "Merge",
+  "customMealsMergeSuccessSnackbar": "Merged — {winner} now has {count} logged entries.",
+  "@customMealsMergeSuccessSnackbar": {
+    "placeholders": {
+      "count": { "type": "int" },
+      "winner": { "type": "String" }
+    }
+  }
 }

--- a/lib/l10n/intl_en.arb
+++ b/lib/l10n/intl_en.arb
@@ -935,8 +935,12 @@
     }
   },
   "customMealsMergeConfirmAction": "Merge",
-  "customMealsMergeSuccessSnackbar": "Merged — {winner} now has {count} logged entries.",
-  "@customMealsMergeSuccessSnackbar": {
+  "customMealsMergeSuccessSnackbarOne": "Merged — {winner} now has 1 logged entry.",
+  "@customMealsMergeSuccessSnackbarOne": {
+    "placeholders": { "winner": { "type": "String" } }
+  },
+  "customMealsMergeSuccessSnackbarOther": "Merged — {winner} now has {count} logged entries.",
+  "@customMealsMergeSuccessSnackbarOther": {
     "placeholders": {
       "count": { "type": "int" },
       "winner": { "type": "String" }

--- a/lib/l10n/intl_it.arb
+++ b/lib/l10n/intl_it.arb
@@ -887,8 +887,12 @@
     }
   },
   "customMealsMergeConfirmAction": "Unisci",
-  "customMealsMergeSuccessSnackbar": "Uniti — {winner} ora ha {count} voci registrate.",
-  "@customMealsMergeSuccessSnackbar": {
+  "customMealsMergeSuccessSnackbarOne": "Unito — {winner} ora ha 1 voce registrata.",
+  "@customMealsMergeSuccessSnackbarOne": {
+    "placeholders": { "winner": { "type": "String" } }
+  },
+  "customMealsMergeSuccessSnackbarOther": "Unito — {winner} ora ha {count} voci registrate.",
+  "@customMealsMergeSuccessSnackbarOther": {
     "placeholders": {
       "count": { "type": "int" },
       "winner": { "type": "String" }

--- a/lib/l10n/intl_it.arb
+++ b/lib/l10n/intl_it.arb
@@ -839,5 +839,26 @@
   "settingsWaterGoalDescription": "Usato dal contatore d'acqua nella schermata principale.",
   "settingsWaterGoalLabel": "Obiettivo idrico giornaliero",
   "waterChipLabel": "{current} / {goal} ml",
-  "zincLabel": "zinco"
+  "zincLabel": "zinco",
+  "customMealsRowMoreTooltip": "Altre azioni",
+  "customMealsMergeAction": "Unisci a un altro alimento personalizzato",
+  "customMealsMergePickerTitle": "Scegli l'alimento personalizzato da unire",
+  "customMealsMergeChooseSurvivorTitle": "Quale rimane?",
+  "customMealsMergeContinueAction": "Continua",
+  "customMealsMergeConfirmTitle": "Unire gli alimenti personalizzati?",
+  "customMealsMergeConfirmContent": "Tutte le voci registrate con {loser} verranno sostituite e mostrate come {winner}, e {loser} sarà rimosso dai tuoi alimenti personalizzati. Questa operazione non può essere annullata.",
+  "@customMealsMergeConfirmContent": {
+    "placeholders": {
+      "loser": { "type": "String" },
+      "winner": { "type": "String" }
+    }
+  },
+  "customMealsMergeConfirmAction": "Unisci",
+  "customMealsMergeSuccessSnackbar": "Uniti — {winner} ora ha {count} voci registrate.",
+  "@customMealsMergeSuccessSnackbar": {
+    "placeholders": {
+      "count": { "type": "int" },
+      "winner": { "type": "String" }
+    }
+  }
 }

--- a/lib/l10n/intl_pl.arb
+++ b/lib/l10n/intl_pl.arb
@@ -839,5 +839,26 @@
   "settingsWaterGoalDescription": "Używane przez wskaźnik wody na ekranie głównym.",
   "settingsWaterGoalLabel": "Dzienny cel wody",
   "waterChipLabel": "{current} / {goal} ml",
-  "zincLabel": "cynk"
+  "zincLabel": "cynk",
+  "customMealsRowMoreTooltip": "Więcej akcji",
+  "customMealsMergeAction": "Połącz z innym własnym produktem",
+  "customMealsMergePickerTitle": "Wybierz własny produkt do połączenia",
+  "customMealsMergeChooseSurvivorTitle": "Który zostaje?",
+  "customMealsMergeContinueAction": "Kontynuuj",
+  "customMealsMergeConfirmTitle": "Połączyć własne produkty?",
+  "customMealsMergeConfirmContent": "Spowoduje to zastąpienie wszystkich wpisów zarejestrowanych z {loser}, tak by pokazywały {winner}, oraz usunie {loser} z Twoich własnych produktów. Tej operacji nie można cofnąć.",
+  "@customMealsMergeConfirmContent": {
+    "placeholders": {
+      "loser": { "type": "String" },
+      "winner": { "type": "String" }
+    }
+  },
+  "customMealsMergeConfirmAction": "Połącz",
+  "customMealsMergeSuccessSnackbar": "Połączono — {winner} ma teraz {count} zarejestrowanych wpisów.",
+  "@customMealsMergeSuccessSnackbar": {
+    "placeholders": {
+      "count": { "type": "int" },
+      "winner": { "type": "String" }
+    }
+  }
 }

--- a/lib/l10n/intl_pl.arb
+++ b/lib/l10n/intl_pl.arb
@@ -887,8 +887,12 @@
     }
   },
   "customMealsMergeConfirmAction": "Połącz",
-  "customMealsMergeSuccessSnackbar": "Połączono — {winner} ma teraz {count} zarejestrowanych wpisów.",
-  "@customMealsMergeSuccessSnackbar": {
+  "customMealsMergeSuccessSnackbarOne": "Połączono — {winner} ma teraz 1 wpis.",
+  "@customMealsMergeSuccessSnackbarOne": {
+    "placeholders": { "winner": { "type": "String" } }
+  },
+  "customMealsMergeSuccessSnackbarOther": "Połączono — {winner} ma teraz {count} wpisów.",
+  "@customMealsMergeSuccessSnackbarOther": {
     "placeholders": {
       "count": { "type": "int" },
       "winner": { "type": "String" }

--- a/lib/l10n/intl_sk.arb
+++ b/lib/l10n/intl_sk.arb
@@ -917,8 +917,12 @@
     }
   },
   "customMealsMergeConfirmAction": "Zlúčiť",
-  "customMealsMergeSuccessSnackbar": "Zlúčené — {winner} má teraz {count} zaznamenaných záznamov.",
-  "@customMealsMergeSuccessSnackbar": {
+  "customMealsMergeSuccessSnackbarOne": "Zlúčené — {winner} má teraz 1 záznam.",
+  "@customMealsMergeSuccessSnackbarOne": {
+    "placeholders": { "winner": { "type": "String" } }
+  },
+  "customMealsMergeSuccessSnackbarOther": "Zlúčené — {winner} má teraz {count} záznamov.",
+  "@customMealsMergeSuccessSnackbarOther": {
     "placeholders": {
       "count": { "type": "int" },
       "winner": { "type": "String" }

--- a/lib/l10n/intl_sk.arb
+++ b/lib/l10n/intl_sk.arb
@@ -869,5 +869,26 @@
   "settingsWaterGoalDescription": "Používa sa ukazovateľom vody na hlavnej obrazovke.",
   "settingsWaterGoalLabel": "Denný cieľ pitia vody",
   "waterChipLabel": "{current} / {goal} ml",
-  "zincLabel": "zinok"
+  "zincLabel": "zinok",
+  "customMealsRowMoreTooltip": "Ďalšie akcie",
+  "customMealsMergeAction": "Zlúčiť s iným vlastným jedlom",
+  "customMealsMergePickerTitle": "Vyberte vlastné jedlo na zlúčenie",
+  "customMealsMergeChooseSurvivorTitle": "Ktoré ostane?",
+  "customMealsMergeContinueAction": "Pokračovať",
+  "customMealsMergeConfirmTitle": "Zlúčiť vlastné jedlá?",
+  "customMealsMergeConfirmContent": "Tým sa všetky záznamy zapísané s {loser} nahradia, aby zobrazovali {winner}, a {loser} bude odstránené z vašich vlastných jedál. Túto akciu nemožno vrátiť späť.",
+  "@customMealsMergeConfirmContent": {
+    "placeholders": {
+      "loser": { "type": "String" },
+      "winner": { "type": "String" }
+    }
+  },
+  "customMealsMergeConfirmAction": "Zlúčiť",
+  "customMealsMergeSuccessSnackbar": "Zlúčené — {winner} má teraz {count} zaznamenaných záznamov.",
+  "@customMealsMergeSuccessSnackbar": {
+    "placeholders": {
+      "count": { "type": "int" },
+      "winner": { "type": "String" }
+    }
+  }
 }

--- a/lib/l10n/intl_tr.arb
+++ b/lib/l10n/intl_tr.arb
@@ -870,5 +870,26 @@
   "settingsWaterGoalDescription": "Ana ekrandaki su göstergesinin kullandığı hedef.",
   "settingsWaterGoalLabel": "Günlük su hedefi",
   "waterChipLabel": "{current} / {goal} ml",
-  "zincLabel": "çinko"
+  "zincLabel": "çinko",
+  "customMealsRowMoreTooltip": "Diğer eylemler",
+  "customMealsMergeAction": "Başka bir özel yiyecekle birleştir",
+  "customMealsMergePickerTitle": "Birleştirilecek özel yiyeceği seç",
+  "customMealsMergeChooseSurvivorTitle": "Hangisi kalsın?",
+  "customMealsMergeContinueAction": "Devam et",
+  "customMealsMergeConfirmTitle": "Özel yiyecekler birleştirilsin mi?",
+  "customMealsMergeConfirmContent": "Bu işlem, {loser} ile kaydedilen tüm girdileri değiştirip {winner} olarak gösterir ve {loser} özel yiyeceklerinden kaldırılır. Bu işlem geri alınamaz.",
+  "@customMealsMergeConfirmContent": {
+    "placeholders": {
+      "loser": { "type": "String" },
+      "winner": { "type": "String" }
+    }
+  },
+  "customMealsMergeConfirmAction": "Birleştir",
+  "customMealsMergeSuccessSnackbar": "Birleştirildi — {winner} artık {count} kayıtlı girdiye sahip.",
+  "@customMealsMergeSuccessSnackbar": {
+    "placeholders": {
+      "count": { "type": "int" },
+      "winner": { "type": "String" }
+    }
+  }
 }

--- a/lib/l10n/intl_tr.arb
+++ b/lib/l10n/intl_tr.arb
@@ -918,8 +918,12 @@
     }
   },
   "customMealsMergeConfirmAction": "Birleştir",
-  "customMealsMergeSuccessSnackbar": "Birleştirildi — {winner} artık {count} kayıtlı girdiye sahip.",
-  "@customMealsMergeSuccessSnackbar": {
+  "customMealsMergeSuccessSnackbarOne": "Birleştirildi — {winner} artık 1 kayda sahip.",
+  "@customMealsMergeSuccessSnackbarOne": {
+    "placeholders": { "winner": { "type": "String" } }
+  },
+  "customMealsMergeSuccessSnackbarOther": "Birleştirildi — {winner} artık {count} kayda sahip.",
+  "@customMealsMergeSuccessSnackbarOther": {
     "placeholders": {
       "count": { "type": "int" },
       "winner": { "type": "String" }

--- a/lib/l10n/intl_uk.arb
+++ b/lib/l10n/intl_uk.arb
@@ -887,8 +887,12 @@
     }
   },
   "customMealsMergeConfirmAction": "Об’єднати",
-  "customMealsMergeSuccessSnackbar": "Об’єднано — {winner} тепер має {count} записів.",
-  "@customMealsMergeSuccessSnackbar": {
+  "customMealsMergeSuccessSnackbarOne": "Об'єднано — {winner} тепер має 1 запис.",
+  "@customMealsMergeSuccessSnackbarOne": {
+    "placeholders": { "winner": { "type": "String" } }
+  },
+  "customMealsMergeSuccessSnackbarOther": "Об'єднано — {winner} тепер має {count} записів.",
+  "@customMealsMergeSuccessSnackbarOther": {
     "placeholders": {
       "count": { "type": "int" },
       "winner": { "type": "String" }

--- a/lib/l10n/intl_uk.arb
+++ b/lib/l10n/intl_uk.arb
@@ -839,5 +839,26 @@
   "settingsWaterGoalDescription": "Використовується індикатором води на головному екрані.",
   "settingsWaterGoalLabel": "Денна ціль вживання води",
   "waterChipLabel": "{current} / {goal} мл",
-  "zincLabel": "цинк"
+  "zincLabel": "цинк",
+  "customMealsRowMoreTooltip": "Більше дій",
+  "customMealsMergeAction": "Об’єднати з іншою власною стравою",
+  "customMealsMergePickerTitle": "Виберіть власну страву для об’єднання",
+  "customMealsMergeChooseSurvivorTitle": "Яка залишається?",
+  "customMealsMergeContinueAction": "Продовжити",
+  "customMealsMergeConfirmTitle": "Об’єднати власні страви?",
+  "customMealsMergeConfirmContent": "Це замінить усі записи, додані з {loser}, щоб вони показували {winner}, і видалить {loser} з ваших власних страв. Цю дію не можна скасувати.",
+  "@customMealsMergeConfirmContent": {
+    "placeholders": {
+      "loser": { "type": "String" },
+      "winner": { "type": "String" }
+    }
+  },
+  "customMealsMergeConfirmAction": "Об’єднати",
+  "customMealsMergeSuccessSnackbar": "Об’єднано — {winner} тепер має {count} записів.",
+  "@customMealsMergeSuccessSnackbar": {
+    "placeholders": {
+      "count": { "type": "int" },
+      "winner": { "type": "String" }
+    }
+  }
 }

--- a/lib/l10n/intl_zh.arb
+++ b/lib/l10n/intl_zh.arb
@@ -840,5 +840,26 @@
   "settingsWaterGoalDescription": "主屏幕上的饮水提示使用此目标。",
   "settingsWaterGoalLabel": "每日饮水目标",
   "waterChipLabel": "{current} / {goal} 毫升",
-  "zincLabel": "锌"
+  "zincLabel": "锌",
+  "customMealsRowMoreTooltip": "更多操作",
+  "customMealsMergeAction": "与另一项自定义食物合并",
+  "customMealsMergePickerTitle": "选择要合并的自定义食物",
+  "customMealsMergeChooseSurvivorTitle": "保留哪一项?",
+  "customMealsMergeContinueAction": "继续",
+  "customMealsMergeConfirmTitle": "合并自定义食物?",
+  "customMealsMergeConfirmContent": "这会把所有用 {loser} 记录的条目改为显示 {winner},并把 {loser} 从你的自定义食物中移除。此操作无法撤销。",
+  "@customMealsMergeConfirmContent": {
+    "placeholders": {
+      "loser": { "type": "String" },
+      "winner": { "type": "String" }
+    }
+  },
+  "customMealsMergeConfirmAction": "合并",
+  "customMealsMergeSuccessSnackbar": "已合并 — {winner} 现在有 {count} 条记录。",
+  "@customMealsMergeSuccessSnackbar": {
+    "placeholders": {
+      "count": { "type": "int" },
+      "winner": { "type": "String" }
+    }
+  }
 }

--- a/lib/l10n/intl_zh.arb
+++ b/lib/l10n/intl_zh.arb
@@ -888,8 +888,12 @@
     }
   },
   "customMealsMergeConfirmAction": "合并",
-  "customMealsMergeSuccessSnackbar": "已合并 — {winner} 现在有 {count} 条记录。",
-  "@customMealsMergeSuccessSnackbar": {
+  "customMealsMergeSuccessSnackbarOne": "已合并 — {winner} 现在有 1 条记录。",
+  "@customMealsMergeSuccessSnackbarOne": {
+    "placeholders": { "winner": { "type": "String" } }
+  },
+  "customMealsMergeSuccessSnackbarOther": "已合并 — {winner} 现在有 {count} 条记录。",
+  "@customMealsMergeSuccessSnackbarOther": {
     "placeholders": {
       "count": { "type": "int" },
       "winner": { "type": "String" }

--- a/test/unit_test/merge_custom_meals_usecase_test.dart
+++ b/test/unit_test/merge_custom_meals_usecase_test.dart
@@ -1,0 +1,128 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:hive_ce/hive.dart';
+import 'package:opennutritracker/core/data/data_source/custom_meal_data_source.dart';
+import 'package:opennutritracker/core/data/data_source/intake_data_source.dart';
+import 'package:opennutritracker/core/data/data_source/tracked_day_data_source.dart';
+import 'package:opennutritracker/core/data/dbo/intake_dbo.dart';
+import 'package:opennutritracker/core/data/dbo/intake_type_dbo.dart';
+import 'package:opennutritracker/core/data/dbo/meal_dbo.dart';
+import 'package:opennutritracker/core/data/dbo/meal_nutriments_dbo.dart';
+import 'package:opennutritracker/core/data/dbo/tracked_day_dbo.dart';
+import 'package:opennutritracker/core/data/repository/intake_repository.dart';
+import 'package:opennutritracker/core/data/repository/tracked_day_repository.dart';
+import 'package:opennutritracker/core/domain/usecase/add_tracked_day_usecase.dart';
+import 'package:opennutritracker/core/domain/usecase/merge_custom_meals_usecase.dart';
+
+import '../helpers/hive_test_setup.dart';
+
+MealNutrimentsDBO _nutriments({double kcal = 100, double protein = 5}) =>
+    MealNutrimentsDBO(
+      energyKcal100: kcal,
+      carbohydrates100: 10,
+      fat100: 2,
+      proteins100: protein,
+      sugars100: null,
+      saturatedFat100: null,
+      fiber100: null,
+    );
+
+MealDBO _customMeal({
+  required String code,
+  required String name,
+  double kcal = 100,
+}) =>
+    MealDBO(
+      code: code,
+      name: name,
+      brands: null,
+      thumbnailImageUrl: null,
+      mainImageUrl: null,
+      url: null,
+      mealQuantity: '100',
+      mealUnit: 'g',
+      servingQuantity: null,
+      servingUnit: 'g',
+      servingSize: null,
+      nutriments: _nutriments(kcal: kcal),
+      source: MealSourceDBO.custom,
+    );
+
+IntakeDBO _intake({
+  required String id,
+  required MealDBO meal,
+  DateTime? at,
+}) =>
+    IntakeDBO(
+      id: id,
+      unit: 'g',
+      amount: 100,
+      type: IntakeTypeDBO.lunch,
+      meal: meal,
+      dateTime: at ?? DateTime.utc(2025, 1, 1),
+    );
+
+void main() {
+  group('MergeCustomMealsUseCase', () {
+    late Box<MealDBO> customBox;
+    late Box<IntakeDBO> intakeBox;
+    late Box<TrackedDayDBO> trackedDayBox;
+    late MergeCustomMealsUseCase usecase;
+
+    setUpAll(() {
+      TestWidgetsFlutterBinding.ensureInitialized();
+      Hive.init('.');
+      registerHiveAdaptersOnce();
+    });
+
+    setUp(() async {
+      final stamp = DateTime.now().microsecondsSinceEpoch;
+      customBox = await Hive.openBox<MealDBO>('merge_custom_meals_$stamp');
+      intakeBox = await Hive.openBox<IntakeDBO>('merge_intake_$stamp');
+      trackedDayBox =
+          await Hive.openBox<TrackedDayDBO>('merge_tracked_$stamp');
+      final customDs = CustomMealDataSource(customBox);
+      final intakeRepo = IntakeRepository(IntakeDataSource(intakeBox));
+      final trackedRepo =
+          TrackedDayRepository(TrackedDayDataSource(trackedDayBox));
+      usecase = MergeCustomMealsUseCase(
+        customDs,
+        intakeRepo,
+        AddTrackedDayUsecase(trackedRepo),
+      );
+    });
+
+    tearDown(() async {
+      await customBox.deleteFromDisk();
+      await intakeBox.deleteFromDisk();
+      await trackedDayBox.deleteFromDisk();
+    });
+
+    test('rewrites loser intakes to winner and deletes loser meal', () async {
+      final loser = _customMeal(code: 'L', name: 'Apple (dup)', kcal: 50);
+      final winner = _customMeal(code: 'W', name: 'Apple', kcal: 50);
+      await customBox.add(loser);
+      await customBox.add(winner);
+
+      await intakeBox.add(_intake(id: 'i1', meal: loser));
+      await intakeBox.add(_intake(id: 'i2', meal: loser));
+      await intakeBox.add(_intake(id: 'i3', meal: loser));
+
+      final result = await usecase.merge(loserKey: 'L', winnerKey: 'W');
+
+      expect(result.rewrittenIntakeCount, equals(3));
+      expect(result.winnerDisplayName, equals('Apple'));
+
+      // Loser is gone from the saved-meals list; winner remains.
+      final remainingCustom = customBox.values.map((m) => m.code).toSet();
+      expect(remainingCustom, equals({'W'}));
+
+      // Every intake now snapshots the winner.
+      final rewrittenCodes =
+          intakeBox.values.map((i) => i.meal.code).toList();
+      expect(rewrittenCodes, equals(['W', 'W', 'W']));
+      // And keeps its original id so existing references stay valid.
+      final rewrittenIds = intakeBox.values.map((i) => i.id).toSet();
+      expect(rewrittenIds, equals({'i1', 'i2', 'i3'}));
+    });
+  });
+}


### PR DESCRIPTION
Closes #422.

## What this is

If you've ever scanned the same product twice from slightly different label variants — `Greek yoghurt` and `Greek yogurt`, say, or `Oat milk` and `Oats milk` — you end up with two custom foods sitting side by side in your saved list, with the same nutrition behind them. This branch lets you merge those two entries: pick a successor, confirm, and every intake that referenced the loser is rewritten to point at the survivor, the loser is removed from your custom-meal box, and the tracked-day totals stay consistent throughout.

Scope is **custom foods only** for v1. Merging Open Food Facts or FDC entries isn't supported because those aren't user-owned and the database canonicalises them upstream.

## Where the action lives

A popup-menu item appears on each row of the **Recipes → Custom Meals** tab, modelled on the diary sort popup from #82. Tapping **Merge with another custom food** opens:

1. A modal bottom-sheet picker listing the remaining custom foods (excluding the row you tapped from), so you can choose the duplicate.
2. A **Which one stays?** alert with two radio rows showing both names, defaulting to the row you tapped from.
3. A confirm dialog that warns you the operation rewrites every intake logged with the loser and removes the loser from your custom foods, with the usual Cancel and Merge actions.

On confirm, a SnackBar reports the count of remapped intakes so you have visible proof the action ran.

## Data model surprise worth flagging

The original brief assumed custom foods lived as `RecipeDBO` entries. They don't — custom foods are `MealDBO` rows in the `customMealBox`, keyed by `meal.code ?? meal.name`. Recipes are a separate concept that share the same UI surface. Once that was clear, the work landed exactly where #82's popup-menu pattern already pointed.

Because `IntakeDBO.meal` carries the entire `MealDBO` snapshot rather than a foreign key, the merge has to **rewrite the snapshot** on every loser intake — preserving the intake's `id`, `unit`, `amount`, `type`, and `dateTime` while swapping in the winner's full `MealDBO`. `TrackedDayDBO` totals are reconciled from per-intake macro deltas through the existing `AddTrackedDayUsecase`, so identical-nutrition merges are no-ops in the daily totals and diverging-nutrition merges keep the charts consistent.

## Files of note

- \`lib/core/domain/usecase/merge_custom_meals_usecase.dart\` (new) — the merge orchestration.
- \`lib/core/data/data_source/intake_data_source.dart\` + \`lib/core/data/repository/intake_repository.dart\` — \`remapCustomMealOnIntakes\` lives here, iterating the intake box and rewriting the embedded \`MealDBO\` snapshot.
- \`lib/features/recipes/presentation/widgets/custom_meals_tab.dart\` — the popup menu, picker bottom-sheet, survivor radio dialog, and confirm dialog, with the documented Semantics identifiers (\`custom-foods-merge-open\`, \`custom-foods-merge-successor-a\` / \`-successor-b\`, \`custom-foods-merge-confirm\` / \`-cancel\`).
- \`lib/features/settings/presentation/bloc/custom_meals_*.dart\` — new \`MergeCustomMealsEvent\` and \`CustomMealsMergedState\`; the SnackBar surfaces via \`BlocConsumer.listener\`.
- ARB + manually-maintained \`generated/l10n.dart\` + \`messages_<locale>.dart\` × 9 locales with real translations for every new string.
- \`test/unit_test/merge_custom_meals_usecase_test.dart\` (new) — happy-path coverage: two recipes, three intakes logging the loser, merge → loser deleted, three intakes now point at the winner.

## Test plan

- [x] \`just check_intl && fvm flutter analyze && fvm flutter test\` clean — 565 tests pass
- [x] Manual on-device: create two near-duplicate custom meals (Greek yoghurt / Greek yogurt) with Atwater-compliant nutrition, log one of them, merge via the popup menu → picker → survivor radio → confirm. Loser disappears from Custom Meals, intake in Diary now shows the survivor's name.
- [x] Cancel path verified — tapping Cancel on the confirm dialog leaves both meals intact.
- [x] Round-trips through the kcal-scaling fix from #428 — typed values save and reopen verbatim, no silent ×100 multiplication on the duplicate creations.

## Known polish point (not a blocker)

The success SnackBar copy currently reads "Merged — Greek yogurt now has 1 logged entries." — that "1 logged entries" is grammatically off in English. A pluralisation pass on this string (and any other count-driven strings in the same locale family) would be a friendly follow-up.