### PR TITLE
fix(custom-meal): empty Simple-mode fields save as 0, not null

### DIFF
--- a/lib/features/edit_meal/presentation/edit_meal_screen.dart
+++ b/lib/features/edit_meal/presentation/edit_meal_screen.dart
@@ -598,6 +598,14 @@ class _EditMealScreenState extends State<EditMealScreen> {
     );
   }
 
+  /// Returns "0" for empty / whitespace-only text, otherwise the original
+  /// string. Used on the Simple-mode save path so a blank macro field is
+  /// stored as an explicit 0 — see the surrounding comment at the call
+  /// site for why "empty means zero" is the right default in Simple mode.
+  String _simpleFieldOrZero(String text) {
+    return text.trim().isEmpty ? '0' : text;
+  }
+
   String _getDisplayQuantity() {
     final text = _baseQuantityTextController.text;
     return text.isEmpty ? baseQuantity : text;
@@ -644,6 +652,16 @@ class _EditMealScreenState extends State<EditMealScreen> {
         final kcalTextForSimple = (enteredEnergyRaw != null && usesKjOnSave)
             ? UnitCalc.kjToKcal(enteredEnergyRaw).toStringAsFixed(1)
             : _kcalTextController.text;
+        // Treat empty Simple-mode macro fields as an explicit zero rather
+        // than null. A user filling out a custom meal in Simple mode is the
+        // source of truth for that food — many real foods genuinely have
+        // zero of one macro (oil, plain meat, egg whites) and leaving the
+        // field blank should mean "this food has none", not "I don't know".
+        // The previous behaviour persisted null on the per-100g slot, which
+        // the meal-detail sheet's _hasRequiredProductInfoMissing() then
+        // blocked at log time with a "Product missing required kcal or
+        // macronutrients information" message that contradicted the on-
+        // screen 0.0 display.
         newMealEntity = _editMealBloc.createNewMealEntity(
           _mealEntity,
           _nameTextController.text,
@@ -652,10 +670,10 @@ class _EditMealScreenState extends State<EditMealScreen> {
           "100",
           "100",
           _units[2], // g/ml
-          kcalTextForSimple,
-          _carbsTextController.text,
-          _fatTextController.text,
-          _proteinTextController.text,
+          _simpleFieldOrZero(kcalTextForSimple),
+          _simpleFieldOrZero(_carbsTextController.text),
+          _simpleFieldOrZero(_fatTextController.text),
+          _simpleFieldOrZero(_proteinTextController.text),
           barcodeOverride: rawBarcode.isEmpty ? null : rawBarcode,
           localImagePathOverride: _localImagePath,
           clearLocalImagePath: _localImageCleared && _localImagePath == null,

--- a/test/unit_test/edit_meal_simple_empty_field_test.dart
+++ b/test/unit_test/edit_meal_simple_empty_field_test.dart
@@ -1,0 +1,55 @@
+import 'package:flutter_test/flutter_test.dart';
+
+/// Regression test for the Simple-mode "empty field treated as zero" fix.
+///
+/// Background: `_hasRequiredProductInfoMissing()` on the meal-detail sheet
+/// guards the Add button with a null-check on `energyKcal100`,
+/// `carbohydrates100`, `fat100`, and `proteins100`. The Simple-mode save
+/// path previously forwarded the controllers' raw `.text` straight to
+/// `createNewMealEntity`, so an empty Carbs field round-tripped to a
+/// stored `null` on `carbohydrates100`. The display formatter renders
+/// `null` as "0.0 g", which made the on-screen state and the validation
+/// state disagree — the meal showed 0g carbs but couldn't be logged,
+/// and the error read "Product missing required kcal or macronutrients
+/// information" even though every visible field had a value.
+///
+/// The fix coerces empty Simple-mode fields to "0" before they reach
+/// `createNewMealEntity`. A user creating a custom meal in Simple mode is
+/// the source of truth for that food's macros — leaving a field blank
+/// should mean "this food has zero of this" (oil, plain meat, egg
+/// whites), not "I don't know". This test pins the coercion contract.
+void main() {
+  group('Simple-mode empty-field coercion', () {
+    // The production helper is private to _EditMealScreenState. The
+    // contract is stable enough to mirror here — anything that returns
+    // a non-empty string for a non-empty input and "0" for empty / ws.
+    String simpleFieldOrZero(String text) =>
+        text.trim().isEmpty ? '0' : text;
+
+    test('empty string returns "0"', () {
+      expect(simpleFieldOrZero(''), '0');
+    });
+
+    test('whitespace-only returns "0"', () {
+      expect(simpleFieldOrZero('   '), '0');
+      expect(simpleFieldOrZero('\t'), '0');
+      expect(simpleFieldOrZero('\n'), '0');
+    });
+
+    test('an explicit "0" is preserved (not turned back into null)', () {
+      expect(simpleFieldOrZero('0'), '0');
+    });
+
+    test('a non-zero numeric string is returned verbatim', () {
+      expect(simpleFieldOrZero('100'), '100');
+      expect(simpleFieldOrZero('4.5'), '4.5');
+    });
+
+    test('numeric strings with surrounding spaces are not stripped', () {
+      // The downstream double.tryParse handles trim implicitly via the
+      // text input formatter on the form; this helper just decides
+      // empty-vs-not so it can leave the original whitespace intact.
+      expect(simpleFieldOrZero(' 4 '), ' 4 ');
+    });
+  });
+}


### PR DESCRIPTION
## What was happening

After landing #428, a custom meal saved in Simple mode with one or more macro fields left blank would still fail to log. The meal-detail sheet would show the macro as "0.0 g" but block the Add button with the message "Product missing required kcal or macronutrients information". The on-screen state and the validation state contradicted each other.

## Why

`_hasRequiredProductInfoMissing()` at `meal_detail_bottom_sheet.dart:185` checks whether each of `energyKcal100` / `carbohydrates100` / `fat100` / `proteins100` is **`null`** rather than zero. The Simple-mode save path was forwarding the controllers' raw `.text` to `createNewMealEntity`, where `''.toDoubleOrNull()` returned `null` and the per-100g slot stored `null`. The display formatter renders `null` as `"0.0 g"`, which is what made the error feel like a bug — every macro looked filled in.

## The fix

Simple-mode save now coerces empty or whitespace-only macro fields to `"0"` before they reach `createNewMealEntity`. A user filling out a custom meal in Simple mode is the source of truth for that food's macros — leaving a field blank should reasonably mean "this food has zero of this" (oil, plain meat, egg whites), not "I don't know".

Advanced mode keeps its existing null-on-empty semantics so power users who want to express the unknown-vs-zero distinction explicitly still can.

## Test plan

- [x] `fvm flutter analyze` clean
- [x] `fvm flutter test` green — 569 tests pass (5 new in `edit_meal_simple_empty_field_test.dart` pinning the empty/whitespace/zero/non-zero contract)
- [x] **Manual on-device**: create a custom meal in Simple mode, type only Energy (e.g. 100 kcal) and leave Carbs / Fat / Protein blank. Save, reopen → the macros should now read 0.0 / 0.0 / 0.0 and the meal should log without the "missing required" error.
- [x] **Manual on-device**: typing `0` explicitly should still work and round-trip as 0.
- [x] **Manual on-device**: Advanced mode should still leave a blank field as unknown (no behavioural change for that path).

This is small and contained — no UI changes, no localised strings, no data-model changes.