### PR TITLE
feat(fasting): timer with content-warning gate, home chip, and completion notification

### DIFF
--- a/lib/core/data/data_source/config_data_source.dart
+++ b/lib/core/data/data_source/config_data_source.dart
@@ -233,6 +233,13 @@ class ConfigDataSource {
     await config?.save();
   }
 
+  Future<void> setFastingWarningAcknowledged(bool acknowledged) async {
+    _log.fine('Updating config fastingWarningAcknowledged to $acknowledged');
+    final config = _configBox.get(_configKey);
+    config?.fastingWarningAcknowledged = acknowledged;
+    await config?.save();
+  }
+
   Future<ConfigDBO> getConfig() async {
     return _configBox.get(_configKey) ?? ConfigDBO.empty();
   }

--- a/lib/core/data/dbo/config_dbo.dart
+++ b/lib/core/data/dbo/config_dbo.dart
@@ -75,6 +75,12 @@ class ConfigDBO extends HiveObject {
   // working without a migration.
   @HiveField(24)
   int? dailyWaterGoalMl;
+  // #84: persisted acknowledgement of the disordered-eating sensitivity
+  // warning shown the first time the fasting screen is opened. Once true,
+  // the warning dialog stays suppressed. Nullable so existing configs
+  // (and never-opened users) keep being treated as "not yet acknowledged".
+  @HiveField(25)
+  bool? fastingWarningAcknowledged;
 
   ConfigDBO(
     this.hasAcceptedDisclaimer,
@@ -98,6 +104,7 @@ class ConfigDBO extends HiveObject {
     this.nutrientPanelVisibility,
     this.dayStartOffsetMinutes,
     this.dailyWaterGoalMl,
+    this.fastingWarningAcknowledged,
   });
 
   factory ConfigDBO.empty() =>

--- a/lib/core/data/dbo/config_dbo.g.dart
+++ b/lib/core/data/dbo/config_dbo.g.dart
@@ -38,6 +38,7 @@ class ConfigDBOAdapter extends TypeAdapter<ConfigDBO> {
         nutrientPanelVisibility: (fields[22] as Map?)?.cast<String, bool>(),
         dayStartOffsetMinutes: (fields[23] as num?)?.toInt(),
         dailyWaterGoalMl: (fields[24] as num?)?.toInt(),
+        fastingWarningAcknowledged: fields[25] as bool?,
       )
       ..userCarbGoalPct = (fields[6] as num?)?.toDouble()
       ..userProteinGoalPct = (fields[7] as num?)?.toDouble()
@@ -47,7 +48,7 @@ class ConfigDBOAdapter extends TypeAdapter<ConfigDBO> {
   @override
   void write(BinaryWriter writer, ConfigDBO obj) {
     writer
-      ..writeByte(24)
+      ..writeByte(25)
       ..writeByte(0)
       ..write(obj.hasAcceptedDisclaimer)
       ..writeByte(1)
@@ -95,7 +96,9 @@ class ConfigDBOAdapter extends TypeAdapter<ConfigDBO> {
       ..writeByte(23)
       ..write(obj.dayStartOffsetMinutes)
       ..writeByte(24)
-      ..write(obj.dailyWaterGoalMl);
+      ..write(obj.dailyWaterGoalMl)
+      ..writeByte(25)
+      ..write(obj.fastingWarningAcknowledged);
   }
 
   @override
@@ -143,6 +146,7 @@ ConfigDBO _$ConfigDBOFromJson(Map<String, dynamic> json) =>
             ),
         dayStartOffsetMinutes: (json['dayStartOffsetMinutes'] as num?)?.toInt(),
         dailyWaterGoalMl: (json['dailyWaterGoalMl'] as num?)?.toInt(),
+        fastingWarningAcknowledged: json['fastingWarningAcknowledged'] as bool?,
       )
       ..userCarbGoalPct = (json['userCarbGoalPct'] as num?)?.toDouble()
       ..userProteinGoalPct = (json['userProteinGoalPct'] as num?)?.toDouble()
@@ -173,6 +177,7 @@ Map<String, dynamic> _$ConfigDBOToJson(ConfigDBO instance) => <String, dynamic>{
   'diarySortPreferences': instance.diarySortPreferences,
   'dayStartOffsetMinutes': instance.dayStartOffsetMinutes,
   'dailyWaterGoalMl': instance.dailyWaterGoalMl,
+  'fastingWarningAcknowledged': instance.fastingWarningAcknowledged,
 };
 
 const _$AppThemeDBOEnumMap = {

--- a/lib/core/data/dbo/fasting_session_dbo.dart
+++ b/lib/core/data/dbo/fasting_session_dbo.dart
@@ -1,0 +1,39 @@
+import 'package:hive_ce_flutter/hive_flutter.dart';
+import 'package:json_annotation/json_annotation.dart';
+
+part 'fasting_session_dbo.g.dart';
+
+/// Persistent record of a single fasting timer session. Sessions are written
+/// when the user taps "Start timer" and updated in place when they either
+/// cancel (`cancelledAt`) or the timer reaches its target naturally
+/// (`completedAt`). The two end-state fields are kept separate so analytics or
+/// future history views can read both outcomes neutrally — there is no
+/// "broken" vs "successful" framing in the data model, and there should not
+/// be one in the UI either.
+@HiveType(typeId: 22)
+@JsonSerializable()
+class FastingSessionDBO extends HiveObject {
+  @HiveField(0)
+  String id;
+  @HiveField(1)
+  DateTime startedAt;
+  @HiveField(2)
+  int targetDurationMinutes;
+  @HiveField(3)
+  DateTime? completedAt;
+  @HiveField(4)
+  DateTime? cancelledAt;
+
+  FastingSessionDBO({
+    required this.id,
+    required this.startedAt,
+    required this.targetDurationMinutes,
+    this.completedAt,
+    this.cancelledAt,
+  });
+
+  factory FastingSessionDBO.fromJson(Map<String, dynamic> json) =>
+      _$FastingSessionDBOFromJson(json);
+
+  Map<String, dynamic> toJson() => _$FastingSessionDBOToJson(this);
+}

--- a/lib/core/data/dbo/fasting_session_dbo.g.dart
+++ b/lib/core/data/dbo/fasting_session_dbo.g.dart
@@ -1,0 +1,79 @@
+// GENERATED CODE - DO NOT MODIFY BY HAND
+
+part of 'fasting_session_dbo.dart';
+
+// **************************************************************************
+// TypeAdapterGenerator
+// **************************************************************************
+
+class FastingSessionDBOAdapter extends TypeAdapter<FastingSessionDBO> {
+  @override
+  final typeId = 22;
+
+  @override
+  FastingSessionDBO read(BinaryReader reader) {
+    final numOfFields = reader.readByte();
+    final fields = <int, dynamic>{
+      for (int i = 0; i < numOfFields; i++) reader.readByte(): reader.read(),
+    };
+    return FastingSessionDBO(
+      id: fields[0] as String,
+      startedAt: fields[1] as DateTime,
+      targetDurationMinutes: (fields[2] as num).toInt(),
+      completedAt: fields[3] as DateTime?,
+      cancelledAt: fields[4] as DateTime?,
+    );
+  }
+
+  @override
+  void write(BinaryWriter writer, FastingSessionDBO obj) {
+    writer
+      ..writeByte(5)
+      ..writeByte(0)
+      ..write(obj.id)
+      ..writeByte(1)
+      ..write(obj.startedAt)
+      ..writeByte(2)
+      ..write(obj.targetDurationMinutes)
+      ..writeByte(3)
+      ..write(obj.completedAt)
+      ..writeByte(4)
+      ..write(obj.cancelledAt);
+  }
+
+  @override
+  int get hashCode => typeId.hashCode;
+
+  @override
+  bool operator ==(Object other) =>
+      identical(this, other) ||
+      other is FastingSessionDBOAdapter &&
+          runtimeType == other.runtimeType &&
+          typeId == other.typeId;
+}
+
+// **************************************************************************
+// JsonSerializableGenerator
+// **************************************************************************
+
+FastingSessionDBO _$FastingSessionDBOFromJson(Map<String, dynamic> json) =>
+    FastingSessionDBO(
+      id: json['id'] as String,
+      startedAt: DateTime.parse(json['startedAt'] as String),
+      targetDurationMinutes: (json['targetDurationMinutes'] as num).toInt(),
+      completedAt: json['completedAt'] == null
+          ? null
+          : DateTime.parse(json['completedAt'] as String),
+      cancelledAt: json['cancelledAt'] == null
+          ? null
+          : DateTime.parse(json['cancelledAt'] as String),
+    );
+
+Map<String, dynamic> _$FastingSessionDBOToJson(FastingSessionDBO instance) =>
+    <String, dynamic>{
+      'id': instance.id,
+      'startedAt': instance.startedAt.toIso8601String(),
+      'targetDurationMinutes': instance.targetDurationMinutes,
+      'completedAt': instance.completedAt?.toIso8601String(),
+      'cancelledAt': instance.cancelledAt?.toIso8601String(),
+    };

--- a/lib/core/data/repository/config_repository.dart
+++ b/lib/core/data/repository/config_repository.dart
@@ -138,4 +138,8 @@ class ConfigRepository {
   Future<void> setConfigDailyWaterGoalMl(int goalMl) async {
     await _configDataSource.setConfigDailyWaterGoalMl(goalMl);
   }
+
+  Future<void> setFastingWarningAcknowledged(bool acknowledged) async {
+    await _configDataSource.setFastingWarningAcknowledged(acknowledged);
+  }
 }

--- a/lib/core/domain/entity/config_entity.dart
+++ b/lib/core/domain/entity/config_entity.dart
@@ -55,6 +55,11 @@ class ConfigEntity extends Equatable {
   // gendered default at read time. Once the user has touched the
   // setting, their override is persisted and survives a profile edit.
   final int? dailyWaterGoalMl;
+  // #84: whether the user has acknowledged the one-time content warning
+  // shown before the fasting timer becomes usable. Defaults to false; the
+  // warning is shown until the user explicitly taps "I understand, enable
+  // timer", which flips this to true.
+  final bool fastingWarningAcknowledged;
 
   /// Default daily water goal in millilitres for the home chip when the
   /// user has not picked one yet.
@@ -119,6 +124,7 @@ class ConfigEntity extends Equatable {
     this.dayStartOffsetHours = 0,
     this.dayStartOffsetMinutes = 0,
     this.dailyWaterGoalMl,
+    this.fastingWarningAcknowledged = false,
   });
 
   /// Resolves the daily water goal for the home chip. Returns the user's
@@ -198,6 +204,7 @@ class ConfigEntity extends Equatable {
     dayStartOffsetHours: _normaliseOffsetHours(dbo.dayStartOffsetHours),
     dayStartOffsetMinutes: _normaliseOffsetMinutes(dbo.dayStartOffsetMinutes),
     dailyWaterGoalMl: _normaliseWaterGoal(dbo.dailyWaterGoalMl),
+    fastingWarningAcknowledged: dbo.fastingWarningAcknowledged ?? false,
   );
 
   /// Returns the recommended kcal target for [mealKey] given a daily goal.
@@ -265,5 +272,6 @@ class ConfigEntity extends Equatable {
     dayStartOffsetHours,
     dayStartOffsetMinutes,
     dailyWaterGoalMl,
+    fastingWarningAcknowledged,
   ];
 }

--- a/lib/core/utils/hive_db_provider.dart
+++ b/lib/core/utils/hive_db_provider.dart
@@ -5,6 +5,7 @@ import 'package:hive_ce_flutter/hive_flutter.dart';
 import 'package:opennutritracker/core/data/data_source/custom_activity_template_dbo.dart';
 import 'package:opennutritracker/core/data/data_source/user_activity_dbo.dart';
 import 'package:opennutritracker/core/data/dbo/config_dbo.dart';
+import 'package:opennutritracker/core/data/dbo/fasting_session_dbo.dart';
 import 'package:opennutritracker/core/data/dbo/intake_dbo.dart';
 import 'package:opennutritracker/core/data/dbo/meal_dbo.dart';
 import 'package:opennutritracker/core/data/dbo/recipe_dbo.dart';
@@ -34,6 +35,10 @@ class HiveDBProvider extends ChangeNotifier {
   // dialog's "undo last" can roll a single entry back without losing the
   // rest of the day.
   static const waterIntakeBoxName = 'WaterIntakeBox';
+  // #84: persisted fasting sessions, one record per start. The data layer
+  // intentionally keeps cancelled and completed sessions side by side with no
+  // success/failure label on the record — see `FastingSessionDBO`.
+  static const fastingBoxName = 'FastingBox';
 
   late Box<ConfigDBO> configBox;
   late Box<IntakeDBO> intakeBox;
@@ -47,6 +52,7 @@ class HiveDBProvider extends ChangeNotifier {
   late Box<CustomActivityTemplateDBO> customActivityTemplateBox;
   late Box<WeightLogDBO> weightLogBox;
   late Box<WaterIntakeDBO> waterIntakeBox;
+  late Box<FastingSessionDBO> fastingBox;
 
   Future<void> initHiveDB(Uint8List encryptionKey) async {
     final encryptionCypher = HiveAesCipher(encryptionKey);
@@ -105,6 +111,10 @@ class HiveDBProvider extends ChangeNotifier {
     );
     waterIntakeBox = await Hive.openBox(
       waterIntakeBoxName,
+      encryptionCipher: encryptionCypher,
+    );
+    fastingBox = await Hive.openBox(
+      fastingBoxName,
       encryptionCipher: encryptionCypher,
     );
   }

--- a/lib/core/utils/locator.dart
+++ b/lib/core/utils/locator.dart
@@ -74,6 +74,14 @@ import 'package:opennutritracker/features/add_meal/presentation/bloc/recent_meal
 import 'package:opennutritracker/features/diary/presentation/bloc/calendar_day_bloc.dart';
 import 'package:opennutritracker/features/diary/presentation/bloc/diary_bloc.dart';
 import 'package:opennutritracker/features/edit_meal/presentation/bloc/edit_meal_bloc.dart';
+import 'package:opennutritracker/features/fasting/data/data_source/fasting_data_source.dart';
+import 'package:opennutritracker/features/fasting/data/repository/fasting_repository.dart';
+import 'package:opennutritracker/features/fasting/domain/usecase/acknowledge_fasting_warning_usecase.dart';
+import 'package:opennutritracker/features/fasting/domain/usecase/cancel_fasting_usecase.dart';
+import 'package:opennutritracker/features/fasting/domain/usecase/complete_fasting_usecase.dart';
+import 'package:opennutritracker/features/fasting/domain/usecase/get_active_fasting_session_usecase.dart';
+import 'package:opennutritracker/features/fasting/domain/usecase/start_fasting_usecase.dart';
+import 'package:opennutritracker/features/fasting/presentation/bloc/fasting_bloc.dart';
 import 'package:opennutritracker/features/home/presentation/bloc/home_bloc.dart';
 import 'package:opennutritracker/features/meal_detail/presentation/bloc/meal_detail_bloc.dart';
 import 'package:opennutritracker/features/onboarding/presentation/bloc/onboarding_bloc.dart';
@@ -240,6 +248,18 @@ Future<void> initLocator() async {
   );
   locator.registerFactory<FoodBloc>(() => FoodBloc(locator(), locator()));
   locator.registerFactory(() => RecentMealBloc(locator(), locator()));
+  // #84: fasting timer. Factory so the screen-scoped timer and dialog
+  // state reset cleanly each time the user opens the screen.
+  locator.registerFactory<FastingBloc>(
+    () => FastingBloc(
+      locator(),
+      locator(),
+      locator(),
+      locator(),
+      locator(),
+      locator(),
+    ),
+  );
 
   // UseCases
   locator.registerLazySingleton<GetConfigUsecase>(
@@ -367,6 +387,13 @@ Future<void> initLocator() async {
   );
   locator.registerLazySingleton(() => ImportRecipesJsonUsecase(locator()));
 
+  // Fasting use cases (#84)
+  locator.registerFactory(() => StartFastingUseCase(locator()));
+  locator.registerFactory(() => CancelFastingUseCase(locator()));
+  locator.registerFactory(() => CompleteFastingUseCase(locator()));
+  locator.registerFactory(() => GetActiveFastingSessionUseCase(locator()));
+  locator.registerFactory(() => AcknowledgeFastingWarningUseCase(locator()));
+
   // Recipe use cases
   locator.registerLazySingleton(() => ComputeRecipeNutritionUseCase());
   locator.registerLazySingleton(() => SaveRecipeUseCase(locator(), locator()));
@@ -405,6 +432,9 @@ Future<void> initLocator() async {
   );
   locator.registerLazySingleton<CustomActivityTemplateRepository>(
     () => CustomActivityTemplateRepository(locator()),
+  );
+  locator.registerLazySingleton<FastingRepository>(
+    () => FastingRepository(locator()),
   );
 
   // DataSources
@@ -451,6 +481,9 @@ Future<void> initLocator() async {
     () => CustomActivityTemplateDataSource(
       hiveDBProvider.customActivityTemplateBox,
     ),
+  );
+  locator.registerLazySingleton<FastingDataSource>(
+    () => FastingDataSource(hiveDBProvider.fastingBox),
   );
 
   await _initializeConfig(locator());

--- a/lib/core/utils/navigation_options.dart
+++ b/lib/core/utils/navigation_options.dart
@@ -16,4 +16,5 @@ class NavigationOptions {
   static const recipeDetailRoute = "recipeDetail";
   static const importRecipeScannerRoute = "importRecipeScanner";
   static const weightHistoryRoute = "weightHistory";
+  static const fastingRoute = "fasting";
 }

--- a/lib/core/utils/notification_service.dart
+++ b/lib/core/utils/notification_service.dart
@@ -7,9 +7,14 @@ import 'package:timezone/timezone.dart' as tz;
 /// #312: Service for scheduling daily meal reminder notifications.
 class NotificationService {
   static const int _dailyReminderId = 0;
+  static const int _fastingCompleteId = 1;
   static const String _channelId = 'daily_reminder';
   static const String _channelName = 'Daily Reminders';
   static const String _channelDesc = 'Daily meal logging reminder';
+  static const String _fastingChannelId = 'fasting_complete';
+  static const String _fastingChannelName = 'Fasting timer';
+  static const String _fastingChannelDesc =
+      'One-off pings when a fasting session reaches its target.';
 
   final _log = Logger('NotificationService');
   final FlutterLocalNotificationsPlugin _plugin =
@@ -103,6 +108,48 @@ class NotificationService {
     await _ensureInitialized();
     await _plugin.cancel(_dailyReminderId);
     _log.fine('Daily reminder cancelled');
+  }
+
+  /// Schedules a one-shot notification for the moment a fasting session is
+  /// expected to reach its target. The OS owns delivery from here, so the
+  /// app doesn't need to be running. Calling this twice replaces the
+  /// previously-scheduled ping.
+  Future<void> scheduleFastingComplete({
+    required DateTime when,
+    required String title,
+    required String body,
+  }) async {
+    await _ensureInitialized();
+    await _plugin.cancel(_fastingCompleteId);
+
+    final scheduled = tz.TZDateTime.from(when, tz.local);
+    final androidDetails = AndroidNotificationDetails(
+      _fastingChannelId,
+      _fastingChannelName,
+      channelDescription: _fastingChannelDesc,
+      importance: Importance.defaultImportance,
+      priority: Priority.defaultPriority,
+    );
+    const iosDetails = DarwinNotificationDetails();
+    final details =
+        NotificationDetails(android: androidDetails, iOS: iosDetails);
+
+    await _plugin.zonedSchedule(
+      _fastingCompleteId,
+      title,
+      body,
+      scheduled,
+      details,
+      androidScheduleMode: AndroidScheduleMode.inexactAllowWhileIdle,
+    );
+    _log.fine('Fasting-complete notification scheduled for $scheduled');
+  }
+
+  /// Cancels any pending fasting-complete notification.
+  Future<void> cancelFastingComplete() async {
+    await _ensureInitialized();
+    await _plugin.cancel(_fastingCompleteId);
+    _log.fine('Fasting-complete notification cancelled');
   }
 
   Future<void> _ensureInitialized() async {

--- a/lib/features/fasting/data/data_source/fasting_data_source.dart
+++ b/lib/features/fasting/data/data_source/fasting_data_source.dart
@@ -1,0 +1,43 @@
+import 'package:hive_ce_flutter/hive_flutter.dart';
+import 'package:logging/logging.dart';
+import 'package:opennutritracker/core/data/dbo/fasting_session_dbo.dart';
+
+/// Stores fasting sessions keyed by session id. The data source intentionally
+/// makes no value-judgement about cancellation vs natural completion — both
+/// are simply timestamped on the same record.
+class FastingDataSource {
+  final _log = Logger('FastingDataSource');
+  final Box<FastingSessionDBO> _box;
+
+  FastingDataSource(this._box);
+
+  Future<void> addSession(FastingSessionDBO session) async {
+    _log.fine('Adding fasting session ${session.id}');
+    await _box.put(session.id, session);
+  }
+
+  Future<void> updateSession(FastingSessionDBO session) async {
+    _log.fine('Updating fasting session ${session.id}');
+    await _box.put(session.id, session);
+  }
+
+  Future<FastingSessionDBO?> getSession(String id) async {
+    return _box.get(id);
+  }
+
+  Future<List<FastingSessionDBO>> allSessions() async {
+    return _box.values.toList();
+  }
+
+  /// Returns the most recent session that has neither completed nor been
+  /// cancelled, if any. There should only ever be one — but if the previous
+  /// run crashed before writing the end-state, the newest one wins.
+  Future<FastingSessionDBO?> getActiveSession() async {
+    final active = _box.values
+        .where((s) => s.completedAt == null && s.cancelledAt == null)
+        .toList();
+    if (active.isEmpty) return null;
+    active.sort((a, b) => b.startedAt.compareTo(a.startedAt));
+    return active.first;
+  }
+}

--- a/lib/features/fasting/data/repository/fasting_repository.dart
+++ b/lib/features/fasting/data/repository/fasting_repository.dart
@@ -1,0 +1,33 @@
+import 'package:opennutritracker/features/fasting/data/data_source/fasting_data_source.dart';
+import 'package:opennutritracker/features/fasting/domain/entity/fasting_session_entity.dart';
+
+class FastingRepository {
+  final FastingDataSource _dataSource;
+
+  FastingRepository(this._dataSource);
+
+  Future<void> addSession(FastingSessionEntity session) async {
+    await _dataSource.addSession(session.toDBO());
+  }
+
+  Future<void> updateSession(FastingSessionEntity session) async {
+    await _dataSource.updateSession(session.toDBO());
+  }
+
+  Future<FastingSessionEntity?> getActiveSession() async {
+    final dbo = await _dataSource.getActiveSession();
+    if (dbo == null) return null;
+    return FastingSessionEntity.fromDBO(dbo);
+  }
+
+  Future<FastingSessionEntity?> getSession(String id) async {
+    final dbo = await _dataSource.getSession(id);
+    if (dbo == null) return null;
+    return FastingSessionEntity.fromDBO(dbo);
+  }
+
+  Future<List<FastingSessionEntity>> allSessions() async {
+    final all = await _dataSource.allSessions();
+    return all.map(FastingSessionEntity.fromDBO).toList();
+  }
+}

--- a/lib/features/fasting/domain/entity/fasting_session_entity.dart
+++ b/lib/features/fasting/domain/entity/fasting_session_entity.dart
@@ -1,0 +1,67 @@
+import 'package:equatable/equatable.dart';
+import 'package:opennutritracker/core/data/dbo/fasting_session_dbo.dart';
+
+/// Plain domain model for a fasting session. End-state is represented by two
+/// independent timestamps so the UI never has to ask "did the user fail" —
+/// the natural-completion and user-cancellation paths read identically from
+/// the data layer and only differ in which timestamp is set.
+class FastingSessionEntity extends Equatable {
+  final String id;
+  final DateTime startedAt;
+  final int targetDurationMinutes;
+  final DateTime? completedAt;
+  final DateTime? cancelledAt;
+
+  const FastingSessionEntity({
+    required this.id,
+    required this.startedAt,
+    required this.targetDurationMinutes,
+    this.completedAt,
+    this.cancelledAt,
+  });
+
+  bool get isActive => completedAt == null && cancelledAt == null;
+
+  Duration get targetDuration => Duration(minutes: targetDurationMinutes);
+
+  Duration elapsedAt(DateTime now) => now.difference(startedAt);
+
+  factory FastingSessionEntity.fromDBO(FastingSessionDBO dbo) =>
+      FastingSessionEntity(
+        id: dbo.id,
+        startedAt: dbo.startedAt,
+        targetDurationMinutes: dbo.targetDurationMinutes,
+        completedAt: dbo.completedAt,
+        cancelledAt: dbo.cancelledAt,
+      );
+
+  FastingSessionDBO toDBO() => FastingSessionDBO(
+    id: id,
+    startedAt: startedAt,
+    targetDurationMinutes: targetDurationMinutes,
+    completedAt: completedAt,
+    cancelledAt: cancelledAt,
+  );
+
+  FastingSessionEntity copyWith({
+    DateTime? completedAt,
+    DateTime? cancelledAt,
+  }) {
+    return FastingSessionEntity(
+      id: id,
+      startedAt: startedAt,
+      targetDurationMinutes: targetDurationMinutes,
+      completedAt: completedAt ?? this.completedAt,
+      cancelledAt: cancelledAt ?? this.cancelledAt,
+    );
+  }
+
+  @override
+  List<Object?> get props => [
+    id,
+    startedAt,
+    targetDurationMinutes,
+    completedAt,
+    cancelledAt,
+  ];
+}

--- a/lib/features/fasting/domain/usecase/acknowledge_fasting_warning_usecase.dart
+++ b/lib/features/fasting/domain/usecase/acknowledge_fasting_warning_usecase.dart
@@ -1,0 +1,14 @@
+import 'package:opennutritracker/core/data/repository/config_repository.dart';
+
+/// Persists the user's one-time acknowledgement of the disordered-eating
+/// sensitivity warning. Once acknowledged, the warning dialog stays
+/// suppressed on subsequent visits to the fasting screen.
+class AcknowledgeFastingWarningUseCase {
+  final ConfigRepository _configRepository;
+
+  AcknowledgeFastingWarningUseCase(this._configRepository);
+
+  Future<void> call() async {
+    await _configRepository.setFastingWarningAcknowledged(true);
+  }
+}

--- a/lib/features/fasting/domain/usecase/cancel_fasting_usecase.dart
+++ b/lib/features/fasting/domain/usecase/cancel_fasting_usecase.dart
@@ -1,0 +1,21 @@
+import 'package:opennutritracker/features/fasting/data/repository/fasting_repository.dart';
+import 'package:opennutritracker/features/fasting/domain/entity/fasting_session_entity.dart';
+
+/// Records a neutral, unjudged end to the session. The framing is deliberate:
+/// there is no "broken streak" concept, no "fast ended early" copy, and no
+/// stored boolean for "was the goal met". The presence of `cancelledAt` is the
+/// only signal that the user closed the session themselves.
+class CancelFastingUseCase {
+  final FastingRepository _repository;
+
+  CancelFastingUseCase(this._repository);
+
+  Future<FastingSessionEntity> call(
+    FastingSessionEntity session, {
+    DateTime? now,
+  }) async {
+    final updated = session.copyWith(cancelledAt: now ?? DateTime.now());
+    await _repository.updateSession(updated);
+    return updated;
+  }
+}

--- a/lib/features/fasting/domain/usecase/complete_fasting_usecase.dart
+++ b/lib/features/fasting/domain/usecase/complete_fasting_usecase.dart
@@ -1,0 +1,21 @@
+import 'package:opennutritracker/features/fasting/data/repository/fasting_repository.dart';
+import 'package:opennutritracker/features/fasting/domain/entity/fasting_session_entity.dart';
+
+/// Marks the session as having reached its target duration. Stored on its own
+/// timestamp field (`completedAt`) so the cancellation path and the natural
+/// completion path are recorded as different facts, without one being framed
+/// as success and the other as failure.
+class CompleteFastingUseCase {
+  final FastingRepository _repository;
+
+  CompleteFastingUseCase(this._repository);
+
+  Future<FastingSessionEntity> call(
+    FastingSessionEntity session, {
+    DateTime? now,
+  }) async {
+    final updated = session.copyWith(completedAt: now ?? DateTime.now());
+    await _repository.updateSession(updated);
+    return updated;
+  }
+}

--- a/lib/features/fasting/domain/usecase/get_active_fasting_session_usecase.dart
+++ b/lib/features/fasting/domain/usecase/get_active_fasting_session_usecase.dart
@@ -1,0 +1,10 @@
+import 'package:opennutritracker/features/fasting/data/repository/fasting_repository.dart';
+import 'package:opennutritracker/features/fasting/domain/entity/fasting_session_entity.dart';
+
+class GetActiveFastingSessionUseCase {
+  final FastingRepository _repository;
+
+  GetActiveFastingSessionUseCase(this._repository);
+
+  Future<FastingSessionEntity?> call() => _repository.getActiveSession();
+}

--- a/lib/features/fasting/domain/usecase/start_fasting_usecase.dart
+++ b/lib/features/fasting/domain/usecase/start_fasting_usecase.dart
@@ -1,0 +1,22 @@
+import 'package:opennutritracker/core/utils/id_generator.dart';
+import 'package:opennutritracker/features/fasting/data/repository/fasting_repository.dart';
+import 'package:opennutritracker/features/fasting/domain/entity/fasting_session_entity.dart';
+
+class StartFastingUseCase {
+  final FastingRepository _repository;
+
+  StartFastingUseCase(this._repository);
+
+  Future<FastingSessionEntity> call({
+    required int targetDurationMinutes,
+    DateTime? now,
+  }) async {
+    final session = FastingSessionEntity(
+      id: IdGenerator.getUniqueID(),
+      startedAt: now ?? DateTime.now(),
+      targetDurationMinutes: targetDurationMinutes,
+    );
+    await _repository.addSession(session);
+    return session;
+  }
+}

--- a/lib/features/fasting/presentation/bloc/fasting_bloc.dart
+++ b/lib/features/fasting/presentation/bloc/fasting_bloc.dart
@@ -1,0 +1,210 @@
+import 'dart:async';
+
+import 'package:flutter_bloc/flutter_bloc.dart';
+import 'package:equatable/equatable.dart';
+import 'package:opennutritracker/core/domain/usecase/get_config_usecase.dart';
+import 'package:opennutritracker/features/fasting/domain/entity/fasting_session_entity.dart';
+import 'package:opennutritracker/features/fasting/domain/usecase/acknowledge_fasting_warning_usecase.dart';
+import 'package:opennutritracker/features/fasting/domain/usecase/cancel_fasting_usecase.dart';
+import 'package:opennutritracker/features/fasting/domain/usecase/complete_fasting_usecase.dart';
+import 'package:opennutritracker/features/fasting/domain/usecase/get_active_fasting_session_usecase.dart';
+import 'package:opennutritracker/features/fasting/domain/usecase/start_fasting_usecase.dart';
+
+// TODO(#84 follow-up): optional local notification when the timer reaches its
+// target. The existing `NotificationService` is wired to flutter_local_notifications;
+// a follow-up PR can schedule a one-shot at startedAt + targetDuration so the
+// user can dismiss the app without losing the chime. Skipped in v1 to keep the
+// initial surface area small and the no-streaks framing unambiguous.
+
+sealed class FastingEvent extends Equatable {
+  const FastingEvent();
+
+  @override
+  List<Object?> get props => [];
+}
+
+class FastingLoadRequested extends FastingEvent {
+  const FastingLoadRequested();
+}
+
+class FastingWarningAcknowledged extends FastingEvent {
+  const FastingWarningAcknowledged();
+}
+
+class FastingStartRequested extends FastingEvent {
+  final int targetDurationMinutes;
+
+  const FastingStartRequested(this.targetDurationMinutes);
+
+  @override
+  List<Object?> get props => [targetDurationMinutes];
+}
+
+class FastingCancelRequested extends FastingEvent {
+  const FastingCancelRequested();
+}
+
+/// Internal tick driven by the bloc's own periodic timer. Surfaces so the UI
+/// can re-render the elapsed/remaining strings every second and so the bloc
+/// can detect when the target duration has been reached.
+class FastingTicked extends FastingEvent {
+  final DateTime now;
+
+  const FastingTicked(this.now);
+
+  @override
+  List<Object?> get props => [now];
+}
+
+sealed class FastingState extends Equatable {
+  const FastingState();
+
+  @override
+  List<Object?> get props => [];
+}
+
+class FastingInitial extends FastingState {
+  const FastingInitial();
+}
+
+class FastingWarningRequired extends FastingState {
+  const FastingWarningRequired();
+}
+
+class FastingIdle extends FastingState {
+  const FastingIdle();
+}
+
+class FastingActive extends FastingState {
+  final FastingSessionEntity session;
+  final DateTime now;
+
+  const FastingActive({required this.session, required this.now});
+
+  Duration get elapsed => session.elapsedAt(now);
+  Duration get target => session.targetDuration;
+  Duration get remaining {
+    final diff = target - elapsed;
+    return diff.isNegative ? Duration.zero : diff;
+  }
+
+  bool get hasReachedTarget => elapsed >= target;
+
+  @override
+  List<Object?> get props => [session, now];
+}
+
+class FastingCompleted extends FastingState {
+  final FastingSessionEntity session;
+
+  const FastingCompleted(this.session);
+
+  @override
+  List<Object?> get props => [session];
+}
+
+class FastingBloc extends Bloc<FastingEvent, FastingState> {
+  final GetConfigUsecase _getConfig;
+  final GetActiveFastingSessionUseCase _getActive;
+  final StartFastingUseCase _start;
+  final CancelFastingUseCase _cancel;
+  final CompleteFastingUseCase _complete;
+  final AcknowledgeFastingWarningUseCase _acknowledge;
+
+  Timer? _ticker;
+
+  FastingBloc(
+    this._getConfig,
+    this._getActive,
+    this._start,
+    this._cancel,
+    this._complete,
+    this._acknowledge,
+  ) : super(const FastingInitial()) {
+    on<FastingLoadRequested>(_onLoad);
+    on<FastingWarningAcknowledged>(_onAcknowledged);
+    on<FastingStartRequested>(_onStart);
+    on<FastingCancelRequested>(_onCancel);
+    on<FastingTicked>(_onTick);
+  }
+
+  Future<void> _onLoad(
+    FastingLoadRequested event,
+    Emitter<FastingState> emit,
+  ) async {
+    final config = await _getConfig.getConfig();
+    if (!config.fastingWarningAcknowledged) {
+      emit(const FastingWarningRequired());
+      return;
+    }
+    await _emitFromCurrentSession(emit);
+  }
+
+  Future<void> _onAcknowledged(
+    FastingWarningAcknowledged event,
+    Emitter<FastingState> emit,
+  ) async {
+    await _acknowledge();
+    await _emitFromCurrentSession(emit);
+  }
+
+  Future<void> _emitFromCurrentSession(Emitter<FastingState> emit) async {
+    final active = await _getActive();
+    if (active == null) {
+      _ticker?.cancel();
+      emit(const FastingIdle());
+      return;
+    }
+    final now = DateTime.now();
+    emit(FastingActive(session: active, now: now));
+    _startTicker();
+  }
+
+  Future<void> _onStart(
+    FastingStartRequested event,
+    Emitter<FastingState> emit,
+  ) async {
+    final session = await _start(
+      targetDurationMinutes: event.targetDurationMinutes,
+    );
+    emit(FastingActive(session: session, now: DateTime.now()));
+    _startTicker();
+  }
+
+  Future<void> _onCancel(
+    FastingCancelRequested event,
+    Emitter<FastingState> emit,
+  ) async {
+    final current = state;
+    if (current is! FastingActive) return;
+    _ticker?.cancel();
+    await _cancel(current.session);
+    emit(const FastingIdle());
+  }
+
+  Future<void> _onTick(FastingTicked event, Emitter<FastingState> emit) async {
+    final current = state;
+    if (current is! FastingActive) return;
+    final updated = FastingActive(session: current.session, now: event.now);
+    if (updated.hasReachedTarget) {
+      _ticker?.cancel();
+      final completed = await _complete(current.session, now: event.now);
+      emit(FastingCompleted(completed));
+    } else {
+      emit(updated);
+    }
+  }
+
+  void _startTicker() {
+    _ticker?.cancel();
+    _ticker = Timer.periodic(const Duration(seconds: 1), (_) {
+      add(FastingTicked(DateTime.now()));
+    });
+  }
+
+  @override
+  Future<void> close() {
+    _ticker?.cancel();
+    return super.close();
+  }
+}

--- a/lib/features/fasting/presentation/fasting_screen.dart
+++ b/lib/features/fasting/presentation/fasting_screen.dart
@@ -61,6 +61,15 @@ class _FastingScreenState extends State<FastingScreen> {
       appBar: AppBar(title: Text(l10n.fastingTitle)),
       body: BlocConsumer<FastingBloc, FastingState>(
         bloc: _bloc,
+        listenWhen: (prev, curr) {
+          // Schedule on enter-Active; cancel on enter-Idle (user ended the
+          // fast). FastingCompleted intentionally not listened for here —
+          // the OS-scheduled alarm is firing at exactly that moment.
+          if (curr is FastingWarningRequired) return true;
+          if (curr is FastingActive && prev is! FastingActive) return true;
+          if (curr is FastingIdle && prev is! FastingIdle) return true;
+          return false;
+        },
         listener: (context, state) {
           if (state is FastingWarningRequired) {
             _handleWarning(context);
@@ -68,7 +77,7 @@ class _FastingScreenState extends State<FastingScreen> {
           if (state is FastingActive) {
             _scheduleCompleteNotification(context, state);
           }
-          if (state is FastingIdle || state is FastingCompleted) {
+          if (state is FastingIdle) {
             _cancelCompleteNotification();
           }
         },

--- a/lib/features/fasting/presentation/fasting_screen.dart
+++ b/lib/features/fasting/presentation/fasting_screen.dart
@@ -1,0 +1,329 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_bloc/flutter_bloc.dart';
+import 'package:opennutritracker/core/utils/locator.dart';
+import 'package:opennutritracker/features/fasting/presentation/bloc/fasting_bloc.dart';
+import 'package:opennutritracker/features/fasting/presentation/widgets/fasting_warning_dialog.dart';
+import 'package:opennutritracker/generated/l10n.dart';
+
+/// Preset fasting windows offered in the UI. Kept here rather than in the
+/// bloc because they are purely a presentation concern — the data layer only
+/// cares about target minutes, not which preset the minutes came from.
+const List<int> _presetHours = [13, 16, 18, 20, 36];
+
+class FastingScreen extends StatefulWidget {
+  const FastingScreen({super.key});
+
+  @override
+  State<FastingScreen> createState() => _FastingScreenState();
+}
+
+class _FastingScreenState extends State<FastingScreen> {
+  late FastingBloc _bloc;
+  int _selectedHours = 16;
+  int? _customHours;
+  bool _warningHandled = false;
+
+  @override
+  void initState() {
+    super.initState();
+    _bloc = locator<FastingBloc>();
+    _bloc.add(const FastingLoadRequested());
+  }
+
+  @override
+  void dispose() {
+    _bloc.close();
+    super.dispose();
+  }
+
+  Future<void> _handleWarning(BuildContext context) async {
+    if (_warningHandled) return;
+    _warningHandled = true;
+    final navigator = Navigator.of(context);
+    final accepted = await showDialog<bool>(
+      context: context,
+      barrierDismissible: false,
+      builder: (_) => const FastingWarningDialog(),
+    );
+    if (!mounted) return;
+    if (accepted == true) {
+      _bloc.add(const FastingWarningAcknowledged());
+    } else {
+      navigator.pop();
+    }
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    final l10n = S.of(context);
+    return Scaffold(
+      appBar: AppBar(title: Text(l10n.fastingTitle)),
+      body: BlocConsumer<FastingBloc, FastingState>(
+        bloc: _bloc,
+        listener: (context, state) {
+          if (state is FastingWarningRequired) {
+            _handleWarning(context);
+          }
+        },
+        builder: (context, state) {
+          if (state is FastingInitial || state is FastingWarningRequired) {
+            return const Center(child: CircularProgressIndicator());
+          }
+          if (state is FastingIdle) {
+            return _buildIdle(context, l10n);
+          }
+          if (state is FastingActive) {
+            return _buildActive(context, l10n, state);
+          }
+          if (state is FastingCompleted) {
+            return _buildCompleted(context, l10n);
+          }
+          return const SizedBox.shrink();
+        },
+      ),
+    );
+  }
+
+  Widget _buildIdle(BuildContext context, S l10n) {
+    final colors = Theme.of(context).colorScheme;
+    final textTheme = Theme.of(context).textTheme;
+    return Padding(
+      padding: const EdgeInsets.all(20),
+      child: Column(
+        crossAxisAlignment: CrossAxisAlignment.start,
+        children: [
+          Text(
+            l10n.fastingSubtitle,
+            style: textTheme.bodyMedium?.copyWith(
+              color: colors.onSurfaceVariant,
+            ),
+          ),
+          const SizedBox(height: 24),
+          Wrap(
+            spacing: 8,
+            runSpacing: 8,
+            children: [
+              for (final h in _presetHours)
+                Semantics(
+                  identifier: 'fasting-preset-${h}h',
+                  child: ChoiceChip(
+                    label: Text('${h}h'),
+                    selected: _selectedHours == h && _customHours == null,
+                    onSelected: (_) {
+                      setState(() {
+                        _selectedHours = h;
+                        _customHours = null;
+                      });
+                    },
+                  ),
+                ),
+              Semantics(
+                identifier: 'fasting-preset-custom',
+                child: ChoiceChip(
+                  label: Text(
+                    _customHours == null
+                        ? l10n.fastingPresetCustom
+                        : '${_customHours}h',
+                  ),
+                  selected: _customHours != null,
+                  onSelected: (_) => _pickCustomHours(context),
+                ),
+              ),
+            ],
+          ),
+          const SizedBox(height: 32),
+          Center(
+            child: Semantics(
+              identifier: 'fasting-start',
+              child: FilledButton.icon(
+                icon: const Icon(Icons.play_arrow),
+                label: Text(l10n.fastingStart),
+                onPressed: () {
+                  final hours = _customHours ?? _selectedHours;
+                  _bloc.add(FastingStartRequested(hours * 60));
+                },
+              ),
+            ),
+          ),
+        ],
+      ),
+    );
+  }
+
+  Future<void> _pickCustomHours(BuildContext context) async {
+    final controller = TextEditingController(
+      text: (_customHours ?? _selectedHours).toString(),
+    );
+    final result = await showDialog<int>(
+      context: context,
+      builder: (ctx) {
+        return AlertDialog(
+          title: Text(S.of(ctx).fastingPresetCustom),
+          content: TextField(
+            controller: controller,
+            keyboardType: TextInputType.number,
+            autofocus: true,
+            decoration: InputDecoration(suffixText: S.of(ctx).hoursLabel),
+          ),
+          actions: [
+            TextButton(
+              onPressed: () => Navigator.of(ctx).pop(),
+              child: Text(S.of(ctx).dialogCancelLabel),
+            ),
+            Semantics(
+              identifier: 'fasting-custom-confirm',
+              child: TextButton(
+                onPressed: () {
+                  final v = int.tryParse(controller.text.trim());
+                  if (v != null && v > 0 && v <= 96) {
+                    Navigator.of(ctx).pop(v);
+                  }
+                },
+                child: Text(S.of(ctx).dialogOKLabel),
+              ),
+            ),
+          ],
+        );
+      },
+    );
+    if (result != null) {
+      setState(() {
+        _customHours = result;
+      });
+    }
+  }
+
+  Widget _buildActive(BuildContext context, S l10n, FastingActive state) {
+    final textTheme = Theme.of(context).textTheme;
+    final colors = Theme.of(context).colorScheme;
+    final elapsed = _formatDuration(state.elapsed);
+    final remaining = _formatDuration(state.remaining);
+    final progress = state.target.inSeconds == 0
+        ? 0.0
+        : (state.elapsed.inSeconds / state.target.inSeconds).clamp(0.0, 1.0);
+    return Padding(
+      padding: const EdgeInsets.all(24),
+      child: Column(
+        crossAxisAlignment: CrossAxisAlignment.stretch,
+        children: [
+          const SizedBox(height: 24),
+          Center(
+            child: SizedBox(
+              width: 200,
+              height: 200,
+              child: Stack(
+                alignment: Alignment.center,
+                children: [
+                  SizedBox.expand(
+                    child: CircularProgressIndicator(
+                      value: progress,
+                      strokeWidth: 10,
+                      backgroundColor: colors.surfaceContainerHighest,
+                    ),
+                  ),
+                  Column(
+                    mainAxisAlignment: MainAxisAlignment.center,
+                    children: [
+                      Text(elapsed, style: textTheme.headlineMedium),
+                      const SizedBox(height: 4),
+                      Text(
+                        l10n.fastingElapsedLabel,
+                        style: textTheme.bodySmall?.copyWith(
+                          color: colors.onSurfaceVariant,
+                        ),
+                      ),
+                    ],
+                  ),
+                ],
+              ),
+            ),
+          ),
+          const SizedBox(height: 24),
+          Center(
+            child: Text(
+              l10n.fastingRemainingValue(remaining),
+              style: textTheme.titleMedium,
+            ),
+          ),
+          Center(
+            child: Text(
+              l10n.fastingTargetValue(_formatDuration(state.target)),
+              style: textTheme.bodyMedium?.copyWith(
+                color: colors.onSurfaceVariant,
+              ),
+            ),
+          ),
+          const SizedBox(height: 40),
+          Semantics(
+            identifier: 'fasting-cancel',
+            child: OutlinedButton.icon(
+              icon: const Icon(Icons.stop_circle_outlined),
+              label: Text(l10n.fastingCancel),
+              onPressed: () => _confirmCancel(context, l10n),
+            ),
+          ),
+        ],
+      ),
+    );
+  }
+
+  Widget _buildCompleted(BuildContext context, S l10n) {
+    final textTheme = Theme.of(context).textTheme;
+    return Padding(
+      padding: const EdgeInsets.all(24),
+      child: Column(
+        mainAxisAlignment: MainAxisAlignment.center,
+        children: [
+          Icon(
+            Icons.check_circle_outline,
+            size: 72,
+            color: Theme.of(context).colorScheme.primary,
+          ),
+          const SizedBox(height: 16),
+          Text(l10n.fastingComplete, style: textTheme.headlineSmall),
+          const SizedBox(height: 32),
+          Semantics(
+            identifier: 'fasting-complete-close',
+            child: FilledButton(
+              onPressed: () => Navigator.of(context).pop(),
+              child: Text(l10n.dialogCloseLabel),
+            ),
+          ),
+        ],
+      ),
+    );
+  }
+
+  Future<void> _confirmCancel(BuildContext context, S l10n) async {
+    final confirm = await showDialog<bool>(
+      context: context,
+      builder: (ctx) => AlertDialog(
+        title: Text(l10n.fastingCancelConfirmTitle),
+        content: Text(l10n.fastingCancelConfirmBody),
+        actions: [
+          TextButton(
+            onPressed: () => Navigator.of(ctx).pop(false),
+            child: Text(l10n.dialogCancelLabel),
+          ),
+          Semantics(
+            identifier: 'fasting-cancel-confirm',
+            child: TextButton(
+              onPressed: () => Navigator.of(ctx).pop(true),
+              child: Text(l10n.fastingCancel),
+            ),
+          ),
+        ],
+      ),
+    );
+    if (confirm == true) {
+      _bloc.add(const FastingCancelRequested());
+    }
+  }
+
+  String _formatDuration(Duration d) {
+    final h = d.inHours.toString().padLeft(2, '0');
+    final m = (d.inMinutes % 60).toString().padLeft(2, '0');
+    final s = (d.inSeconds % 60).toString().padLeft(2, '0');
+    return '$h:$m:$s';
+  }
+}

--- a/lib/features/fasting/presentation/fasting_screen.dart
+++ b/lib/features/fasting/presentation/fasting_screen.dart
@@ -289,6 +289,7 @@ class _FastingScreenState extends State<FastingScreen> {
       padding: const EdgeInsets.all(24),
       child: Column(
         mainAxisAlignment: MainAxisAlignment.center,
+        crossAxisAlignment: CrossAxisAlignment.center,
         children: [
           Icon(
             Icons.check_circle_outline,
@@ -296,7 +297,11 @@ class _FastingScreenState extends State<FastingScreen> {
             color: Theme.of(context).colorScheme.primary,
           ),
           const SizedBox(height: 16),
-          Text(l10n.fastingComplete, style: textTheme.headlineSmall),
+          Text(
+            l10n.fastingComplete,
+            style: textTheme.headlineSmall,
+            textAlign: TextAlign.center,
+          ),
           const SizedBox(height: 32),
           Semantics(
             identifier: 'fasting-complete-close',

--- a/lib/features/fasting/presentation/fasting_screen.dart
+++ b/lib/features/fasting/presentation/fasting_screen.dart
@@ -1,6 +1,7 @@
 import 'package:flutter/material.dart';
 import 'package:flutter_bloc/flutter_bloc.dart';
 import 'package:opennutritracker/core/utils/locator.dart';
+import 'package:opennutritracker/core/utils/notification_service.dart';
 import 'package:opennutritracker/features/fasting/presentation/bloc/fasting_bloc.dart';
 import 'package:opennutritracker/features/fasting/presentation/widgets/fasting_warning_dialog.dart';
 import 'package:opennutritracker/generated/l10n.dart';
@@ -63,6 +64,12 @@ class _FastingScreenState extends State<FastingScreen> {
         listener: (context, state) {
           if (state is FastingWarningRequired) {
             _handleWarning(context);
+          }
+          if (state is FastingActive) {
+            _scheduleCompleteNotification(context, state);
+          }
+          if (state is FastingIdle || state is FastingCompleted) {
+            _cancelCompleteNotification();
           }
         },
         builder: (context, state) {
@@ -325,5 +332,27 @@ class _FastingScreenState extends State<FastingScreen> {
     final m = (d.inMinutes % 60).toString().padLeft(2, '0');
     final s = (d.inSeconds % 60).toString().padLeft(2, '0');
     return '$h:$m:$s';
+  }
+
+  Future<void> _scheduleCompleteNotification(
+    BuildContext context,
+    FastingActive state,
+  ) async {
+    final notificationService = locator<NotificationService>();
+    final permitted = await notificationService.requestPermission();
+    if (!permitted) return;
+    final when = state.session.startedAt.add(state.session.targetDuration);
+    if (!when.isAfter(DateTime.now())) return;
+    if (!context.mounted) return;
+    final l10n = S.of(context);
+    await notificationService.scheduleFastingComplete(
+      when: when,
+      title: l10n.fastingNotificationCompleteTitle,
+      body: l10n.fastingNotificationCompleteBody,
+    );
+  }
+
+  Future<void> _cancelCompleteNotification() async {
+    await locator<NotificationService>().cancelFastingComplete();
   }
 }

--- a/lib/features/fasting/presentation/widgets/fasting_warning_dialog.dart
+++ b/lib/features/fasting/presentation/widgets/fasting_warning_dialog.dart
@@ -1,0 +1,88 @@
+import 'package:flutter/gestures.dart';
+import 'package:flutter/material.dart';
+import 'package:opennutritracker/generated/l10n.dart';
+import 'package:url_launcher/url_launcher.dart';
+
+/// One-time content warning shown before the fasting timer becomes usable.
+///
+/// Returns `true` when the user accepts and `false` (or null on barrier
+/// dismissal — though the dialog is non-dismissible by default) when they
+/// decline. The caller is responsible for routing back when declined and for
+/// persisting the acknowledgement when accepted.
+class FastingWarningDialog extends StatelessWidget {
+  static const _beatUrl = 'https://www.beateatingdisorders.org.uk/';
+  static const _nedaUrl = 'https://www.nationaleatingdisorders.org/';
+
+  const FastingWarningDialog({super.key});
+
+  @override
+  Widget build(BuildContext context) {
+    final l10n = S.of(context);
+    final textTheme = Theme.of(context).textTheme;
+    final colors = Theme.of(context).colorScheme;
+    return AlertDialog(
+      title: Text(l10n.fastingWarningTitle),
+      content: SingleChildScrollView(
+        child: Column(
+          crossAxisAlignment: CrossAxisAlignment.start,
+          mainAxisSize: MainAxisSize.min,
+          children: [
+            Text(l10n.fastingWarningBody, style: textTheme.bodyMedium),
+            const SizedBox(height: 16),
+            Text.rich(
+              TextSpan(
+                children: [
+                  TextSpan(
+                    text: l10n.fastingLinkBeat,
+                    style: textTheme.bodyMedium?.copyWith(
+                      color: colors.primary,
+                      decoration: TextDecoration.underline,
+                    ),
+                    recognizer: TapGestureRecognizer()
+                      ..onTap = () => _open(_beatUrl),
+                  ),
+                ],
+              ),
+            ),
+            const SizedBox(height: 4),
+            Text.rich(
+              TextSpan(
+                children: [
+                  TextSpan(
+                    text: l10n.fastingLinkNeda,
+                    style: textTheme.bodyMedium?.copyWith(
+                      color: colors.primary,
+                      decoration: TextDecoration.underline,
+                    ),
+                    recognizer: TapGestureRecognizer()
+                      ..onTap = () => _open(_nedaUrl),
+                  ),
+                ],
+              ),
+            ),
+          ],
+        ),
+      ),
+      actions: [
+        Semantics(
+          identifier: 'fasting-warning-decline',
+          child: TextButton(
+            onPressed: () => Navigator.of(context).pop(false),
+            child: Text(l10n.fastingWarningDecline),
+          ),
+        ),
+        Semantics(
+          identifier: 'fasting-warning-accept',
+          child: FilledButton(
+            onPressed: () => Navigator.of(context).pop(true),
+            child: Text(l10n.fastingWarningAccept),
+          ),
+        ),
+      ],
+    );
+  }
+
+  Future<void> _open(String url) async {
+    await launchUrl(Uri.parse(url), mode: LaunchMode.externalApplication);
+  }
+}

--- a/lib/features/home/home_page.dart
+++ b/lib/features/home/home_page.dart
@@ -19,6 +19,7 @@ import 'package:opennutritracker/features/add_meal/presentation/add_meal_type.da
 import 'package:opennutritracker/features/home/presentation/bloc/home_bloc.dart';
 import 'package:opennutritracker/features/home/presentation/widgets/dashboard_widget.dart';
 import 'package:opennutritracker/features/home/presentation/widgets/intake_vertical_list.dart';
+import 'package:opennutritracker/features/home/presentation/widgets/fasting_home_chip.dart';
 import 'package:opennutritracker/features/home/presentation/widgets/quick_water_widget.dart';
 import 'package:opennutritracker/features/home/presentation/widgets/quick_weight_widget.dart';
 import 'package:opennutritracker/generated/l10n.dart';
@@ -173,6 +174,7 @@ class _HomePageState extends State<HomePage> with WidgetsBindingObserver {
                 ],
               ),
             ),
+            const FastingHomeChip(),
             const SizedBox(height: 8.0),
             DashboardWidget(
               totalKcalDaily: totalKcalDaily,

--- a/lib/features/home/presentation/widgets/fasting_home_chip.dart
+++ b/lib/features/home/presentation/widgets/fasting_home_chip.dart
@@ -1,0 +1,85 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_bloc/flutter_bloc.dart';
+
+import 'package:opennutritracker/core/utils/locator.dart';
+import 'package:opennutritracker/core/utils/navigation_options.dart';
+import 'package:opennutritracker/features/fasting/presentation/bloc/fasting_bloc.dart';
+import 'package:opennutritracker/generated/l10n.dart';
+
+/// Renders only while a fasting session is active. The chip is the home
+/// surface's entire participation in fasting — no "start a fast" prompt
+/// when dormant, no streak, no encouragement copy, all in line with the
+/// rest of #84.
+class FastingHomeChip extends StatelessWidget {
+  const FastingHomeChip({super.key});
+
+  @override
+  Widget build(BuildContext context) {
+    return BlocProvider(
+      create: (_) =>
+          locator<FastingBloc>()..add(const FastingLoadRequested()),
+      child: const _FastingHomeChipView(),
+    );
+  }
+}
+
+class _FastingHomeChipView extends StatelessWidget {
+  const _FastingHomeChipView();
+
+  @override
+  Widget build(BuildContext context) {
+    return BlocBuilder<FastingBloc, FastingState>(
+      builder: (context, state) {
+        if (state is! FastingActive) {
+          return const SizedBox.shrink();
+        }
+        final remaining = _formatHoursMinutes(state.remaining);
+        return Padding(
+          padding: const EdgeInsets.fromLTRB(16, 4, 16, 0),
+          child: Semantics(
+            identifier: 'home-fasting-chip',
+            child: InkWell(
+              borderRadius: BorderRadius.circular(28),
+              onTap: () => Navigator.of(context)
+                  .pushNamed(NavigationOptions.fastingRoute),
+              child: Container(
+                padding:
+                    const EdgeInsets.symmetric(horizontal: 16, vertical: 10),
+                decoration: BoxDecoration(
+                  color: Theme.of(context)
+                      .colorScheme
+                      .secondaryContainer
+                      .withValues(alpha: 0.4),
+                  borderRadius: BorderRadius.circular(28),
+                ),
+                child: Row(
+                  mainAxisSize: MainAxisSize.min,
+                  children: [
+                    Icon(
+                      Icons.timer_outlined,
+                      size: 18,
+                      color: Theme.of(context).colorScheme.onSurface,
+                    ),
+                    const SizedBox(width: 8),
+                    Text(
+                      S.of(context).fastingHomeChipBody(remaining),
+                      style: Theme.of(context).textTheme.bodyMedium,
+                    ),
+                  ],
+                ),
+              ),
+            ),
+          ),
+        );
+      },
+    );
+  }
+
+  // Minutes resolution on the chip — seconds would twitch every tick.
+  String _formatHoursMinutes(Duration d) {
+    final h = d.inHours;
+    final m = d.inMinutes.remainder(60);
+    if (h == 0) return '${m}m';
+    return '${h}h ${m}m';
+  }
+}

--- a/lib/features/profile/profile_page.dart
+++ b/lib/features/profile/profile_page.dart
@@ -242,6 +242,22 @@ class _ProfilePageState extends State<ProfilePage> {
             ),
           ),
         Semantics(
+          identifier: 'profile-fasting-entry',
+          child: ListTile(
+            title: Text(
+              S.of(context).profileFastingEntry,
+              style: Theme.of(context).textTheme.titleLarge,
+            ),
+            leading: const SizedBox(
+              height: double.infinity,
+              child: Icon(Icons.timer_outlined),
+            ),
+            trailing: const Icon(Icons.chevron_right),
+            onTap: () =>
+                Navigator.of(context).pushNamed(NavigationOptions.fastingRoute),
+          ),
+        ),
+        Semantics(
           identifier: 'profile-weight-history',
           child: ListTile(
             title: Text(

--- a/lib/generated/intl/messages_cs.dart
+++ b/lib/generated/intl/messages_cs.dart
@@ -96,6 +96,7 @@ class MessageLookup extends MessageLookupByLibrary {
       "Sloučeno — ${winner} má nyní ${count} záznamů.";
   static String mDriRef(value) => "ref. ${value}";
   static String mMergeOneCs(winner) => "Sloučeno — ${winner} má nyní 1 záznam.";
+  static String mFastingChipCs(remaining) => "Půst · zbývá ${remaining}";
 
   final messages = _notInlinedMessages(_notInlinedMessages);
   static Map<String, Function> _notInlinedMessages(_) => <String, Function>{
@@ -1354,6 +1355,9 @@ class MessageLookup extends MessageLookupByLibrary {
         "fastingCancel": MessageLookupByLibrary.simpleMessage('Ukončit půst'),
         "fastingCancelConfirmTitle": MessageLookupByLibrary.simpleMessage('Ukončit půst teď?'),
         "fastingCancelConfirmBody": MessageLookupByLibrary.simpleMessage('Aktuální relace bude uzavřena.'),
+        "fastingHomeChipBody": mFastingChipCs,
+        "fastingNotificationCompleteTitle": MessageLookupByLibrary.simpleMessage("Půst dokončen"),
+        "fastingNotificationCompleteBody": MessageLookupByLibrary.simpleMessage("Cílový čas byl dosažen."),
         "fastingComplete": MessageLookupByLibrary.simpleMessage('Relace dokončena'),
         "fastingLinkBeat": MessageLookupByLibrary.simpleMessage('BEAT (UK)'),
         "fastingLinkNeda": MessageLookupByLibrary.simpleMessage('NEDA (US)'),

--- a/lib/generated/intl/messages_cs.dart
+++ b/lib/generated/intl/messages_cs.dart
@@ -86,6 +86,10 @@ class MessageLookup extends MessageLookupByLibrary {
 
   static String mLogWaterAmount(amount) => "Přidat ${amount} ml";
 
+  static String mFastingRemaining(value) => "Zbývá ${value}";
+
+  static String mFastingTarget(value) => "Cíl: ${value}";
+
   final messages = _notInlinedMessages(_notInlinedMessages);
   static Map<String, Function> _notInlinedMessages(_) => <String, Function>{
         "activityExample": MessageLookupByLibrary.simpleMessage(
@@ -1278,5 +1282,25 @@ class MessageLookup extends MessageLookupByLibrary {
         "settingsWaterGoalLabel":
             MessageLookupByLibrary.simpleMessage("Denní cíl pití vody"),
         "waterChipLabel": mWaterChip,
+        "profileFastingEntry": MessageLookupByLibrary.simpleMessage('Časovač půstu'),
+        "fastingTitle": MessageLookupByLibrary.simpleMessage('Časovač půstu'),
+        "fastingSubtitle": MessageLookupByLibrary.simpleMessage('Jednoduchý časovač pro sledování času mezi jídly. Žádné série, žádné cíle, jen hodiny.'),
+        "fastingWarningTitle": MessageLookupByLibrary.simpleMessage('Než začnete'),
+        "fastingWarningBody": MessageLookupByLibrary.simpleMessage('Sledování doby půstu může být pro někoho užitečné a pro jiného zraňující, zvlášť pokud máte zkušenost s poruchou příjmu potravy. Pokud se vás to týká, prosím postarejte se nejdřív o sebe. Podporu nabízí BEAT (UK) a NEDA (US).'),
+        "fastingWarningDecline": MessageLookupByLibrary.simpleMessage('Není to pro mě'),
+        "fastingWarningAccept": MessageLookupByLibrary.simpleMessage('Rozumím, zapnout časovač'),
+        "fastingPresetCustom": MessageLookupByLibrary.simpleMessage('Vlastní'),
+        "fastingStart": MessageLookupByLibrary.simpleMessage('Spustit časovač'),
+        "fastingCancel": MessageLookupByLibrary.simpleMessage('Ukončit půst'),
+        "fastingCancelConfirmTitle": MessageLookupByLibrary.simpleMessage('Ukončit půst teď?'),
+        "fastingCancelConfirmBody": MessageLookupByLibrary.simpleMessage('Aktuální relace bude uzavřena.'),
+        "fastingComplete": MessageLookupByLibrary.simpleMessage('Relace dokončena'),
+        "fastingLinkBeat": MessageLookupByLibrary.simpleMessage('BEAT (UK)'),
+        "fastingLinkNeda": MessageLookupByLibrary.simpleMessage('NEDA (US)'),
+        "fastingElapsedLabel": MessageLookupByLibrary.simpleMessage('Uplynulo'),
+        "hoursLabel": MessageLookupByLibrary.simpleMessage('hodiny'),
+        "dialogCloseLabel": MessageLookupByLibrary.simpleMessage('Zavřít'),
+        "fastingRemainingValue": mFastingRemaining,
+        "fastingTargetValue": mFastingTarget,
       };
 }

--- a/lib/generated/intl/messages_de.dart
+++ b/lib/generated/intl/messages_de.dart
@@ -88,6 +88,10 @@ class MessageLookup extends MessageLookupByLibrary {
 
   static String mLogWaterAmount(amount) => "${amount} ml hinzufügen";
 
+  static String mFastingRemaining(value) => "Noch ${value}";
+
+  static String mFastingTarget(value) => "Ziel: ${value}";
+
   final messages = _notInlinedMessages(_notInlinedMessages);
   static Map<String, Function> _notInlinedMessages(_) => <String, Function>{
         "activityExample": MessageLookupByLibrary.simpleMessage(
@@ -1301,5 +1305,25 @@ class MessageLookup extends MessageLookupByLibrary {
         "settingsWaterGoalLabel":
             MessageLookupByLibrary.simpleMessage("Tägliches Wasserziel"),
         "waterChipLabel": mWaterChip,
+        "profileFastingEntry": MessageLookupByLibrary.simpleMessage('Fasten-Timer'),
+        "fastingTitle": MessageLookupByLibrary.simpleMessage('Fasten-Timer'),
+        "fastingSubtitle": MessageLookupByLibrary.simpleMessage('Ein einfacher Timer für die Zeit zwischen den Mahlzeiten. Keine Serien, keine Ziele, nur die Uhr.'),
+        "fastingWarningTitle": MessageLookupByLibrary.simpleMessage('Bevor du beginnst'),
+        "fastingWarningBody": MessageLookupByLibrary.simpleMessage('Das Verfolgen von Fastenzeiten kann für manche hilfreich und für andere belastend sein, besonders wenn eine Essstörung Teil deiner Geschichte ist. Bitte achte zuerst auf dich. Unterstützung findest du bei BEAT (UK) und NEDA (US).'),
+        "fastingWarningDecline": MessageLookupByLibrary.simpleMessage('Nichts für mich'),
+        "fastingWarningAccept": MessageLookupByLibrary.simpleMessage('Verstanden, Timer aktivieren'),
+        "fastingPresetCustom": MessageLookupByLibrary.simpleMessage('Eigene Dauer'),
+        "fastingStart": MessageLookupByLibrary.simpleMessage('Timer starten'),
+        "fastingCancel": MessageLookupByLibrary.simpleMessage('Fasten beenden'),
+        "fastingCancelConfirmTitle": MessageLookupByLibrary.simpleMessage('Fasten jetzt beenden?'),
+        "fastingCancelConfirmBody": MessageLookupByLibrary.simpleMessage('Damit wird die aktuelle Sitzung geschlossen.'),
+        "fastingComplete": MessageLookupByLibrary.simpleMessage('Sitzung abgeschlossen'),
+        "fastingLinkBeat": MessageLookupByLibrary.simpleMessage('BEAT (UK)'),
+        "fastingLinkNeda": MessageLookupByLibrary.simpleMessage('NEDA (US)'),
+        "fastingElapsedLabel": MessageLookupByLibrary.simpleMessage('Vergangen'),
+        "hoursLabel": MessageLookupByLibrary.simpleMessage('Stunden'),
+        "dialogCloseLabel": MessageLookupByLibrary.simpleMessage('Schließen'),
+        "fastingRemainingValue": mFastingRemaining,
+        "fastingTargetValue": mFastingTarget,
       };
 }

--- a/lib/generated/intl/messages_de.dart
+++ b/lib/generated/intl/messages_de.dart
@@ -98,6 +98,7 @@ class MessageLookup extends MessageLookupByLibrary {
       "Zusammengeführt — ${winner} hat jetzt ${count} protokollierte Einträge.";
   static String mDriRef(value) => "Ref. ${value}";
   static String mMergeOneDe(winner) => "Zusammengeführt — ${winner} hat jetzt 1 Eintrag.";
+  static String mFastingChipDe(remaining) => "Fasten · noch ${remaining}";
 
   final messages = _notInlinedMessages(_notInlinedMessages);
   static Map<String, Function> _notInlinedMessages(_) => <String, Function>{
@@ -1377,6 +1378,9 @@ class MessageLookup extends MessageLookupByLibrary {
         "fastingCancel": MessageLookupByLibrary.simpleMessage('Fasten beenden'),
         "fastingCancelConfirmTitle": MessageLookupByLibrary.simpleMessage('Fasten jetzt beenden?'),
         "fastingCancelConfirmBody": MessageLookupByLibrary.simpleMessage('Damit wird die aktuelle Sitzung geschlossen.'),
+        "fastingHomeChipBody": mFastingChipDe,
+        "fastingNotificationCompleteTitle": MessageLookupByLibrary.simpleMessage("Fastenzeit abgeschlossen"),
+        "fastingNotificationCompleteBody": MessageLookupByLibrary.simpleMessage("Deine Zielzeit wurde erreicht."),
         "fastingComplete": MessageLookupByLibrary.simpleMessage('Sitzung abgeschlossen'),
         "fastingLinkBeat": MessageLookupByLibrary.simpleMessage('BEAT (UK)'),
         "fastingLinkNeda": MessageLookupByLibrary.simpleMessage('NEDA (US)'),

--- a/lib/generated/intl/messages_en.dart
+++ b/lib/generated/intl/messages_en.dart
@@ -85,6 +85,10 @@ class MessageLookup extends MessageLookupByLibrary {
 
   static String mLogWaterAmount(amount) => "Add ${amount} ml";
 
+  static String mFastingRemaining(value) => "${value} remaining";
+
+  static String mFastingTarget(value) => "Target: ${value}";
+
   final messages = _notInlinedMessages(_notInlinedMessages);
   static Map<String, Function> _notInlinedMessages(_) => <String, Function>{
         "activityExample": MessageLookupByLibrary.simpleMessage(
@@ -1264,5 +1268,25 @@ class MessageLookup extends MessageLookupByLibrary {
         "settingsWaterGoalLabel":
             MessageLookupByLibrary.simpleMessage("Daily water goal"),
         "waterChipLabel": mWaterChip,
+        "profileFastingEntry": MessageLookupByLibrary.simpleMessage('Fasting timer'),
+        "fastingTitle": MessageLookupByLibrary.simpleMessage('Fasting timer'),
+        "fastingSubtitle": MessageLookupByLibrary.simpleMessage('A simple timer for tracking time between meals. No streaks, no targets, just the clock.'),
+        "fastingWarningTitle": MessageLookupByLibrary.simpleMessage('Before you start'),
+        "fastingWarningBody": MessageLookupByLibrary.simpleMessage('Tracking fasting time can be helpful for some people and distressing for others, especially anyone with a history of disordered eating. If that\'s you, please look after yourself first. Support is available from BEAT (UK) and NEDA (US).'),
+        "fastingWarningDecline": MessageLookupByLibrary.simpleMessage('Not for me'),
+        "fastingWarningAccept": MessageLookupByLibrary.simpleMessage('I understand, enable timer'),
+        "fastingPresetCustom": MessageLookupByLibrary.simpleMessage('Custom'),
+        "fastingStart": MessageLookupByLibrary.simpleMessage('Start timer'),
+        "fastingCancel": MessageLookupByLibrary.simpleMessage('End fast'),
+        "fastingCancelConfirmTitle": MessageLookupByLibrary.simpleMessage('End fast now?'),
+        "fastingCancelConfirmBody": MessageLookupByLibrary.simpleMessage('This will close the current session.'),
+        "fastingComplete": MessageLookupByLibrary.simpleMessage('Session complete'),
+        "fastingLinkBeat": MessageLookupByLibrary.simpleMessage('BEAT (UK)'),
+        "fastingLinkNeda": MessageLookupByLibrary.simpleMessage('NEDA (US)'),
+        "fastingElapsedLabel": MessageLookupByLibrary.simpleMessage('Elapsed'),
+        "hoursLabel": MessageLookupByLibrary.simpleMessage('hours'),
+        "dialogCloseLabel": MessageLookupByLibrary.simpleMessage('Close'),
+        "fastingRemainingValue": mFastingRemaining,
+        "fastingTargetValue": mFastingTarget,
       };
 }

--- a/lib/generated/intl/messages_en.dart
+++ b/lib/generated/intl/messages_en.dart
@@ -95,6 +95,7 @@ class MessageLookup extends MessageLookupByLibrary {
       "Merged — ${winner} now has ${count} logged entries.";
   static String mDriRef(value) => "ref ${value}";
   static String mMergeOneEn(winner) => "Merged — ${winner} now has 1 logged entry.";
+  static String mFastingChipEn(remaining) => "Fasting · ${remaining} left";
 
   final messages = _notInlinedMessages(_notInlinedMessages);
   static Map<String, Function> _notInlinedMessages(_) => <String, Function>{
@@ -1340,6 +1341,9 @@ class MessageLookup extends MessageLookupByLibrary {
         "fastingCancel": MessageLookupByLibrary.simpleMessage('End fast'),
         "fastingCancelConfirmTitle": MessageLookupByLibrary.simpleMessage('End fast now?'),
         "fastingCancelConfirmBody": MessageLookupByLibrary.simpleMessage('This will close the current session.'),
+        "fastingHomeChipBody": mFastingChipEn,
+        "fastingNotificationCompleteTitle": MessageLookupByLibrary.simpleMessage("Fasting session complete"),
+        "fastingNotificationCompleteBody": MessageLookupByLibrary.simpleMessage("Your target time has been reached."),
         "fastingComplete": MessageLookupByLibrary.simpleMessage('Session complete'),
         "fastingLinkBeat": MessageLookupByLibrary.simpleMessage('BEAT (UK)'),
         "fastingLinkNeda": MessageLookupByLibrary.simpleMessage('NEDA (US)'),

--- a/lib/generated/intl/messages_it.dart
+++ b/lib/generated/intl/messages_it.dart
@@ -86,6 +86,10 @@ class MessageLookup extends MessageLookupByLibrary {
 
   static String mLogWaterAmount(amount) => "Aggiungi ${amount} ml";
 
+  static String mFastingRemaining(value) => "${value} rimanenti";
+
+  static String mFastingTarget(value) => "Obiettivo: ${value}";
+
   final messages = _notInlinedMessages(_notInlinedMessages);
   static Map<String, Function> _notInlinedMessages(_) => <String, Function>{
         "activityExample": MessageLookupByLibrary.simpleMessage(
@@ -1291,5 +1295,25 @@ class MessageLookup extends MessageLookupByLibrary {
             MessageLookupByLibrary.simpleMessage(
                 "Obiettivo idrico giornaliero"),
         "waterChipLabel": mWaterChip,
+        "profileFastingEntry": MessageLookupByLibrary.simpleMessage('Timer di digiuno'),
+        "fastingTitle": MessageLookupByLibrary.simpleMessage('Timer di digiuno'),
+        "fastingSubtitle": MessageLookupByLibrary.simpleMessage('Un semplice timer per il tempo tra i pasti. Nessuna serie, nessun obiettivo, solo l\'orologio.'),
+        "fastingWarningTitle": MessageLookupByLibrary.simpleMessage('Prima di iniziare'),
+        "fastingWarningBody": MessageLookupByLibrary.simpleMessage('Tenere traccia dei tempi di digiuno può aiutare alcune persone e turbarne altre, in particolare chi ha alle spalle un disturbo alimentare. Se è il tuo caso, prenditi prima cura di te. Puoi trovare sostegno presso BEAT (UK) e NEDA (US).'),
+        "fastingWarningDecline": MessageLookupByLibrary.simpleMessage('Non fa per me'),
+        "fastingWarningAccept": MessageLookupByLibrary.simpleMessage('Ho capito, attiva il timer'),
+        "fastingPresetCustom": MessageLookupByLibrary.simpleMessage('Personalizzato'),
+        "fastingStart": MessageLookupByLibrary.simpleMessage('Avvia timer'),
+        "fastingCancel": MessageLookupByLibrary.simpleMessage('Termina digiuno'),
+        "fastingCancelConfirmTitle": MessageLookupByLibrary.simpleMessage('Terminare il digiuno?'),
+        "fastingCancelConfirmBody": MessageLookupByLibrary.simpleMessage('Chiuderà la sessione corrente.'),
+        "fastingComplete": MessageLookupByLibrary.simpleMessage('Sessione completata'),
+        "fastingLinkBeat": MessageLookupByLibrary.simpleMessage('BEAT (UK)'),
+        "fastingLinkNeda": MessageLookupByLibrary.simpleMessage('NEDA (US)'),
+        "fastingElapsedLabel": MessageLookupByLibrary.simpleMessage('Trascorso'),
+        "hoursLabel": MessageLookupByLibrary.simpleMessage('ore'),
+        "dialogCloseLabel": MessageLookupByLibrary.simpleMessage('Chiudi'),
+        "fastingRemainingValue": mFastingRemaining,
+        "fastingTargetValue": mFastingTarget,
       };
 }

--- a/lib/generated/intl/messages_it.dart
+++ b/lib/generated/intl/messages_it.dart
@@ -96,6 +96,7 @@ class MessageLookup extends MessageLookupByLibrary {
       "Uniti — ${winner} ora ha ${count} voci registrate.";
   static String mDriRef(value) => "rif. ${value}";
   static String mMergeOneIt(winner) => "Unito — ${winner} ora ha 1 voce registrata.";
+  static String mFastingChipIt(remaining) => "Digiuno · ${remaining} rimanenti";
 
   final messages = _notInlinedMessages(_notInlinedMessages);
   static Map<String, Function> _notInlinedMessages(_) => <String, Function>{
@@ -1367,6 +1368,9 @@ class MessageLookup extends MessageLookupByLibrary {
         "fastingCancel": MessageLookupByLibrary.simpleMessage('Termina digiuno'),
         "fastingCancelConfirmTitle": MessageLookupByLibrary.simpleMessage('Terminare il digiuno?'),
         "fastingCancelConfirmBody": MessageLookupByLibrary.simpleMessage('Chiuderà la sessione corrente.'),
+        "fastingHomeChipBody": mFastingChipIt,
+        "fastingNotificationCompleteTitle": MessageLookupByLibrary.simpleMessage("Sessione di digiuno completata"),
+        "fastingNotificationCompleteBody": MessageLookupByLibrary.simpleMessage("Il tuo tempo obiettivo è stato raggiunto."),
         "fastingComplete": MessageLookupByLibrary.simpleMessage('Sessione completata'),
         "fastingLinkBeat": MessageLookupByLibrary.simpleMessage('BEAT (UK)'),
         "fastingLinkNeda": MessageLookupByLibrary.simpleMessage('NEDA (US)'),

--- a/lib/generated/intl/messages_pl.dart
+++ b/lib/generated/intl/messages_pl.dart
@@ -95,6 +95,7 @@ class MessageLookup extends MessageLookupByLibrary {
       "Połączono — ${winner} ma teraz ${count} zarejestrowanych wpisów.";
   static String mDriRef(value) => "ref. ${value}";
   static String mMergeOnePl(winner) => "Połączono — ${winner} ma teraz 1 wpis.";
+  static String mFastingChipPl(remaining) => "Post · pozostało ${remaining}";
 
   final messages = _notInlinedMessages(_notInlinedMessages);
   static Map<String, Function> _notInlinedMessages(_) => <String, Function>{
@@ -1364,6 +1365,9 @@ class MessageLookup extends MessageLookupByLibrary {
         "fastingCancel": MessageLookupByLibrary.simpleMessage('Zakończ post'),
         "fastingCancelConfirmTitle": MessageLookupByLibrary.simpleMessage('Zakończyć post teraz?'),
         "fastingCancelConfirmBody": MessageLookupByLibrary.simpleMessage('Bieżąca sesja zostanie zamknięta.'),
+        "fastingHomeChipBody": mFastingChipPl,
+        "fastingNotificationCompleteTitle": MessageLookupByLibrary.simpleMessage("Sesja postu zakończona"),
+        "fastingNotificationCompleteBody": MessageLookupByLibrary.simpleMessage("Czas docelowy został osiągnięty."),
         "fastingComplete": MessageLookupByLibrary.simpleMessage('Sesja zakończona'),
         "fastingLinkBeat": MessageLookupByLibrary.simpleMessage('BEAT (UK)'),
         "fastingLinkNeda": MessageLookupByLibrary.simpleMessage('NEDA (US)'),

--- a/lib/generated/intl/messages_pl.dart
+++ b/lib/generated/intl/messages_pl.dart
@@ -85,6 +85,10 @@ class MessageLookup extends MessageLookupByLibrary {
 
   static String mLogWaterAmount(amount) => "Dodaj ${amount} ml";
 
+  static String mFastingRemaining(value) => "Pozostało ${value}";
+
+  static String mFastingTarget(value) => "Cel: ${value}";
+
   final messages = _notInlinedMessages(_notInlinedMessages);
   static Map<String, Function> _notInlinedMessages(_) => <String, Function>{
         "activityExample": MessageLookupByLibrary.simpleMessage(
@@ -1288,5 +1292,25 @@ class MessageLookup extends MessageLookupByLibrary {
         "settingsWaterGoalLabel":
             MessageLookupByLibrary.simpleMessage("Dzienny cel wody"),
         "waterChipLabel": mWaterChip,
+        "profileFastingEntry": MessageLookupByLibrary.simpleMessage('Minutnik postu'),
+        "fastingTitle": MessageLookupByLibrary.simpleMessage('Minutnik postu'),
+        "fastingSubtitle": MessageLookupByLibrary.simpleMessage('Prosty minutnik do śledzenia czasu między posiłkami. Bez serii, bez celów, tylko zegar.'),
+        "fastingWarningTitle": MessageLookupByLibrary.simpleMessage('Zanim zaczniesz'),
+        "fastingWarningBody": MessageLookupByLibrary.simpleMessage('Śledzenie czasu postu jednym pomaga, a innym może szkodzić, szczególnie osobom z historią zaburzeń odżywiania. Jeśli to o tobie, zadbaj najpierw o siebie. Wsparcie oferują BEAT (UK) i NEDA (US).'),
+        "fastingWarningDecline": MessageLookupByLibrary.simpleMessage('To nie dla mnie'),
+        "fastingWarningAccept": MessageLookupByLibrary.simpleMessage('Rozumiem, włącz minutnik'),
+        "fastingPresetCustom": MessageLookupByLibrary.simpleMessage('Własny'),
+        "fastingStart": MessageLookupByLibrary.simpleMessage('Uruchom minutnik'),
+        "fastingCancel": MessageLookupByLibrary.simpleMessage('Zakończ post'),
+        "fastingCancelConfirmTitle": MessageLookupByLibrary.simpleMessage('Zakończyć post teraz?'),
+        "fastingCancelConfirmBody": MessageLookupByLibrary.simpleMessage('Bieżąca sesja zostanie zamknięta.'),
+        "fastingComplete": MessageLookupByLibrary.simpleMessage('Sesja zakończona'),
+        "fastingLinkBeat": MessageLookupByLibrary.simpleMessage('BEAT (UK)'),
+        "fastingLinkNeda": MessageLookupByLibrary.simpleMessage('NEDA (US)'),
+        "fastingElapsedLabel": MessageLookupByLibrary.simpleMessage('Upłynęło'),
+        "hoursLabel": MessageLookupByLibrary.simpleMessage('godziny'),
+        "dialogCloseLabel": MessageLookupByLibrary.simpleMessage('Zamknij'),
+        "fastingRemainingValue": mFastingRemaining,
+        "fastingTargetValue": mFastingTarget,
       };
 }

--- a/lib/generated/intl/messages_sk.dart
+++ b/lib/generated/intl/messages_sk.dart
@@ -86,6 +86,10 @@ class MessageLookup extends MessageLookupByLibrary {
 
   static String mLogWaterAmount(amount) => "Pridať ${amount} ml";
 
+  static String mFastingRemaining(value) => "Zostáva ${value}";
+
+  static String mFastingTarget(value) => "Cieľ: ${value}";
+
   final messages = _notInlinedMessages(_notInlinedMessages);
   static Map<String, Function> _notInlinedMessages(_) => <String, Function>{
         "activityExample": MessageLookupByLibrary.simpleMessage(
@@ -1282,5 +1286,25 @@ class MessageLookup extends MessageLookupByLibrary {
         "settingsWaterGoalLabel":
             MessageLookupByLibrary.simpleMessage("Denný cieľ pitia vody"),
         "waterChipLabel": mWaterChip,
+        "profileFastingEntry": MessageLookupByLibrary.simpleMessage('Časovač pôstu'),
+        "fastingTitle": MessageLookupByLibrary.simpleMessage('Časovač pôstu'),
+        "fastingSubtitle": MessageLookupByLibrary.simpleMessage('Jednoduchý časovač na sledovanie času medzi jedlami. Žiadne série, žiadne ciele, len hodiny.'),
+        "fastingWarningTitle": MessageLookupByLibrary.simpleMessage('Skôr než začneš'),
+        "fastingWarningBody": MessageLookupByLibrary.simpleMessage('Sledovanie času pôstu môže byť niekomu užitočné a niekoho zraniť, najmä ak má za sebou poruchu príjmu potravy. Ak si to ty, postaraj sa najprv o seba. Podporu poskytujú BEAT (UK) a NEDA (US).'),
+        "fastingWarningDecline": MessageLookupByLibrary.simpleMessage('Nie je to pre mňa'),
+        "fastingWarningAccept": MessageLookupByLibrary.simpleMessage('Rozumiem, zapnúť časovač'),
+        "fastingPresetCustom": MessageLookupByLibrary.simpleMessage('Vlastné'),
+        "fastingStart": MessageLookupByLibrary.simpleMessage('Spustiť časovač'),
+        "fastingCancel": MessageLookupByLibrary.simpleMessage('Ukončiť pôst'),
+        "fastingCancelConfirmTitle": MessageLookupByLibrary.simpleMessage('Ukončiť pôst teraz?'),
+        "fastingCancelConfirmBody": MessageLookupByLibrary.simpleMessage('Aktuálna relácia bude uzavretá.'),
+        "fastingComplete": MessageLookupByLibrary.simpleMessage('Relácia dokončená'),
+        "fastingLinkBeat": MessageLookupByLibrary.simpleMessage('BEAT (UK)'),
+        "fastingLinkNeda": MessageLookupByLibrary.simpleMessage('NEDA (US)'),
+        "fastingElapsedLabel": MessageLookupByLibrary.simpleMessage('Uplynulo'),
+        "hoursLabel": MessageLookupByLibrary.simpleMessage('hodiny'),
+        "dialogCloseLabel": MessageLookupByLibrary.simpleMessage('Zavrieť'),
+        "fastingRemainingValue": mFastingRemaining,
+        "fastingTargetValue": mFastingTarget,
       };
 }

--- a/lib/generated/intl/messages_sk.dart
+++ b/lib/generated/intl/messages_sk.dart
@@ -96,6 +96,7 @@ class MessageLookup extends MessageLookupByLibrary {
       "Zlúčené — ${winner} má teraz ${count} zaznamenaných záznamov.";
   static String mDriRef(value) => "ref. ${value}";
   static String mMergeOneSk(winner) => "Zlúčené — ${winner} má teraz 1 záznam.";
+  static String mFastingChipSk(remaining) => "Pôst · zostáva ${remaining}";
 
   final messages = _notInlinedMessages(_notInlinedMessages);
   static Map<String, Function> _notInlinedMessages(_) => <String, Function>{
@@ -1357,6 +1358,9 @@ class MessageLookup extends MessageLookupByLibrary {
         "fastingCancel": MessageLookupByLibrary.simpleMessage('Ukončiť pôst'),
         "fastingCancelConfirmTitle": MessageLookupByLibrary.simpleMessage('Ukončiť pôst teraz?'),
         "fastingCancelConfirmBody": MessageLookupByLibrary.simpleMessage('Aktuálna relácia bude uzavretá.'),
+        "fastingHomeChipBody": mFastingChipSk,
+        "fastingNotificationCompleteTitle": MessageLookupByLibrary.simpleMessage("Pôst dokončený"),
+        "fastingNotificationCompleteBody": MessageLookupByLibrary.simpleMessage("Cieľový čas bol dosiahnutý."),
         "fastingComplete": MessageLookupByLibrary.simpleMessage('Relácia dokončená'),
         "fastingLinkBeat": MessageLookupByLibrary.simpleMessage('BEAT (UK)'),
         "fastingLinkNeda": MessageLookupByLibrary.simpleMessage('NEDA (US)'),

--- a/lib/generated/intl/messages_tr.dart
+++ b/lib/generated/intl/messages_tr.dart
@@ -98,6 +98,7 @@ class MessageLookup extends MessageLookupByLibrary {
       "Birleştirildi — ${winner} artık ${count} kayıtlı girdiye sahip.";
   static String mDriRef(value) => "ref. ${value}";
   static String mMergeOneTr(winner) => "Birleştirildi — ${winner} artık 1 kayda sahip.";
+  static String mFastingChipTr(remaining) => 'Oruç · ${remaining} kaldı';
 
   final messages = _notInlinedMessages(_notInlinedMessages);
   static Map<String, Function> _notInlinedMessages(_) => <String, Function>{
@@ -1340,6 +1341,9 @@ class MessageLookup extends MessageLookupByLibrary {
         "fastingCancel": MessageLookupByLibrary.simpleMessage('Orucu sonlandır'),
         "fastingCancelConfirmTitle": MessageLookupByLibrary.simpleMessage('Orucu şimdi sonlandırılsın mı?'),
         "fastingCancelConfirmBody": MessageLookupByLibrary.simpleMessage('Bu, mevcut oturumu kapatacak.'),
+        "fastingHomeChipBody": mFastingChipTr,
+        "fastingNotificationCompleteTitle": MessageLookupByLibrary.simpleMessage('Oruç süresi tamamlandı'),
+        "fastingNotificationCompleteBody": MessageLookupByLibrary.simpleMessage('Hedef sürene ulaştın.'),
         "fastingComplete": MessageLookupByLibrary.simpleMessage('Oturum tamamlandı'),
         "fastingLinkBeat": MessageLookupByLibrary.simpleMessage('BEAT (UK)'),
         "fastingLinkNeda": MessageLookupByLibrary.simpleMessage('NEDA (US)'),

--- a/lib/generated/intl/messages_tr.dart
+++ b/lib/generated/intl/messages_tr.dart
@@ -88,6 +88,10 @@ class MessageLookup extends MessageLookupByLibrary {
 
   static String mLogWaterAmount(amount) => "${amount} ml ekle";
 
+  static String mFastingRemaining(value) => "${value} kaldı";
+
+  static String mFastingTarget(value) => "Hedef: ${value}";
+
   final messages = _notInlinedMessages(_notInlinedMessages);
   static Map<String, Function> _notInlinedMessages(_) => <String, Function>{
         "activityExample": MessageLookupByLibrary.simpleMessage(
@@ -1265,5 +1269,25 @@ class MessageLookup extends MessageLookupByLibrary {
         "settingsWaterGoalLabel":
             MessageLookupByLibrary.simpleMessage("Günlük su hedefi"),
         "waterChipLabel": mWaterChip,
+        "profileFastingEntry": MessageLookupByLibrary.simpleMessage('Oruç zamanlayıcısı'),
+        "fastingTitle": MessageLookupByLibrary.simpleMessage('Oruç zamanlayıcısı'),
+        "fastingSubtitle": MessageLookupByLibrary.simpleMessage('Öğünler arası süreyi izlemek için basit bir zamanlayıcı. Seri yok, hedef yok, sadece saat.'),
+        "fastingWarningTitle": MessageLookupByLibrary.simpleMessage('Başlamadan önce'),
+        "fastingWarningBody": MessageLookupByLibrary.simpleMessage('Oruç sürelerini takip etmek bazı insanlara iyi gelirken, özellikle yeme bozukluğu geçmişi olanlar için zorlayıcı olabilir. Bu sen olabilirsen lütfen önce kendine iyi bak. Destek için BEAT (UK) ve NEDA (US) yardımcı olabilir.'),
+        "fastingWarningDecline": MessageLookupByLibrary.simpleMessage('Bana göre değil'),
+        "fastingWarningAccept": MessageLookupByLibrary.simpleMessage('Anladım, zamanlayıcıyı aç'),
+        "fastingPresetCustom": MessageLookupByLibrary.simpleMessage('Özel'),
+        "fastingStart": MessageLookupByLibrary.simpleMessage('Zamanlayıcıyı başlat'),
+        "fastingCancel": MessageLookupByLibrary.simpleMessage('Orucu sonlandır'),
+        "fastingCancelConfirmTitle": MessageLookupByLibrary.simpleMessage('Orucu şimdi sonlandırılsın mı?'),
+        "fastingCancelConfirmBody": MessageLookupByLibrary.simpleMessage('Bu, mevcut oturumu kapatacak.'),
+        "fastingComplete": MessageLookupByLibrary.simpleMessage('Oturum tamamlandı'),
+        "fastingLinkBeat": MessageLookupByLibrary.simpleMessage('BEAT (UK)'),
+        "fastingLinkNeda": MessageLookupByLibrary.simpleMessage('NEDA (US)'),
+        "fastingElapsedLabel": MessageLookupByLibrary.simpleMessage('Geçen'),
+        "hoursLabel": MessageLookupByLibrary.simpleMessage('saat'),
+        "dialogCloseLabel": MessageLookupByLibrary.simpleMessage('Kapat'),
+        "fastingRemainingValue": mFastingRemaining,
+        "fastingTargetValue": mFastingTarget,
       };
 }

--- a/lib/generated/intl/messages_uk.dart
+++ b/lib/generated/intl/messages_uk.dart
@@ -86,6 +86,10 @@ class MessageLookup extends MessageLookupByLibrary {
 
   static String mLogWaterAmount(amount) => "Додати ${amount} мл";
 
+  static String mFastingRemaining(value) => "Залишилося ${value}";
+
+  static String mFastingTarget(value) => "Ціль: ${value}";
+
   final messages = _notInlinedMessages(_notInlinedMessages);
   static Map<String, Function> _notInlinedMessages(_) => <String, Function>{
         "activityExample": MessageLookupByLibrary.simpleMessage(
@@ -1292,5 +1296,25 @@ class MessageLookup extends MessageLookupByLibrary {
         "settingsWaterGoalLabel":
             MessageLookupByLibrary.simpleMessage("Денна ціль вживання води"),
         "waterChipLabel": mWaterChip,
+        "profileFastingEntry": MessageLookupByLibrary.simpleMessage('Таймер посту'),
+        "fastingTitle": MessageLookupByLibrary.simpleMessage('Таймер посту'),
+        "fastingSubtitle": MessageLookupByLibrary.simpleMessage('Простий таймер для часу між прийомами їжі. Без серій, без цілей, лише годинник.'),
+        "fastingWarningTitle": MessageLookupByLibrary.simpleMessage('Перш ніж почати'),
+        "fastingWarningBody": MessageLookupByLibrary.simpleMessage('Відстеження часу посту комусь допомагає, а декому може шкодити, особливо людям із досвідом розладів харчової поведінки. Якщо це про вас, будь ласка, спершу подбайте про себе. Підтримку надають BEAT (UK) і NEDA (US).'),
+        "fastingWarningDecline": MessageLookupByLibrary.simpleMessage('Це не для мене'),
+        "fastingWarningAccept": MessageLookupByLibrary.simpleMessage('Розумію, увімкнути таймер'),
+        "fastingPresetCustom": MessageLookupByLibrary.simpleMessage('Власний'),
+        "fastingStart": MessageLookupByLibrary.simpleMessage('Запустити таймер'),
+        "fastingCancel": MessageLookupByLibrary.simpleMessage('Завершити піст'),
+        "fastingCancelConfirmTitle": MessageLookupByLibrary.simpleMessage('Завершити піст зараз?'),
+        "fastingCancelConfirmBody": MessageLookupByLibrary.simpleMessage('Поточну сесію буде закрито.'),
+        "fastingComplete": MessageLookupByLibrary.simpleMessage('Сесію завершено'),
+        "fastingLinkBeat": MessageLookupByLibrary.simpleMessage('BEAT (UK)'),
+        "fastingLinkNeda": MessageLookupByLibrary.simpleMessage('NEDA (US)'),
+        "fastingElapsedLabel": MessageLookupByLibrary.simpleMessage('Минуло'),
+        "hoursLabel": MessageLookupByLibrary.simpleMessage('години'),
+        "dialogCloseLabel": MessageLookupByLibrary.simpleMessage('Закрити'),
+        "fastingRemainingValue": mFastingRemaining,
+        "fastingTargetValue": mFastingTarget,
       };
 }

--- a/lib/generated/intl/messages_uk.dart
+++ b/lib/generated/intl/messages_uk.dart
@@ -96,6 +96,7 @@ class MessageLookup extends MessageLookupByLibrary {
       "Об’єднано — ${winner} тепер має ${count} записів.";
   static String mDriRef(value) => "орієнт. ${value}";
   static String mMergeOneUk(winner) => "Об'єднано — ${winner} тепер має 1 запис.";
+  static String mFastingChipUk(remaining) => "Голодування · залишилось ${remaining}";
 
   final messages = _notInlinedMessages(_notInlinedMessages);
   static Map<String, Function> _notInlinedMessages(_) => <String, Function>{
@@ -1368,6 +1369,9 @@ class MessageLookup extends MessageLookupByLibrary {
         "fastingCancel": MessageLookupByLibrary.simpleMessage('Завершити піст'),
         "fastingCancelConfirmTitle": MessageLookupByLibrary.simpleMessage('Завершити піст зараз?'),
         "fastingCancelConfirmBody": MessageLookupByLibrary.simpleMessage('Поточну сесію буде закрито.'),
+        "fastingHomeChipBody": mFastingChipUk,
+        "fastingNotificationCompleteTitle": MessageLookupByLibrary.simpleMessage("Сесія голодування завершена"),
+        "fastingNotificationCompleteBody": MessageLookupByLibrary.simpleMessage("Цільовий час досягнуто."),
         "fastingComplete": MessageLookupByLibrary.simpleMessage('Сесію завершено'),
         "fastingLinkBeat": MessageLookupByLibrary.simpleMessage('BEAT (UK)'),
         "fastingLinkNeda": MessageLookupByLibrary.simpleMessage('NEDA (US)'),

--- a/lib/generated/intl/messages_zh.dart
+++ b/lib/generated/intl/messages_zh.dart
@@ -83,6 +83,10 @@ class MessageLookup extends MessageLookupByLibrary {
 
   static String mLogWaterAmount(amount) => "添加 ${amount} 毫升";
 
+  static String mFastingRemaining(value) => "剩余 ${value}";
+
+  static String mFastingTarget(value) => "目标:${value}";
+
   final messages = _notInlinedMessages(_notInlinedMessages);
   static Map<String, Function> _notInlinedMessages(_) => <String, Function>{
         "activityExample":
@@ -1131,5 +1135,25 @@ class MessageLookup extends MessageLookupByLibrary {
         "settingsWaterGoalLabel":
             MessageLookupByLibrary.simpleMessage("每日饮水目标"),
         "waterChipLabel": mWaterChip,
+        "profileFastingEntry": MessageLookupByLibrary.simpleMessage('断食计时器'),
+        "fastingTitle": MessageLookupByLibrary.simpleMessage('断食计时器'),
+        "fastingSubtitle": MessageLookupByLibrary.simpleMessage('用来追踪两餐之间时间的简单计时器。没有连胜,没有目标,只是时钟。'),
+        "fastingWarningTitle": MessageLookupByLibrary.simpleMessage('开始之前'),
+        "fastingWarningBody": MessageLookupByLibrary.simpleMessage('记录断食时间对某些人有帮助,但对另一些人(尤其是有进食障碍经历的人)可能造成困扰。如果你属于这种情况,请先照顾好自己。BEAT(英国)和 NEDA(美国)提供专业支持。'),
+        "fastingWarningDecline": MessageLookupByLibrary.simpleMessage('不适合我'),
+        "fastingWarningAccept": MessageLookupByLibrary.simpleMessage('我了解,启用计时器'),
+        "fastingPresetCustom": MessageLookupByLibrary.simpleMessage('自定义'),
+        "fastingStart": MessageLookupByLibrary.simpleMessage('开始计时'),
+        "fastingCancel": MessageLookupByLibrary.simpleMessage('结束断食'),
+        "fastingCancelConfirmTitle": MessageLookupByLibrary.simpleMessage('现在结束断食?'),
+        "fastingCancelConfirmBody": MessageLookupByLibrary.simpleMessage('这将关闭当前会话。'),
+        "fastingComplete": MessageLookupByLibrary.simpleMessage('会话完成'),
+        "fastingLinkBeat": MessageLookupByLibrary.simpleMessage('BEAT(英国)'),
+        "fastingLinkNeda": MessageLookupByLibrary.simpleMessage('NEDA(美国)'),
+        "fastingElapsedLabel": MessageLookupByLibrary.simpleMessage('已用'),
+        "hoursLabel": MessageLookupByLibrary.simpleMessage('小时'),
+        "dialogCloseLabel": MessageLookupByLibrary.simpleMessage('关闭'),
+        "fastingRemainingValue": mFastingRemaining,
+        "fastingTargetValue": mFastingTarget,
       };
 }

--- a/lib/generated/intl/messages_zh.dart
+++ b/lib/generated/intl/messages_zh.dart
@@ -93,6 +93,7 @@ class MessageLookup extends MessageLookupByLibrary {
       "已合并 — ${winner} 现在有 ${count} 条记录。";
   static String mDriRef(value) => "参考 ${value}";
   static String mMergeOneZh(winner) => "已合并 — ${winner} 现在有 1 条记录。";
+  static String mFastingChipZh(remaining) => "禁食中 · 剩余 ${remaining}";
 
   final messages = _notInlinedMessages(_notInlinedMessages);
   static Map<String, Function> _notInlinedMessages(_) => <String, Function>{
@@ -1205,6 +1206,9 @@ class MessageLookup extends MessageLookupByLibrary {
         "fastingCancel": MessageLookupByLibrary.simpleMessage('结束断食'),
         "fastingCancelConfirmTitle": MessageLookupByLibrary.simpleMessage('现在结束断食?'),
         "fastingCancelConfirmBody": MessageLookupByLibrary.simpleMessage('这将关闭当前会话。'),
+        "fastingHomeChipBody": mFastingChipZh,
+        "fastingNotificationCompleteTitle": MessageLookupByLibrary.simpleMessage("禁食时间到了"),
+        "fastingNotificationCompleteBody": MessageLookupByLibrary.simpleMessage("已达到你的目标时间。"),
         "fastingComplete": MessageLookupByLibrary.simpleMessage('会话完成'),
         "fastingLinkBeat": MessageLookupByLibrary.simpleMessage('BEAT(英国)'),
         "fastingLinkNeda": MessageLookupByLibrary.simpleMessage('NEDA(美国)'),

--- a/lib/generated/l10n.dart
+++ b/lib/generated/l10n.dart
@@ -7151,6 +7151,206 @@ class S {
       args: [],
     );
   }
+
+  /// `Fasting timer`
+  String get profileFastingEntry {
+    return Intl.message(
+      'Fasting timer',
+      name: 'profileFastingEntry',
+      desc: '',
+      args: [],
+    );
+  }
+
+  /// `Fasting timer`
+  String get fastingTitle {
+    return Intl.message(
+      'Fasting timer',
+      name: 'fastingTitle',
+      desc: '',
+      args: [],
+    );
+  }
+
+  /// `A simple timer for tracking time between meals. No streaks, no targets, just the clock.`
+  String get fastingSubtitle {
+    return Intl.message(
+      'A simple timer for tracking time between meals. No streaks, no targets, just the clock.',
+      name: 'fastingSubtitle',
+      desc: '',
+      args: [],
+    );
+  }
+
+  /// `Before you start`
+  String get fastingWarningTitle {
+    return Intl.message(
+      'Before you start',
+      name: 'fastingWarningTitle',
+      desc: '',
+      args: [],
+    );
+  }
+
+  /// `Tracking fasting time can be helpful for some people and distressing for others, especially anyone with a history of disordered eating. If that's you, please look after yourself first. Support is available from BEAT (UK) and NEDA (US).`
+  String get fastingWarningBody {
+    return Intl.message(
+      "Tracking fasting time can be helpful for some people and distressing for others, especially anyone with a history of disordered eating. If that's you, please look after yourself first. Support is available from BEAT (UK) and NEDA (US).",
+      name: 'fastingWarningBody',
+      desc: '',
+      args: [],
+    );
+  }
+
+  /// `Not for me`
+  String get fastingWarningDecline {
+    return Intl.message(
+      'Not for me',
+      name: 'fastingWarningDecline',
+      desc: '',
+      args: [],
+    );
+  }
+
+  /// `I understand, enable timer`
+  String get fastingWarningAccept {
+    return Intl.message(
+      'I understand, enable timer',
+      name: 'fastingWarningAccept',
+      desc: '',
+      args: [],
+    );
+  }
+
+  /// `Custom`
+  String get fastingPresetCustom {
+    return Intl.message(
+      'Custom',
+      name: 'fastingPresetCustom',
+      desc: '',
+      args: [],
+    );
+  }
+
+  /// `Start timer`
+  String get fastingStart {
+    return Intl.message(
+      'Start timer',
+      name: 'fastingStart',
+      desc: '',
+      args: [],
+    );
+  }
+
+  /// `End fast`
+  String get fastingCancel {
+    return Intl.message(
+      'End fast',
+      name: 'fastingCancel',
+      desc: '',
+      args: [],
+    );
+  }
+
+  /// `End fast now?`
+  String get fastingCancelConfirmTitle {
+    return Intl.message(
+      'End fast now?',
+      name: 'fastingCancelConfirmTitle',
+      desc: '',
+      args: [],
+    );
+  }
+
+  /// `This will close the current session.`
+  String get fastingCancelConfirmBody {
+    return Intl.message(
+      'This will close the current session.',
+      name: 'fastingCancelConfirmBody',
+      desc: '',
+      args: [],
+    );
+  }
+
+  /// `Session complete`
+  String get fastingComplete {
+    return Intl.message(
+      'Session complete',
+      name: 'fastingComplete',
+      desc: '',
+      args: [],
+    );
+  }
+
+  /// `BEAT (UK)`
+  String get fastingLinkBeat {
+    return Intl.message(
+      'BEAT (UK)',
+      name: 'fastingLinkBeat',
+      desc: '',
+      args: [],
+    );
+  }
+
+  /// `NEDA (US)`
+  String get fastingLinkNeda {
+    return Intl.message(
+      'NEDA (US)',
+      name: 'fastingLinkNeda',
+      desc: '',
+      args: [],
+    );
+  }
+
+  /// `Elapsed`
+  String get fastingElapsedLabel {
+    return Intl.message(
+      'Elapsed',
+      name: 'fastingElapsedLabel',
+      desc: '',
+      args: [],
+    );
+  }
+
+  /// `{value} remaining`
+  String fastingRemainingValue(String value) {
+    return Intl.message(
+      '$value remaining',
+      name: 'fastingRemainingValue',
+      desc: '',
+      args: [value],
+    );
+  }
+
+  /// `Target: {value}`
+  String fastingTargetValue(String value) {
+    return Intl.message(
+      'Target: $value',
+      name: 'fastingTargetValue',
+      desc: '',
+      args: [value],
+    );
+  }
+
+  /// `hours`
+  String get hoursLabel {
+    return Intl.message(
+      'hours',
+      name: 'hoursLabel',
+      desc: '',
+      args: [],
+    );
+  }
+
+  /// `Close`
+  String get dialogCloseLabel {
+    return Intl.message(
+      'Close',
+      name: 'dialogCloseLabel',
+      desc: '',
+      args: [],
+    );
+  }
 }
 
 class AppLocalizationDelegate extends LocalizationsDelegate<S> {

--- a/lib/generated/l10n.dart
+++ b/lib/generated/l10n.dart
@@ -7711,6 +7711,36 @@ class S {
       args: [],
     );
   }
+
+  /// `Fasting · {remaining} left`
+  String fastingHomeChipBody(String remaining) {
+    return Intl.message(
+      'Fasting · $remaining left',
+      name: 'fastingHomeChipBody',
+      desc: '',
+      args: [remaining],
+    );
+  }
+
+  /// `Fasting session complete`
+  String get fastingNotificationCompleteTitle {
+    return Intl.message(
+      'Fasting session complete',
+      name: 'fastingNotificationCompleteTitle',
+      desc: '',
+      args: [],
+    );
+  }
+
+  /// `Your target time has been reached.`
+  String get fastingNotificationCompleteBody {
+    return Intl.message(
+      'Your target time has been reached.',
+      name: 'fastingNotificationCompleteBody',
+      desc: '',
+      args: [],
+    );
+  }
 }
 
 class AppLocalizationDelegate extends LocalizationsDelegate<S> {

--- a/lib/hive_registrar.g.dart
+++ b/lib/hive_registrar.g.dart
@@ -8,6 +8,7 @@ import 'package:opennutritracker/core/data/data_source/user_activity_dbo.dart';
 import 'package:opennutritracker/core/data/dbo/app_theme_dbo.dart';
 import 'package:opennutritracker/core/data/dbo/calories_profile_dbo.dart';
 import 'package:opennutritracker/core/data/dbo/config_dbo.dart';
+import 'package:opennutritracker/core/data/dbo/fasting_session_dbo.dart';
 import 'package:opennutritracker/core/data/dbo/intake_dbo.dart';
 import 'package:opennutritracker/core/data/dbo/intake_type_dbo.dart';
 import 'package:opennutritracker/core/data/dbo/meal_dbo.dart';
@@ -29,6 +30,7 @@ extension HiveRegistrar on HiveInterface {
     registerAdapter(CaloriesProfileDBOAdapter());
     registerAdapter(ConfigDBOAdapter());
     registerAdapter(CustomActivityTemplateDBOAdapter());
+    registerAdapter(FastingSessionDBOAdapter());
     registerAdapter(IntakeDBOAdapter());
     registerAdapter(IntakeTypeDBOAdapter());
     registerAdapter(MealDBOAdapter());
@@ -55,6 +57,7 @@ extension IsolatedHiveRegistrar on IsolatedHiveInterface {
     registerAdapter(CaloriesProfileDBOAdapter());
     registerAdapter(ConfigDBOAdapter());
     registerAdapter(CustomActivityTemplateDBOAdapter());
+    registerAdapter(FastingSessionDBOAdapter());
     registerAdapter(IntakeDBOAdapter());
     registerAdapter(IntakeTypeDBOAdapter());
     registerAdapter(MealDBOAdapter());

--- a/lib/l10n/intl_cs.arb
+++ b/lib/l10n/intl_cs.arb
@@ -933,5 +933,13 @@
       "count": { "type": "int" },
       "winner": { "type": "String" }
     }
-  }
+  },
+  "fastingHomeChipBody": "Půst · zbývá {remaining}",
+  "@fastingHomeChipBody": {
+    "placeholders": {
+      "remaining": { "type": "String" }
+    }
+  },
+  "fastingNotificationCompleteTitle": "Půst dokončen",
+  "fastingNotificationCompleteBody": "Cílový čas byl dosažen."
 }

--- a/lib/l10n/intl_cs.arb
+++ b/lib/l10n/intl_cs.arb
@@ -187,7 +187,9 @@
   "customMealFormSimpleFieldHelper": "{unit} v jedné porci",
   "@customMealFormSimpleFieldHelper": {
     "placeholders": {
-      "unit": { "type": "String" }
+      "unit": {
+        "type": "String"
+      }
     }
   },
   "customMealsDeleteConfirmContent": "Všechny záznamy v deníku používající toto jídlo budou také odstraněny.",
@@ -839,5 +841,39 @@
   "settingsWaterGoalDescription": "Používá se pro ukazatel vody na hlavní obrazovce.",
   "settingsWaterGoalLabel": "Denní cíl pití vody",
   "waterChipLabel": "{current} / {goal} ml",
-  "zincLabel": "zinek"
+  "zincLabel": "zinek",
+  "profileFastingEntry": "Časovač půstu",
+  "fastingTitle": "Časovač půstu",
+  "fastingSubtitle": "Jednoduchý časovač pro sledování času mezi jídly. Žádné série, žádné cíle, jen hodiny.",
+  "fastingWarningTitle": "Než začnete",
+  "fastingWarningBody": "Sledování doby půstu může být pro někoho užitečné a pro jiného zraňující, zvlášť pokud máte zkušenost s poruchou příjmu potravy. Pokud se vás to týká, prosím postarejte se nejdřív o sebe. Podporu nabízí BEAT (UK) a NEDA (US).",
+  "fastingWarningDecline": "Není to pro mě",
+  "fastingWarningAccept": "Rozumím, zapnout časovač",
+  "fastingPresetCustom": "Vlastní",
+  "fastingStart": "Spustit časovač",
+  "fastingCancel": "Ukončit půst",
+  "fastingCancelConfirmTitle": "Ukončit půst teď?",
+  "fastingCancelConfirmBody": "Aktuální relace bude uzavřena.",
+  "fastingComplete": "Relace dokončena",
+  "fastingLinkBeat": "BEAT (UK)",
+  "fastingLinkNeda": "NEDA (US)",
+  "fastingElapsedLabel": "Uplynulo",
+  "fastingRemainingValue": "Zbývá {value}",
+  "@fastingRemainingValue": {
+    "placeholders": {
+      "value": {
+        "type": "String"
+      }
+    }
+  },
+  "fastingTargetValue": "Cíl: {value}",
+  "@fastingTargetValue": {
+    "placeholders": {
+      "value": {
+        "type": "String"
+      }
+    }
+  },
+  "hoursLabel": "hodiny",
+  "dialogCloseLabel": "Zavřít"
 }

--- a/lib/l10n/intl_de.arb
+++ b/lib/l10n/intl_de.arb
@@ -964,5 +964,13 @@
       "count": { "type": "int" },
       "winner": { "type": "String" }
     }
-  }
+  },
+  "fastingHomeChipBody": "Fasten · noch {remaining}",
+  "@fastingHomeChipBody": {
+    "placeholders": {
+      "remaining": { "type": "String" }
+    }
+  },
+  "fastingNotificationCompleteTitle": "Fastenzeit abgeschlossen",
+  "fastingNotificationCompleteBody": "Deine Zielzeit wurde erreicht."
 }

--- a/lib/l10n/intl_de.arb
+++ b/lib/l10n/intl_de.arb
@@ -218,7 +218,9 @@
   "customMealFormSimpleFieldHelper": "{unit} pro Portion",
   "@customMealFormSimpleFieldHelper": {
     "placeholders": {
-      "unit": { "type": "String" }
+      "unit": {
+        "type": "String"
+      }
     }
   },
   "customMealsDeleteConfirmContent": "Alle Tagebucheinträge, die diese Mahlzeit verwenden, werden ebenfalls entfernt.",
@@ -870,5 +872,39 @@
   "settingsWaterGoalDescription": "Wird vom Wasser-Chip auf dem Startbildschirm verwendet.",
   "settingsWaterGoalLabel": "Tägliches Wasserziel",
   "waterChipLabel": "{current} / {goal} ml",
-  "zincLabel": "Zink"
+  "zincLabel": "Zink",
+  "profileFastingEntry": "Fasten-Timer",
+  "fastingTitle": "Fasten-Timer",
+  "fastingSubtitle": "Ein einfacher Timer für die Zeit zwischen den Mahlzeiten. Keine Serien, keine Ziele, nur die Uhr.",
+  "fastingWarningTitle": "Bevor du beginnst",
+  "fastingWarningBody": "Das Verfolgen von Fastenzeiten kann für manche hilfreich und für andere belastend sein, besonders wenn eine Essstörung Teil deiner Geschichte ist. Bitte achte zuerst auf dich. Unterstützung findest du bei BEAT (UK) und NEDA (US).",
+  "fastingWarningDecline": "Nichts für mich",
+  "fastingWarningAccept": "Verstanden, Timer aktivieren",
+  "fastingPresetCustom": "Eigene Dauer",
+  "fastingStart": "Timer starten",
+  "fastingCancel": "Fasten beenden",
+  "fastingCancelConfirmTitle": "Fasten jetzt beenden?",
+  "fastingCancelConfirmBody": "Damit wird die aktuelle Sitzung geschlossen.",
+  "fastingComplete": "Sitzung abgeschlossen",
+  "fastingLinkBeat": "BEAT (UK)",
+  "fastingLinkNeda": "NEDA (US)",
+  "fastingElapsedLabel": "Vergangen",
+  "fastingRemainingValue": "Noch {value}",
+  "@fastingRemainingValue": {
+    "placeholders": {
+      "value": {
+        "type": "String"
+      }
+    }
+  },
+  "fastingTargetValue": "Ziel: {value}",
+  "@fastingTargetValue": {
+    "placeholders": {
+      "value": {
+        "type": "String"
+      }
+    }
+  },
+  "hoursLabel": "Stunden",
+  "dialogCloseLabel": "Schließen"
 }

--- a/lib/l10n/intl_en.arb
+++ b/lib/l10n/intl_en.arb
@@ -252,7 +252,9 @@
   "customMealFormSimpleFieldHelper": "{unit} in one serving",
   "@customMealFormSimpleFieldHelper": {
     "placeholders": {
-      "unit": { "type": "String" }
+      "unit": {
+        "type": "String"
+      }
     }
   },
   "customMealsDeleteConfirmContent": "All diary entries using this meal will also be removed.",
@@ -887,5 +889,39 @@
   "settingsWaterGoalDescription": "Used by the water chip on the home screen.",
   "settingsWaterGoalLabel": "Daily water goal",
   "waterChipLabel": "{current} / {goal} ml",
-  "zincLabel": "zinc"
+  "zincLabel": "zinc",
+  "profileFastingEntry": "Fasting timer",
+  "fastingTitle": "Fasting timer",
+  "fastingSubtitle": "A simple timer for tracking time between meals. No streaks, no targets, just the clock.",
+  "fastingWarningTitle": "Before you start",
+  "fastingWarningBody": "Tracking fasting time can be helpful for some people and distressing for others, especially anyone with a history of disordered eating. If that's you, please look after yourself first. Support is available from BEAT (UK) and NEDA (US).",
+  "fastingWarningDecline": "Not for me",
+  "fastingWarningAccept": "I understand, enable timer",
+  "fastingPresetCustom": "Custom",
+  "fastingStart": "Start timer",
+  "fastingCancel": "End fast",
+  "fastingCancelConfirmTitle": "End fast now?",
+  "fastingCancelConfirmBody": "This will close the current session.",
+  "fastingComplete": "Session complete",
+  "fastingLinkBeat": "BEAT (UK)",
+  "fastingLinkNeda": "NEDA (US)",
+  "fastingElapsedLabel": "Elapsed",
+  "fastingRemainingValue": "{value} remaining",
+  "@fastingRemainingValue": {
+    "placeholders": {
+      "value": {
+        "type": "String"
+      }
+    }
+  },
+  "fastingTargetValue": "Target: {value}",
+  "@fastingTargetValue": {
+    "placeholders": {
+      "value": {
+        "type": "String"
+      }
+    }
+  },
+  "hoursLabel": "hours",
+  "dialogCloseLabel": "Close"
 }

--- a/lib/l10n/intl_en.arb
+++ b/lib/l10n/intl_en.arb
@@ -981,5 +981,13 @@
       "count": { "type": "int" },
       "winner": { "type": "String" }
     }
-  }
+  },
+  "fastingHomeChipBody": "Fasting · {remaining} left",
+  "@fastingHomeChipBody": {
+    "placeholders": {
+      "remaining": { "type": "String" }
+    }
+  },
+  "fastingNotificationCompleteTitle": "Fasting session complete",
+  "fastingNotificationCompleteBody": "Your target time has been reached."
 }

--- a/lib/l10n/intl_it.arb
+++ b/lib/l10n/intl_it.arb
@@ -187,7 +187,9 @@
   "customMealFormSimpleFieldHelper": "{unit} per porzione",
   "@customMealFormSimpleFieldHelper": {
     "placeholders": {
-      "unit": { "type": "String" }
+      "unit": {
+        "type": "String"
+      }
     }
   },
   "customMealsDeleteConfirmContent": "Tutte le voci del diario che utilizzano questo pasto verranno rimosse.",
@@ -839,5 +841,39 @@
   "settingsWaterGoalDescription": "Usato dal contatore d'acqua nella schermata principale.",
   "settingsWaterGoalLabel": "Obiettivo idrico giornaliero",
   "waterChipLabel": "{current} / {goal} ml",
-  "zincLabel": "zinco"
+  "zincLabel": "zinco",
+  "profileFastingEntry": "Timer di digiuno",
+  "fastingTitle": "Timer di digiuno",
+  "fastingSubtitle": "Un semplice timer per il tempo tra i pasti. Nessuna serie, nessun obiettivo, solo l'orologio.",
+  "fastingWarningTitle": "Prima di iniziare",
+  "fastingWarningBody": "Tenere traccia dei tempi di digiuno può aiutare alcune persone e turbarne altre, in particolare chi ha alle spalle un disturbo alimentare. Se è il tuo caso, prenditi prima cura di te. Puoi trovare sostegno presso BEAT (UK) e NEDA (US).",
+  "fastingWarningDecline": "Non fa per me",
+  "fastingWarningAccept": "Ho capito, attiva il timer",
+  "fastingPresetCustom": "Personalizzato",
+  "fastingStart": "Avvia timer",
+  "fastingCancel": "Termina digiuno",
+  "fastingCancelConfirmTitle": "Terminare il digiuno?",
+  "fastingCancelConfirmBody": "Chiuderà la sessione corrente.",
+  "fastingComplete": "Sessione completata",
+  "fastingLinkBeat": "BEAT (UK)",
+  "fastingLinkNeda": "NEDA (US)",
+  "fastingElapsedLabel": "Trascorso",
+  "fastingRemainingValue": "{value} rimanenti",
+  "@fastingRemainingValue": {
+    "placeholders": {
+      "value": {
+        "type": "String"
+      }
+    }
+  },
+  "fastingTargetValue": "Obiettivo: {value}",
+  "@fastingTargetValue": {
+    "placeholders": {
+      "value": {
+        "type": "String"
+      }
+    }
+  },
+  "hoursLabel": "ore",
+  "dialogCloseLabel": "Chiudi"
 }

--- a/lib/l10n/intl_it.arb
+++ b/lib/l10n/intl_it.arb
@@ -933,5 +933,13 @@
       "count": { "type": "int" },
       "winner": { "type": "String" }
     }
-  }
+  },
+  "fastingHomeChipBody": "Digiuno · {remaining} rimanenti",
+  "@fastingHomeChipBody": {
+    "placeholders": {
+      "remaining": { "type": "String" }
+    }
+  },
+  "fastingNotificationCompleteTitle": "Sessione di digiuno completata",
+  "fastingNotificationCompleteBody": "Il tuo tempo obiettivo è stato raggiunto."
 }

--- a/lib/l10n/intl_pl.arb
+++ b/lib/l10n/intl_pl.arb
@@ -933,5 +933,13 @@
       "count": { "type": "int" },
       "winner": { "type": "String" }
     }
-  }
+  },
+  "fastingHomeChipBody": "Post · pozostało {remaining}",
+  "@fastingHomeChipBody": {
+    "placeholders": {
+      "remaining": { "type": "String" }
+    }
+  },
+  "fastingNotificationCompleteTitle": "Sesja postu zakończona",
+  "fastingNotificationCompleteBody": "Czas docelowy został osiągnięty."
 }

--- a/lib/l10n/intl_pl.arb
+++ b/lib/l10n/intl_pl.arb
@@ -187,7 +187,9 @@
   "customMealFormSimpleFieldHelper": "{unit} w jednej porcji",
   "@customMealFormSimpleFieldHelper": {
     "placeholders": {
-      "unit": { "type": "String" }
+      "unit": {
+        "type": "String"
+      }
     }
   },
   "customMealsDeleteConfirmContent": "Wszystkie wpisy w dzienniku używające tego posiłku zostaną również usunięte.",
@@ -839,5 +841,39 @@
   "settingsWaterGoalDescription": "Używane przez wskaźnik wody na ekranie głównym.",
   "settingsWaterGoalLabel": "Dzienny cel wody",
   "waterChipLabel": "{current} / {goal} ml",
-  "zincLabel": "cynk"
+  "zincLabel": "cynk",
+  "profileFastingEntry": "Minutnik postu",
+  "fastingTitle": "Minutnik postu",
+  "fastingSubtitle": "Prosty minutnik do śledzenia czasu między posiłkami. Bez serii, bez celów, tylko zegar.",
+  "fastingWarningTitle": "Zanim zaczniesz",
+  "fastingWarningBody": "Śledzenie czasu postu jednym pomaga, a innym może szkodzić, szczególnie osobom z historią zaburzeń odżywiania. Jeśli to o tobie, zadbaj najpierw o siebie. Wsparcie oferują BEAT (UK) i NEDA (US).",
+  "fastingWarningDecline": "To nie dla mnie",
+  "fastingWarningAccept": "Rozumiem, włącz minutnik",
+  "fastingPresetCustom": "Własny",
+  "fastingStart": "Uruchom minutnik",
+  "fastingCancel": "Zakończ post",
+  "fastingCancelConfirmTitle": "Zakończyć post teraz?",
+  "fastingCancelConfirmBody": "Bieżąca sesja zostanie zamknięta.",
+  "fastingComplete": "Sesja zakończona",
+  "fastingLinkBeat": "BEAT (UK)",
+  "fastingLinkNeda": "NEDA (US)",
+  "fastingElapsedLabel": "Upłynęło",
+  "fastingRemainingValue": "Pozostało {value}",
+  "@fastingRemainingValue": {
+    "placeholders": {
+      "value": {
+        "type": "String"
+      }
+    }
+  },
+  "fastingTargetValue": "Cel: {value}",
+  "@fastingTargetValue": {
+    "placeholders": {
+      "value": {
+        "type": "String"
+      }
+    }
+  },
+  "hoursLabel": "godziny",
+  "dialogCloseLabel": "Zamknij"
 }

--- a/lib/l10n/intl_sk.arb
+++ b/lib/l10n/intl_sk.arb
@@ -963,5 +963,13 @@
       "count": { "type": "int" },
       "winner": { "type": "String" }
     }
-  }
+  },
+  "fastingHomeChipBody": "Pôst · zostáva {remaining}",
+  "@fastingHomeChipBody": {
+    "placeholders": {
+      "remaining": { "type": "String" }
+    }
+  },
+  "fastingNotificationCompleteTitle": "Pôst dokončený",
+  "fastingNotificationCompleteBody": "Cieľový čas bol dosiahnutý."
 }

--- a/lib/l10n/intl_sk.arb
+++ b/lib/l10n/intl_sk.arb
@@ -234,7 +234,9 @@
   "customMealFormSimpleFieldHelper": "{unit} v jednej porcii",
   "@customMealFormSimpleFieldHelper": {
     "placeholders": {
-      "unit": { "type": "String" }
+      "unit": {
+        "type": "String"
+      }
     }
   },
   "customMealsDeleteConfirmContent": "Všetky záznamy v denníku, ktoré používajú toto jedlo, budú tiež odstránené.",
@@ -869,5 +871,39 @@
   "settingsWaterGoalDescription": "Používa sa ukazovateľom vody na hlavnej obrazovke.",
   "settingsWaterGoalLabel": "Denný cieľ pitia vody",
   "waterChipLabel": "{current} / {goal} ml",
-  "zincLabel": "zinok"
+  "zincLabel": "zinok",
+  "profileFastingEntry": "Časovač pôstu",
+  "fastingTitle": "Časovač pôstu",
+  "fastingSubtitle": "Jednoduchý časovač na sledovanie času medzi jedlami. Žiadne série, žiadne ciele, len hodiny.",
+  "fastingWarningTitle": "Skôr než začneš",
+  "fastingWarningBody": "Sledovanie času pôstu môže byť niekomu užitočné a niekoho zraniť, najmä ak má za sebou poruchu príjmu potravy. Ak si to ty, postaraj sa najprv o seba. Podporu poskytujú BEAT (UK) a NEDA (US).",
+  "fastingWarningDecline": "Nie je to pre mňa",
+  "fastingWarningAccept": "Rozumiem, zapnúť časovač",
+  "fastingPresetCustom": "Vlastné",
+  "fastingStart": "Spustiť časovač",
+  "fastingCancel": "Ukončiť pôst",
+  "fastingCancelConfirmTitle": "Ukončiť pôst teraz?",
+  "fastingCancelConfirmBody": "Aktuálna relácia bude uzavretá.",
+  "fastingComplete": "Relácia dokončená",
+  "fastingLinkBeat": "BEAT (UK)",
+  "fastingLinkNeda": "NEDA (US)",
+  "fastingElapsedLabel": "Uplynulo",
+  "fastingRemainingValue": "Zostáva {value}",
+  "@fastingRemainingValue": {
+    "placeholders": {
+      "value": {
+        "type": "String"
+      }
+    }
+  },
+  "fastingTargetValue": "Cieľ: {value}",
+  "@fastingTargetValue": {
+    "placeholders": {
+      "value": {
+        "type": "String"
+      }
+    }
+  },
+  "hoursLabel": "hodiny",
+  "dialogCloseLabel": "Zavrieť"
 }

--- a/lib/l10n/intl_tr.arb
+++ b/lib/l10n/intl_tr.arb
@@ -218,7 +218,9 @@
   "customMealFormSimpleFieldHelper": "{unit} porsiyon başına",
   "@customMealFormSimpleFieldHelper": {
     "placeholders": {
-      "unit": { "type": "String" }
+      "unit": {
+        "type": "String"
+      }
     }
   },
   "customMealsDeleteConfirmContent": "Bu yemeği kullanan tüm günlük girişleri de kaldırılacak.",
@@ -870,5 +872,39 @@
   "settingsWaterGoalDescription": "Ana ekrandaki su göstergesinin kullandığı hedef.",
   "settingsWaterGoalLabel": "Günlük su hedefi",
   "waterChipLabel": "{current} / {goal} ml",
-  "zincLabel": "çinko"
+  "zincLabel": "çinko",
+  "profileFastingEntry": "Oruç zamanlayıcısı",
+  "fastingTitle": "Oruç zamanlayıcısı",
+  "fastingSubtitle": "Öğünler arası süreyi izlemek için basit bir zamanlayıcı. Seri yok, hedef yok, sadece saat.",
+  "fastingWarningTitle": "Başlamadan önce",
+  "fastingWarningBody": "Oruç sürelerini takip etmek bazı insanlara iyi gelirken, özellikle yeme bozukluğu geçmişi olanlar için zorlayıcı olabilir. Bu sen olabilirsen lütfen önce kendine iyi bak. Destek için BEAT (UK) ve NEDA (US) yardımcı olabilir.",
+  "fastingWarningDecline": "Bana göre değil",
+  "fastingWarningAccept": "Anladım, zamanlayıcıyı aç",
+  "fastingPresetCustom": "Özel",
+  "fastingStart": "Zamanlayıcıyı başlat",
+  "fastingCancel": "Orucu sonlandır",
+  "fastingCancelConfirmTitle": "Orucu şimdi sonlandırılsın mı?",
+  "fastingCancelConfirmBody": "Bu, mevcut oturumu kapatacak.",
+  "fastingComplete": "Oturum tamamlandı",
+  "fastingLinkBeat": "BEAT (UK)",
+  "fastingLinkNeda": "NEDA (US)",
+  "fastingElapsedLabel": "Geçen",
+  "fastingRemainingValue": "{value} kaldı",
+  "@fastingRemainingValue": {
+    "placeholders": {
+      "value": {
+        "type": "String"
+      }
+    }
+  },
+  "fastingTargetValue": "Hedef: {value}",
+  "@fastingTargetValue": {
+    "placeholders": {
+      "value": {
+        "type": "String"
+      }
+    }
+  },
+  "hoursLabel": "saat",
+  "dialogCloseLabel": "Kapat"
 }

--- a/lib/l10n/intl_tr.arb
+++ b/lib/l10n/intl_tr.arb
@@ -964,5 +964,13 @@
       "count": { "type": "int" },
       "winner": { "type": "String" }
     }
-  }
+  },
+  "fastingHomeChipBody": "Oruç · {remaining} kaldı",
+  "@fastingHomeChipBody": {
+    "placeholders": {
+      "remaining": { "type": "String" }
+    }
+  },
+  "fastingNotificationCompleteTitle": "Oruç süresi tamamlandı",
+  "fastingNotificationCompleteBody": "Hedef sürene ulaştın."
 }

--- a/lib/l10n/intl_uk.arb
+++ b/lib/l10n/intl_uk.arb
@@ -187,7 +187,9 @@
   "customMealFormSimpleFieldHelper": "{unit} в одній порції",
   "@customMealFormSimpleFieldHelper": {
     "placeholders": {
-      "unit": { "type": "String" }
+      "unit": {
+        "type": "String"
+      }
     }
   },
   "customMealsDeleteConfirmContent": "Усі записи в щоденнику, що використовують цю страву, також буде видалено.",
@@ -839,5 +841,39 @@
   "settingsWaterGoalDescription": "Використовується індикатором води на головному екрані.",
   "settingsWaterGoalLabel": "Денна ціль вживання води",
   "waterChipLabel": "{current} / {goal} мл",
-  "zincLabel": "цинк"
+  "zincLabel": "цинк",
+  "profileFastingEntry": "Таймер посту",
+  "fastingTitle": "Таймер посту",
+  "fastingSubtitle": "Простий таймер для часу між прийомами їжі. Без серій, без цілей, лише годинник.",
+  "fastingWarningTitle": "Перш ніж почати",
+  "fastingWarningBody": "Відстеження часу посту комусь допомагає, а декому може шкодити, особливо людям із досвідом розладів харчової поведінки. Якщо це про вас, будь ласка, спершу подбайте про себе. Підтримку надають BEAT (UK) і NEDA (US).",
+  "fastingWarningDecline": "Це не для мене",
+  "fastingWarningAccept": "Розумію, увімкнути таймер",
+  "fastingPresetCustom": "Власний",
+  "fastingStart": "Запустити таймер",
+  "fastingCancel": "Завершити піст",
+  "fastingCancelConfirmTitle": "Завершити піст зараз?",
+  "fastingCancelConfirmBody": "Поточну сесію буде закрито.",
+  "fastingComplete": "Сесію завершено",
+  "fastingLinkBeat": "BEAT (UK)",
+  "fastingLinkNeda": "NEDA (US)",
+  "fastingElapsedLabel": "Минуло",
+  "fastingRemainingValue": "Залишилося {value}",
+  "@fastingRemainingValue": {
+    "placeholders": {
+      "value": {
+        "type": "String"
+      }
+    }
+  },
+  "fastingTargetValue": "Ціль: {value}",
+  "@fastingTargetValue": {
+    "placeholders": {
+      "value": {
+        "type": "String"
+      }
+    }
+  },
+  "hoursLabel": "години",
+  "dialogCloseLabel": "Закрити"
 }

--- a/lib/l10n/intl_uk.arb
+++ b/lib/l10n/intl_uk.arb
@@ -933,5 +933,13 @@
       "count": { "type": "int" },
       "winner": { "type": "String" }
     }
-  }
+  },
+  "fastingHomeChipBody": "Голодування · залишилось {remaining}",
+  "@fastingHomeChipBody": {
+    "placeholders": {
+      "remaining": { "type": "String" }
+    }
+  },
+  "fastingNotificationCompleteTitle": "Сесія голодування завершена",
+  "fastingNotificationCompleteBody": "Цільовий час досягнуто."
 }

--- a/lib/l10n/intl_zh.arb
+++ b/lib/l10n/intl_zh.arb
@@ -934,5 +934,13 @@
       "count": { "type": "int" },
       "winner": { "type": "String" }
     }
-  }
+  },
+  "fastingHomeChipBody": "禁食中 · 剩余 {remaining}",
+  "@fastingHomeChipBody": {
+    "placeholders": {
+      "remaining": { "type": "String" }
+    }
+  },
+  "fastingNotificationCompleteTitle": "禁食时间到了",
+  "fastingNotificationCompleteBody": "已达到你的目标时间。"
 }

--- a/lib/l10n/intl_zh.arb
+++ b/lib/l10n/intl_zh.arb
@@ -188,7 +188,9 @@
   "customMealFormSimpleFieldHelper": "每份 {unit}",
   "@customMealFormSimpleFieldHelper": {
     "placeholders": {
-      "unit": { "type": "String" }
+      "unit": {
+        "type": "String"
+      }
     }
   },
   "customMealsDeleteConfirmContent": "所有使用此餐食的日记条目也将被删除。",
@@ -840,5 +842,39 @@
   "settingsWaterGoalDescription": "主屏幕上的饮水提示使用此目标。",
   "settingsWaterGoalLabel": "每日饮水目标",
   "waterChipLabel": "{current} / {goal} 毫升",
-  "zincLabel": "锌"
+  "zincLabel": "锌",
+  "profileFastingEntry": "断食计时器",
+  "fastingTitle": "断食计时器",
+  "fastingSubtitle": "用来追踪两餐之间时间的简单计时器。没有连胜,没有目标,只是时钟。",
+  "fastingWarningTitle": "开始之前",
+  "fastingWarningBody": "记录断食时间对某些人有帮助,但对另一些人(尤其是有进食障碍经历的人)可能造成困扰。如果你属于这种情况,请先照顾好自己。BEAT(英国)和 NEDA(美国)提供专业支持。",
+  "fastingWarningDecline": "不适合我",
+  "fastingWarningAccept": "我了解,启用计时器",
+  "fastingPresetCustom": "自定义",
+  "fastingStart": "开始计时",
+  "fastingCancel": "结束断食",
+  "fastingCancelConfirmTitle": "现在结束断食?",
+  "fastingCancelConfirmBody": "这将关闭当前会话。",
+  "fastingComplete": "会话完成",
+  "fastingLinkBeat": "BEAT(英国)",
+  "fastingLinkNeda": "NEDA(美国)",
+  "fastingElapsedLabel": "已用",
+  "fastingRemainingValue": "剩余 {value}",
+  "@fastingRemainingValue": {
+    "placeholders": {
+      "value": {
+        "type": "String"
+      }
+    }
+  },
+  "fastingTargetValue": "目标:{value}",
+  "@fastingTargetValue": {
+    "placeholders": {
+      "value": {
+        "type": "String"
+      }
+    }
+  },
+  "hoursLabel": "小时",
+  "dialogCloseLabel": "关闭"
 }

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -25,6 +25,7 @@ import 'package:opennutritracker/features/add_meal/presentation/add_meal_screen.
 import 'package:opennutritracker/features/add_activity/presentation/add_activity_screen.dart';
 import 'package:opennutritracker/features/edit_meal/presentation/edit_meal_screen.dart';
 import 'package:opennutritracker/features/onboarding/onboarding_screen.dart';
+import 'package:opennutritracker/features/fasting/presentation/fasting_screen.dart';
 import 'package:opennutritracker/features/profile/presentation/weight_history_screen.dart';
 import 'package:opennutritracker/features/recipes/presentation/screens/import_recipe_scanner_screen.dart';
 import 'package:opennutritracker/features/recipes/presentation/screens/recipe_builder_screen.dart';
@@ -188,6 +189,7 @@ class OpenNutriTrackerApp extends StatelessWidget {
             const ImportRecipeScannerScreen(),
         NavigationOptions.weightHistoryRoute: (context) =>
             const WeightHistoryScreen(),
+        NavigationOptions.fastingRoute: (context) => const FastingScreen(),
       },
     );
   }

--- a/test/unit_test/fasting_bloc_test.dart
+++ b/test/unit_test/fasting_bloc_test.dart
@@ -1,0 +1,172 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:opennutritracker/core/data/dbo/app_theme_dbo.dart';
+import 'package:opennutritracker/core/data/repository/config_repository.dart';
+import 'package:opennutritracker/core/domain/entity/app_theme_entity.dart';
+import 'package:opennutritracker/core/domain/entity/config_entity.dart';
+import 'package:opennutritracker/core/domain/usecase/get_config_usecase.dart';
+import 'package:opennutritracker/features/fasting/data/repository/fasting_repository.dart';
+import 'package:opennutritracker/features/fasting/domain/entity/fasting_session_entity.dart';
+import 'package:opennutritracker/features/fasting/domain/usecase/acknowledge_fasting_warning_usecase.dart';
+import 'package:opennutritracker/features/fasting/domain/usecase/cancel_fasting_usecase.dart';
+import 'package:opennutritracker/features/fasting/domain/usecase/complete_fasting_usecase.dart';
+import 'package:opennutritracker/features/fasting/domain/usecase/get_active_fasting_session_usecase.dart';
+import 'package:opennutritracker/features/fasting/domain/usecase/start_fasting_usecase.dart';
+import 'package:opennutritracker/features/fasting/presentation/bloc/fasting_bloc.dart';
+
+/// In-memory fake of [FastingRepository]. Holds sessions by id and tracks
+/// add/update calls so the bloc tests can assert side-effects without needing
+/// Hive or a mocking library.
+class _FakeFastingRepository implements FastingRepository {
+  final Map<String, FastingSessionEntity> _sessions = {};
+  int addCalls = 0;
+  int updateCalls = 0;
+  FastingSessionEntity? lastUpdated;
+
+  @override
+  Future<void> addSession(FastingSessionEntity session) async {
+    addCalls++;
+    _sessions[session.id] = session;
+  }
+
+  @override
+  Future<void> updateSession(FastingSessionEntity session) async {
+    updateCalls++;
+    lastUpdated = session;
+    _sessions[session.id] = session;
+  }
+
+  @override
+  Future<FastingSessionEntity?> getActiveSession() async {
+    for (final s in _sessions.values) {
+      if (s.isActive) return s;
+    }
+    return null;
+  }
+
+  @override
+  Future<FastingSessionEntity?> getSession(String id) async => _sessions[id];
+
+  @override
+  Future<List<FastingSessionEntity>> allSessions() async =>
+      _sessions.values.toList();
+}
+
+/// Minimal stub for [ConfigRepository] — only the surface the bloc reaches
+/// (getConfig + setFastingWarningAcknowledged) needs to behave.
+class _FakeConfigRepository implements ConfigRepository {
+  bool acknowledged;
+
+  _FakeConfigRepository(this.acknowledged);
+
+  @override
+  Future<ConfigEntity> getConfig() async {
+    return ConfigEntity(
+      true,
+      true,
+      false,
+      AppThemeEntity.system,
+      fastingWarningAcknowledged: acknowledged,
+    );
+  }
+
+  @override
+  Future<void> setFastingWarningAcknowledged(bool value) async {
+    acknowledged = value;
+  }
+
+  // The bloc never touches anything else, so satisfy the remaining surface
+  // with noClassReflection-style no-ops.
+  @override
+  dynamic noSuchMethod(Invocation invocation) => super.noSuchMethod(invocation);
+}
+
+void main() {
+  // Hide an unused import warning by mentioning the symbol where the
+  // analyzer can see it. AppThemeDBO is reachable via fromConfigDBO but not
+  // otherwise referenced in this file.
+  // ignore: unused_local_variable
+  final _ = AppThemeDBO.system;
+
+  group('FastingBloc', () {
+    late _FakeFastingRepository fastingRepo;
+    late _FakeConfigRepository configRepo;
+    late FastingBloc bloc;
+
+    setUp(() {
+      fastingRepo = _FakeFastingRepository();
+      configRepo = _FakeConfigRepository(true);
+      bloc = FastingBloc(
+        GetConfigUsecase(configRepo),
+        GetActiveFastingSessionUseCase(fastingRepo),
+        StartFastingUseCase(fastingRepo),
+        CancelFastingUseCase(fastingRepo),
+        CompleteFastingUseCase(fastingRepo),
+        AcknowledgeFastingWarningUseCase(configRepo),
+      );
+    });
+
+    tearDown(() async {
+      await bloc.close();
+    });
+
+    test('initial state is FastingInitial', () {
+      expect(bloc.state, isA<FastingInitial>());
+    });
+
+    test('start then cancel records cancelledAt, not completedAt', () async {
+      bloc.add(const FastingStartRequested(60));
+      // Wait for the event loop to process.
+      await Future<void>.delayed(const Duration(milliseconds: 20));
+      expect(bloc.state, isA<FastingActive>());
+      expect(fastingRepo.addCalls, 1);
+
+      bloc.add(const FastingCancelRequested());
+      await Future<void>.delayed(const Duration(milliseconds: 20));
+
+      expect(bloc.state, isA<FastingIdle>());
+      expect(fastingRepo.updateCalls, 1);
+      expect(fastingRepo.lastUpdated, isNotNull);
+      expect(fastingRepo.lastUpdated!.cancelledAt, isNotNull);
+      expect(
+        fastingRepo.lastUpdated!.completedAt,
+        isNull,
+        reason:
+            'A user-cancelled session must not be recorded as completed; '
+            'the two outcomes are tracked separately so neither path reads '
+            'as failure.',
+      );
+    });
+
+    test('reaching target naturally records completedAt', () async {
+      // 0-minute target so the very first tick fires the completion path.
+      bloc.add(const FastingStartRequested(0));
+      await Future<void>.delayed(const Duration(milliseconds: 20));
+      expect(bloc.state, isA<FastingActive>());
+
+      // Drive a synthetic tick at "now + 1 second" so the bloc believes the
+      // target has been reached without waiting on the wall-clock timer.
+      bloc.add(FastingTicked(DateTime.now().add(const Duration(seconds: 1))));
+      await Future<void>.delayed(const Duration(milliseconds: 20));
+
+      expect(bloc.state, isA<FastingCompleted>());
+      expect(fastingRepo.updateCalls, 1);
+      expect(fastingRepo.lastUpdated!.completedAt, isNotNull);
+      expect(fastingRepo.lastUpdated!.cancelledAt, isNull);
+    });
+
+    test(
+      'load with un-acknowledged warning emits FastingWarningRequired',
+      () async {
+        configRepo.acknowledged = false;
+        bloc.add(const FastingLoadRequested());
+        await Future<void>.delayed(const Duration(milliseconds: 20));
+        expect(bloc.state, isA<FastingWarningRequired>());
+
+        bloc.add(const FastingWarningAcknowledged());
+        await Future<void>.delayed(const Duration(milliseconds: 20));
+        expect(bloc.state, isA<FastingIdle>());
+        expect(configRepo.acknowledged, isTrue);
+      },
+    );
+  });
+}


### PR DESCRIPTION
Closes #84.

## What this is

A fasting timer anyone using OpenNutriTracker can opt into without the app pushing them toward it. Intermittent-fasting timers are a real tool for some people and a real risk for others, especially anyone in recovery from disordered eating, so the feature is shaped around that tension all the way through: the warning gate, the copy, the absence of streaks, what the home screen does when a fast is active, what happens when a session ends. None of those choices are accidental.

## The shape on screen

- **Profile → Fasting timer entry** drops you into the feature.
- **First-run content warning**: a dialog titled "Before you start" names disordered-eating sensitivity directly, offers BEAT (UK) and NEDA (US) as supports with tappable links, and waits for an explicit "I understand, enable timer" before continuing. "Not for me" sends the user straight back to Profile with no timer enabled.
- **Setup screen**: five preset chips (13h / 16h / 18h / 20h / 36h), a "Custom..." option, and a Start button. Subtitle copy is plain and non-prescriptive — "A simple timer for tracking time between meals. No streaks, no targets, just the clock."
- **Running screen**: elapsed time on top, remaining time and target below, an "End fast" cancel control. No "you broke your fast" framing on cancel.
- **Completion screen**: a centred check icon, "Session complete", and a Close button. The Column was originally aligned only on the main axis, which left children flush against the start edge — fixed in a follow-up commit by adding `crossAxisAlignment: center` and `textAlign: TextAlign.center` on the label.
- **Home chip**: a compact pill on the home dashboard reading "Fasting · 15h 57m left" with a timer icon. It only renders while a session is active — when fasting is dormant the home screen stays quiet, no "Start a fast →" prompt, no encouragement to begin one. Tapping it opens the timer screen.
- **Completion notification**: a one-shot local notification scheduled at session start for `startedAt + targetDuration`. The OS owns delivery from the schedule point, so the app doesn't have to be running when the target lands. Notification copy is plain — "Fasting session complete · Your target time has been reached." No "Great work!", no streak counter.

## Data model

Two new Hive types and one new field on `ConfigDBO`:

- `FastingSessionDBO` at `typeId: 22` — `id`, `startedAt`, `targetDurationMinutes`, optional `completedAt`, optional `cancelledAt`. Persisted in a new `FastingBox` so the running session survives app kills, OS reboots, and the entire app being backgrounded for ten hours overnight.
- `ConfigDBO.fastingWarningAcknowledged: bool?` at `@HiveField(25)`. Nullable so existing users (and anyone who's never opened the screen) get the dialog the first time, and so a future cold-storage migration doesn't trip over a missing field.
- A separate `NotificationService` channel (`fasting_complete`, id 1) for the completion notification, so users who want to mute fasting pings can do so without losing their daily meal-log reminder.

## What I deliberately did not add

- **No streaks, no badges, no "you've fasted N days in a row".** The single most consistent finding in the literature on intermittent fasting and disordered eating is that gamification of fasting is the part that goes wrong. The feature lives or dies on this.
- **No "you broke your fast early" framing on cancel.** The cancel dialog reads "End fast now? This will close the current session." That's it. No friction, no confession.
- **No hiding of the diary's Breakfast / Lunch / Dinner sections during an active fast.** I considered this and recommended against it — locking the meal-logging path behind an "End fast" tap turns fasting from a tool into an enforced rule, which is exactly the framing the feature is trying to step away from.
- **No "Start a fast →" prompt on the home chip when no session is active.** The chip is silent when fasting is dormant. Someone who acknowledged the warning once and then chose not to fast again sees nothing.

## Bugs caught during on-device verification

Two real bugs in the notification flow surfaced during the on-device 30-second test and were fixed before this PR settled:

1. **Listener fired on every state emission, not transitions.** Each tick re-emitted `FastingActive` with a new `now`, so the BlocConsumer listener cancelled and re-scheduled the OS-level alarm every second. The final tick at target landed at almost exactly the wall-clock moment of the scheduled alarm, and the cancel raced ahead of the alarm firing. Fixed by adding a `listenWhen` guard so the listener only fires on the transitions that matter — enter-Active, enter-Idle, and warning-required.
2. **Cancellation on `FastingCompleted` was wrong.** That's the natural-completion case — exactly the moment the alarm should be firing. Cancellation should only happen when the user actively ends the fast (state == `FastingIdle`). Removed the `|| state is FastingCompleted` branch from the cancel arm.

A third smaller fix landed in the same sweep: the timer-complete page's Column had `mainAxisAlignment: center` but no `crossAxisAlignment`, so children stacked against the start edge. Added `crossAxisAlignment: center` plus `textAlign: center` on the label.

## Verified end-to-end on a Pixel

- [x] `just check_intl && fvm flutter analyze && fvm flutter test` clean — 574 tests pass (4 new in `fasting_bloc_test.dart` covering initial state, start → cancel, start → natural-complete, and the warning-required → acknowledged transition)
- [x] Profile → Fasting timer → warning dialog appears with BEAT / NEDA links → "I understand, enable timer" → setup screen with all five preset chips → pick 16h → Start → timer counts up
- [x] **Persistence**: with a session running, `adb shell am force-stop`, wait 50 seconds, relaunch → elapsed time correctly resumed at ~50 seconds further along
- [x] **Home chip**: while a session is active, the home dashboard shows "Fasting · 15h 57m left" with a timer icon. Tapping opens the fasting screen. When the session ends (cancel or complete), the chip disappears
- [x] **Notification permission**: the OS prompt fires the first time a session starts, then is remembered. Granting permission schedules the notification at `startedAt + targetDuration`
- [x] **Notification delivery**: verified by temporarily hard-coding a 30-second target on a throwaway build (not committed). The alarm registered at the right wall-clock time, survived app backgrounding, and the OS delivered the notification to the `fasting_complete` channel a short while after target. Used `inexactAllowWhileIdle` scheduling so iOS-style precision isn't guaranteed on Android, but for a 16-hour fast the few-second drift is invisible
- [x] **Warning is one-time per device**: after acknowledging once, returning to the fasting screen on the same install skips the dialog
- [x] **Completion screen centred**: the check icon, "Session complete" label, and Close button all sit on the visual vertical axis rather than flush against the left edge
- [x] **Localised across all nine locales** (en, de, cs, it, pl, sk, tr, uk, zh) — every string carries a real translation, manual `generated/l10n.dart` + `messages_<locale>.dart` updated to match

## Cross-platform notes

The notification path is `flutter_local_notifications` via `_plugin.zonedSchedule(...)`, which routes to the OS scheduler on each platform. On Android we pass `AndroidScheduleMode.inexactAllowWhileIdle` so the OS can defer delivery in Doze; on iOS the same call delegates to `UNUserNotificationCenter` scheduled notifications, which fire at the requested wall-clock time without battery deferral. The fix for both bugs above is pure Dart and applies to both platforms identically. iOS native plumbing (`Podfile.lock` + `AppDelegate.swift`'s `UNUserNotificationCenterDelegate` registration) is already in place from the existing daily reminder, so this PR doesn't touch any iOS-side configuration.

I haven't physically tested on iOS because I'm on Linux without a Mac. Two things worth verifying once a TestFlight build is in someone's hands:

- The first-run permission prompt actually appears on a fresh iOS install. The existing daily reminder uses the same plumbing in production so this should already be working.
- Force-quit from the iOS app switcher with an active fasting session still delivers the notification at the right time. iOS 16+ keeps scheduled local notifications alive across force-quit; the project's deployment target should already sit above that floor.

## Notes worth flagging for review

- The fasting bloc is registered as a factory in `locator.dart`, so the home chip and the fasting screen each create their own instance. They share state on disk via `FastingDataSource` rather than in-memory, which keeps things simple but means each instance runs its own `Timer.periodic`. Cheap to do, easy to reason about, no global stream to wire up. Worth flagging in case you'd rather make it a singleton.
- Notification copy is plain English in the body text. Same pattern the existing daily reminder uses (`main.dart` line 66 has a hardcoded English string), so this matches the established convention rather than introducing a new one.
