### PR TITLE
Reduce border size of MealDetailBottomSheet

### DIFF
--- a/lib/features/meal_detail/presentation/widgets/meal_detail_bottom_sheet.dart
+++ b/lib/features/meal_detail/presentation/widgets/meal_detail_bottom_sheet.dart
@@ -68,14 +68,16 @@ class _MealDetailBottomSheetState extends State<MealDetailBottomSheet> {
       builder: (context) {
         return Container(
           decoration: BoxDecoration(
-            border: Border.all(
-              color: Theme.of(context).colorScheme.outline,
-              width: 0.5,
+            border: Border(
+              top: BorderSide(
+                color: Theme.of(context).colorScheme.outline,
+                width: 0.5,
+              ),
             ),
             color: Theme.of(context).colorScheme.surface,
             borderRadius: const BorderRadius.only(
-              topLeft: Radius.circular(32),
-              topRight: Radius.circular(32),
+              topLeft: Radius.circular(24),
+              topRight: Radius.circular(24),
             ),
           ),
           child: SafeArea(


### PR DESCRIPTION
The full border around the MealDetailBottomSheet looks somewhat off, especially on devices with rounded screen corners. 

This reduces the border to top only, and reduces the radius. 

Before (note the white line on the right, this is even more notable on real devices): 
<img width="415" height="176" alt="Image" src="https://github.com/user-attachments/assets/fde8873c-c994-4ac8-850f-9aac5cc71515" />

After:
<img width="407" height="312" alt="Image" src="https://github.com/user-attachments/assets/aa10aba9-66b9-4cf8-8e61-ef1f43168888" />