### PR TITLE
Preselect quantity in MealDetailBottomSheet

### DIFF
--- a/lib/features/meal_detail/presentation/widgets/meal_detail_bottom_sheet.dart
+++ b/lib/features/meal_detail/presentation/widgets/meal_detail_bottom_sheet.dart
@@ -39,16 +39,38 @@ class MealDetailBottomSheet extends StatefulWidget {
 }
 
 class _MealDetailBottomSheetState extends State<MealDetailBottomSheet> {
+  final _quantityFocusNode = FocusNode();
+
   @override
   void initState() {
     super.initState();
     widget.quantityTextController.addListener(_onQuantityChanged);
+    _quantityFocusNode.addListener(_onQuantityFocusChanged);
   }
 
   @override
   void dispose() {
+    _quantityFocusNode.removeListener(_onQuantityFocusChanged);
+    _quantityFocusNode.dispose();
     widget.quantityTextController.removeListener(_onQuantityChanged);
     super.dispose();
+  }
+
+  void _onQuantityFocusChanged() {
+    if (_quantityFocusNode.hasFocus) {
+      WidgetsBinding.instance.addPostFrameCallback((_) {
+        if (!mounted || !_quantityFocusNode.hasFocus) return;
+        _selectAllQuantityText();
+      });
+    }
+  }
+
+  void _selectAllQuantityText() {
+    final text = widget.quantityTextController.text;
+    widget.quantityTextController.selection = TextSelection(
+      baseOffset: 0,
+      extentOffset: text.length,
+    );
   }
 
   void _onQuantityChanged() {
@@ -92,6 +114,8 @@ class _MealDetailBottomSheetState extends State<MealDetailBottomSheet> {
                             child: TextFormField(
                               enabled: !productMissingRequiredInfo,
                               controller: widget.quantityTextController,
+                              focusNode: _quantityFocusNode,
+                              onTap: _selectAllQuantityText,
                               keyboardType: TextInputType.numberWithOptions(
                                 decimal: true,
                               ),


### PR DESCRIPTION
When tapping into the quantity field, the 1 thats usually there usually needs to get removed manually. 

This adds an listener that highlights the whole field, so the number can be replaced straight away. 

This seems like a somewhat convoluted implementation, I'm sure there are more elegant ways. 

<img width="413" height="736" alt="Image" src="https://github.com/user-attachments/assets/1324e105-4dc9-4e80-88e9-5bc6087b4d61" />