### PR TITLE
feat(meal-detail): show daily kcal budget on meal detail screen (#452)

### DIFF
--- a/lib/core/utils/locator.dart
+++ b/lib/core/utils/locator.dart
@@ -243,6 +243,7 @@ Future<void> initLocator() async {
       locator(),
       locator(),
       locator(),
+      locator(),
     ),
   );
   locator.registerFactory<ScannerBloc>(() => ScannerBloc(locator(), locator()));

--- a/lib/features/meal_detail/meal_detail_screen.dart
+++ b/lib/features/meal_detail/meal_detail_screen.dart
@@ -13,6 +13,7 @@ import 'package:opennutritracker/core/utils/navigation_options.dart';
 import 'package:opennutritracker/features/add_meal/domain/entity/meal_entity.dart';
 import 'package:opennutritracker/features/edit_meal/presentation/edit_meal_screen.dart';
 import 'package:opennutritracker/features/meal_detail/presentation/bloc/meal_detail_bloc.dart';
+import 'package:opennutritracker/features/meal_detail/presentation/widgets/daily_kcal_overview.dart';
 import 'package:opennutritracker/features/meal_detail/presentation/widgets/meal_detail_bottom_sheet.dart';
 import 'package:opennutritracker/features/meal_detail/presentation/widgets/meal_detail_macro_nutrients.dart';
 import 'package:opennutritracker/features/meal_detail/presentation/widgets/meal_detail_nutriments_table.dart';
