### PR TITLE
fix(scanner): own + dispose mobile_scanner controllers, observe app lifecycle

### DIFF
--- a/lib/features/edit_meal/presentation/edit_meal_screen.dart
+++ b/lib/features/edit_meal/presentation/edit_meal_screen.dart
@@ -1,3 +1,4 @@
+import 'dart:async';
 import 'dart:math' as math;
 
 import 'dart:io';
@@ -1092,15 +1093,38 @@ class _EditMealBarcodeScanPage extends StatefulWidget {
       _EditMealBarcodeScanPageState();
 }
 
-class _EditMealBarcodeScanPageState extends State<_EditMealBarcodeScanPage> {
+class _EditMealBarcodeScanPageState extends State<_EditMealBarcodeScanPage>
+    with WidgetsBindingObserver {
   static final _log = Logger('EditMealBarcodeScan');
   final MobileScannerController _controller = MobileScannerController();
   bool _done = false;
 
   @override
+  void initState() {
+    super.initState();
+    WidgetsBinding.instance.addObserver(this);
+  }
+
+  @override
   void dispose() {
+    WidgetsBinding.instance.removeObserver(this);
     _controller.dispose();
     super.dispose();
+  }
+
+  @override
+  void didChangeAppLifecycleState(AppLifecycleState state) {
+    if (!_controller.value.hasCameraPermission) return;
+    switch (state) {
+      case AppLifecycleState.detached:
+      case AppLifecycleState.hidden:
+      case AppLifecycleState.paused:
+        unawaited(_controller.stop());
+      case AppLifecycleState.resumed:
+        unawaited(_controller.start());
+      case AppLifecycleState.inactive:
+        break;
+    }
   }
 
   void _onDetect(BarcodeCapture capture) {

--- a/lib/features/home/presentation/screens/import_activity_scanner_screen.dart
+++ b/lib/features/home/presentation/screens/import_activity_scanner_screen.dart
@@ -1,3 +1,5 @@
+import 'dart:async';
+
 import 'package:collection/collection.dart';
 import 'package:flutter/material.dart';
 import 'package:mobile_scanner/mobile_scanner.dart';
@@ -30,19 +32,46 @@ class ImportActivityScannerScreen extends StatefulWidget {
 }
 
 class _ImportActivityScannerScreenState
-    extends State<ImportActivityScannerScreen> {
+    extends State<ImportActivityScannerScreen> with WidgetsBindingObserver {
   late ActivityDetailBloc _activityDetailBloc;
   late GetPhysicalActivityUsecase _getPhysicalActivityUsecase;
   late GetUserUsecase _getUserUsecase;
   bool _isProcessing = false;
   bool _handledInitialCode = false;
+  late final MobileScannerController _cameraController;
 
   @override
   void initState() {
+    super.initState();
     _activityDetailBloc = locator<ActivityDetailBloc>();
     _getPhysicalActivityUsecase = locator<GetPhysicalActivityUsecase>();
     _getUserUsecase = locator<GetUserUsecase>();
-    super.initState();
+    _cameraController = MobileScannerController(
+      formats: const [BarcodeFormat.qrCode],
+    );
+    WidgetsBinding.instance.addObserver(this);
+  }
+
+  @override
+  void dispose() {
+    WidgetsBinding.instance.removeObserver(this);
+    unawaited(_cameraController.dispose());
+    super.dispose();
+  }
+
+  @override
+  void didChangeAppLifecycleState(AppLifecycleState state) {
+    if (!_cameraController.value.hasCameraPermission) return;
+    switch (state) {
+      case AppLifecycleState.detached:
+      case AppLifecycleState.hidden:
+      case AppLifecycleState.paused:
+        unawaited(_cameraController.stop());
+      case AppLifecycleState.resumed:
+        unawaited(_cameraController.start());
+      case AppLifecycleState.inactive:
+        break;
+    }
   }
 
   @override
@@ -74,9 +103,7 @@ class _ImportActivityScannerScreenState
         ],
       ),
       body: MobileScanner(
-        controller: MobileScannerController(
-          formats: const [BarcodeFormat.qrCode],
-        ),
+        controller: _cameraController,
         onDetect: _onDetect,
       ),
     );

--- a/lib/features/home/presentation/screens/import_meal_scanner_screen.dart
+++ b/lib/features/home/presentation/screens/import_meal_scanner_screen.dart
@@ -1,3 +1,5 @@
+import 'dart:async';
+
 import 'package:collection/collection.dart';
 import 'package:flutter/material.dart';
 import 'package:mobile_scanner/mobile_scanner.dart';
@@ -48,19 +50,47 @@ class ImportMealScannerScreen extends StatefulWidget {
       _ImportMealScannerScreenState();
 }
 
-class _ImportMealScannerScreenState extends State<ImportMealScannerScreen> {
+class _ImportMealScannerScreenState extends State<ImportMealScannerScreen>
+    with WidgetsBindingObserver {
   late MealDetailBloc _mealDetailBloc;
   late SearchProductByBarcodeUseCase _searchProductByBarcodeUseCase;
   late IntakeTypeEntity _intakeTypeEntity;
   late AddMealType _addMealType;
   late DateTime _day;
   bool _isProcessing = false;
+  late final MobileScannerController _cameraController;
 
   @override
   void initState() {
+    super.initState();
     _mealDetailBloc = locator<MealDetailBloc>();
     _searchProductByBarcodeUseCase = locator<SearchProductByBarcodeUseCase>();
-    super.initState();
+    _cameraController = MobileScannerController(
+      formats: const [BarcodeFormat.qrCode],
+    );
+    WidgetsBinding.instance.addObserver(this);
+  }
+
+  @override
+  void dispose() {
+    WidgetsBinding.instance.removeObserver(this);
+    unawaited(_cameraController.dispose());
+    super.dispose();
+  }
+
+  @override
+  void didChangeAppLifecycleState(AppLifecycleState state) {
+    if (!_cameraController.value.hasCameraPermission) return;
+    switch (state) {
+      case AppLifecycleState.detached:
+      case AppLifecycleState.hidden:
+      case AppLifecycleState.paused:
+        unawaited(_cameraController.stop());
+      case AppLifecycleState.resumed:
+        unawaited(_cameraController.start());
+      case AppLifecycleState.inactive:
+        break;
+    }
   }
 
   bool _handledInitialCode = false;
@@ -99,9 +129,7 @@ class _ImportMealScannerScreenState extends State<ImportMealScannerScreen> {
         ],
       ),
       body: MobileScanner(
-        controller: MobileScannerController(
-          formats: const [BarcodeFormat.qrCode],
-        ),
+        controller: _cameraController,
         onDetect: _onDetect,
       ),
     );

--- a/lib/features/recipes/presentation/screens/import_recipe_scanner_screen.dart
+++ b/lib/features/recipes/presentation/screens/import_recipe_scanner_screen.dart
@@ -1,3 +1,5 @@
+import 'dart:async';
+
 import 'package:collection/collection.dart';
 import 'package:flutter/material.dart';
 import 'package:mobile_scanner/mobile_scanner.dart';
@@ -24,9 +26,42 @@ class ImportRecipeScannerScreen extends StatefulWidget {
       _ImportRecipeScannerScreenState();
 }
 
-class _ImportRecipeScannerScreenState extends State<ImportRecipeScannerScreen> {
+class _ImportRecipeScannerScreenState extends State<ImportRecipeScannerScreen>
+    with WidgetsBindingObserver {
   bool _isProcessing = false;
   bool _handledInitialCode = false;
+  late final MobileScannerController _cameraController;
+
+  @override
+  void initState() {
+    super.initState();
+    _cameraController = MobileScannerController(
+      formats: const [BarcodeFormat.qrCode],
+    );
+    WidgetsBinding.instance.addObserver(this);
+  }
+
+  @override
+  void dispose() {
+    WidgetsBinding.instance.removeObserver(this);
+    unawaited(_cameraController.dispose());
+    super.dispose();
+  }
+
+  @override
+  void didChangeAppLifecycleState(AppLifecycleState state) {
+    if (!_cameraController.value.hasCameraPermission) return;
+    switch (state) {
+      case AppLifecycleState.detached:
+      case AppLifecycleState.hidden:
+      case AppLifecycleState.paused:
+        unawaited(_cameraController.stop());
+      case AppLifecycleState.resumed:
+        unawaited(_cameraController.start());
+      case AppLifecycleState.inactive:
+        break;
+    }
+  }
 
   @override
   void didChangeDependencies() {
@@ -57,9 +92,7 @@ class _ImportRecipeScannerScreenState extends State<ImportRecipeScannerScreen> {
         ],
       ),
       body: MobileScanner(
-        controller: MobileScannerController(
-          formats: const [BarcodeFormat.qrCode],
-        ),
+        controller: _cameraController,
         onDetect: _onDetect,
       ),
     );

--- a/lib/features/scanner/scanner_screen.dart
+++ b/lib/features/scanner/scanner_screen.dart
@@ -1,3 +1,5 @@
+import 'dart:async';
+
 import 'package:flutter/material.dart';
 import 'package:flutter/services.dart';
 import 'package:flutter_bloc/flutter_bloc.dart';
@@ -24,7 +26,8 @@ class ScannerScreen extends StatefulWidget {
   State<ScannerScreen> createState() => _ScannerScreenState();
 }
 
-class _ScannerScreenState extends State<ScannerScreen> {
+class _ScannerScreenState extends State<ScannerScreen>
+    with WidgetsBindingObserver {
   final log = Logger('ScannerScreen');
 
   String? _scannedBarcode;
@@ -41,11 +44,37 @@ class _ScannerScreenState extends State<ScannerScreen> {
   bool _navigatedAfterLoad = false;
 
   late ScannerBloc _scannerBloc;
+  // MobileScanner stops but doesn't dispose externally-owned controllers.
+  late final MobileScannerController _cameraController;
 
   @override
   void initState() {
-    _scannerBloc = locator<ScannerBloc>();
     super.initState();
+    _scannerBloc = locator<ScannerBloc>();
+    _cameraController = MobileScannerController();
+    WidgetsBinding.instance.addObserver(this);
+  }
+
+  @override
+  void dispose() {
+    WidgetsBinding.instance.removeObserver(this);
+    unawaited(_cameraController.dispose());
+    super.dispose();
+  }
+
+  @override
+  void didChangeAppLifecycleState(AppLifecycleState state) {
+    if (!_cameraController.value.hasCameraPermission) return;
+    switch (state) {
+      case AppLifecycleState.detached:
+      case AppLifecycleState.hidden:
+      case AppLifecycleState.paused:
+        unawaited(_cameraController.stop());
+      case AppLifecycleState.resumed:
+        unawaited(_cameraController.start());
+      case AppLifecycleState.inactive:
+        break;
+    }
   }
 
   @override
@@ -123,14 +152,13 @@ class _ScannerScreenState extends State<ScannerScreen> {
   }
 
   Scaffold _getScannerContent(BuildContext context) {
-    final cameraController = MobileScannerController();
     return Scaffold(
       appBar: AppBar(
         title: Text(S.of(context).scanProductLabel),
         actions: [
           IconButton(
             icon: ValueListenableBuilder(
-              valueListenable: cameraController,
+              valueListenable: _cameraController,
               builder: (context, state, child) {
                 switch (state.torchState) {
                   case TorchState.off || TorchState.unavailable:
@@ -143,11 +171,11 @@ class _ScannerScreenState extends State<ScannerScreen> {
                 }
               },
             ),
-            onPressed: () => cameraController.toggleTorch(),
+            onPressed: () => _cameraController.toggleTorch(),
           ),
           IconButton(
             icon: const Icon(Icons.flip_camera_android_outlined),
-            onPressed: () => cameraController.switchCamera(),
+            onPressed: () => _cameraController.switchCamera(),
           ),
         ],
       ),
@@ -155,7 +183,7 @@ class _ScannerScreenState extends State<ScannerScreen> {
         children: [
           Expanded(
             child: MobileScanner(
-              controller: cameraController,
+              controller: _cameraController,
               onDetect: (capture) {
                 if (_scannedBarcode != null) return;
                 final List<Barcode> barcodes = capture.barcodes;


### PR DESCRIPTION
Hey! Small bugfix for the barcode scanning.

Five screens use `mobile_scanner`: `scanner_screen.dart`, three `import_*_scanner_screen.dart` flows, and `_EditMealBarcodeScanPage` in `edit_meal_screen.dart`. All pass an externally-owned `MobileScannerController` — but:

- **`MobileScanner` doesn't dispose external controllers**, only `stop()`s them. Four screens created the controller inline in `build()` and never disposed → leaked
  `AVCaptureSession` until GC.
- **`scanner_screen.dart` re-created the controller on every rebuild**, so the AppBar torch / camera-flip buttons could end up bound to an orphan controller via                   
  `ValueListenableBuilder` (silent no-op).
- **No app-lifecycle handling** → backgrounding the app leaves the camera session running.

## Fix
Same pattern in all five screens:

1. Hoist `MobileScannerController` into a `late final` `State` field, init in `initState`.
2. Dispose in `dispose()`.
3. Mix in `WidgetsBindingObserver`; in `didChangeAppLifecycleState`:
     - `paused` / `hidden` / `detached` → `stop()`
     - `resumed` → `start()`
     - `inactive` → no-op
     
     
---

Did smoke test on the iphone