### PR TITLE
chore(adb-driver): hint-based form-field helpers with scroll + keyboard dismiss

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -153,13 +153,37 @@ Always verify with `adb shell uiautomator dump /sdcard/d.xml && adb pull /sdcard
 
 When inspecting the uiautomator dump, the visible text of Flutter widgets is reported under `content-desc`, not `text`. System dialogs (DatePicker, AlertDialog) use `text`. Test drivers that find widgets by visible label must check both.
 
+### Form fields drift between taps
+
+Flutter `TextField` / `TextFormField` widgets all report screen-wide `bounds` in the uiautomator dump (the `container: true` gotcha applied to every form input). Tapping a field by hard-coded coordinates from an earlier dump only works once — the moment the keyboard pops up, every layout in the form shifts, and the next tap lands on the wrong row.
+
+The `adb-driver.sh` helpers `tap_field_by_hint`, `enter_text_in_field`, and `fill_fields_by_hint` re-dump the UI before every tap and locate the field by its placeholder `hint` attribute (uiautomator dumps the TextField's placeholder there even when there's no `Semantics(identifier:)` on the field). They also hide the keyboard between fields so the next field's hit target is calculated against the post-IME layout, not the pre-IME one.
+
+Use them for any custom-meal / recipe / onboarding flow that fills more than one input:
+
+```bash
+source tools/adb/adb-driver.sh
+fill_fields_by_hint \
+  'Meal name'     'Greek%syoghurt' \
+  'Energy (kcal)' '100' \
+  'Carbohydrates' '4' \
+  'Fat'           '5' \
+  'Protein'       '10'
+```
+
+Pass `clear` as a third argument to `enter_text_in_field` when overwriting an existing value:
+
+```bash
+enter_text_in_field 'Protein' '10' clear
+```
+
 ### ADB test tooling
 
 Reusable ADB scripts live in `tools/adb/`:
 
 | Script | Purpose |
 |--------|---------|
-| `adb-driver.sh` | Core driver library: `tap_id`, `wait_for_id`, `enter_text_at`, `_tap_text`, `screenshot`, `list_ids`, etc. Source from any test script. |
+| `adb-driver.sh` | Core driver library: `tap_id`, `wait_for_id`, `enter_text_at`, `_tap_text`, `screenshot`, `list_ids`, plus form-field helpers `tap_field_by_hint`, `enter_text_in_field`, `fill_fields_by_hint`, `clear_focused_field`, `hide_keyboard`. Source from any test script. |
 | `walk-onboarding.sh` | Walks the 6-page onboarding flow, lands the app on the main screen. Exports `walk_onboarding()`. Run standalone or source it. |
 | `run-branch-tests.sh` | Sequential smoke-test runner for all triage branches: builds a debug APK, installs it, walks onboarding, and runs a branch-specific probe. Produces a pass/fail summary and per-branch screenshots. |
 

--- a/tools/adb/adb-driver.sh
+++ b/tools/adb/adb-driver.sh
@@ -161,3 +161,138 @@ for n in tree.getroot().iter():
         print(rid)
 EOF
 }
+
+# Print the on-screen centre coords of the first EditText whose `hint`
+# attribute equals the needle. Flutter's TextField / TextFormField
+# widgets don't typically carry a `resource-id`, but uiautomator dumps
+# their placeholder text as `hint`, so this is the most reliable way to
+# locate a form field without sprinkling Semantics identifiers across
+# every input. Returns nothing (and exits non-zero) when not found.
+_center_of_hint() {
+  local needle="$1"
+  local dump_file
+  dump_file=$(dump_ui)
+  python3 <<EOF
+import re, sys, xml.etree.ElementTree as ET
+tree = ET.parse("$dump_file")
+for n in tree.getroot().iter():
+    if 'EditText' not in n.attrib.get('class', ''):
+        continue
+    if n.attrib.get('hint', '') != "$needle":
+        continue
+    m = re.match(r'\[(\d+),(\d+)\]\[(\d+),(\d+)\]', n.attrib.get('bounds', ''))
+    if m:
+        x1, y1, x2, y2 = (int(g) for g in m.groups())
+        print(f"{(x1+x2)//2} {(y1+y2)//2}")
+        sys.exit(0)
+sys.exit(1)
+EOF
+}
+
+# Tap an EditText by its placeholder hint, re-dumping the UI first.
+# Use this for Flutter form fields whose bounds shift between taps
+# (a keyboard popping up rearranges the layout under the field you're
+# about to tap, so cached coordinates from an earlier dump go stale).
+#
+# If the field isn't in the current viewport, the helper scrolls the
+# form down (up to `max_scrolls` times) looking for it. Forms longer
+# than one screen — custom meal create, recipe builder, settings —
+# regularly hide fields below the fold after a keyboard close, and
+# uiautomator's dump only includes nodes that are actually rendered.
+#
+# Usage: tap_field_by_hint 'Meal name'
+tap_field_by_hint() {
+  local needle="$1"
+  local max_scrolls="${2:-5}"
+  local coords
+  for ((attempt=0; attempt<=max_scrolls; attempt++)); do
+    coords=$(_center_of_hint "$needle")
+    if [[ -n "$coords" ]]; then
+      adb -s "$DEVICE" shell input tap $coords
+      return 0
+    fi
+    # Scroll the form upward (drag the screen contents up so lower
+    # fields rise into view). Anchor near the bottom of the safe
+    # area for the from-coord and stop above the soft-nav region for
+    # the to-coord so the swipe doesn't get intercepted.
+    adb -s "$DEVICE" shell input swipe 720 2400 720 1200 200
+    sleep 0.4
+  done
+  echo "tap_field_by_hint: no EditText with hint '$needle' after $max_scrolls scrolls" >&2
+  return 1
+}
+
+# Hide the on-screen keyboard. KEYCODE_BACK (4) is the only reliable way
+# to close a soft keyboard on modern Android — KEYCODE_ESCAPE (111) is
+# documented as "close keyboard" but several stock IMEs (including the
+# Pixel keyboard the test rig uses) ignore it, leaving the keyboard up
+# and turning subsequent scroll gestures into spurious taps on the
+# suggestion bar. BACK doubles as "navigate up" when the keyboard isn't
+# up, so only call this immediately after typing — never as a generic
+# screen reset.
+hide_keyboard() {
+  adb -s "$DEVICE" shell input keyevent 4
+}
+
+# Erase the contents of the currently-focused text field. Moves the
+# cursor to the end of the line then sends `max_chars` deletes. The
+# default of 200 is enough for any sane form input — empty fields are a
+# no-op so over-deleting costs nothing.
+clear_focused_field() {
+  local max_chars="${1:-200}"
+  adb -s "$DEVICE" shell input keyevent KEYCODE_MOVE_END
+  for ((i=0; i<max_chars; i++)); do
+    adb -s "$DEVICE" shell input keyevent 67 > /dev/null 2>&1
+  done
+}
+
+# Enter `text` into the EditText with the given `hint`. Re-dumps the UI
+# before locating the field (so coordinates are fresh), taps the field,
+# optionally clears any existing content, types, and hides the keyboard
+# so the next field's coordinates aren't shifted by an open IME.
+#
+# Spaces in `text` should be passed as %s — same convention as
+# `enter_text_at` and the underlying `adb shell input text`.
+#
+# Usage:
+#   enter_text_in_field 'Meal name' 'Greek%syoghurt'
+#   enter_text_in_field 'Energy (kcal)' '100' clear
+enter_text_in_field() {
+  local hint="$1"
+  local text="$2"
+  local mode="${3:-keep}"  # keep | clear
+  tap_field_by_hint "$hint" || return 1
+  sleep 0.4
+  if [[ "$mode" == "clear" ]]; then
+    clear_focused_field
+    sleep 0.2
+  fi
+  adb -s "$DEVICE" shell input text "$text"
+  sleep 0.2
+  hide_keyboard
+  sleep 0.4
+}
+
+# Fill an arbitrary sequence of (hint, value) pairs in one call. Re-dumps
+# before each field, taps, types, and hides the keyboard between them so
+# the next field's hit-target isn't sitting under a stale layout. The
+# pairs are positional: hint1 val1 hint2 val2 hint3 val3 ...
+#
+# Usage:
+#   fill_fields_by_hint \
+#     'Meal name'       'Greek%syoghurt' \
+#     'Energy (kcal)'   '100' \
+#     'Carbohydrates'   '4' \
+#     'Fat'             '5' \
+#     'Protein'         '10'
+fill_fields_by_hint() {
+  while (( $# >= 2 )); do
+    local hint="$1"
+    local value="$2"
+    shift 2
+    if ! enter_text_in_field "$hint" "$value"; then
+      echo "fill_fields_by_hint: failed on field '$hint'" >&2
+      return 1
+    fi
+  done
+}


### PR DESCRIPTION
## Why

Flutter `TextField` / `TextFormField` widgets all report screen-wide bounds in the uiautomator dump (the `container: true` gotcha applied to every form input). Coordinate-based tapping for ADB tests therefore only works once — the moment the keyboard pops up, every layout in the form shifts, and the next tap lands on the wrong row, smearing typed text into earlier fields.

I hit this hard during the manual #422 verification yesterday: filling a five-field custom-meal form with cached coordinates produced things like "Greek yoghurty100v4 5" in the Meal name field because the "100" / "4" / "5" never reached their intended slots. Custom-meal create, recipe builder, settings, onboarding — every form longer than one screen has the same shape, so this needs to be fixed once in the driver rather than re-discovered per probe.

## What

Five new helpers in `tools/adb/adb-driver.sh`:

| Helper | What it does |
|---|---|
| `_center_of_hint(hint)` | Looks up an `EditText` by its `hint` attribute — uiautomator dumps the placeholder text there even when the widget has no `Semantics(identifier:)`. |
| `tap_field_by_hint(hint, max_scrolls=5)` | Re-dumps the UI before every attempt, scrolls the form upward when the field isn't currently rendered. uiautomator dumps don't include nodes outside the viewport, so fields below the fold are invisible until brought into view. |
| `hide_keyboard()` | `KEYCODE_BACK` to dismiss the soft keyboard. ESC (111) is documented as "close keyboard" but Pixel's stock IME ignores it; BACK is the only reliable dismiss on modern Android. Only safe to call right after typing — would otherwise pop the screen. |
| `clear_focused_field(max_chars=200)` | `MOVE_END` plus repeated `DEL` to empty the currently-focused field before re-typing. |
| `enter_text_in_field(hint, text, mode=keep|clear)` | Single-field convenience — locate by hint, clear if asked, type, hide the keyboard between fields. |
| `fill_fields_by_hint(hint val hint val ...)` | Drives a whole form in one call. Re-dumps between fields so coordinates stay fresh. |

The `CLAUDE.md` "ADB test tooling" section gets a new "Form fields drift between taps" subsection documenting the gotcha and pointing at the new helpers.

## Test plan

- [x] `bash -n` passes on the modified driver.
- [x] End-to-end smoke test on the device: clear app data → walk onboarding → Recipes → Custom Meals → `+` → New Custom Food → `fill_fields_by_hint` with five fields → save → reopen the meal → every field round-trips exactly as typed. No coordinate drift, no smeared input.

```bash
source tools/adb/adb-driver.sh
fill_fields_by_hint \
  'Meal name'     'Greek%syoghurt' \
  'Energy (kcal)' '100' \
  'Carbohydrates' '4' \
  'Fat'           '5' \
  'Protein'       '10'
```

No app code touched. CLAUDE.md docs updated to point future agents at the new helpers.