@@ -74,6 +75,8 @@ class _MealDetailScreenState extends State<MealDetailScreen> {
     intakeTypeEntity = args.intakeTypeEntity;
     _usesImperialUnits = args.usesImperialUnits;
 
+    _mealDetailBloc.add(LoadDailyTotalsEvent(_day));
+
     // Set initial unit
     if (_initialUnit == "") {
       if (meal.hasServingValues) {
@@ -122,14 +125,25 @@ class _MealDetailScreenState extends State<MealDetailScreen> {
           bloc: _mealDetailBloc,
           builder: (context, state) {
             if (state is MealDetailInitial) {
-              return _getLoadedContent(
-                context,
-                state.totalQuantityConverted,
-                state.totalKcal,
-                state.totalCarbs,
-                state.totalFat,
-                state.totalProtein,
-                state.selectedUnit,
+              return Column(
+                children: [
+                  DailyKcalOverview(
+                    dayKcalConsumed: state.dayKcalConsumed,
+                    dayKcalGoal: state.dayKcalGoal,
+                    currentSelectionKcal: state.totalKcal,
+                  ),
+                  Expanded(
+                    child: _getLoadedContent(
+                      context,
+                      state.totalQuantityConverted,
+                      state.totalKcal,
+                      state.totalCarbs,
+                      state.totalFat,
+                      state.totalProtein,
+                      state.selectedUnit,
+                    ),
+                  ),
+                ],
               );
             }
             return const Center(child: CircularProgressIndicator());

--- a/lib/features/meal_detail/meal_detail_screen.dart
+++ b/lib/features/meal_detail/meal_detail_screen.dart
@@ -125,25 +125,16 @@ class _MealDetailScreenState extends State<MealDetailScreen> {
           bloc: _mealDetailBloc,
           builder: (context, state) {
             if (state is MealDetailInitial) {
-              return Column(
-                children: [
-                  DailyKcalOverview(
-                    dayKcalConsumed: state.dayKcalConsumed,
-                    dayKcalGoal: state.dayKcalGoal,
-                    currentSelectionKcal: state.totalKcal,
-                  ),
-                  Expanded(
-                    child: _getLoadedContent(
-                      context,
-                      state.totalQuantityConverted,
-                      state.totalKcal,
-                      state.totalCarbs,
-                      state.totalFat,
-                      state.totalProtein,
-                      state.selectedUnit,
-                    ),
-                  ),
-                ],
+              return _getLoadedContent(
+                context,
+                state.totalQuantityConverted,
+                state.totalKcal,
+                state.totalCarbs,
+                state.totalFat,
+                state.totalProtein,
+                state.selectedUnit,
+                state.dayKcalConsumed,
+                state.dayKcalGoal,
               );
             }
             return const Center(child: CircularProgressIndicator());
@@ -176,13 +167,23 @@ class _MealDetailScreenState extends State<MealDetailScreen> {
     double totalFat,
     double totalProtein,
     String selectedUnit,
+    double dayKcalConsumed,
+    double dayKcalGoal,
   ) {
     return CustomScrollView(
       controller: _scrollController,
       slivers: [
         SliverAppBar(
           pinned: true,
-          expandedHeight: 200,
+          expandedHeight: dayKcalGoal > 0 ? 268 : 200,
+          bottom: PreferredSize(
+            preferredSize: Size.fromHeight(dayKcalGoal > 0 ? 68 : 0),
+            child: DailyKcalOverview(
+              dayKcalConsumed: dayKcalConsumed,
+              dayKcalGoal: dayKcalGoal,
+              currentSelectionKcal: totalKcal,
+            ),
+          ),
           flexibleSpace: LayoutBuilder(
             builder: (BuildContext context, BoxConstraints constraints) {
               final top = constraints.biggest.height;
@@ -191,9 +192,14 @@ class _MealDetailScreenState extends State<MealDetailScreen> {
               const offset = 10;
               return FlexibleSpaceBar(
                 expandedTitleScale: 1, // don't scale title
-                background: MealTitleExpanded(
-                  meal: meal,
-                  usesImperialUnits: _usesImperialUnits,
+                background: Padding(
+                  padding: EdgeInsets.only(
+                    bottom: dayKcalGoal > 0 ? 68 : 0,
+                  ),
+                  child: MealTitleExpanded(
+                    meal: meal,
+                    usesImperialUnits: _usesImperialUnits,
+                  ),
                 ),
                 title: AnimatedOpacity(
                   opacity: 1.0,
@@ -362,3 +368,4 @@ class MealDetailScreenArguments {
     this.usesImperialUnits,
   );
 }
+

--- a/lib/features/meal_detail/presentation/bloc/meal_detail_bloc.dart
+++ b/lib/features/meal_detail/presentation/bloc/meal_detail_bloc.dart
@@ -12,6 +12,7 @@ import 'package:opennutritracker/core/domain/usecase/add_intake_usecase.dart';
 import 'package:opennutritracker/core/domain/usecase/add_tracked_day_usecase.dart';
 import 'package:opennutritracker/core/domain/usecase/get_kcal_goal_usecase.dart';
 import 'package:opennutritracker/core/domain/usecase/get_macro_goal_usecase.dart';
+import 'package:opennutritracker/core/domain/usecase/get_tracked_day_usecase.dart';
 import 'package:opennutritracker/core/utils/calc/unit_calc.dart';
 import 'package:opennutritracker/core/utils/id_generator.dart';
 import 'package:opennutritracker/features/add_meal/data/repository/products_repository.dart';
@@ -28,6 +29,7 @@ class MealDetailBloc extends Bloc<MealDetailEvent, MealDetailState> {
   final AddTrackedDayUsecase _addTrackedDayUsecase;
   final GetKcalGoalUsecase _getKcalGoalUsecase;
   final GetMacroGoalUsecase _getMacroGoalUsecase;
+  final GetTrackedDayUsecase _getTrackedDayUsecase;
   final ProductsRepository _productsRepository;
   final RemoteSearchCacheDataSource _remoteSearchCacheDataSource;
 
@@ -36,6 +38,7 @@ class MealDetailBloc extends Bloc<MealDetailEvent, MealDetailState> {
     this._addTrackedDayUsecase,
     this._getKcalGoalUsecase,
     this._getMacroGoalUsecase,
+    this._getTrackedDayUsecase,
     this._productsRepository,
     this._remoteSearchCacheDataSource,
   ) : super(
@@ -88,6 +91,31 @@ class MealDetailBloc extends Bloc<MealDetailEvent, MealDetailState> {
         );
       } catch (e) {
         log.severe('Error calculating kcal: $e');
+        Sentry.captureException(e);
+      }
+    });
+
+    on<LoadDailyTotalsEvent>((event, emit) async {
+      try {
+        final tracked = await _getTrackedDayUsecase.getTrackedDay(event.day);
+        if (tracked != null) {
+          emit(
+            state.copyWith(
+              dayKcalConsumed: tracked.caloriesTracked,
+              dayKcalGoal: tracked.calorieGoal,
+            ),
+          );
+        } else {
+          final goal = await _getKcalGoalUsecase.getKcalGoal();
+          emit(
+            state.copyWith(
+              dayKcalConsumed: 0,
+              dayKcalGoal: goal,
+            ),
+          );
+        }
+      } catch (e) {
+        log.severe('Error loading daily totals: $e');
         Sentry.captureException(e);
       }
     });

--- a/lib/features/meal_detail/presentation/bloc/meal_detail_event.dart
+++ b/lib/features/meal_detail/presentation/bloc/meal_detail_event.dart
@@ -31,3 +31,12 @@ class UpdateKcalEvent extends MealDetailEvent {
         selectedUnit,
       ];
 }
+
+class LoadDailyTotalsEvent extends MealDetailEvent {
+  final DateTime day;
+
+  const LoadDailyTotalsEvent(this.day);
+
+  @override
+  List<Object?> get props => [day];
+}

--- a/lib/features/meal_detail/presentation/bloc/meal_detail_state.dart
+++ b/lib/features/meal_detail/presentation/bloc/meal_detail_state.dart
@@ -9,6 +9,9 @@ abstract class MealDetailState extends Equatable {
 
   final String selectedUnit;
 
+  final double dayKcalConsumed;
+  final double dayKcalGoal;
+
   const MealDetailState({
     required this.totalQuantityConverted,
     this.totalKcal = 0,
@@ -16,6 +19,8 @@ abstract class MealDetailState extends Equatable {
     this.totalFat = 0,
     this.totalProtein = 0,
     required this.selectedUnit,
+    this.dayKcalConsumed = 0,
+    this.dayKcalGoal = 0,
   });
 
   @override
@@ -26,6 +31,8 @@ abstract class MealDetailState extends Equatable {
         totalFat,
         totalProtein,
         selectedUnit,
+        dayKcalConsumed,
+        dayKcalGoal,
       ];
 
   MealDetailInitial copyWith({
@@ -35,6 +42,8 @@ abstract class MealDetailState extends Equatable {
     double? totalFat,
     double? totalProtein,
     String? selectedUnit,
+    double? dayKcalConsumed,
+    double? dayKcalGoal,
   }) {
     return MealDetailInitial(
       totalQuantityConverted:
@@ -44,6 +53,8 @@ abstract class MealDetailState extends Equatable {
       totalFat: totalFat ?? this.totalFat,
       totalProtein: totalProtein ?? this.totalProtein,
       selectedUnit: selectedUnit ?? this.selectedUnit,
+      dayKcalConsumed: dayKcalConsumed ?? this.dayKcalConsumed,
+      dayKcalGoal: dayKcalGoal ?? this.dayKcalGoal,
     );
   }
 }
@@ -56,5 +67,7 @@ class MealDetailInitial extends MealDetailState {
     super.totalFat,
     super.totalProtein,
     required super.selectedUnit,
+    super.dayKcalConsumed,
+    super.dayKcalGoal,
   });
 }

--- a/lib/features/meal_detail/presentation/widgets/daily_kcal_overview.dart
+++ b/lib/features/meal_detail/presentation/widgets/daily_kcal_overview.dart
@@ -1,0 +1,89 @@
+import 'package:flutter/material.dart';
+import 'package:opennutritracker/generated/l10n.dart';
+
+class DailyKcalOverview extends StatelessWidget {
+  final double dayKcalConsumed;
+  final double dayKcalGoal;
+  final double currentSelectionKcal;
+
+  const DailyKcalOverview({
+    super.key,
+    required this.dayKcalConsumed,
+    required this.dayKcalGoal,
+    required this.currentSelectionKcal,
+  });
+
+  @override
+  Widget build(BuildContext context) {
+    if (dayKcalGoal <= 0) {
+      return const SizedBox.shrink();
+    }
+
+    final colorScheme = Theme.of(context).colorScheme;
+    final textTheme = Theme.of(context).textTheme;
+
+    final projected = dayKcalConsumed + currentSelectionKcal;
+
+    final consumedFactor = (dayKcalConsumed / dayKcalGoal).clamp(0.0, 1.0);
+    final projectedFactor = (projected / dayKcalGoal).clamp(0.0, 1.0);
+
+    final hasLiveSelection = currentSelectionKcal > 0;
+
+    return Padding(
+      padding: const EdgeInsets.fromLTRB(16, 8, 16, 8),
+      child: Column(
+        crossAxisAlignment: CrossAxisAlignment.stretch,
+        mainAxisSize: MainAxisSize.min,
+        children: [
+          ClipRRect(
+            borderRadius: BorderRadius.circular(6),
+            child: SizedBox(
+              height: 8,
+              child: Stack(
+                children: [
+                  Container(color: colorScheme.primary.withValues(alpha: 0.15)),
+                  FractionallySizedBox(
+                    alignment: Alignment.centerLeft,
+                    widthFactor: projectedFactor,
+                    child: Container(
+                      color: colorScheme.primary.withValues(alpha: 0.45),
+                    ),
+                  ),
+                  FractionallySizedBox(
+                    alignment: Alignment.centerLeft,
+                    widthFactor: consumedFactor,
+                    child: Container(color: colorScheme.primary),
+                  ),
+                ],
+              ),
+            ),
+          ),
+          const SizedBox(height: 6),
+          Text(
+            S.of(context).mealDetailDayTotalLabel(
+                  projected.toStringAsFixed(0),
+                  dayKcalGoal.toStringAsFixed(0),
+                ),
+            style: textTheme.labelLarge?.copyWith(
+              color: colorScheme.primary,
+              fontWeight: FontWeight.w600,
+            ),
+            textAlign: TextAlign.center,
+          ),
+          if (hasLiveSelection) ...[
+            const SizedBox(height: 2),
+            Text(
+              S.of(context).mealDetailCurrentSelectionLabel(
+                    currentSelectionKcal.toStringAsFixed(0),
+                  ),
+              style: textTheme.labelSmall?.copyWith(
+                color: colorScheme.onSurfaceVariant,
+              ),
+              textAlign: TextAlign.center,
+            ),
+          ],
+        ],
+      ),
+    );
+  }
+}

--- a/lib/features/meal_detail/presentation/widgets/daily_kcal_overview.dart
+++ b/lib/features/meal_detail/presentation/widgets/daily_kcal_overview.dart
@@ -29,7 +29,8 @@ class DailyKcalOverview extends StatelessWidget {
 
     final hasLiveSelection = currentSelectionKcal > 0;
 
-    return Padding(
+    return Container(
+      color: colorScheme.surface,
       padding: const EdgeInsets.fromLTRB(16, 8, 16, 8),
       child: Column(
         crossAxisAlignment: CrossAxisAlignment.stretch,

--- a/lib/generated/intl/messages_cs.dart
+++ b/lib/generated/intl/messages_cs.dart
@@ -98,6 +98,12 @@ class MessageLookup extends MessageLookupByLibrary {
   static String mMergeOneCs(winner) => "Sloučeno — ${winner} má nyní 1 záznam.";
   static String mFastingChipCs(remaining) => "Půst · zbývá ${remaining}";
 
+  static String mMealDetailDayTotal(consumed, goal) =>
+      "Denní součet: ${consumed} / ${goal}";
+
+  static String mMealDetailCurrentSelection(kcal) =>
+      "(+${kcal} kcal aktuální výběr)";
+
   final messages = _notInlinedMessages(_notInlinedMessages);
   static Map<String, Function> _notInlinedMessages(_) => <String, Function>{
         "activityExample": MessageLookupByLibrary.simpleMessage(
@@ -437,6 +443,8 @@ class MessageLookup extends MessageLookupByLibrary {
         "mealBrandsLabel":
             MessageLookupByLibrary.simpleMessage("Výrobce, značka"),
         "mealCarbsLabel": MessageLookupByLibrary.simpleMessage("Sacharidy"),
+        "mealDetailCurrentSelectionLabel": mMealDetailCurrentSelection,
+        "mealDetailDayTotalLabel": mMealDetailDayTotal,
         "mealFatLabel": MessageLookupByLibrary.simpleMessage("Tuky"),
         "mealKcalLabel": MessageLookupByLibrary.simpleMessage("kcal na"),
         "mealEnergyLabel": MessageLookupByLibrary.simpleMessage("Energie"),

--- a/lib/generated/intl/messages_de.dart
+++ b/lib/generated/intl/messages_de.dart
@@ -100,6 +100,12 @@ class MessageLookup extends MessageLookupByLibrary {
   static String mMergeOneDe(winner) => "Zusammengeführt — ${winner} hat jetzt 1 Eintrag.";
   static String mFastingChipDe(remaining) => "Fasten · noch ${remaining}";
 
+  static String mMealDetailDayTotal(consumed, goal) =>
+      "Tagessumme: ${consumed} / ${goal}";
+
+  static String mMealDetailCurrentSelection(kcal) =>
+      "(+${kcal} kcal aktuelle Auswahl)";
+
   final messages = _notInlinedMessages(_notInlinedMessages);
   static Map<String, Function> _notInlinedMessages(_) => <String, Function>{
         "activityExample": MessageLookupByLibrary.simpleMessage(
@@ -448,6 +454,8 @@ class MessageLookup extends MessageLookupByLibrary {
         "mealBrandsLabel": MessageLookupByLibrary.simpleMessage("Marken"),
         "mealCarbsLabel":
             MessageLookupByLibrary.simpleMessage("Kohlenhydrate"),
+        "mealDetailCurrentSelectionLabel": mMealDetailCurrentSelection,
+        "mealDetailDayTotalLabel": mMealDetailDayTotal,
         "mealFatLabel":
             MessageLookupByLibrary.simpleMessage("Fett"),
         "mealKcalLabel":

--- a/lib/generated/intl/messages_en.dart
+++ b/lib/generated/intl/messages_en.dart
@@ -97,6 +97,12 @@ class MessageLookup extends MessageLookupByLibrary {
   static String mMergeOneEn(winner) => "Merged — ${winner} now has 1 logged entry.";
   static String mFastingChipEn(remaining) => "Fasting · ${remaining} left";
 
+  static String mMealDetailDayTotal(consumed, goal) =>
+      "Day total: ${consumed} / ${goal}";
+
+  static String mMealDetailCurrentSelection(kcal) =>
+      "(+${kcal} kcal current selection)";
+
   final messages = _notInlinedMessages(_notInlinedMessages);
   static Map<String, Function> _notInlinedMessages(_) => <String, Function>{
         "activityExample": MessageLookupByLibrary.simpleMessage(
@@ -431,6 +437,8 @@ class MessageLookup extends MessageLookupByLibrary {
             MessageLookupByLibrary.simpleMessage("Macronutrient Distribution:"),
         "mealBrandsLabel": MessageLookupByLibrary.simpleMessage("Brands"),
         "mealCarbsLabel": MessageLookupByLibrary.simpleMessage("Carbohydrates"),
+        "mealDetailCurrentSelectionLabel": mMealDetailCurrentSelection,
+        "mealDetailDayTotalLabel": mMealDetailDayTotal,
         "mealFatLabel": MessageLookupByLibrary.simpleMessage("Fat"),
         "mealKcalLabel": MessageLookupByLibrary.simpleMessage("kcal per"),
         "mealEnergyLabel": MessageLookupByLibrary.simpleMessage("Energy"),

--- a/lib/generated/intl/messages_it.dart
+++ b/lib/generated/intl/messages_it.dart
@@ -98,6 +98,12 @@ class MessageLookup extends MessageLookupByLibrary {
   static String mMergeOneIt(winner) => "Unito — ${winner} ora ha 1 voce registrata.";
   static String mFastingChipIt(remaining) => "Digiuno · ${remaining} rimanenti";
 
+  static String mMealDetailDayTotal(consumed, goal) =>
+      "Totale giornaliero: ${consumed} / ${goal}";
+
+  static String mMealDetailCurrentSelection(kcal) =>
+      "(+${kcal} kcal selezione attuale)";
+
   final messages = _notInlinedMessages(_notInlinedMessages);
   static Map<String, Function> _notInlinedMessages(_) => <String, Function>{
         "activityExample": MessageLookupByLibrary.simpleMessage(
@@ -442,6 +448,8 @@ class MessageLookup extends MessageLookupByLibrary {
         "mealBrandsLabel": MessageLookupByLibrary.simpleMessage("Marche"),
         "mealCarbsLabel":
             MessageLookupByLibrary.simpleMessage("Carboidrati"),
+        "mealDetailCurrentSelectionLabel": mMealDetailCurrentSelection,
+        "mealDetailDayTotalLabel": mMealDetailDayTotal,
         "mealFatLabel": MessageLookupByLibrary.simpleMessage("Grassi"),
         "mealKcalLabel": MessageLookupByLibrary.simpleMessage("kcal per"),
         "mealEnergyLabel": MessageLookupByLibrary.simpleMessage("Energia"),

--- a/lib/generated/intl/messages_pl.dart
+++ b/lib/generated/intl/messages_pl.dart
@@ -97,6 +97,12 @@ class MessageLookup extends MessageLookupByLibrary {
   static String mMergeOnePl(winner) => "Połączono — ${winner} ma teraz 1 wpis.";
   static String mFastingChipPl(remaining) => "Post · pozostało ${remaining}";
 
+  static String mMealDetailDayTotal(consumed, goal) =>
+      "Suma dzienna: ${consumed} / ${goal}";
+
+  static String mMealDetailCurrentSelection(kcal) =>
+      "(+${kcal} kcal bieżący wybór)";
+
   final messages = _notInlinedMessages(_notInlinedMessages);
   static Map<String, Function> _notInlinedMessages(_) => <String, Function>{
         "activityExample": MessageLookupByLibrary.simpleMessage(
@@ -439,6 +445,8 @@ class MessageLookup extends MessageLookupByLibrary {
         "mealBrandsLabel": MessageLookupByLibrary.simpleMessage("Marki"),
         "mealCarbsLabel":
             MessageLookupByLibrary.simpleMessage("Węglowodany"),
+        "mealDetailCurrentSelectionLabel": mMealDetailCurrentSelection,
+        "mealDetailDayTotalLabel": mMealDetailDayTotal,
         "mealFatLabel": MessageLookupByLibrary.simpleMessage("Tłuszcze"),
         "mealKcalLabel": MessageLookupByLibrary.simpleMessage("kcal na"),
         "mealEnergyLabel": MessageLookupByLibrary.simpleMessage("Energia"),

--- a/lib/generated/intl/messages_sk.dart
+++ b/lib/generated/intl/messages_sk.dart
@@ -98,6 +98,12 @@ class MessageLookup extends MessageLookupByLibrary {
   static String mMergeOneSk(winner) => "Zlúčené — ${winner} má teraz 1 záznam.";
   static String mFastingChipSk(remaining) => "Pôst · zostáva ${remaining}";
 
+  static String mMealDetailDayTotal(consumed, goal) =>
+      "Denný súčet: ${consumed} / ${goal}";
+
+  static String mMealDetailCurrentSelection(kcal) =>
+      "(+${kcal} kcal aktuálny výber)";
+
   final messages = _notInlinedMessages(_notInlinedMessages);
   static Map<String, Function> _notInlinedMessages(_) => <String, Function>{
         "activityExample": MessageLookupByLibrary.simpleMessage(
@@ -424,6 +430,8 @@ class MessageLookup extends MessageLookupByLibrary {
         "magnesiumLabel": MessageLookupByLibrary.simpleMessage("horčík"),
         "mealBrandsLabel": MessageLookupByLibrary.simpleMessage("Značky"),
         "mealCarbsLabel": MessageLookupByLibrary.simpleMessage("Sacharidy"),
+        "mealDetailCurrentSelectionLabel": mMealDetailCurrentSelection,
+        "mealDetailDayTotalLabel": mMealDetailDayTotal,
         "mealFatLabel": MessageLookupByLibrary.simpleMessage("Tuky"),
         "mealKcalLabel": MessageLookupByLibrary.simpleMessage("kcal"),
         "mealNameLabel": MessageLookupByLibrary.simpleMessage("Názov jedla"),

--- a/lib/generated/intl/messages_tr.dart
+++ b/lib/generated/intl/messages_tr.dart
@@ -100,6 +100,12 @@ class MessageLookup extends MessageLookupByLibrary {
   static String mMergeOneTr(winner) => "Birleştirildi — ${winner} artık 1 kayda sahip.";
   static String mFastingChipTr(remaining) => 'Oruç · ${remaining} kaldı';
 
+  static String mMealDetailDayTotal(consumed, goal) =>
+      "Günlük toplam: ${consumed} / ${goal}";
+
+  static String mMealDetailCurrentSelection(kcal) =>
+      "(+${kcal} kcal mevcut seçim)";
+
   final messages = _notInlinedMessages(_notInlinedMessages);
   static Map<String, Function> _notInlinedMessages(_) => <String, Function>{
         "activityExample": MessageLookupByLibrary.simpleMessage(
@@ -440,6 +446,8 @@ class MessageLookup extends MessageLookupByLibrary {
         "mealBrandsLabel": MessageLookupByLibrary.simpleMessage("Markalar"),
         "mealCarbsLabel":
             MessageLookupByLibrary.simpleMessage("Karbonhidrat"),
+        "mealDetailCurrentSelectionLabel": mMealDetailCurrentSelection,
+        "mealDetailDayTotalLabel": mMealDetailDayTotal,
         "mealFatLabel": MessageLookupByLibrary.simpleMessage("Yağ"),
         "mealKcalLabel": MessageLookupByLibrary.simpleMessage("kcal başına"),
         "mealEnergyLabel": MessageLookupByLibrary.simpleMessage("Enerji"),

--- a/lib/generated/intl/messages_uk.dart
+++ b/lib/generated/intl/messages_uk.dart
@@ -98,6 +98,12 @@ class MessageLookup extends MessageLookupByLibrary {
   static String mMergeOneUk(winner) => "Об'єднано — ${winner} тепер має 1 запис.";
   static String mFastingChipUk(remaining) => "Голодування · залишилось ${remaining}";
 
+  static String mMealDetailDayTotal(consumed, goal) =>
+      "Денний підсумок: ${consumed} / ${goal}";
+
+  static String mMealDetailCurrentSelection(kcal) =>
+      "(+${kcal} kcal поточний вибір)";
+
   final messages = _notInlinedMessages(_notInlinedMessages);
   static Map<String, Function> _notInlinedMessages(_) => <String, Function>{
         "activityExample": MessageLookupByLibrary.simpleMessage(
@@ -441,6 +447,8 @@ class MessageLookup extends MessageLookupByLibrary {
         "magnesiumLabel": MessageLookupByLibrary.simpleMessage("магній"),
         "mealBrandsLabel": MessageLookupByLibrary.simpleMessage("Бренди"),
         "mealCarbsLabel": MessageLookupByLibrary.simpleMessage("Вуглеводи"),
+        "mealDetailCurrentSelectionLabel": mMealDetailCurrentSelection,
+        "mealDetailDayTotalLabel": mMealDetailDayTotal,
         "mealFatLabel": MessageLookupByLibrary.simpleMessage("Жири"),
         "mealKcalLabel": MessageLookupByLibrary.simpleMessage("ккал на"),
         "mealEnergyLabel": MessageLookupByLibrary.simpleMessage("Енергія"),

--- a/lib/generated/intl/messages_zh.dart
+++ b/lib/generated/intl/messages_zh.dart
@@ -95,6 +95,12 @@ class MessageLookup extends MessageLookupByLibrary {
   static String mMergeOneZh(winner) => "已合并 — ${winner} 现在有 1 条记录。";
   static String mFastingChipZh(remaining) => "禁食中 · 剩余 ${remaining}";
 
+  static String mMealDetailDayTotal(consumed, goal) =>
+      "今日总计：${consumed} / ${goal}";
+
+  static String mMealDetailCurrentSelection(kcal) =>
+      "（+${kcal} 千卡 当前选择）";
+
   final messages = _notInlinedMessages(_notInlinedMessages);
   static Map<String, Function> _notInlinedMessages(_) => <String, Function>{
         "activityExample":
@@ -404,6 +410,8 @@ class MessageLookup extends MessageLookupByLibrary {
         "magnesiumLabel": MessageLookupByLibrary.simpleMessage("镁"),
         "mealBrandsLabel": MessageLookupByLibrary.simpleMessage("品牌"),
         "mealCarbsLabel": MessageLookupByLibrary.simpleMessage("碳水化合物"),
+        "mealDetailCurrentSelectionLabel": mMealDetailCurrentSelection,
+        "mealDetailDayTotalLabel": mMealDetailDayTotal,
         "mealFatLabel": MessageLookupByLibrary.simpleMessage("脂肪"),
         "mealKcalLabel": MessageLookupByLibrary.simpleMessage("卡路里每"),
         "mealEnergyLabel": MessageLookupByLibrary.simpleMessage("能量"),

--- a/lib/generated/l10n.dart
+++ b/lib/generated/l10n.dart
@@ -4171,6 +4171,26 @@ class S {
     );
   }
 
+  /// `Day total: {consumed} / {goal}`
+  String mealDetailDayTotalLabel(String consumed, String goal) {
+    return Intl.message(
+      'Day total: $consumed / $goal',
+      name: 'mealDetailDayTotalLabel',
+      desc: '',
+      args: [consumed, goal],
+    );
+  }
+
+  /// `(+{kcal} kcal current selection)`
+  String mealDetailCurrentSelectionLabel(String kcal) {
+    return Intl.message(
+      '(+$kcal kcal current selection)',
+      name: 'mealDetailCurrentSelectionLabel',
+      desc: '',
+      args: [kcal],
+    );
+  }
+
   /// `Fat (g)`
   String get mealFatLabel {
     return Intl.message(

--- a/lib/l10n/intl_cs.arb
+++ b/lib/l10n/intl_cs.arb
@@ -337,6 +337,8 @@
   "magnesiumLabel": "hořčík",
   "mealBrandsLabel": "Výrobce, značka",
   "mealCarbsLabel": "Sacharidy",
+  "mealDetailCurrentSelectionLabel": "(+{kcal} kcal aktuální výběr)",
+  "mealDetailDayTotalLabel": "Denní součet: {consumed} / {goal}",
   "mealEnergyLabel": "Energie",
   "mealFatLabel": "Tuky",
   "mealImageLabel": "Přidat fotku",

--- a/lib/l10n/intl_de.arb
+++ b/lib/l10n/intl_de.arb
@@ -368,6 +368,8 @@
   "magnesiumLabel": "Magnesium",
   "mealBrandsLabel": "Marken",
   "mealCarbsLabel": "Kohlenhydrate",
+  "mealDetailCurrentSelectionLabel": "(+{kcal} kcal aktuelle Auswahl)",
+  "mealDetailDayTotalLabel": "Tagessumme: {consumed} / {goal}",
   "mealEnergyLabel": "Energie",
   "mealFatLabel": "Fett",
   "mealImageLabel": "Foto hinzufügen",

--- a/lib/l10n/intl_en.arb
+++ b/lib/l10n/intl_en.arb
@@ -86,6 +86,23 @@
       }
     }
   },
+  "@mealDetailCurrentSelectionLabel": {
+    "placeholders": {
+      "kcal": {
+        "type": "String"
+      }
+    }
+  },
+  "@mealDetailDayTotalLabel": {
+    "placeholders": {
+      "consumed": {
+        "type": "String"
+      },
+      "goal": {
+        "type": "String"
+      }
+    }
+  },
   "@mealNutrientsPerQtyLabel": {
     "placeholders": {
       "qty": {
@@ -402,6 +419,8 @@
   "magnesiumLabel": "magnesium",
   "mealBrandsLabel": "Brands",
   "mealCarbsLabel": "Carbohydrates",
+  "mealDetailCurrentSelectionLabel": "(+{kcal} kcal current selection)",
+  "mealDetailDayTotalLabel": "Day total: {consumed} / {goal}",
   "mealEnergyLabel": "Energy",
   "mealFatLabel": "Fat",
   "mealImageLabel": "Add a photo",

--- a/lib/l10n/intl_it.arb
+++ b/lib/l10n/intl_it.arb
@@ -337,6 +337,8 @@
   "magnesiumLabel": "magnesio",
   "mealBrandsLabel": "Marche",
   "mealCarbsLabel": "Carboidrati",
+  "mealDetailCurrentSelectionLabel": "(+{kcal} kcal selezione attuale)",
+  "mealDetailDayTotalLabel": "Totale giornaliero: {consumed} / {goal}",
   "mealEnergyLabel": "Energia",
   "mealFatLabel": "Grassi",
   "mealImageLabel": "Aggiungi una foto",

--- a/lib/l10n/intl_pl.arb
+++ b/lib/l10n/intl_pl.arb
@@ -337,6 +337,8 @@
   "magnesiumLabel": "magnez",
   "mealBrandsLabel": "Marki",
   "mealCarbsLabel": "Węglowodany",
+  "mealDetailCurrentSelectionLabel": "(+{kcal} kcal bieżący wybór)",
+  "mealDetailDayTotalLabel": "Suma dzienna: {consumed} / {goal}",
   "mealEnergyLabel": "Energia",
   "mealFatLabel": "Tłuszcze",
   "mealImageLabel": "Dodaj zdjęcie",

--- a/lib/l10n/intl_sk.arb
+++ b/lib/l10n/intl_sk.arb
@@ -384,6 +384,8 @@
   "magnesiumLabel": "horčík",
   "mealBrandsLabel": "Značky",
   "mealCarbsLabel": "Sacharidy",
+  "mealDetailCurrentSelectionLabel": "(+{kcal} kcal aktuálny výber)",
+  "mealDetailDayTotalLabel": "Denný súčet: {consumed} / {goal}",
   "mealEnergyLabel": "Energia",
   "mealFatLabel": "Tuky",
   "mealImageLabel": "Pridať fotku",

--- a/lib/l10n/intl_tr.arb
+++ b/lib/l10n/intl_tr.arb
@@ -368,6 +368,8 @@
   "magnesiumLabel": "magnezyum",
   "mealBrandsLabel": "Markalar",
   "mealCarbsLabel": "Karbonhidrat",
+  "mealDetailCurrentSelectionLabel": "(+{kcal} kcal mevcut seçim)",
+  "mealDetailDayTotalLabel": "Günlük toplam: {consumed} / {goal}",
   "mealEnergyLabel": "Enerji",
   "mealFatLabel": "Yağ",
   "mealImageLabel": "Fotoğraf ekle",

--- a/lib/l10n/intl_uk.arb
+++ b/lib/l10n/intl_uk.arb
@@ -337,6 +337,8 @@
   "magnesiumLabel": "магній",
   "mealBrandsLabel": "Бренди",
   "mealCarbsLabel": "Вуглеводи",
+  "mealDetailCurrentSelectionLabel": "(+{kcal} kcal поточний вибір)",
+  "mealDetailDayTotalLabel": "Денний підсумок: {consumed} / {goal}",
   "mealEnergyLabel": "Енергія",
   "mealFatLabel": "Жири",
   "mealImageLabel": "Додати фото",

--- a/lib/l10n/intl_zh.arb
+++ b/lib/l10n/intl_zh.arb
@@ -338,6 +338,8 @@
   "magnesiumLabel": "镁",
   "mealBrandsLabel": "品牌",
   "mealCarbsLabel": "碳水化合物",
+  "mealDetailCurrentSelectionLabel": "（+{kcal} 千卡 当前选择）",
+  "mealDetailDayTotalLabel": "今日总计：{consumed} / {goal}",
   "mealEnergyLabel": "能量",
   "mealFatLabel": "脂肪",
   "mealImageLabel": "添加照片",

--- a/test/unit_test/meal_detail_manual_add_serving_default_test.dart
+++ b/test/unit_test/meal_detail_manual_add_serving_default_test.dart
@@ -4,6 +4,7 @@ import 'package:opennutritracker/core/domain/usecase/add_intake_usecase.dart';
 import 'package:opennutritracker/core/domain/usecase/add_tracked_day_usecase.dart';
 import 'package:opennutritracker/core/domain/usecase/get_kcal_goal_usecase.dart';
 import 'package:opennutritracker/core/domain/usecase/get_macro_goal_usecase.dart';
+import 'package:opennutritracker/core/domain/usecase/get_tracked_day_usecase.dart';
 import 'package:opennutritracker/features/add_meal/data/repository/products_repository.dart';
 import 'package:opennutritracker/features/add_meal/domain/entity/meal_entity.dart';
 import 'package:opennutritracker/features/add_meal/domain/entity/meal_nutriments_entity.dart';
@@ -30,6 +31,8 @@ class _FakeGetKcalGoalUsecase extends Fake implements GetKcalGoalUsecase {}
 
 class _FakeGetMacroGoalUsecase extends Fake implements GetMacroGoalUsecase {}
 
+class _FakeGetTrackedDayUsecase extends Fake implements GetTrackedDayUsecase {}
+
 class _FakeProductsRepository extends Fake implements ProductsRepository {}
 
 class _FakeRemoteSearchCacheDataSource extends Fake
@@ -40,6 +43,7 @@ MealDetailBloc _buildBloc() => MealDetailBloc(
       _FakeAddTrackedDayUsecase(),
       _FakeGetKcalGoalUsecase(),
       _FakeGetMacroGoalUsecase(),
+      _FakeGetTrackedDayUsecase(),
       _FakeProductsRepository(),
       _FakeRemoteSearchCacheDataSource(),
     );


### PR DESCRIPTION
## Summary

Closes #452. Adds a compact banner to the meal detail screen so the
person scanning a barcode can see how much of their
day's kcal budget is already spoken for without backing out to the
home dashboard.

The bar reads in two tones from the same primary-green family: a
solid segment up to the kcal already logged for the day the user is
logging against, and a lighter segment on top showing what adding
the current selection would do. The shades belong to the same colour
family so the bar still feels like one indicator, but the lighter
section makes the "this is the projection if I add it" portion
visually distinct from "this is already on my plate today." A label
underneath reads `Day total: <projection> / <goal>`, and when the
selection is non-zero a smaller `(+N kcal current selection)` line
appears so the bar's motion is legible.

The banner sits in the SliverAppBar's `bottom:` slot below the back
arrow and edit action, and stays pinned alongside the collapsing app
bar as the rest of the screen scrolls past. Already-consumed values
come from `GetTrackedDayUsecase`; when no intake has been logged for
the day yet, the goal falls back to `GetKcalGoalUsecase`.

## Design decisions

Two product choices, both confirmed before implementation:

- **Live projection** rather than already-consumed only — the bar
  moves as the user adjusts quantity, so the decision and the budget
  sit together in one place.
- **Selected-day anchor** rather than always today — editing a past
  entry still answers the right question for that day. The label
  reads "Day total" rather than "Cal today" so it stays accurate
  regardless.

## Localisation

All nine locales updated for parity: en, de, cs, it, pl, sk, tr, uk,
zh. Two new keys — `mealDetailDayTotalLabel` and
`mealDetailCurrentSelectionLabel` — added across the ARB files and
manually threaded through `l10n.dart` and `messages_<locale>.dart`
following this repo's existing manual-l10n pattern.

## Test plan

- [x] `flutter analyze` clean
- [x] `flutter test` — all 594 tests pass (existing meal-detail
      bloc-constructor unit test updated for the new use case)
- [x] Linux desktop run with light + dark themes
- [x] ADB-driven verification on a Pixel device with the develop
      flavor APK: walk onboarding, log an intake to make consumed
      non-zero, open meal detail and confirm both tones render, scroll
      the screen and confirm the banner stays pinned