### PR TITLE
docs: refresh README, CONTRIBUTING, CLAUDE.md, and store copy for the next release

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -76,7 +76,7 @@ dart run build_runner build
 
 ## Localization
 
-Source strings live in `lib/l10n/intl_en.arb` (and locale ARBs for `de`, `cs`, `it`, `pl`, `tr`, `uk`, `zh`). Generated Dart files live in `lib/generated/intl/` and `lib/generated/l10n.dart`.
+Source strings live in `lib/l10n/intl_en.arb` (and locale ARBs for `de`, `cs`, `it`, `pl`, `sk`, `tr`, `uk`, `zh`). Generated Dart files live in `lib/generated/intl/` and `lib/generated/l10n.dart`.
 
 The generated files in `lib/generated/` are **manually maintained** — do not regenerate them with `intl_translation:generate_from_arb`, as the generator output conflicts with the project's 120-char formatting. Edit them directly when adding strings, then run `just check_intl` to verify CI passes.
 
@@ -233,16 +233,18 @@ lib/
     styles/       # Color schemes, typography
     utils/        # locator.dart (DI), hive_db_provider.dart, env.dart, calc/, etc.
   features/       # One folder per screen/flow
-    home/         # Dashboard with daily kcal/macro summary
-    diary/        # Calendar-based food diary
-    profile/      # User stats, BMI, goals
+    home/         # Dashboard with daily kcal/macro summary, water chip, fasting chip
+    diary/        # Calendar-based food diary, micronutrient panel, sort controls
+    profile/      # User stats, BMI, goals, weight history chart
     add_meal/     # Food search (text + barcode) and meal logging
-    meal_detail/  # Nutritional detail view for a food item
-    edit_meal/    # Edit a logged intake entry
-    scanner/      # Barcode camera scanner
-    add_activity/ # Log physical activity
+    meal_detail/  # Nutritional detail view for a food item, with daily kcal banner
+    edit_meal/    # Edit a logged intake entry, custom meal create / template
+    scanner/      # Barcode camera scanner (with manual entry fallback)
+    add_activity/ # Log physical activity, including custom kcal templates
     activity_detail/ # View logged activity
-    settings/     # App settings, data export/import
+    fasting/      # Intermittent-fasting timer with content-warning gate
+    recipes/      # Reusable recipes with photo, brand, ingredient picker
+    settings/     # App settings, data export/import, day-start, theme picker
     onboarding/   # First-run user setup flow
   generated/      # Intl files — maintained manually (see Localization above)
   l10n/           # Source ARB translation files
@@ -271,17 +273,25 @@ Named routes are defined in `NavigationOptions` and registered in `main.dart`. T
 
 ### Local database
 
-**hive_ce** (the actively maintained community fork of Hive) is used for all persistent local storage, AES-256 encrypted. The five boxes opened by `HiveDBProvider`:
+**hive_ce** (the actively maintained community fork of Hive) is used for all persistent local storage, AES-256 encrypted. The boxes opened by `HiveDBProvider`:
 
-| Box               | DBO type          | Purpose                                                         |
-| ----------------- | ----------------- | --------------------------------------------------------------- |
-| `ConfigBox`       | `ConfigDBO`       | App settings: theme, units, kcal adjustment, per-macro % goals  |
-| `IntakeBox`       | `IntakeDBO`       | Meal log entries (links to `MealDBO`, typed by `IntakeTypeDBO`) |
-| `UserActivityBox` | `UserActivityDBO` | Logged physical activities                                      |
-| `UserBox`         | `UserDBO`         | User profile: height, weight, birthday, gender, PAL, goal       |
-| `TrackedDayBox`   | `TrackedDayDBO`   | Per-day calorie/macro running totals for diary calendar         |
+| Box                            | DBO type / payload          | Purpose                                                              |
+| ------------------------------ | --------------------------- | -------------------------------------------------------------------- |
+| `ConfigBox`                    | `ConfigDBO`                 | App settings: theme, units, kcal adjustment, per-macro % goals       |
+| `IntakeBox`                    | `IntakeDBO`                 | Meal log entries (links to `MealDBO`, typed by `IntakeTypeDBO`)      |
+| `UserActivityBox`              | `UserActivityDBO`           | Logged physical activities                                           |
+| `UserBox`                      | `UserDBO`                   | User profile: height, weight, birthday, gender, PAL, goal            |
+| `TrackedDayBox`                | `TrackedDayDBO`             | Per-day calorie/macro running totals for diary calendar              |
+| `CustomMealBox`                | `MealDBO`                   | User-saved custom meals (search index for the food picker)           |
+| `RecipeBox`                    | `RecipeDBO`                 | User-saved recipes with photo, brand, ingredients                    |
+| `CachedOffMealBox`             | `MealDBO`                   | Open Food Facts response cache for offline / slow-connection use     |
+| `CachedOffMealTimestampsBox`   | `int`                       | Cache freshness timestamps for the OFF cache                         |
+| `CustomActivityTemplateBox`    | `CustomActivityTemplateDBO` | Reusable templates for custom-kcal activities                        |
+| `WeightLogBox`                 | `WeightLogDBO`              | Weight history points for the profile trend chart                    |
+| `WaterIntakeBox`               | `WaterIntakeDBO`            | Water log entries powering the home chip                             |
+| `FastingBox`                   | `FastingSessionDBO`         | Fasting sessions (current and historical) for the timer              |
 
