### PR TITLE
fix(settings): make Show Activity Tracking toggle hide blocks

### DIFF
--- a/lib/core/presentation/main_screen.dart
+++ b/lib/core/presentation/main_screen.dart
@@ -1,4 +1,5 @@
 import 'package:flutter/material.dart';
+import 'package:opennutritracker/core/domain/usecase/get_config_usecase.dart';
 import 'package:opennutritracker/core/presentation/widgets/add_item_bottom_sheet.dart';
 import 'package:opennutritracker/core/utils/locator.dart';
 import 'package:opennutritracker/core/utils/navigation_options.dart';
@@ -195,7 +196,9 @@ class _MainScreenState extends State<MainScreen> {
     }
   }
 
-  void _onFabPressed(BuildContext context) {
+  Future<void> _onFabPressed(BuildContext context) async {
+    final config = await locator<GetConfigUsecase>().getConfig();
+    if (!context.mounted) return;
     showModalBottomSheet(
       context: context,
       isScrollControlled: true,
@@ -206,7 +209,10 @@ class _MainScreenState extends State<MainScreen> {
         ),
       ),
       builder: (BuildContext context) {
-        return AddItemBottomSheet(day: DateTime.now());
+        return AddItemBottomSheet(
+          day: DateTime.now(),
+          showActivityTracking: config.showActivityTracking,
+        );
       },
     );
   }

--- a/lib/core/presentation/widgets/add_item_bottom_sheet.dart
+++ b/lib/core/presentation/widgets/add_item_bottom_sheet.dart
@@ -9,8 +9,13 @@ import 'package:opennutritracker/generated/l10n.dart';
 
 class AddItemBottomSheet extends StatelessWidget {
   final DateTime day;
+  final bool showActivityTracking;
 
-  const AddItemBottomSheet({super.key, required this.day});
+  const AddItemBottomSheet({
+    super.key,
+    required this.day,
+    this.showActivityTracking = true,
+  });
 
   @override
   Widget build(BuildContext context) {
@@ -29,37 +34,39 @@ class AddItemBottomSheet extends StatelessWidget {
                   ),
             ),
           ),
