### PR TITLE
fix: restore the Nix dev flake dropped in the #247 merge

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -1,0 +1,59 @@
+{
+  "nodes": {
+    "flake-utils": {
+      "inputs": {
+        "systems": "systems"
+      },
+      "locked": {
+        "lastModified": 1710146030,
+        "narHash": "sha256-SZ5L6eA7HJ/nmkzGG7/ISclqe6oZdOZTNoesiInkXPQ=",
+        "owner": "numtide",
+        "repo": "flake-utils",
+        "rev": "b1d9ab70662946ef0850d488da1c9019f3a9752a",
+        "type": "github"
+      },
+      "original": {
+        "owner": "numtide",
+        "repo": "flake-utils",
+        "type": "github"
+      }
+    },
+    "nixpkgs": {
+      "locked": {
+        "lastModified": 1724395761,
+        "narHash": "sha256-zRkDV/nbrnp3Y8oCADf5ETl1sDrdmAW6/bBVJ8EbIdQ=",
+        "owner": "NixOS",
+        "repo": "nixpkgs",
+        "rev": "ae815cee91b417be55d43781eb4b73ae1ecc396c",
+        "type": "github"
+      },
+      "original": {
+        "id": "nixpkgs",
+        "type": "indirect"
+      }
+    },
+    "root": {
+      "inputs": {
+        "flake-utils": "flake-utils",
+        "nixpkgs": "nixpkgs"
+      }
+    },
+    "systems": {
+      "locked": {
+        "lastModified": 1681028828,
+        "narHash": "sha256-Vy1rq5AaRuLzOxct8nz4T6wlgyUR7zLU309k9mBC768=",
+        "owner": "nix-systems",
+        "repo": "default",
+        "rev": "da67096a3b9bf56a91d16901293e51ba5b49a27e",
+        "type": "github"
+      },
+      "original": {
+        "owner": "nix-systems",
+        "repo": "default",
+        "type": "github"
+      }
+    }
+  },
+  "root": "root",
+  "version": 7
+}

--- a/flake.nix
+++ b/flake.nix
@@ -1,0 +1,58 @@
+{
+  description = "OpenNutriTracker reproducible development environment (Flutter + Android SDK)";
+  inputs = {
+    nixpkgs.url = "github:NixOS/nixpkgs/nixos-unstable";
+    flake-utils.url = "github:numtide/flake-utils";
+  };
+  outputs = { self, nixpkgs, flake-utils }:
+    flake-utils.lib.eachDefaultSystem (system:
+      let
+        pkgs = import nixpkgs {
+          inherit system;
+          config = {
+            android_sdk.accept_license = true;
+            allowUnfree = true;
+          };
+        };
+        # Match what `android/app/build.gradle` and `android/settings.gradle`
+        # ask for on current develop: compileSdk / targetSdk 36, AGP 8.11.1,
+        # JDK 17. These platform and build-tools versions have to exist in the
+        # pinned nixpkgs; bump them together with the Gradle config when the
+        # app's Android targets move. No NDK is pulled in because the build
+        # has no native C/C++ to compile; add `includeNDK = true;` with a
+        # matching `ndkVersions` list if a plugin ever needs it.
+        androidPkgs = pkgs.androidenv.composeAndroidPackages {
+          platformVersions = [ "34" "35" "36" ];
+          buildToolsVersions = [ "34.0.0" "35.0.0" "36.0.0" ];
+        };
+        androidSdk = androidPkgs.androidsdk;
+        androidSdkRoot = "${androidSdk}/libexec/android-sdk";
+      in
+      {
+        # The flake pins the Android toolchain, but Flutter itself is the
+        # version nixpkgs provides rather than the FVM-pinned 3.41.7 in
+        # `.fvmrc`. It needs to satisfy the Dart `>=3.11.0` constraint in
+        # pubspec.yaml; if nixpkgs lags, run `nix flake update` to pull a
+        # newer Flutter, or layer FVM on top of this shell for an exact match.
+        #
+        # Build a debug APK once you are in the shell:
+        #   dart run build_runner build --delete-conflicting-outputs
+        #   flutter build apk --flavor develop --debug
+        devShells.default = pkgs.mkShell {
+          ANDROID_SDK_ROOT = androidSdkRoot;
+          ANDROID_HOME = androidSdkRoot;
+          buildInputs = [
+            pkgs.flutter
+            pkgs.jdk17
+            pkgs.git
+            androidSdk
+          ];
+          # Nix ships its own read-only aapt2; point Gradle at it so the build
+          # does not try to fetch and exec a downloaded binary, which fails on
+          # NixOS because of the patched dynamic loader.
+          shellHook = ''
+            export GRADLE_OPTS="-Dorg.gradle.project.android.aapt2FromMavenOverride=${androidSdkRoot}/build-tools/36.0.0/aapt2"
+          '';
+        };
+      });
+}


### PR DESCRIPTION
Closes #462.

STSchiff opened #462 to ask where the `flake.nix` went, and it turned out to be a quiet casualty of a merge rather than a deliberate removal. The `flake.nix` and `flake.lock` were both present on the develop side of `50f62eb` (the PR #247 merge), and the conflict resolution lost them. The `.envrc` with its `use flake` line survived, so anyone with direnv has been dropping into a broken shell ever since. Thank you for catching this, and sorry it bit you in the first place.

I did not want to just restore the files as they were, because develop has moved on a long way since August 2024. The old flake pinned Android build-tools `30.0.3` and platforms up to `34`, which will not build the current app. So this restores them brought up to date:

- Android `platformVersions` `34/35/36` and `buildToolsVersions` `34/35/36.0.0`, matching `compileSdk`/`targetSdk 36` in `android/app/build.gradle` and AGP 8.11.1 in `android/settings.gradle`. JDK stays at 17.
- `nixpkgs` pinned to `nixos-unstable` so the bundled Flutter is recent enough for the Dart `>=3.11.0` constraint in `pubspec.yaml`.
- A `shellHook` that points Gradle at the SDK own `aapt2`, since the Maven-downloaded binary will not exec under the NixOS loader.

One honest caveat for review: Flutter comes from nixpkgs here, not the FVM-pinned 3.41.7 in `.fvmrc`, so the exact version will drift with the channel. The flake comments explain how to layer FVM on top when an exact match matters. I also do not have a Nix environment to build this in, so I would be really grateful if you (@chrisheib) could confirm `nix develop` resolves and a debug APK builds on your NixOS box before this merges. If `composeAndroidPackages` complains about a missing build-tools `36.0.0` or wants an NDK, that is the first thing to adjust.