-When adding a new `@HiveType`, assign a unique `typeId`. Check all existing DBOs to avoid collisions — IDs are currently scattered across 0–15+.
+When adding a new `@HiveType`, assign a unique `typeId`. Check all existing DBOs to avoid collisions — IDs are currently scattered across 0–30+.
 
 ### Food data sources
 
@@ -306,7 +316,7 @@ Calculation utilities live in `lib/core/utils/calc/`:
 
 ### Data export / import
 
-Settings screen exports to a `.zip` containing three JSON files (user activities, intakes, tracked days). Import merges from a user-selected zip. User profile data is **not** included in the export.
+Settings screen exports to a `.zip` that bundles intakes, activities, tracked days, and recipes in both JSON (canonical, re-importable) and CSV (flat, for spreadsheets) formats — see [`docs/export-format.md`](docs/export-format.md) for the full schema. Import accepts the same zip and merges its contents into the existing boxes. User profile data (height, weight, birthday, PAL, goal) is intentionally **not** included in the export. Settings → Import also supports a pasted JSON blob for ad-hoc meal imports.
 
 ## Naming Conventions
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -38,6 +38,7 @@ When adding a new string key in the same PR you must:
    | `intl_cs.arb` | Czech |
    | `intl_it.arb` | Italian |
    | `intl_pl.arb` | Polish |
+   | `intl_sk.arb` | Slovak |
    | `intl_tr.arb` | Turkish |
    | `intl_uk.arb` | Ukrainian |
    | `intl_zh.arb` | Chinese (Simplified) |