-          Semantics(
-            identifier: 'add-item-activity',
-            child: ListTile(
-              title: Text(
-                S.of(context).activityLabel,
-                style: Theme.of(context).textTheme.titleLarge?.copyWith(
-                      color: Theme.of(context).colorScheme.onSurface,
-                    ),
-              ),
-              subtitle: Text(
-                S.of(context).activityExample,
-                style: Theme.of(context).textTheme.titleMedium?.copyWith(
-                      color: Theme.of(
-                        context,
-                      ).colorScheme.onSurface.withValues(alpha: 0.7),
-                    ),
-              ),
-              // ignore: sized_box_for_whitespace
-              leading: Container(
-                height: double.infinity,
-                child: Icon(
-                  UserActivityEntity.getIconData(),
-                  color: Theme.of(context).colorScheme.onSurface,
+          if (showActivityTracking) ...[
+            Semantics(
+              identifier: 'add-item-activity',
+              child: ListTile(
+                title: Text(
+                  S.of(context).activityLabel,
+                  style: Theme.of(context).textTheme.titleLarge?.copyWith(
+                        color: Theme.of(context).colorScheme.onSurface,
+                      ),
                 ),
+                subtitle: Text(
+                  S.of(context).activityExample,
+                  style: Theme.of(context).textTheme.titleMedium?.copyWith(
+                        color: Theme.of(
+                          context,
+                        ).colorScheme.onSurface.withValues(alpha: 0.7),
+                      ),
+                ),
+                // ignore: sized_box_for_whitespace
+                leading: Container(
+                  height: double.infinity,
+                  child: Icon(
+                    UserActivityEntity.getIconData(),
+                    color: Theme.of(context).colorScheme.onSurface,
+                  ),
+                ),
+                onTap: () {
+                  _showAddActivityScreen(context);
+                },
               ),
-              onTap: () {
-                _showAddActivityScreen(context);
-              },
             ),
-          ),
-          const Divider(indent: 16, endIndent: 16),
+            const Divider(indent: 16, endIndent: 16),
+          ],
           Semantics(
             identifier: 'add-item-breakfast',
             child: ListTile(

--- a/lib/features/diary/diary_page.dart
+++ b/lib/features/diary/diary_page.dart
@@ -71,6 +71,7 @@ class _DiaryPageState extends State<DiaryPage> with WidgetsBindingObserver {
             state.trackedDayMap,
             state.usesImperialUnits,
             state.showMealMacros,
+            state.showActivityTracking,
           );
         }
         return const SizedBox();
@@ -95,6 +96,7 @@ class _DiaryPageState extends State<DiaryPage> with WidgetsBindingObserver {
     Map<String, TrackedDayEntity> trackedDaysMap,
     bool usesImperialUnits,
     bool showMealMacros,
+    bool showActivityTracking,
   ) {
     return ListView(
       children: [
@@ -131,6 +133,7 @@ class _DiaryPageState extends State<DiaryPage> with WidgetsBindingObserver {
                 onEditActivity: _onEditActivityItem,
                 usesImperialUnits: usesImperialUnits,
                 showMealMacros: showMealMacros,
+                showActivityTracking: showActivityTracking,
                 breakfastKcalTarget: state.breakfastKcalTarget,
                 lunchKcalTarget: state.lunchKcalTarget,
                 dinnerKcalTarget: state.dinnerKcalTarget,

--- a/lib/features/diary/presentation/bloc/diary_bloc.dart
+++ b/lib/features/diary/presentation/bloc/diary_bloc.dart
@@ -26,6 +26,7 @@ class DiaryBloc extends Bloc<DiaryEvent, DiaryState> {
       final config = await _getConfigUsecase.getConfig();
       final usesImperialUnits = config.usesImperialUnits;
       final showMealMacros = config.showMealMacros;
+      final showActivityTracking = config.showActivityTracking;
 
       // #139: pin currentDay to the user's logical "today" so the
       // diary calendar's today-marker shifts with the configured boundary.
@@ -50,6 +51,7 @@ class DiaryBloc extends Bloc<DiaryEvent, DiaryState> {
         trackedDaysMap,
         usesImperialUnits,
         showMealMacros: showMealMacros,
+        showActivityTracking: showActivityTracking,
       ));
     });
   }

--- a/lib/features/diary/presentation/bloc/diary_state.dart
+++ b/lib/features/diary/presentation/bloc/diary_state.dart
@@ -18,13 +18,16 @@ class DiaryLoadedState extends DiaryState {
   final Map<String, TrackedDayEntity> trackedDayMap;
   final bool usesImperialUnits;
   final bool showMealMacros;
+  final bool showActivityTracking;
 
   const DiaryLoadedState(
     this.trackedDayMap,
     this.usesImperialUnits, {
     this.showMealMacros = true,
+    this.showActivityTracking = true,
   });
 
   @override
-  List<Object?> get props => [trackedDayMap, usesImperialUnits, showMealMacros];
+  List<Object?> get props =>
+      [trackedDayMap, usesImperialUnits, showMealMacros, showActivityTracking];
 }

--- a/lib/features/diary/presentation/widgets/day_info_widget.dart
+++ b/lib/features/diary/presentation/widgets/day_info_widget.dart
@@ -46,6 +46,9 @@ class DayInfoWidget extends StatefulWidget {
 
   final bool usesImperialUnits;
   final bool showMealMacros;
+  // #277: when the user disables Show Activity Tracking in Settings, the
+  // diary's per-day Activity section is hidden alongside the home one.
+  final bool showActivityTracking;
   // Persisted per-meal sort preference loaded by [CalendarDayBloc]. Keys are
   // meal-type strings (breakfast / lunch / dinner / snack) and values are
   // [DiarySortType] enum indices. Null when the user has never picked a
@@ -82,6 +85,7 @@ class DayInfoWidget extends StatefulWidget {
     required this.snackIntake,
     required this.usesImperialUnits,
     this.showMealMacros = true,
+    this.showActivityTracking = true,
     this.diarySortPreferences,
     required this.onDeleteIntake,
     required this.onDeleteActivity,
@@ -257,19 +261,21 @@ class _DayInfoWidgetState extends State<DayInfoWidget> {
                 selectedDay: widget.selectedDay,
                 trackedDay: widget.trackedDayEntity,
               ),
-            const SizedBox(height: 8.0),
-            ActivityVerticalList(
-              day: widget.selectedDay,
-              title: S.of(context).activityLabel,
-              userActivityList: widget.userActivities,
-              onItemLongPressedCallback: onActivityItemLongPressed,
-              onItemTappedCallback: widget.onEditActivity,
-              onCopyActivityCallback:
-                  DateUtils.isSameDay(widget.selectedDay, DateTime.now())
-                      ? null
-                      : (activity) =>
-                          widget.onCopyActivity(activity, widget.trackedDayEntity),
-            ),
+            if (widget.showActivityTracking) ...[
+              const SizedBox(height: 8.0),
+              ActivityVerticalList(
+                day: widget.selectedDay,
+                title: S.of(context).activityLabel,
+                userActivityList: widget.userActivities,
+                onItemLongPressedCallback: onActivityItemLongPressed,
+                onItemTappedCallback: widget.onEditActivity,
+                onCopyActivityCallback:
+                    DateUtils.isSameDay(widget.selectedDay, DateTime.now())
+                        ? null
+                        : (activity) =>
+                            widget.onCopyActivity(activity, widget.trackedDayEntity),
+              ),
+            ],
             // #150 follow-up: a 0% share hides the section entirely so OMAD
             // users (and anyone else who's set a meal slot to 0%) don't see
             // a meal type they explicitly opted out of. Logged intakes for a

--- a/lib/features/diary/presentation/widgets/day_info_widget.dart
+++ b/lib/features/diary/presentation/widgets/day_info_widget.dart
@@ -46,8 +46,8 @@ class DayInfoWidget extends StatefulWidget {
 
   final bool usesImperialUnits;
   final bool showMealMacros;
-  // #277: when the user disables Show Activity Tracking in Settings, the
-  // diary's per-day Activity section is hidden alongside the home one.
+  // When the user disables Show Activity Tracking in Settings, the diary's
+  // per-day Activity section is hidden alongside the home one.
   final bool showActivityTracking;
   // Persisted per-meal sort preference loaded by [CalendarDayBloc]. Keys are
   // meal-type strings (breakfast / lunch / dinner / snack) and values are

--- a/lib/features/home/home_page.dart
+++ b/lib/features/home/home_page.dart
@@ -84,6 +84,7 @@ class _HomePageState extends State<HomePage> with WidgetsBindingObserver {
             state.snackIntakeList,
             state.userActivityList,
             state.usesImperialUnits,
+            state.showActivityTracking,
             state.showMealMacros,
             state.userWeightKg,
             state.breakfastKcalTarget,
@@ -138,6 +139,7 @@ class _HomePageState extends State<HomePage> with WidgetsBindingObserver {
     List<IntakeEntity> snackIntakeList,
     List<UserActivityEntity> userActivities,
     bool usesImperialUnits,
+    bool showActivityTracking,
     bool showMealMacros,
     double userWeightKg,
     double breakfastKcalTarget,
@@ -199,14 +201,15 @@ class _HomePageState extends State<HomePage> with WidgetsBindingObserver {
                   caloriesProfile: userCaloriesProfile,
                 ),
               ),
-            ActivityVerticalList(
-              day: DateTime.now(),
-              title: S.of(context).activityLabel,
-              userActivityList: userActivities,
-              onItemLongPressedCallback: onActivityItemLongPressed,
-              onItemTappedCallback: onActivityItemTapped,
-              onItemDragCallback: onActivityItemDrag,
-            ),
+            if (showActivityTracking)
+              ActivityVerticalList(
+                day: DateTime.now(),
+                title: S.of(context).activityLabel,
+                userActivityList: userActivities,
+                onItemLongPressedCallback: onActivityItemLongPressed,
+                onItemTappedCallback: onActivityItemTapped,
+                onItemDragCallback: onActivityItemDrag,
+              ),
             // #150 follow-up: a 0% share (e.g. OMAD sets snack to 0) hides the
             // section entirely so the home view doesn't carry an empty header
             // the user explicitly opted out of. Already-logged intakes for a

--- a/lib/features/home/presentation/bloc/home_bloc.dart
+++ b/lib/features/home/presentation/bloc/home_bloc.dart
@@ -85,6 +85,7 @@ class HomeBloc extends Bloc<HomeEvent, HomeState> {
       final usesImperialUnits = configData.usesImperialUnits;
       final showDisclaimerDialog = !configData.hasAcceptedDisclaimer;
       final showMealMacros = configData.showMealMacros;
+      final showActivityTracking = configData.showActivityTracking;
 
       final breakfastIntakeList = await _getIntakeUsecase
           .getTodayBreakfastIntake(
@@ -216,6 +217,7 @@ class HomeBloc extends Bloc<HomeEvent, HomeState> {
           snackIntakeList: snackIntakeList,
           userActivityList: userActivities,
           usesImperialUnits: usesImperialUnits,
+          showActivityTracking: showActivityTracking,
           showMealMacros: showMealMacros,
           userWeightKg: user.weightKG,
           breakfastKcalTarget: breakfastKcalTarget,

--- a/lib/features/home/presentation/bloc/home_state.dart
+++ b/lib/features/home/presentation/bloc/home_state.dart
@@ -106,5 +106,6 @@ class HomeLoadedState extends HomeState {
     waterMlToday,
     waterGoalMl,
     waterIntakes,
+    showActivityTracking,
   ];
 }

--- a/lib/features/settings/settings_screen.dart
+++ b/lib/features/settings/settings_screen.dart
@@ -152,6 +152,11 @@ class _SettingsScreenState extends State<SettingsScreen> {
                     _settingsBloc.setShowActivityTracking(value);
                     _settingsBloc.add(LoadSettingsEvent());
                     _homeBloc.add(LoadItemsEvent());
+                    // #277: DiaryBloc is a lazy singleton so its loaded state
+                    // survives navigation. Without an explicit reload here the
+                    // diary keeps the stale flag and the per-day Activity
+                    // section stays visible after the user has toggled off.
+                    _diaryBloc.add(const LoadDiaryYearEvent());
                   },
                 ),
                 SwitchListTile(

--- a/lib/features/settings/settings_screen.dart
+++ b/lib/features/settings/settings_screen.dart
@@ -152,7 +152,7 @@ class _SettingsScreenState extends State<SettingsScreen> {
                     _settingsBloc.setShowActivityTracking(value);
                     _settingsBloc.add(LoadSettingsEvent());
                     _homeBloc.add(LoadItemsEvent());
-                    // #277: DiaryBloc is a lazy singleton so its loaded state
+                    // DiaryBloc is a lazy singleton so its loaded state
                     // survives navigation. Without an explicit reload here the
                     // diary keeps the stale flag and the per-day Activity
                     // section stays visible after the user has toggled off.

--- a/test/core/presentation/widgets/add_item_bottom_sheet_test.dart
+++ b/test/core/presentation/widgets/add_item_bottom_sheet_test.dart
@@ -1,0 +1,70 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:opennutritracker/core/presentation/widgets/add_item_bottom_sheet.dart';
+import 'package:opennutritracker/generated/l10n.dart';
+
+// #277: the Show Activity Tracking toggle in Settings has been wired to
+// hide every activity-related surface in the app. AddItemBottomSheet is
+// the FAB's add-something menu — when the toggle is off, the Activity
+// row at the top should disappear so the meal options are all that's on
+// offer. Locking the behaviour in here so a future refactor that drops
+// the conditional or its default trips the test instead of slipping past
+// review.
+
+Widget _wrapWithMaterial(Widget child) {
+  return MaterialApp(
+    localizationsDelegates: const [S.delegate],
+    supportedLocales: S.delegate.supportedLocales,
+    home: Scaffold(body: child),
+  );
+}
+
+void main() {
+  testWidgets(
+    'shows the Activity tile when showActivityTracking is true',
+    (tester) async {
+      await tester.pumpWidget(_wrapWithMaterial(
+        AddItemBottomSheet(
+          day: DateTime(2026, 1, 1),
+          showActivityTracking: true,
+        ),
+      ));
+      await tester.pumpAndSettle();
+
+      expect(find.text(S.current.activityLabel), findsOneWidget);
+      expect(find.text(S.current.breakfastLabel), findsOneWidget);
+    },
+  );
+
+  testWidgets(
+    'hides the Activity tile when showActivityTracking is false',
+    (tester) async {
+      await tester.pumpWidget(_wrapWithMaterial(
+        AddItemBottomSheet(
+          day: DateTime(2026, 1, 1),
+          showActivityTracking: false,
+        ),
+      ));
+      await tester.pumpAndSettle();
+
+      expect(find.text(S.current.activityLabel), findsNothing);
+      // Meal tiles still render so the sheet stays useful for food logging.
+      expect(find.text(S.current.breakfastLabel), findsOneWidget);
+      expect(find.text(S.current.lunchLabel), findsOneWidget);
+      expect(find.text(S.current.dinnerLabel), findsOneWidget);
+      expect(find.text(S.current.snackLabel), findsOneWidget);
+    },
+  );
+
+  testWidgets(
+    'defaults to showing the Activity tile when the flag is omitted',
+    (tester) async {
+      await tester.pumpWidget(_wrapWithMaterial(
+        AddItemBottomSheet(day: DateTime(2026, 1, 1)),
+      ));
+      await tester.pumpAndSettle();
+
+      expect(find.text(S.current.activityLabel), findsOneWidget);
+    },
+  );
+}


### PR DESCRIPTION
Hey! Could you please take a look!  
Currently there is a bug: Show Activity Tracking buttons does absolutely nothing.

No other changes, only use existing setting `showActivityTracking` to conditionally hide blocks in the main screen and add button.

| toggle On | toggle Off | toggle Off |
|---|---|---|
| <img width="200" alt="Simulator Screenshot - iPhone 17 - 2026-05-22 at 23 19 12" src="https://github.com/user-attachments/assets/f9366706-d252-476c-ad20-5aa1edb4b3c1" /> | <img width="200" alt="Simulator Screenshot - iPhone 17 - 2026-05-22 at 23 19 04" src="https://github.com/user-attachments/assets/547ea2c5-c7bd-49f1-a0ea-3df2777d3e57" /> | <img width="200" alt="Simulator Screenshot - iPhone 17 - 2026-05-23 at 09 35 42" src="https://github.com/user-attachments/assets/f2c12570-9485-416c-b595-c65132e8c3b7" /> |
