### PR TITLE
feat(recipes): barcode scanner for the ingredient picker

### DIFF
--- a/lib/features/recipes/presentation/screens/recipe_builder_screen.dart
+++ b/lib/features/recipes/presentation/screens/recipe_builder_screen.dart
@@ -7,6 +7,7 @@ import 'package:image_picker/image_picker.dart';
 import 'package:opennutritracker/core/domain/entity/recipe_entity.dart';
 import 'package:opennutritracker/core/presentation/widgets/user_image_picker_tile.dart';
 import 'package:opennutritracker/core/utils/locator.dart';
+import 'package:opennutritracker/core/utils/navigation_options.dart';
 import 'package:opennutritracker/core/utils/user_image_storage.dart';
 import 'package:opennutritracker/features/add_meal/domain/entity/meal_entity.dart';
 import 'package:opennutritracker/features/recipes/presentation/bloc/recipe_builder_bloc.dart';
@@ -14,6 +15,7 @@ import 'package:opennutritracker/features/recipes/presentation/widgets/food_sear
 import 'package:opennutritracker/features/recipes/presentation/widgets/ingredient_list_item.dart';
 import 'package:opennutritracker/features/recipes/presentation/widgets/ingredient_quantity_dialog.dart';
 import 'package:opennutritracker/features/recipes/presentation/widgets/recipe_nutrition_summary.dart';
