### PR TITLE
feat(add-meal): show emoji icons for FDC base-food items

### DIFF
--- a/lib/features/add_meal/presentation/widgets/meal_item_card.dart
+++ b/lib/features/add_meal/presentation/widgets/meal_item_card.dart
@@ -7,6 +7,7 @@ import 'package:opennutritracker/core/utils/locator.dart';
 import 'package:opennutritracker/core/utils/navigation_options.dart';
 import 'package:opennutritracker/features/add_meal/domain/entity/meal_entity.dart';
 import 'package:opennutritracker/features/add_meal/presentation/add_meal_type.dart';
+import 'package:opennutritracker/features/add_meal/util/food_emoji_resolver.dart';
 import 'package:opennutritracker/features/meal_detail/meal_detail_screen.dart';
 import 'package:opennutritracker/generated/l10n.dart';
 
@@ -27,6 +28,14 @@ class MealItemCard extends StatelessWidget {
   @override
   Widget build(BuildContext context) {
     final isRecipe = mealEntity.source == MealSourceEntity.recipe;
+    // Colored emoji is reserved for FDC base-food items where the head
+    // noun reliably identifies the food ("Milk, fluid, nonfat..." → milk).
+    // OFF products are branded, so a head-noun match would often be
+    // misleading; they keep the outline icon as a placeholder.
+    final emoji = (mealEntity.thumbnailImageUrl == null &&
+            mealEntity.source == MealSourceEntity.fdc)
+        ? resolveFoodEmoji(mealEntity.name)
+        : null;
     return Card(
       elevation: 0,
       shape: RoundedRectangleBorder(
@@ -59,19 +68,25 @@ class MealItemCard extends StatelessWidget {
                       child: Container(
                         width: 60,
                         height: 60,
+                        alignment: Alignment.center,
                         color: isRecipe
                             ? Theme.of(context).colorScheme.primaryContainer
                             : Theme.of(context).colorScheme.secondaryContainer,
-                        child: Icon(
-                          isRecipe
-                              ? Icons.menu_book
-                              : Icons.restaurant_outlined,
-                          color: isRecipe
-                              ? Theme.of(context)
-                                  .colorScheme
-                                  .onPrimaryContainer
-                              : null,
-                        ),
+                        child: emoji != null
+                            ? Text(
+                                emoji,
+                                style: const TextStyle(fontSize: 32),
+                              )
+                            : Icon(
+                                isRecipe
+                                    ? Icons.menu_book
+                                    : Icons.restaurant_outlined,
+                                color: isRecipe
+                                    ? Theme.of(context)
+                                        .colorScheme
+                                        .onPrimaryContainer
+                                    : null,
+                              ),
                       ),
                     ),
               title: AutoSizeText.rich(

--- a/lib/features/add_meal/presentation/widgets/meal_item_card.dart
+++ b/lib/features/add_meal/presentation/widgets/meal_item_card.dart
@@ -73,9 +73,11 @@ class MealItemCard extends StatelessWidget {
                             ? Theme.of(context).colorScheme.primaryContainer
                             : Theme.of(context).colorScheme.secondaryContainer,
                         child: emoji != null
-                            ? Text(
-                                emoji,
-                                style: const TextStyle(fontSize: 32),
+                            ? ExcludeSemantics(
+                                child: Text(
+                                  emoji,
+                                  style: const TextStyle(fontSize: 32),
+                                ),
                               )
                             : Icon(
                                 isRecipe

--- a/lib/features/add_meal/util/food_emoji_resolver.dart
+++ b/lib/features/add_meal/util/food_emoji_resolver.dart
@@ -6,8 +6,9 @@
 /// Lookup is name-only — no category fallback. USDA descriptions follow
 /// `Head noun, qualifier, qualifier, …`, so the first token is the
 /// real identity of the food ("Milk, fluid, nonfat..." → "milk").
-/// OFF product names happen to follow the same loose convention often
-/// enough that the same resolver also helps for unimaged OFF entries.
+/// The only caller applies this to FDC base-food items; OFF products are
+/// branded, so they keep their placeholder icon rather than risk a
+/// misleading head-noun match.
 ///
 /// Returns `null` when the head noun isn't in the curated map — callers
 /// should fall back to their existing iconography. Keeping the map small

--- a/lib/features/add_meal/util/food_emoji_resolver.dart
+++ b/lib/features/add_meal/util/food_emoji_resolver.dart
@@ -1,0 +1,196 @@
+/// Maps a food's head noun (first comma-separated token of the
+/// description) to a representative emoji. Rendered as a Text widget so the
+/// platform's color emoji font draws it — Apple Color Emoji on iOS, Noto
+/// Color Emoji on Android.
+///
+/// Lookup is name-only — no category fallback. USDA descriptions follow
+/// `Head noun, qualifier, qualifier, …`, so the first token is the
+/// real identity of the food ("Milk, fluid, nonfat..." → "milk").
+/// OFF product names happen to follow the same loose convention often
+/// enough that the same resolver also helps for unimaged OFF entries.
+///
+/// Returns `null` when the head noun isn't in the curated map — callers
+/// should fall back to their existing iconography. Keeping the map small
+/// and curated avoids a long-tail with mismatched emoji ("seaweed" → 🌿
+/// looks wrong; we'd rather show no emoji than a misleading one).
+String? resolveFoodEmoji(String? name) {
+  if (name == null || name.isEmpty) return null;
+  final head = name.split(',').first.trim().toLowerCase();
+  if (head.isEmpty) return null;
+  return _nounToEmoji[head];
+}
+
+/// Source of truth: each emoji owns the head nouns it should match.
+/// Grouping by emoji makes duplicates obvious at a glance and keeps the
+/// noun→emoji direction easy to extend (just append to the right list).
+///
+/// **Plural and spacing variants are generated automatically** by
+/// [_variantsOf] when building [_nounToEmoji]: a regular `+s` plural and,
+/// for multi-word nouns, the same forms with spaces collapsed
+/// ("olive oil" → also matches "oliveoil" / "oliveoils"). So only list
+/// the canonical singular here. Irregular plurals (-ies, -oes, fungus→fungi)
+/// must still be listed explicitly because the variant generator only
+/// handles regular cases.
+const Map<String, List<String>> _emojiToNouns = {
+  // dairy + eggs
+  '🥛': ['milk', 'cream', 'buttermilk', 'almond milk', 'soy milk', 'coconut milk', 'rice milk', 'oat milk'],
+  '🧀': ['cheese'],
+  '🍦': ['yogurt', 'yoghurt', 'ice cream', 'frozen yogurt', 'milk dessert'],
+  '🧈': ['butter', 'almond butter', 'sesame butter'],
+  '🥚': ['egg'],
+
+  // meat
+  '🥩': ['beef', 'bison', 'venison', 'goat'],
+  '🥓': ['pork', 'bacon'],
+  '🍖': ['lamb', 'veal', 'game meat', 'ham'],
+  '🍗': ['chicken'],
+  '🦃': ['turkey'],
+  '🦆': ['duck'],
+  '🌭': ['sausage', 'hot dog'],
+
+  // seafood
+  '🐟': ['fish', 'salmon', 'tuna', 'sea bass', 'cod', 'herring', 'mackerel', 'sardine', 'fish oil'],
+  '🦐': ['shrimp', 'crustacean'],
+  '🦀': ['crab', 'crab meat', 'seafood'],
+  '🦞': ['lobster'],
+  '🦪': ['mollusk', 'oyster', 'scallop', 'clam'],
+  '🦑': ['squid'],
+  '🍤': ['fried shrimp', 'tempura'],
+
+  // grains + bread
+  '🍞': ['bread'],
+  '🥖': ['baguette'],
+  '🥯': ['bagel'],
+  '🥐': ['croissant'],
+  '🍚': ['rice', 'wild rice', 'rice flour'],
+  '🍝': ['pasta', 'spaghetti'],
+  '🍜': ['noodle', 'ramen'],
+  '🥣': ['cereal', 'cereals ready-to-eat', 'oatmeal'],
+  '🌾': ['wheat flour', 'oat', 'bulgur', 'couscous', 'quinoa', 'buckwheat', 'buckwheat flour'],
+  '🥞': ['pancake', 'crepe'],
+  '🧇': ['waffle'],
+  '🫓': ['tortilla', 'flatbread'],
+
+  // vegetables
+  '🥔': ['potato', 'potatoes', 'potato flour'],
+  '🍠': ['sweet potato', 'sweet potatoes', 'sweet potato flour'],
+  '🌽': ['corn', 'maize', 'corn flour'],
+  '🍅': ['tomato', 'tomatoes'],
+  '🧅': ['onion', 'shallot', 'leek', 'onion powder', 'onion flake', 'onion ring'],
+  '🧄': ['garlic', 'garlic powder'],
+  '🥕': ['carrot'],
+  '🥦': ['broccoli'],
+  '🥬': ['cabbage', 'lettuce', 'salad green', 'greens', 'celery'],
+  '🍃': ['spinach', 'kale', 'rucola', 'arugula', 'collard green'],
+  '🥒': ['cucumber', 'pickle', 'zucchini', 'courgette'],
+  '🌶️': ['pepper', 'chili'],
+  '🍄‍🟫': ['mushroom', 'fungus', 'fungi', 'truffle'],
+  '🍆': ['eggplant', 'aubergine'],
+  '🎃': ['squash', 'pumpkin', 'pumpkin flour'],
+  '🥑': ['avocado', 'guacamole'],
+  '🟢': ['pea'],
+  '🫘': ['bean', 'red bean', 'black bean', 'lima bean', 'chickpea', 'mung bean', 'lentil'],
+  '🎍': ['bamboo shoot', 'asparagus'],
+  '🌱': ['sprout', 'microgreen'],
+  '🫛': ['pod', 'edamame', 'fava bean', 'soybean', 'soybean flour', 'pea flour'],
+
+  // fruit
+  '🍎': ['apple', 'fruit salad'],
+  '🍌': ['banana'],
+  '🍊': ['orange', 'clementine', 'mandarin'],
+  '🍋': ['lemon', 'lime'],
+  '🍇': ['grape'],
+  '🍓': ['strawberry', 'strawberries', 'raspberry', 'raspberries'],
+  '🫐': ['blueberry', 'blueberries', 'blackberry', 'blackberries'],
+  '🍒': ['cherry', 'cherries'],
+  '🍉': ['watermelon'],
+  '🍈': ['melon'],
+  '🍍': ['pineapple'],
+  '🥭': ['mango'],
+  '🍑': ['peach', 'peaches', 'nectarine', 'apricot'],
+  '🍐': ['pear'],
+  '🥝': ['kiwi', 'kiwifruit'],
+  '🥥': ['coconut', 'coconut water', 'coconut flour'],
+
+  // nuts + seeds
+  '🥜': ['nut', 'peanut', 'almond', 'walnut'],
+  '🌰': ['seed', 'chestnut', 'chia seed', 'flaxseed', 'hemp seed', 'sesame seed', 'sunflower seed', 'pumpkin seed'],
+
+  // sweets
+  '🍬': ['candy', 'candies', 'sugar'],
+  '🍫': ['chocolate', 'baking chocolate', 'cocoa', 'brownie'],
+  '🍪': ['cookie', 'biscuit'],
+  '🍰': ['cake', 'dessert', 'flan'],
+  '🥧': ['pie', 'egg custard'],
+  '🍩': ['donut', 'doughnut'],
+  '🧁': ['cupcake', 'muffin'],
+  '🍮': ['pudding'],
+  '🍯': ['honey', 'syrup'],
+
+  // fats + oils
+  '🫒': ['oil', 'olive oil', 'olive'],
+
+  // snacks
+  '🍿': ['popcorn'],
+  '🥨': ['pretzel', 'cracker'],
+  '🍟': ['chip', 'fries', 'french fries', 'potato chip'],
+
+  // composed dishes
+  '🍕': ['pizza'],
+  '🍔': ['burger', 'hamburger', 'fast food'],
+  '🥪': ['sandwich', 'toast', 'french toast'],
+  '🌮': ['taco'],
+  '🌯': ['burrito', 'wrap', 'kebab', 'gyro', 'shawarma', 'doner', 'falafel wrap', 'döner', 'dürüm', 'doner kebab'],
+  '🍛': ['curry', 'curry powder', 'butter chicken', 'biriyani'],
+  '🧆': ['falafel'],
+  '🍣': ['sushi', 'sashimi', 'nigiri', 'maki'],
+  '🍙': ['rice ball', 'onigiri'],
+  '🍘': ['rice cracker', 'senbei'],
+  '🍲': ['soup', 'stew', 'chicken noodle'],
+  '🥗': ['salad', 'salad dressing'],
+  '🥟': ['dumpling', 'ravioli', 'pierogi'],
+  '🍳': ['egg dish', 'omelette', 'frittata', 'quiche', 'fried egg'],
+
+  // beverages
+  '☕': ['coffee'],
+  '🍵': ['tea'],
+  '💧': ['water'],
+  '🧃': ['juice', 'orange juice', 'apple juice', 'grape juice', 'grapefruit juice', 'vegetable juice', 'lemon juice', 'lime juice', 'cherry juice', 'fruit juice', 'carrot juice', 'blackberry juice', 'blueberry juice', 'strawberry juice', 'tomato juice', 'cranberry juice'],
+  '🥤': ['soda', 'milkshake', 'beverage'],
+  '🍺': ['beer'],
+  '🍷': ['wine'],
+  '🍸': ['cocktail'],
+  '🥃': ['whiskey'],
+
+  // baby and other
+  '🍼': ['infant formula', 'babyfood'],
+  '🧬': ['protein', 'protein powder', 'amino acid', 'supplement', 'rennin'],
+
+  // condiments + others
+  '🧂': ['salt'],
+  '🥫': ['sauce', 'condiment', 'ketchup'],
+  '🫚': ['spice', 'cinnamon', 'nutmeg', 'clove', 'cardamom', 'cumin', 'coriander', 'paprika', 'turmeric', 'ginger'],
+};
+
+/// For each entry in [_emojiToNouns], yield the canonical noun plus its
+/// regular `+s` plural; for multi-word nouns, also yield the no-space
+/// form and its `+s` plural. This way "egg" auto-matches "eggs",
+/// "olive oil" auto-matches "olive oils" / "oliveoil" / "oliveoils".
+Iterable<String> _variantsOf(String noun) sync* {
+  yield noun;
+  yield '${noun}s';
+  if (noun.contains(' ')) {
+    final flat = noun.replaceAll(' ', '');
+    yield flat;
+    yield '${flat}s';
+  }
+}
+
+/// Reverse-lookup table built once at module init. Marked `final` rather
+/// than `const` because [_variantsOf] uses `sync*` which isn't
+/// const-eligible. Build cost is a single pass at first use.
+final Map<String, String> _nounToEmoji = {
+  for (final entry in _emojiToNouns.entries)
+    for (final noun in entry.value)
+      for (final variant in _variantsOf(noun)) variant: entry.key,
+};

--- a/lib/features/add_meal/util/food_emoji_resolver.dart
+++ b/lib/features/add_meal/util/food_emoji_resolver.dart
@@ -84,15 +84,14 @@ const Map<String, List<String>> _emojiToNouns = {
   '🍃': ['spinach', 'kale', 'rucola', 'arugula', 'collard green'],
   '🥒': ['cucumber', 'pickle', 'zucchini', 'courgette'],
   '🌶️': ['pepper', 'chili'],
-  '🍄‍🟫': ['mushroom', 'fungus', 'fungi', 'truffle'],
+  '🍄': ['mushroom', 'fungus', 'fungi', 'truffle'],
   '🍆': ['eggplant', 'aubergine'],
   '🎃': ['squash', 'pumpkin', 'pumpkin flour'],
   '🥑': ['avocado', 'guacamole'],
-  '🟢': ['pea'],
+  '🟢': ['pea', 'pod', 'edamame', 'fava bean', 'soybean', 'soybean flour', 'pea flour'],
   '🫘': ['bean', 'red bean', 'black bean', 'lima bean', 'chickpea', 'mung bean', 'lentil'],
   '🎍': ['bamboo shoot', 'asparagus'],
   '🌱': ['sprout', 'microgreen'],
-  '🫛': ['pod', 'edamame', 'fava bean', 'soybean', 'soybean flour', 'pea flour'],
 
   // fruit
   '🍎': ['apple', 'fruit salad'],
@@ -155,7 +154,11 @@ const Map<String, List<String>> _emojiToNouns = {
   '☕': ['coffee'],
   '🍵': ['tea'],
   '💧': ['water'],
-  '🧃': ['juice', 'orange juice', 'apple juice', 'grape juice', 'grapefruit juice', 'vegetable juice', 'lemon juice', 'lime juice', 'cherry juice', 'fruit juice', 'carrot juice', 'blackberry juice', 'blueberry juice', 'strawberry juice', 'tomato juice', 'cranberry juice'],
+  '🧃': [
+    'juice', 'orange juice', 'apple juice', 'grape juice', 'grapefruit juice', 'vegetable juice',
+    'lemon juice', 'lime juice', 'cherry juice', 'fruit juice', 'carrot juice', 'blackberry juice',
+    'blueberry juice', 'strawberry juice', 'tomato juice', 'cranberry juice',
+  ],
   '🥤': ['soda', 'milkshake', 'beverage'],
   '🍺': ['beer'],
   '🍷': ['wine'],
@@ -169,7 +172,7 @@ const Map<String, List<String>> _emojiToNouns = {
   // condiments + others
   '🧂': ['salt'],
   '🥫': ['sauce', 'condiment', 'ketchup'],
-  '🫚': ['spice', 'cinnamon', 'nutmeg', 'clove', 'cardamom', 'cumin', 'coriander', 'paprika', 'turmeric', 'ginger'],
+  '🌿': ['spice', 'cinnamon', 'nutmeg', 'clove', 'cardamom', 'cumin', 'coriander', 'paprika', 'turmeric', 'ginger'],
 };
 
 /// For each entry in [_emojiToNouns], yield the canonical noun plus its

--- a/test/unit_test/food_emoji_resolver_test.dart
+++ b/test/unit_test/food_emoji_resolver_test.dart
@@ -1,0 +1,116 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:opennutritracker/features/add_meal/util/food_emoji_resolver.dart';
+
+void main() {
+  group('resolveFoodEmoji — null / empty', () {
+    test('null name → null', () {
+      expect(resolveFoodEmoji(null), isNull);
+    });
+
+    test('empty name → null', () {
+      expect(resolveFoodEmoji(''), isNull);
+    });
+
+    test('whitespace-only name → null', () {
+      expect(resolveFoodEmoji('   '), isNull);
+    });
+
+    test('leading comma → null', () {
+      // split(',').first is empty after trim.
+      expect(resolveFoodEmoji(', whatever'), isNull);
+    });
+  });
+
+  group('resolveFoodEmoji — direct lookup', () {
+    test('single-word head matches', () {
+      expect(resolveFoodEmoji('milk'), '🥛');
+    });
+
+    test('multi-word head matches', () {
+      expect(resolveFoodEmoji('sweet potato'), '🍠');
+    });
+
+    test('case-insensitive', () {
+      expect(resolveFoodEmoji('MILK'), '🥛');
+      expect(resolveFoodEmoji('Olive Oil'), '🫒');
+    });
+
+    test('USDA comma-separated description: first token is the head', () {
+      expect(
+        resolveFoodEmoji('Milk, fluid, nonfat, calcium fortified (fat free or skim)'),
+        '🥛',
+      );
+      expect(
+        resolveFoodEmoji('Apples, raw, fuji, with skin'),
+        '🍎',
+      );
+    });
+
+    test('leading/trailing whitespace is trimmed', () {
+      expect(resolveFoodEmoji('  apple  '), '🍎');
+    });
+  });
+
+  group('resolveFoodEmoji — auto-generated variants', () {
+    test('regular +s plural is generated from the singular', () {
+      // 'eggs' / 'apples' aren't listed; auto-generated from 'egg' / 'apple'.
+      expect(resolveFoodEmoji('eggs'), '🥚');
+      expect(resolveFoodEmoji('apples'), '🍎');
+    });
+
+    test('multi-word noun also matches without internal spaces', () {
+      // 'olive oil' is listed; 'oliveoil' and 'oliveoils' are auto-gen.
+      expect(resolveFoodEmoji('olive oil'), '🫒');
+      expect(resolveFoodEmoji('olive oils'), '🫒');
+      expect(resolveFoodEmoji('oliveoil'), '🫒');
+      expect(resolveFoodEmoji('oliveoils'), '🫒');
+    });
+
+    test('irregular plurals must be listed explicitly', () {
+      // -ies, -oes, etc. don't reduce from the singular by +s, so they need
+      // to be in the map verbatim. These regress if someone removes them.
+      expect(resolveFoodEmoji('cherries'), '🍒');
+      expect(resolveFoodEmoji('strawberries'), '🍓');
+      expect(resolveFoodEmoji('potatoes'), '🥔');
+      expect(resolveFoodEmoji('tomatoes'), '🍅');
+      expect(resolveFoodEmoji('fungi'), '🍄‍🟫');
+    });
+  });
+
+  group('resolveFoodEmoji — no false positives', () {
+    test('unknown noun returns null (no fallback fabrication)', () {
+      // 'seaweed' is intentionally omitted — no good emoji.
+      expect(resolveFoodEmoji('seaweed'), isNull);
+    });
+
+    test("'s'-ending non-plural that isn't in the map returns null", () {
+      // 'bass' isn't listed (only 'sea bass' is). The resolver no longer
+      // strips trailing 's' from the input, so 'bass' must not match
+      // anything in the map — guards against future map additions that
+      // might accidentally introduce a 'bas' key.
+      expect(resolveFoodEmoji('bass'), isNull);
+    });
+
+    test('one-character input does not throw', () {
+      expect(() => resolveFoodEmoji('s'), returnsNormally);
+      expect(resolveFoodEmoji('s'), isNull);
+    });
+  });
+
+  group('resolveFoodEmoji — anti-regressions', () {
+    // Adjacent string literals in Dart get silently concatenated. A missing
+    // comma between two list entries collapses them into a single garbled
+    // string, breaking both. These spot-checks would have caught that.
+    test('yoghurt (UK spelling) and ice cream both resolve', () {
+      expect(resolveFoodEmoji('yoghurt'), '🍦');
+      expect(resolveFoodEmoji('ice cream'), '🍦');
+    });
+
+    test('greens (explicit map entry, no singular) resolves', () {
+      // 'greens' is listed verbatim — there's no singular 'green' in the
+      // map. With the new approach the input isn't manipulated, so we'd
+      // miss this if 'greens' got removed.
+      expect(resolveFoodEmoji('greens'), '🥬');
+    });
+  });
+}

--- a/test/unit_test/food_emoji_resolver_test.dart
+++ b/test/unit_test/food_emoji_resolver_test.dart
@@ -73,7 +73,7 @@ void main() {
       expect(resolveFoodEmoji('strawberries'), '🍓');
       expect(resolveFoodEmoji('potatoes'), '🥔');
       expect(resolveFoodEmoji('tomatoes'), '🍅');
-      expect(resolveFoodEmoji('fungi'), '🍄‍🟫');
+      expect(resolveFoodEmoji('fungi'), '🍄');
     });
   });
 


### PR DESCRIPTION
Hey! Could you please have a look on the small change adding icons for base products without images.

**Problem:** Search of the raw food is pretty hard, as eye has nothing to catch on to fast filter options (in the milk search find actual milk)

**Added:** colored emoji icons to the leading slot of FDC search results that don't have a thumbnail. OFF (Products tab) is unchanged.
 "Milk, fluid, nonfat..." → 🥛, "Apples, raw, fuji..." → 🍎,


| OLD | NEW |
|---|---|
|<img width="200" alt="Simulator Screenshot - iPhone 17 - 2026-05-24 at 12 27 20" src="https://github.com/user-attachments/assets/a4fab331-54ef-4a29-a3d5-9328149adff5" /> | <img width="200" alt="Simulator Screenshot - iPhone 17 - 2026-05-24 at 12 24 41" src="https://github.com/user-attachments/assets/f14c11c4-17ce-4cb4-bf04-fa3ef7737a69" /> |


## Design                                                                                                                                                                          
                                                           
  - Emoji-keyed map -- (with Dart compiler refuses to compile duplicate const keys).               
  - A `_variantsOf(noun)` helper auto-generates lookup keys at module init: the canonical noun, its `+s` plural, and (for multi-word entries) the no-space form and its `+s` plural.
  So "olive oil" silently matches "olive oils" / "oliveoil" / "oliveoils" without anyone listing four entries.                                                                       
  - Irregular plurals (-ies, -oes, fungus→fungi, peach→peaches) are listed explicitly.
  - ~80 canonical head nouns covering the most frequent USDA SR Legacy items.