--- a/README.md
+++ b/README.md
@@ -38,23 +38,28 @@ OpenNutriTracker is an open-source mobile application designed to simplify nutri
 [<img src="fastlane/metadata/android/en-US/images/playstore_banner.png" width="30%">](https://play.google.com/store/apps/details?id=com.opennutritracker.ont.opennutritracker)
 
 ## Key Features
-- **🍎 Nutritional Tracking:** Easily log your meals and snacks, and access a vast database of food items and ingredients to get detailed nutritional information.
-- **📓 Food Diary:** Maintain a comprehensive food diary to keep track of your daily food consumption, habits, and progress.
-- **🍽️ Custom Meals:** Plan your meals in advance, create personalized meal plans, and optimize them according to your dietary goals.
-- **📷 Barcode Scanner:** Scan barcodes on packaged food items to instantly retrieve their nutritional information.
-- **🔒 Privacy Focused:** OpenNutriTracker prioritizes the privacy its users. It does not collect or share any personal data without your consent.
-- **🚫💰 No Subscription, In-App Purchases, or Ads:** OpenNutriTracker is completely free to use, without any subscription fees, in-app purchases, or intrusive advertisements.
+
+- **🍎 Nutritional tracking:** Log meals and snacks against a large food database (Open Food Facts plus a curated subset of USDA FDC). Each entry can be searched, scanned, or added straight as a number when you already know the calorie cost.
+- **📓 Food diary:** A calendar-driven diary that breaks the day into Breakfast, Lunch, Dinner, and Snack, with per-meal kcal targets (Standard, OMAD, Five-small, Mediterranean, Two-meal, or a custom share), drag-to-rearrange between meals, and sort by time or by macro contribution.
+- **🥕 Micronutrient panel:** Day and week views for fibre, sodium, saturated fat, sugar, calcium, iron, potassium, vitamin D, vitamin B12, and magnesium, with optional Dietary Reference Intake bars from the IOM tables so you can see where you sit against the reference range.
+- **🍽️ Custom meals + recipes:** Build a one-off custom meal or save a reusable recipe with photo, brand, and barcode. The recipe builder has its own ingredient picker with barcode scanning so you can compose meals from real products without leaving the screen.
+- **⚡ Quick add:** When you already know roughly how much you ate, skip the search flow entirely — Quick add takes a title plus kcal (and optional macros) and logs it straight to the meal section.
+- **📷 Barcode scanner:** Scan packaged items for instant lookup, paste a barcode manually when the camera struggles, or attach a barcode to a custom meal so future scans recognise your own foods.
+- **🏃 Activities:** Log workouts from a categorised activity catalogue or define your own custom activities with direct kcal entry and reusable templates.
+- **💧 Water tracker:** A water chip on the home screen with quick-add increments, an editable goal, and undo for the last entry.
+- **⏱️ Fasting timer:** Optional intermittent-fasting timer with content-warning gate, a home chip showing time remaining, and a completion notification when you reach your window.
+- **⚖️ Weight history:** Capture weight during onboarding and on demand, see the trend on a chart with a dashed line at your target weight, and optionally taper the calorie goal as you approach it.
+- **🎨 Material You + theme picker:** Adopt the system accent colour on Android 12+, or pick from sixteen built-in presets. The app icon adapts to iOS dark and tinted appearances and to Android themed icons.
+- **🔢 kcal or kJ:** Switch the energy unit globally; every diary entry, target, and chart reflects the choice.
+- **📤 Export and import:** Export your full diary, activities, and custom catalogue to a JSON zip or CSV, paste a JSON blob to import meals, and share a single meal or activity as a QR code another phone can scan.
+- **🔒 Privacy first:** All data is AES-encrypted and stored locally. Anonymous crash reporting is opt-in during onboarding, can be turned off at any time, and the App Store privacy manifest declares exactly what the app does and does not collect.
+- **🚫💰 No subscriptions, in-app purchases, or ads:** OpenNutriTracker is free, with no paid tier and no advertising.
 
 ## Privacy
 See [Data Protection](https://www.iubenda.com/privacy-policy/53501884)
 - **Data Encryption**: All collected user data is encrypted and stored locally on your device
 - **Minimal Data Collection**: OpenNutriTracker only collects the necessary information required for tracking nutrition and providing personalized insights. Your data will not be shared with third parties without your consent.
 - **Open-Source**: OpenNutriTracker is an open-source application
-
-## TODOs
-- ~~Add serving sizes to meals~~
-- ~~Add Imperial unit support~~
-- Add support for Material You themes
 
 ## Verifying APK signatures
 
@@ -98,7 +103,9 @@ The application is still under construction. Errors, bugs and crashes might occu
 
 ## Acknowledgments
 The OpenNutriTracker project was inspired by the need for a simple and effective nutrition tracking tool.
-The food database used in OpenNutriTracker is powered by [Open Food Facts](https://world.openfoodfacts.org/) and [Food Data Central](https://fdc.nal.usda.gov/).
+The food database used in OpenNutriTracker is powered by [Open Food Facts](https://world.openfoodfacts.org/) and [Food Data Central](https://fdc.nal.usda.gov/). A curated subset of FDC is hosted in Supabase to keep search responsive on slow connections; the schema and refresh process are documented in [`docs/supabase-fdc-self-hosting.md`](docs/supabase-fdc-self-hosting.md).
+
+Dietary Reference Intake values for the micronutrient panel come from the U.S. National Academies' Institute of Medicine tables. The in-app **Sources & References** screen (one tap from the home calorie ring or the profile BMI card) lists the peer-reviewed sources used for energy needs, BMI classification, macro distribution, MET activity calories, and non-binary calorie estimation.
 
 ## License
 This project is licensed under the GNU General Public License v3.0 License. See the [LICENSE](LICENSE) file for more information.

--- a/fastlane/metadata/android/en-US/full_description.txt
+++ b/fastlane/metadata/android/en-US/full_description.txt
@@ -1,9 +1,18 @@
 OpenNutriTracker is an open-source mobile application designed to simplify nutritional tracking and management. Whether you are looking to improve your health, lose weight, or simply maintain a balanced diet, OpenNutriTracker provides a minimalistic interface to easily track and analyze your daily nutrition.
 
 
-🍎 Nutritional Tracking: Easily log your meals and snacks, and access a vast database of food items and ingredients to get detailed nutritional information.
-📓 Food Diary: Maintain a comprehensive food diary to keep track of your daily food consumption, habits, and progress.
-🍽️ Custom Meals: Plan your meals in advance, create personalized meal plans, and optimize them according to your dietary goals.
-📷 Barcode Scanner: Scan barcodes on packaged food items to instantly retrieve their nutritional information.
-🔒 Privacy Focused: OpenNutriTracker prioritizes the privacy its users. It does not collect or share any personal data without your consent.
-🚫💰 No Subscription, In-App Purchases, or Ads: OpenNutriTracker is completely free to use, without any subscription fees, in-app purchases, or intrusive advertisements.
+🍎 Nutritional tracking: Log meals and snacks against a large food database (Open Food Facts plus a curated subset of USDA FDC). Search, scan, or add straight as a number when you already know the calorie cost.
+📓 Food diary: A calendar-driven diary that breaks the day into Breakfast, Lunch, Dinner, and Snack, with per-meal kcal targets (Standard, OMAD, Five-small, Mediterranean, Two-meal, or a custom share), drag-to-rearrange between meals, and sort by time or by macro contribution.
+🥕 Micronutrient panel: Day and week views for fibre, sodium, saturated fat, sugar, calcium, iron, potassium, vitamin D, vitamin B12, and magnesium, with optional Dietary Reference Intake bars from the IOM tables.
+🍽️ Custom meals & recipes: Build a one-off custom meal or save a reusable recipe with photo, brand, and barcode. The recipe builder has its own ingredient picker with barcode scanning so you can compose meals from real products.
+⚡ Quick add: When you already know roughly how much you ate, skip the search flow entirely — Quick add takes a title plus kcal (and optional macros) and logs it straight to the meal section.
+📷 Barcode scanner: Scan packaged items for instant lookup, paste a barcode manually when the camera struggles, or attach a barcode to a custom meal so future scans recognise your own foods.
+🏃 Activities: Log workouts from a categorised activity catalogue or define your own custom activities with direct kcal entry and reusable templates.
+💧 Water tracker: A water chip on the home screen with quick-add increments, an editable goal, and undo for the last entry.
+⏱️ Fasting timer: Optional intermittent-fasting timer with content-warning gate, a home chip showing time remaining, and a completion notification when you reach your window.
+⚖️ Weight history: Capture weight during onboarding and on demand, see the trend on a chart with a dashed line at your target weight, and optionally taper the calorie goal as you approach it.
+🎨 Material You & theme picker: Adopt the system accent colour on Android 12+, or pick from sixteen built-in presets. The app icon adapts to Android themed icons.
+🔢 kcal or kJ: Switch the energy unit globally; every diary entry, target, and chart reflects the choice.
+📤 Export & import: Export your full diary, activities, and custom catalogue to a JSON zip or CSV, paste a JSON blob to import meals, and share a single meal or activity as a QR code another phone can scan.
+🔒 Privacy first: All data is AES-encrypted and stored locally. Anonymous crash reporting is opt-in during onboarding and can be turned off at any time.
+🚫💰 No subscriptions, in-app purchases, or ads: OpenNutriTracker is completely free, with no paid tier and no advertising.


### PR DESCRIPTION
## Summary

Develop has moved on substantially since the last release to main, and the
docs hadn't caught up with what someone arriving at the repo (or the store
listing) would actually see in the app. This sweep brings the user-facing
and contributor-facing surfaces back into line with the feature set that
is shipping.

## What changed

**README.md.** Replaced the sparse six-bullet feature list with one that
reflects the diary (per-meal kcal share, sort by macros, drag between
meals), the micronutrient panel with IOM DRI bars, recipes alongside
custom meals, Quick add for one-tap kcal entry, the water tracker, the
fasting timer, weight history with target line and optional calorie
taper, the Material You theme picker, the kcal/kJ switch, and the
JSON-zip / CSV export plus QR sharing. Dropped the "Add support for
Material You themes" TODO since it landed in #426. Added a line about
the in-app Sources & References screen and a pointer to the Supabase
FDC self-hosting doc.

**CONTRIBUTING.md.** Added Slovak (`intl_sk.arb`) to the locale table.
The locale landed in #392 but never reached the contributor-facing
list, so anyone adding a string was missing one of the nine ARB files
they needed to update.

**CLAUDE.md.** The directory-structure block now lists the `fasting`
and `recipes` feature folders; the Hive boxes table grew from five to
thirteen entries (custom meals, recipes, OFF cache and its timestamps,
custom-activity templates, weight log, water, fasting); the locale
list mentions Slovak; the data-export blurb reflects that the bundle
now carries JSON and CSV for intakes, activities, tracked days, and
recipes, and points at `docs/export-format.md` for the full schema.

**Fastlane store copy.** Mirrored the refreshed feature list into
`full_description.txt` so the Play Store listing matches what the app
actually does. Short description is still accurate at 76 chars.

## Test plan

- [x] `flutter analyze` clean
- [x] `just check_intl` clean (no generated-file drift; no string
      additions in this PR)
- [x] No code changes, no string changes, no l10n churn — only the
      five doc files above