+import 'package:opennutritracker/features/scanner/scanner_screen.dart';
 import 'package:opennutritracker/generated/l10n.dart';
 
 class RecipeBuilderArguments {
@@ -316,12 +318,27 @@ class _RecipeBuilderScreenState extends State<RecipeBuilderScreen> {
   Future<void> _onAddIngredient(BuildContext context) async {
     final selectedMeal = await Navigator.of(context).push<MealEntity>(
       MaterialPageRoute(
-        builder: (_) => Scaffold(
+        builder: (searchContext) => Scaffold(
           appBar: AppBar(
             title: Text(S.of(context).recipeAddIngredientLabel),
           ),
           body: FoodSearchTabView(
-            onMealSelected: (meal) => Navigator.of(context).pop(meal),
+            onMealSelected: (meal) => Navigator.of(searchContext).pop(meal),
+            onBarcodePressed: () async {
+              // Push the scanner in pick-mode — it pops a MealEntity back to
+              // us instead of routing into the meal-detail logging flow. We
+              // then thread the scanned meal through the same code path the
+              // tap-to-pick handler uses, so the quantity dialog runs
+              // identically whether the user typed or scanned.
+              final scannedMeal = await Navigator.of(searchContext)
+                  .pushNamed(
+                    NavigationOptions.scannerRoute,
+                    arguments: ScannerScreenArguments.pick(),
+                  );
+              if (scannedMeal is MealEntity && searchContext.mounted) {
+                Navigator.of(searchContext).pop(scannedMeal);
+              }
+            },
           ),
         ),
       ),

--- a/lib/features/recipes/presentation/widgets/food_search_tab_view.dart
+++ b/lib/features/recipes/presentation/widgets/food_search_tab_view.dart
@@ -20,8 +20,16 @@ import 'package:opennutritracker/generated/l10n.dart';
 /// existing AddMealScreen flow.
 class FoodSearchTabView extends StatefulWidget {
   final void Function(MealEntity meal) onMealSelected;
+  // When non-null, the search bar shows a barcode-scan suffix icon and
+  // taps are forwarded here. The recipe builder uses this to push the
+  // scanner in pick mode and feed the result back through [onMealSelected].
+  final VoidCallback? onBarcodePressed;
 
-  const FoodSearchTabView({super.key, required this.onMealSelected});
+  const FoodSearchTabView({
+    super.key,
+    required this.onMealSelected,
+    this.onBarcodePressed,
+  });
 
   @override
   State<FoodSearchTabView> createState() => _FoodSearchTabViewState();
@@ -63,7 +71,7 @@ class _FoodSearchTabViewState extends State<FoodSearchTabView>
           MealSearchBar(
             searchStringListener: _searchStringListener,
             onSearchSubmit: _onSearchSubmit,
-            onBarcodePressed: null,
+            onBarcodePressed: widget.onBarcodePressed,
           ),
           const SizedBox(height: 16),
           TabBar(

--- a/lib/features/scanner/scanner_screen.dart
+++ b/lib/features/scanner/scanner_screen.dart
@@ -28,8 +28,17 @@ class _ScannerScreenState extends State<ScannerScreen> {
   final log = Logger('ScannerScreen');
 
   String? _scannedBarcode;
-  late IntakeTypeEntity _intakeTypeEntity;
-  late DateTime _day;
+  IntakeTypeEntity? _intakeTypeEntity;
+  DateTime? _day;
+  bool _pickMode = false;
+  // BlocBuilder can rebuild for [ScannerLoadedState] more than once before
+  // the scanner route is fully unmounted (e.g. the route-transition's
+  // parent rebuild propagates down). Without this latch, the second
+  // microtask races against the now-removed scanner and ends up popping
+  // whichever route is on top — in the recipe ingredient flow that's the
+  // quantity-dialog bottom sheet, which then crashes with a result-type
+  // mismatch. The latch makes the post-load navigation idempotent.
+  bool _navigatedAfterLoad = false;
 
   late ScannerBloc _scannerBloc;
 
@@ -45,6 +54,7 @@ class _ScannerScreenState extends State<ScannerScreen> {
         ModalRoute.of(context)?.settings.arguments as ScannerScreenArguments;
     _intakeTypeEntity = args.intakeTypeEntity;
     _day = args.day;
+    _pickMode = args.pickMode;
     if (args.initialBarcode != null && _scannedBarcode == null) {
       _scannedBarcode = args.initialBarcode;
       _scannerBloc.add(ScannerLoadProductEvent(barcode: args.initialBarcode!));
@@ -72,19 +82,28 @@ class _ScannerScreenState extends State<ScannerScreen> {
           );
         } else if (state is ScannerLoadedState) {
           // Push new route after build
-          Future.microtask(() {
-            if (context.mounted) {
-              return Navigator.of(context).pushReplacementNamed(
+          if (!_navigatedAfterLoad) {
+            _navigatedAfterLoad = true;
+            Future.microtask(() {
+              if (!context.mounted) return;
+              if (_pickMode) {
+                // Recipe ingredient picker — hand the loaded MealEntity back
+                // to whoever pushed us instead of routing into the meal-detail
+                // logging flow.
+                Navigator.of(context).pop(state.product);
+                return;
+              }
+              Navigator.of(context).pushReplacementNamed(
                 NavigationOptions.mealDetailRoute,
                 arguments: MealDetailScreenArguments(
                   state.product,
-                  _intakeTypeEntity,
-                  _day,
+                  _intakeTypeEntity!,
+                  _day!,
                   state.usesImperialUnits,
                 ),
               );
-            }
-          });
+            });
+          }
         } else if (state is ScannerFailedState) {
           return Scaffold(
             appBar: AppBar(),
@@ -148,13 +167,19 @@ class _ScannerScreenState extends State<ScannerScreen> {
                   // arrive as plain text/url (not BarcodeType.product). If
                   // one of these is recognised, hand off to the matching
                   // import screen with the already-scanned code so the
-                  // user doesn't have to scan a second time.
-                  final kind = classifySharedPayload(raw);
-                  if (kind != null) {
-                    _scannedBarcode = raw;
-                    log.fine('Shared payload found: $kind');
-                    _routeToSharedImport(kind, raw);
-                    return;
+                  // user doesn't have to scan a second time. In pick mode
+                  // (recipe ingredient picker) we ignore these — handing
+                  // off would silently abandon the recipe builder mid-edit,
+                  // and a shared meal/recipe/activity isn't a single
+                  // ingredient anyway.
+                  if (!_pickMode) {
+                    final kind = classifySharedPayload(raw);
+                    if (kind != null) {
+                      _scannedBarcode = raw;
+                      log.fine('Shared payload found: $kind');
+                      _routeToSharedImport(kind, raw);
+                      return;
+                    }
                   }
 
                   if (barcode.type == BarcodeType.product) {
@@ -238,6 +263,11 @@ class _ScannerScreenState extends State<ScannerScreen> {
   }
 
   void _routeToSharedImport(SharedPayloadKind kind, String code) {
+    // Pick-mode skips shared-payload handling entirely (see onDetect), so
+    // by the time we land here `_intakeTypeEntity` and `_day` were set from
+    // the logging-flow args.
+    final intakeType = _intakeTypeEntity!;
+    final day = _day!;
     final navigator = Navigator.of(context);
     Future.microtask(() {
       if (!mounted) return;
@@ -246,9 +276,9 @@ class _ScannerScreenState extends State<ScannerScreen> {
           navigator.pushReplacementNamed(
             NavigationOptions.importMealScannerRoute,
             arguments: ImportMealScannerArguments(
-              _intakeTypeEntity,
-              AddMealExtension.fromIntakeTypeEntity(_intakeTypeEntity),
-              _day,
+              intakeType,
+              AddMealExtension.fromIntakeTypeEntity(intakeType),
+              day,
               initialCode: code,
             ),
           );
@@ -279,9 +309,30 @@ class _ScannerScreenState extends State<ScannerScreen> {
 }
 
 class ScannerScreenArguments {
-  final DateTime day;
-  final IntakeTypeEntity intakeTypeEntity;
+  // `day` and `intakeTypeEntity` are required for the normal logging flow
+  // (the scanner routes into MealDetailScreen, which needs both). In
+  // [ScannerScreenArguments.pick] they're left null because the screen
+  // simply pops the scanned [MealEntity] back to its caller — the recipe
+  // ingredient picker doesn't yet know which day or intake the user will
+  // attach it to.
+  final DateTime? day;
+  final IntakeTypeEntity? intakeTypeEntity;
   final String? initialBarcode;
+  final bool pickMode;
 
-  ScannerScreenArguments(this.day, this.intakeTypeEntity, {this.initialBarcode});
+  ScannerScreenArguments(
+    DateTime forDay,
+    IntakeTypeEntity forIntakeType, {
+    this.initialBarcode,
+  })  : day = forDay,
+        intakeTypeEntity = forIntakeType,
+        pickMode = false;
+
+  /// Opens the scanner in "pick" mode: on a successful product load it pops
+  /// the resulting [MealEntity] back to the caller instead of routing into
+  /// the meal-detail logging screen. Used by the recipe ingredient picker.
+  ScannerScreenArguments.pick({this.initialBarcode})
+      : day = null,
+        intakeTypeEntity = null,
+        pickMode = true;
 }

--- a/test/features/scanner/presentation/scanner_screen_pick_mode_test.dart
+++ b/test/features/scanner/presentation/scanner_screen_pick_mode_test.dart
@@ -1,0 +1,246 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:get_it/get_it.dart';
+import 'package:opennutritracker/core/domain/entity/app_theme_entity.dart';
+import 'package:opennutritracker/core/domain/entity/config_entity.dart';
+import 'package:opennutritracker/core/domain/entity/intake_type_entity.dart';
+import 'package:opennutritracker/core/domain/usecase/get_config_usecase.dart';
+import 'package:opennutritracker/core/utils/navigation_options.dart';
+import 'package:opennutritracker/features/add_meal/domain/entity/meal_entity.dart';
+import 'package:opennutritracker/features/add_meal/domain/entity/meal_nutriments_entity.dart';
+import 'package:opennutritracker/features/meal_detail/meal_detail_screen.dart';
+import 'package:opennutritracker/features/scanner/domain/usecase/search_product_by_barcode_usecase.dart';
+import 'package:opennutritracker/features/scanner/presentation/scanner_bloc.dart';
+import 'package:opennutritracker/features/scanner/scanner_screen.dart';
+
+/// Regression cover for GitHub #443: the recipe ingredient picker needs a
+/// scanner that hands a [MealEntity] back to its caller rather than routing
+/// into the meal-detail logging flow.
+void main() {
+  group('ScannerScreenArguments', () {
+    test('pick() sets pickMode true and leaves logging-flow fields null', () {
+      final args = ScannerScreenArguments.pick();
+
+      expect(args.pickMode, isTrue);
+      expect(args.day, isNull);
+      expect(args.intakeTypeEntity, isNull);
+      expect(args.initialBarcode, isNull);
+    });
+
+    test('pick(initialBarcode:) carries the barcode through', () {
+      final args = ScannerScreenArguments.pick(initialBarcode: '1234567890123');
+
+      expect(args.pickMode, isTrue);
+      expect(args.initialBarcode, '1234567890123');
+    });
+
+    test('the default constructor still produces a logging-flow args', () {
+      final args = ScannerScreenArguments(
+        DateTime(2026, 5, 21),
+        IntakeTypeEntity.breakfast,
+      );
+
+      expect(args.pickMode, isFalse);
+      expect(args.day, DateTime(2026, 5, 21));
+      expect(args.intakeTypeEntity, IntakeTypeEntity.breakfast);
+    });
+  });
+
+  group('ScannerScreen pick mode', () {
+    final getIt = GetIt.instance;
+
+    setUp(() async {
+      if (getIt.isRegistered<ScannerBloc>()) {
+        await getIt.unregister<ScannerBloc>();
+      }
+      // The bloc takes a search usecase that returns the canned meal and a
+      // config usecase that yields an unsurprising default. Using the real
+      // bloc keeps the state-transition surface honest — the test only
+      // stubs the data sources.
+      getIt.registerFactory<ScannerBloc>(
+        () => ScannerBloc(
+          _FakeSearchUseCase(_loadedMeal),
+          _FakeGetConfigUsecase(),
+        ),
+      );
+    });
+
+    tearDown(() async {
+      if (getIt.isRegistered<ScannerBloc>()) {
+        await getIt.unregister<ScannerBloc>();
+      }
+    });
+
+    testWidgets(
+      'pops the loaded MealEntity to its caller after a successful scan',
+      (tester) async {
+        MealEntity? receivedMeal;
+
+        await tester.pumpWidget(
+          MaterialApp(
+            home: Builder(
+              builder: (context) => Scaffold(
+                body: Center(
+                  child: ElevatedButton(
+                    onPressed: () async {
+                      final result = await Navigator.of(context).push<MealEntity>(
+                        MaterialPageRoute(
+                          settings: RouteSettings(
+                            // initialBarcode triggers ScannerLoadProductEvent
+                            // straight from didChangeDependencies, which lets
+                            // the test avoid rendering the MobileScanner
+                            // camera widget (no platform channel in unit
+                            // tests).
+                            arguments: ScannerScreenArguments.pick(
+                              initialBarcode: '1234567890123',
+                            ),
+                          ),
+                          builder: (_) => const ScannerScreen(),
+                        ),
+                      );
+                      receivedMeal = result;
+                    },
+                    child: const Text('open scanner'),
+                  ),
+                ),
+              ),
+            ),
+          ),
+        );
+
+        await tester.tap(find.text('open scanner'));
+        // Give the bloc time to resolve the (synchronous) fake usecase and
+        // for the post-build microtask in BlocBuilder to run Navigator.pop.
+        await tester.pumpAndSettle();
+
+        expect(receivedMeal, isNotNull);
+        expect(receivedMeal!.code, '1234567890123');
+        expect(receivedMeal!.name, 'Greek yoghurt');
+      },
+    );
+  });
+
+  group('ScannerScreen logging flow (non-pick)', () {
+    final getIt = GetIt.instance;
+
+    setUp(() async {
+      if (getIt.isRegistered<ScannerBloc>()) {
+        await getIt.unregister<ScannerBloc>();
+      }
+      getIt.registerFactory<ScannerBloc>(
+        () => ScannerBloc(
+          _FakeSearchUseCase(_loadedMeal),
+          _FakeGetConfigUsecase(),
+        ),
+      );
+    });
+
+    tearDown(() async {
+      if (getIt.isRegistered<ScannerBloc>()) {
+        await getIt.unregister<ScannerBloc>();
+      }
+    });
+
+    testWidgets(
+      'replaces the scanner with MealDetailScreen carrying day + intake type',
+      (tester) async {
+        final pushedArgs = <Object?>[];
+
+        await tester.pumpWidget(
+          MaterialApp(
+            onGenerateRoute: (settings) {
+              if (settings.name == NavigationOptions.mealDetailRoute) {
+                pushedArgs.add(settings.arguments);
+                return MaterialPageRoute(
+                  settings: settings,
+                  builder: (_) => const Scaffold(body: Text('meal-detail')),
+                );
+              }
+              return null;
+            },
+            home: Builder(
+              builder: (context) => Scaffold(
+                body: Center(
+                  child: ElevatedButton(
+                    onPressed: () => Navigator.of(context).push(
+                      MaterialPageRoute(
+                        settings: RouteSettings(
+                          arguments: ScannerScreenArguments(
+                            DateTime(2026, 5, 21),
+                            IntakeTypeEntity.breakfast,
+                            initialBarcode: '5449000000996',
+                          ),
+                        ),
+                        builder: (_) => const ScannerScreen(),
+                      ),
+                    ),
+                    child: const Text('open scanner'),
+                  ),
+                ),
+              ),
+            ),
+          ),
+        );
+
+        await tester.tap(find.text('open scanner'));
+        await tester.pumpAndSettle();
+
+        expect(find.text('meal-detail'), findsOneWidget);
+        expect(pushedArgs, hasLength(1),
+            reason: 'scanner should replace itself with meal-detail exactly once');
+        final args = pushedArgs.single as MealDetailScreenArguments;
+        expect(args.day, DateTime(2026, 5, 21));
+        expect(args.intakeTypeEntity, IntakeTypeEntity.breakfast);
+        expect(args.mealEntity.code, '1234567890123');
+      },
+    );
+  });
+
+}
+
+final _loadedMeal = MealEntity(
+  code: '1234567890123',
+  name: 'Greek yoghurt',
+  url: null,
+  mealQuantity: '100',
+  mealUnit: 'g',
+  servingQuantity: null,
+  servingUnit: 'g',
+  servingSize: null,
+  source: MealSourceEntity.off,
+  nutriments: const MealNutrimentsEntity(
+    energyKcal100: 100,
+    carbohydrates100: 4,
+    fat100: 5,
+    proteins100: 10,
+    sugars100: null,
+    saturatedFat100: null,
+    fiber100: null,
+  ),
+);
+
+class _FakeSearchUseCase implements SearchProductByBarcodeUseCase {
+  final MealEntity _result;
+  _FakeSearchUseCase(this._result);
+
+  @override
+  Future<MealEntity> searchProductByBarcode(String barcode) async => _result;
+
+  @override
+  dynamic noSuchMethod(Invocation invocation) =>
+      throw UnimplementedError('Unexpected call: ${invocation.memberName}');
+}
+
+class _FakeGetConfigUsecase implements GetConfigUsecase {
+  @override
+  Future<ConfigEntity> getConfig() async => const ConfigEntity(
+        true,
+        true,
+        false,
+        AppThemeEntity.system,
+      );
+
+  @override
+  dynamic noSuchMethod(Invocation invocation) =>
+      throw UnimplementedError('Unexpected call: ${invocation.memberName}');
+}


### PR DESCRIPTION
Closes #443.

Adding ingredients to a recipe now offers the same barcode-scan affordance the regular Add Meal search has. The contributor on the issue (`jyo64`) flagged that they were having to detour through typed search when they had a product right in front of them, and that's the bit this PR fixes. Tapping the barcode icon opens the scanner; a successful scan threads the loaded `MealEntity` back through the existing `onMealSelected` path, so the quantity dialog and `AddIngredientEvent` flow are identical whether the ingredient came from typed search or from a scan.

## What changed

- `ScannerScreen` gains a pick-mode (`ScannerScreenArguments.pick`) that pops the loaded `MealEntity` back to its caller instead of routing into the meal-detail logging flow.
- In pick mode the shared-payload classification is gated off — handing a shared-meal QR over to the import screen would silently abandon the recipe builder mid-edit, and a shared meal isn't a single ingredient anyway.
- `FoodSearchTabView` now accepts an optional `onBarcodePressed` callback and forwards it to the existing `MealSearchBar`, so the icon only appears when a caller wants it.
- `RecipeBuilderScreen._onAddIngredient` wires the callback to push the scanner in pick mode and feeds the popped meal back through `onMealSelected`, which keeps one code path through `showIngredientQuantityDialog`.

## The race I caught while testing on-device

A real bug surfaced under the cosmetic one. `BlocBuilder` rebuilds for `ScannerLoadedState` more than once before the scanner route is fully unmounted (the route-transition's parent rebuild propagates down). The `Future.microtask` that scheduled the post-load navigation fired twice as a result. In the existing logging flow the second `pushReplacementNamed` was a no-op, but in pick mode the second pop landed on the freshly-pushed quantity-dialog bottom sheet and crashed it with an `IngredientQuantitySelection`-vs-`MealEntity` result-type mismatch — the user would see the dialog stuck on-screen with no errors visible. A small `_navigatedAfterLoad` latch makes the post-load navigation idempotent for both branches.

## Tests

`test/features/scanner/presentation/scanner_screen_pick_mode_test.dart` covers:

- `ScannerScreenArguments.pick()` sets `pickMode` and leaves the logging-flow fields null.
- `ScannerScreenArguments.pick(initialBarcode:)` carries the barcode through.
- The original positional constructor still produces a logging-flow args.
- Pick mode pops the loaded `MealEntity` to its caller after a successful scan.
- Non-pick logging flow replaces the scanner with `MealDetailScreen` carrying the day + intake type, exactly once.

## Test plan

- [x] `just check_intl` (no new strings)
- [x] `flutter analyze` — no issues
- [x] `just test` — 591 tests pass (was 590)
- [x] On-device walkthrough (Pixel 6 Pro):
  - Open a new recipe → Add Ingredient → barcode icon visible in the search bar
  - Tap icon → scanner opens → manual-entry a real EAN-13 (`5449000000996`, Coca-Cola)
  - Quantity dialog opens with the scanned product → enter amount → Add
  - Ingredient appears in the recipe with the correct kcal total
  - Confirmed the typed-barcode shortcut in Add Meal still routes to `MealDetailScreen`
  - Confirmed the barcode-icon tap in Add Meal still routes to `MealDetailScreen`