### PR TITLE
Address review feedback on the v1.4.0 release PR

### DIFF
--- a/lib/core/utils/bounds/ranges_const.dart
+++ b/lib/core/utils/bounds/ranges_const.dart
@@ -12,12 +12,14 @@ class Ranges {
   /// Soft floor below which a computed daily kcal goal is flagged as low
   /// enough that the app surfaces a non-blocking warning encouraging the
   /// user to consult a professional. Aligned with the commonly-cited
-  /// NIH / Mayo Clinic minimums for sustained healthy intake (≈1500 kcal
-  /// for adults with a testosterone-typical hormonal profile, ≈1200 kcal
-  /// otherwise). Non-binary users on the averaged midpoint, or who have
-  /// not yet chosen a calories profile, use the lower (female) floor
-  /// because the averaged TDEE is itself a midpoint and the lower bound
-  /// sits more naturally beside it.
+  /// minimums for sustained healthy intake (≈1500 kcal for adults with a
+  /// testosterone-typical hormonal profile, ≈1200 kcal otherwise). These
+  /// are the figures Harvard Health publishes for safe calorie counting:
+  /// https://www.health.harvard.edu/healthy-aging-and-longevity/calorie-counting-made-easy
+  /// Non-binary users on the averaged midpoint, or who have not yet chosen
+  /// a calories profile, use the lower (female) floor because the averaged
+  /// TDEE is itself a midpoint and the lower bound sits more naturally
+  /// beside it.
   static const double minRecommendedDailyKcalMale = 1500;
   static const double minRecommendedDailyKcalFemale = 1200;
 

--- a/lib/core/utils/calc/dri_reference.dart
+++ b/lib/core/utils/calc/dri_reference.dart
@@ -119,7 +119,10 @@ const Map<String, Map<_LifeStage, DriReference>> _driTable = {
   NutrientPanelKeys.sodium: {
     // IOM CDRR / UL: 2300 mg/day for all adults. The IOM does not publish
     // a sodium RDA — the figure below is the chronic-disease-risk
-    // reduction intake, the same number the FDA Daily Value uses.
+    // reduction intake from the 2019 sodium/potassium update, the same
+    // number the FDA Daily Value uses. Because it is a ceiling rather than
+    // a target, the panel labels this row a "limit" (see _NutrientRow).
+    // https://www.nationalacademies.org/projects/HMD-FNB-17-01
     _LifeStage.m19to30: DriReference(amount: 2300, unit: 'mg', basis: 'UL'),
     _LifeStage.m31to50: DriReference(amount: 2300, unit: 'mg', basis: 'UL'),
     _LifeStage.m51to70: DriReference(amount: 2300, unit: 'mg', basis: 'UL'),
@@ -131,7 +134,10 @@ const Map<String, Map<_LifeStage, DriReference>> _driTable = {
   },
   NutrientPanelKeys.calcium: {
     // IOM RDA: 1000 mg adults 19 to 50 (and men 51 to 70),
-    // 1200 mg women 51+ and everyone 71+.
+    // 1200 mg women 51+ and everyone 71+. The 2011 IOM report set an EAR
+    // and RDA for calcium, replacing the 1997 AI — so these adult figures
+    // are RDAs, not the AI the older table listed.
+    // https://www.nationalacademies.org/our-work/dietary-reference-intakes-for-calcium-and-vitamin-d
     _LifeStage.m19to30: DriReference(amount: 1000, unit: 'mg', basis: 'RDA'),
     _LifeStage.m31to50: DriReference(amount: 1000, unit: 'mg', basis: 'RDA'),
     _LifeStage.m51to70: DriReference(amount: 1000, unit: 'mg', basis: 'RDA'),
@@ -155,6 +161,7 @@ const Map<String, Map<_LifeStage, DriReference>> _driTable = {
   },
   NutrientPanelKeys.potassium: {
     // IOM AI (2019 update): men 3400 mg, women 2600 mg.
+    // https://www.nationalacademies.org/projects/HMD-FNB-17-01
     _LifeStage.m19to30: DriReference(amount: 3400, unit: 'mg', basis: 'AI'),
     _LifeStage.m31to50: DriReference(amount: 3400, unit: 'mg', basis: 'AI'),
     _LifeStage.m51to70: DriReference(amount: 3400, unit: 'mg', basis: 'AI'),
@@ -165,7 +172,11 @@ const Map<String, Map<_LifeStage, DriReference>> _driTable = {
     _LifeStage.f71plus: DriReference(amount: 2600, unit: 'mg', basis: 'AI'),
   },
   NutrientPanelKeys.vitaminD: {
-    // IOM RDA: 15 µg (600 IU) adults to age 70, 20 µg (800 IU) 71+.
+    // IOM RDA: 15 µg (600 IU) adults to age 70, 20 µg (800 IU) 71+. The
+    // 2011 IOM report established an EAR and RDA for vitamin D, superseding
+    // the older 1997 AI values (5/5/10/15 µg by age band) — so these are
+    // current RDAs, not the AI the 1997 table listed.
+    // https://www.nationalacademies.org/our-work/dietary-reference-intakes-for-calcium-and-vitamin-d
     _LifeStage.m19to30: DriReference(amount: 15, unit: 'µg', basis: 'RDA'),
     _LifeStage.m31to50: DriReference(amount: 15, unit: 'µg', basis: 'RDA'),
     _LifeStage.m51to70: DriReference(amount: 15, unit: 'µg', basis: 'RDA'),

--- a/lib/core/utils/notification_service.dart
+++ b/lib/core/utils/notification_service.dart
@@ -8,13 +8,13 @@ import 'package:timezone/timezone.dart' as tz;
 class NotificationService {
   static const int _dailyReminderId = 0;
   static const int _fastingCompleteId = 1;
+  // Channel IDs are stable, locale-independent handles the OS keys each
+  // channel by — they must never be translated. The user-facing channel
+  // name and description are passed in localized by the caller (see
+  // scheduleDailyReminder / scheduleFastingComplete), since they surface in
+  // the system notification settings.
   static const String _channelId = 'daily_reminder';
-  static const String _channelName = 'Daily Reminders';
-  static const String _channelDesc = 'Daily meal logging reminder';
   static const String _fastingChannelId = 'fasting_complete';
-  static const String _fastingChannelName = 'Fasting timer';
-  static const String _fastingChannelDesc =
-      'One-off pings when a fasting session reaches its target.';
 
   final _log = Logger('NotificationService');
   final FlutterLocalNotificationsPlugin _plugin =
@@ -70,14 +70,16 @@ class NotificationService {
     required int minute,
     required String title,
     required String body,
+    required String channelName,
+    required String channelDescription,
   }) async {
     await _ensureInitialized();
     await _plugin.cancel(_dailyReminderId);
 
     final androidDetails = AndroidNotificationDetails(
       _channelId,
-      _channelName,
-      channelDescription: _channelDesc,
+      channelName,
+      channelDescription: channelDescription,
       importance: Importance.defaultImportance,
       priority: Priority.defaultPriority,
     );
@@ -118,6 +120,8 @@ class NotificationService {
     required DateTime when,
     required String title,
     required String body,
+    required String channelName,
+    required String channelDescription,
   }) async {
     await _ensureInitialized();
     await _plugin.cancel(_fastingCompleteId);
@@ -125,8 +129,8 @@ class NotificationService {
     final scheduled = tz.TZDateTime.from(when, tz.local);
     final androidDetails = AndroidNotificationDetails(
       _fastingChannelId,
-      _fastingChannelName,
-      channelDescription: _fastingChannelDesc,
+      channelName,
+      channelDescription: channelDescription,
       importance: Importance.defaultImportance,
       priority: Priority.defaultPriority,
     );

--- a/lib/features/activity_detail/activity_detail_screen.dart
+++ b/lib/features/activity_detail/activity_detail_screen.dart
@@ -181,7 +181,10 @@ class _ActivityDetailScreenState extends State<ActivityDetailScreen> {
                   const SizedBox(height: 8.0),
                   const Divider(),
                   const SizedBox(height: 48.0),
-                  const ActivityInfoButton(),
+                  // The Compendium attribution only makes sense for the
+                  // built-in activities it actually sourced. Custom activities
+                  // are user-entered, so the citation would be misleading.
+                  if (!activityEntity.isCustom) const ActivityInfoButton(),
                   const SizedBox(height: 200.0), // height added to scroll
                 ],
               ),

--- a/lib/features/diary/presentation/widgets/daily_nutrient_panel.dart
+++ b/lib/features/diary/presentation/widgets/daily_nutrient_panel.dart
@@ -749,6 +749,7 @@ class _NutrientRow extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
+    final s = S.of(context);
     final ratio = reference > 0 ? value / reference : 0.0;
     final clamped = ratio.clamp(0.0, 1.0).toDouble();
     final color = _colorForRatio(context, ratio);
@@ -770,14 +771,36 @@ class _NutrientRow extends StatelessWidget {
                   overflow: TextOverflow.ellipsis,
                 ),
               ),
-              Text(
-                valueLabel,
-                style: Theme.of(context).textTheme.bodySmall?.copyWith(
-                      color: Theme.of(context)
-                          .colorScheme
-                          .onSurface
-                          .withValues(alpha: 0.8),
+              Row(
+                mainAxisSize: MainAxisSize.min,
+                children: [
+                  // For ceiling nutrients (sodium, saturated fat, sugar) the
+                  // reference is a limit to stay under, not a target to reach.
+                  // A small qualifier says so, since the bare "x / y" reads as
+                  // a goal otherwise.
+                  if (excessMatters) ...[
+                    Text(
+                      s.nutrientPanelLimitLabel,
+                      style: Theme.of(context).textTheme.labelSmall?.copyWith(
+                            color: Theme.of(context)
+                                .colorScheme
+                                .onSurface
+                                .withValues(alpha: 0.6),
+                            fontStyle: FontStyle.italic,
+                          ),
                     ),
+                    const SizedBox(width: 6.0),
+                  ],
+                  Text(
+                    valueLabel,
+                    style: Theme.of(context).textTheme.bodySmall?.copyWith(
+                          color: Theme.of(context)
+                              .colorScheme
+                              .onSurface
+                              .withValues(alpha: 0.8),
+                        ),
+                  ),
+                ],
               ),
             ],
           ),

--- a/lib/features/fasting/presentation/fasting_screen.dart
+++ b/lib/features/fasting/presentation/fasting_screen.dart
@@ -363,6 +363,8 @@ class _FastingScreenState extends State<FastingScreen> {
       when: when,
       title: l10n.fastingNotificationCompleteTitle,
       body: l10n.fastingNotificationCompleteBody,
+      channelName: l10n.fastingNotificationChannelName,
+      channelDescription: l10n.fastingNotificationChannelDescription,
     );
   }
 

--- a/lib/features/settings/settings_screen.dart
+++ b/lib/features/settings/settings_screen.dart
@@ -386,6 +386,8 @@ class _SettingsScreenState extends State<SettingsScreen> {
         minute: state.notificationMinute,
         title: l10n.notificationsDailyReminderTitle,
         body: l10n.notificationsDailyReminderBody,
+        channelName: l10n.notificationsDailyReminderChannelName,
+        channelDescription: l10n.notificationsDailyReminderChannelDescription,
       );
     } else {
       await notificationService.cancelDailyReminder();
@@ -408,6 +410,8 @@ class _SettingsScreenState extends State<SettingsScreen> {
       minute: picked.minute,
       title: l10n.notificationsDailyReminderTitle,
       body: l10n.notificationsDailyReminderBody,
+      channelName: l10n.notificationsDailyReminderChannelName,
+      channelDescription: l10n.notificationsDailyReminderChannelDescription,
     );
     _settingsBloc.add(LoadSettingsEvent());
   }

--- a/lib/generated/intl/messages_cs.dart
+++ b/lib/generated/intl/messages_cs.dart
@@ -108,6 +108,11 @@ class MessageLookup extends MessageLookupByLibrary {
 
   final messages = _notInlinedMessages(_notInlinedMessages);
   static Map<String, Function> _notInlinedMessages(_) => <String, Function>{
+        "nutrientPanelLimitLabel": MessageLookupByLibrary.simpleMessage("limit"),
+        "notificationsDailyReminderChannelName": MessageLookupByLibrary.simpleMessage("Denní připomenutí"),
+        "notificationsDailyReminderChannelDescription": MessageLookupByLibrary.simpleMessage("Denní připomenutí k zaznamenání jídel"),
+        "fastingNotificationChannelName": MessageLookupByLibrary.simpleMessage("Časovač půstu"),
+        "fastingNotificationChannelDescription": MessageLookupByLibrary.simpleMessage("Jednorázová upozornění, když půst dosáhne svého cíle."),
         "activityExample": MessageLookupByLibrary.simpleMessage(
             "např. běh, cyklistika, jóga ..."),
         "activityLabel": MessageLookupByLibrary.simpleMessage("Activita"),

--- a/lib/generated/intl/messages_de.dart
+++ b/lib/generated/intl/messages_de.dart
@@ -110,6 +110,11 @@ class MessageLookup extends MessageLookupByLibrary {
 
   final messages = _notInlinedMessages(_notInlinedMessages);
   static Map<String, Function> _notInlinedMessages(_) => <String, Function>{
+        "nutrientPanelLimitLabel": MessageLookupByLibrary.simpleMessage("Limit"),
+        "notificationsDailyReminderChannelName": MessageLookupByLibrary.simpleMessage("Tägliche Erinnerungen"),
+        "notificationsDailyReminderChannelDescription": MessageLookupByLibrary.simpleMessage("Tägliche Erinnerung zum Erfassen deiner Mahlzeiten"),
+        "fastingNotificationChannelName": MessageLookupByLibrary.simpleMessage("Fasten-Timer"),
+        "fastingNotificationChannelDescription": MessageLookupByLibrary.simpleMessage("Einmalige Hinweise, wenn eine Fastenphase ihr Ziel erreicht."),
         "activityExample": MessageLookupByLibrary.simpleMessage(
             "z. B. Laufen, Radfahren, Yoga ..."),
         "activityLabel": MessageLookupByLibrary.simpleMessage("Aktivität"),

--- a/lib/generated/intl/messages_en.dart
+++ b/lib/generated/intl/messages_en.dart
@@ -107,6 +107,11 @@ class MessageLookup extends MessageLookupByLibrary {
 
   final messages = _notInlinedMessages(_notInlinedMessages);
   static Map<String, Function> _notInlinedMessages(_) => <String, Function>{
+        "nutrientPanelLimitLabel": MessageLookupByLibrary.simpleMessage("limit"),
+        "notificationsDailyReminderChannelName": MessageLookupByLibrary.simpleMessage("Daily Reminders"),
+        "notificationsDailyReminderChannelDescription": MessageLookupByLibrary.simpleMessage("Daily meal logging reminder"),
+        "fastingNotificationChannelName": MessageLookupByLibrary.simpleMessage("Fasting timer"),
+        "fastingNotificationChannelDescription": MessageLookupByLibrary.simpleMessage("One-off pings when a fasting session reaches its target."),
         "activityExample": MessageLookupByLibrary.simpleMessage(
             "e.g. running, biking, yoga ..."),
         "activityLabel": MessageLookupByLibrary.simpleMessage("Activity"),

--- a/lib/generated/intl/messages_it.dart
+++ b/lib/generated/intl/messages_it.dart
@@ -108,6 +108,11 @@ class MessageLookup extends MessageLookupByLibrary {
 
   final messages = _notInlinedMessages(_notInlinedMessages);
   static Map<String, Function> _notInlinedMessages(_) => <String, Function>{
+        "nutrientPanelLimitLabel": MessageLookupByLibrary.simpleMessage("limite"),
+        "notificationsDailyReminderChannelName": MessageLookupByLibrary.simpleMessage("Promemoria giornalieri"),
+        "notificationsDailyReminderChannelDescription": MessageLookupByLibrary.simpleMessage("Promemoria giornaliero per registrare i pasti"),
+        "fastingNotificationChannelName": MessageLookupByLibrary.simpleMessage("Timer del digiuno"),
+        "fastingNotificationChannelDescription": MessageLookupByLibrary.simpleMessage("Notifiche occasionali quando un digiuno raggiunge il suo obiettivo."),
         "activityExample": MessageLookupByLibrary.simpleMessage(
             "es. corsa, bicicletta, yoga ..."),
         "activityLabel": MessageLookupByLibrary.simpleMessage("Attività"),

--- a/lib/generated/intl/messages_pl.dart
+++ b/lib/generated/intl/messages_pl.dart
@@ -107,6 +107,11 @@ class MessageLookup extends MessageLookupByLibrary {
 
   final messages = _notInlinedMessages(_notInlinedMessages);
   static Map<String, Function> _notInlinedMessages(_) => <String, Function>{
+        "nutrientPanelLimitLabel": MessageLookupByLibrary.simpleMessage("limit"),
+        "notificationsDailyReminderChannelName": MessageLookupByLibrary.simpleMessage("Codzienne przypomnienia"),
+        "notificationsDailyReminderChannelDescription": MessageLookupByLibrary.simpleMessage("Codzienne przypomnienie o zapisaniu posiłków"),
+        "fastingNotificationChannelName": MessageLookupByLibrary.simpleMessage("Minutnik postu"),
+        "fastingNotificationChannelDescription": MessageLookupByLibrary.simpleMessage("Jednorazowe powiadomienia, gdy post osiągnie swój cel."),
         "activityExample": MessageLookupByLibrary.simpleMessage(
             "np. bieganie, rower, joga ..."),
         "activityLabel": MessageLookupByLibrary.simpleMessage("Aktywność"),

--- a/lib/generated/intl/messages_sk.dart
+++ b/lib/generated/intl/messages_sk.dart
@@ -108,6 +108,11 @@ class MessageLookup extends MessageLookupByLibrary {
 
   final messages = _notInlinedMessages(_notInlinedMessages);
   static Map<String, Function> _notInlinedMessages(_) => <String, Function>{
+        "nutrientPanelLimitLabel": MessageLookupByLibrary.simpleMessage("limit"),
+        "notificationsDailyReminderChannelName": MessageLookupByLibrary.simpleMessage("Denné pripomenutia"),
+        "notificationsDailyReminderChannelDescription": MessageLookupByLibrary.simpleMessage("Denné pripomenutie na zaznamenanie jedál"),
+        "fastingNotificationChannelName": MessageLookupByLibrary.simpleMessage("Časovač pôstu"),
+        "fastingNotificationChannelDescription": MessageLookupByLibrary.simpleMessage("Jednorazové upozornenia, keď pôst dosiahne svoj cieľ."),
         "activityExample": MessageLookupByLibrary.simpleMessage(
             "napr. beh, cyklistika, joga ..."),
         "activityLabel": MessageLookupByLibrary.simpleMessage("Aktivita"),

--- a/lib/generated/intl/messages_tr.dart
+++ b/lib/generated/intl/messages_tr.dart
@@ -110,6 +110,11 @@ class MessageLookup extends MessageLookupByLibrary {
 
   final messages = _notInlinedMessages(_notInlinedMessages);
   static Map<String, Function> _notInlinedMessages(_) => <String, Function>{
+        "nutrientPanelLimitLabel": MessageLookupByLibrary.simpleMessage("sınır"),
+        "notificationsDailyReminderChannelName": MessageLookupByLibrary.simpleMessage("Günlük hatırlatıcılar"),
+        "notificationsDailyReminderChannelDescription": MessageLookupByLibrary.simpleMessage("Öğünlerinizi kaydetmeniz için günlük hatırlatma"),
+        "fastingNotificationChannelName": MessageLookupByLibrary.simpleMessage("Oruç zamanlayıcısı"),
+        "fastingNotificationChannelDescription": MessageLookupByLibrary.simpleMessage("Bir oruç hedefe ulaştığında tek seferlik bildirimler."),
         "activityExample": MessageLookupByLibrary.simpleMessage(
             "ör. koşu, bisiklet, yoga ..."),
         "activityLabel": MessageLookupByLibrary.simpleMessage("Aktivite"),

--- a/lib/generated/intl/messages_uk.dart
+++ b/lib/generated/intl/messages_uk.dart
@@ -108,6 +108,11 @@ class MessageLookup extends MessageLookupByLibrary {
 
   final messages = _notInlinedMessages(_notInlinedMessages);
   static Map<String, Function> _notInlinedMessages(_) => <String, Function>{
+        "nutrientPanelLimitLabel": MessageLookupByLibrary.simpleMessage("ліміт"),
+        "notificationsDailyReminderChannelName": MessageLookupByLibrary.simpleMessage("Щоденні нагадування"),
+        "notificationsDailyReminderChannelDescription": MessageLookupByLibrary.simpleMessage("Щоденне нагадування записати прийоми їжі"),
+        "fastingNotificationChannelName": MessageLookupByLibrary.simpleMessage("Таймер голодування"),
+        "fastingNotificationChannelDescription": MessageLookupByLibrary.simpleMessage("Одноразові сповіщення, коли голодування досягає своєї мети."),
         "activityExample": MessageLookupByLibrary.simpleMessage(
             "наприклад, біг, їзда на велосипеді, йога ..."),
         "activityLabel": MessageLookupByLibrary.simpleMessage("Активність"),

--- a/lib/generated/intl/messages_zh.dart
+++ b/lib/generated/intl/messages_zh.dart
@@ -105,6 +105,11 @@ class MessageLookup extends MessageLookupByLibrary {
 
   final messages = _notInlinedMessages(_notInlinedMessages);
   static Map<String, Function> _notInlinedMessages(_) => <String, Function>{
+        "nutrientPanelLimitLabel": MessageLookupByLibrary.simpleMessage("上限"),
+        "notificationsDailyReminderChannelName": MessageLookupByLibrary.simpleMessage("每日提醒"),
+        "notificationsDailyReminderChannelDescription": MessageLookupByLibrary.simpleMessage("每日记录餐食的提醒"),
+        "fastingNotificationChannelName": MessageLookupByLibrary.simpleMessage("断食计时器"),
+        "fastingNotificationChannelDescription": MessageLookupByLibrary.simpleMessage("断食达到目标时的一次性提醒。"),
         "activityExample":
             MessageLookupByLibrary.simpleMessage("例如：跑步、骑车、瑜伽..."),
         "activityLabel": MessageLookupByLibrary.simpleMessage("活动"),

--- a/lib/generated/l10n.dart
+++ b/lib/generated/l10n.dart
@@ -1908,6 +1908,56 @@ class S {
     );
   }
 
+  /// `Daily Reminders`
+  String get notificationsDailyReminderChannelName {
+    return Intl.message(
+      'Daily Reminders',
+      name: 'notificationsDailyReminderChannelName',
+      desc: '',
+      args: [],
+    );
+  }
+
+  /// `Daily meal logging reminder`
+  String get notificationsDailyReminderChannelDescription {
+    return Intl.message(
+      'Daily meal logging reminder',
+      name: 'notificationsDailyReminderChannelDescription',
+      desc: '',
+      args: [],
+    );
+  }
+
+  /// `Fasting timer`
+  String get fastingNotificationChannelName {
+    return Intl.message(
+      'Fasting timer',
+      name: 'fastingNotificationChannelName',
+      desc: '',
+      args: [],
+    );
+  }
+
+  /// `One-off pings when a fasting session reaches its target.`
+  String get fastingNotificationChannelDescription {
+    return Intl.message(
+      'One-off pings when a fasting session reaches its target.',
+      name: 'fastingNotificationChannelDescription',
+      desc: '',
+      args: [],
+    );
+  }
+
+  /// `limit`
+  String get nutrientPanelLimitLabel {
+    return Intl.message(
+      'limit',
+      name: 'nutrientPanelLimitLabel',
+      desc: '',
+      args: [],
+    );
+  }
+
   /// `Don't forget to log your meals today!`
   String get notificationsDailyReminderBody {
     return Intl.message(

--- a/lib/l10n/intl_cs.arb
+++ b/lib/l10n/intl_cs.arb
@@ -373,9 +373,12 @@
   "notAvailableLabel": "neuvedeno",
   "nothingAddedLabel": "Nezadáno",
   "notificationsDailyReminderBody": "Nezapomeňte si dnes zaznamenat svá jídla!",
+  "notificationsDailyReminderChannelName": "Denní připomenutí",
+  "notificationsDailyReminderChannelDescription": "Denní připomenutí k zaznamenání jídel",
   "notificationsDailyReminderTitle": "OpenNutriTracker",
   "notificationsPermissionDeniedSnack": "Oprávnění k upozorněním bylo odepřeno.",
   "nutrientPanelAllHiddenLabel": "Všechny živiny skryté — zapni některé v Nastavení → Živiny.",
+  "nutrientPanelLimitLabel": "limit",
   "nutrientPanelDayLabel": "Den",
   "nutrientPanelWeekLabel": "Týden",
   "nutritionInfoLabel": "Nutriční hodnoty",
@@ -954,6 +957,8 @@
       "remaining": { "type": "String" }
     }
   },
+  "fastingNotificationChannelName": "Časovač půstu",
+  "fastingNotificationChannelDescription": "Jednorázová upozornění, když půst dosáhne svého cíle.",
   "fastingNotificationCompleteTitle": "Půst dokončen",
   "fastingNotificationCompleteBody": "Cílový čas byl dosažen."
 }

--- a/lib/l10n/intl_de.arb
+++ b/lib/l10n/intl_de.arb
@@ -404,9 +404,12 @@
   "notAvailableLabel": "N/A",
   "nothingAddedLabel": "Nichts hinzugefügt",
   "notificationsDailyReminderBody": "Vergiss nicht, heute deine Mahlzeiten zu protokollieren!",
+  "notificationsDailyReminderChannelName": "Tägliche Erinnerungen",
+  "notificationsDailyReminderChannelDescription": "Tägliche Erinnerung zum Erfassen deiner Mahlzeiten",
   "notificationsDailyReminderTitle": "OpenNutriTracker",
   "notificationsPermissionDeniedSnack": "Benachrichtigungsberechtigung verweigert.",
   "nutrientPanelAllHiddenLabel": "Alle Nährstoffe ausgeblendet — schalte einige unter Einstellungen → Nährstoffe ein.",
+  "nutrientPanelLimitLabel": "Limit",
   "nutrientPanelDayLabel": "Tag",
   "nutrientPanelWeekLabel": "Woche",
   "nutritionInfoLabel": "Nährwertangaben",
@@ -985,6 +988,8 @@
       "remaining": { "type": "String" }
     }
   },
+  "fastingNotificationChannelName": "Fasten-Timer",
+  "fastingNotificationChannelDescription": "Einmalige Hinweise, wenn eine Fastenphase ihr Ziel erreicht.",
   "fastingNotificationCompleteTitle": "Fastenzeit abgeschlossen",
   "fastingNotificationCompleteBody": "Deine Zielzeit wurde erreicht."
 }

--- a/lib/l10n/intl_en.arb
+++ b/lib/l10n/intl_en.arb
@@ -462,9 +462,12 @@
   "notAvailableLabel": "N/A",
   "nothingAddedLabel": "Nothing added",
   "notificationsDailyReminderBody": "Don't forget to log your meals today!",
+  "notificationsDailyReminderChannelName": "Daily Reminders",
+  "notificationsDailyReminderChannelDescription": "Daily meal logging reminder",
   "notificationsDailyReminderTitle": "OpenNutriTracker",
   "notificationsPermissionDeniedSnack": "Notification permission denied.",
   "nutrientPanelAllHiddenLabel": "All nutrients hidden — turn some on in Settings → Nutrients.",
+  "nutrientPanelLimitLabel": "limit",
   "nutrientPanelDayLabel": "Day",
   "nutrientPanelWeekLabel": "Week",
   "nutritionInfoLabel": "Nutrition Information",
@@ -1026,6 +1029,8 @@
       "remaining": { "type": "String" }
     }
   },
+  "fastingNotificationChannelName": "Fasting timer",
+  "fastingNotificationChannelDescription": "One-off pings when a fasting session reaches its target.",
   "fastingNotificationCompleteTitle": "Fasting session complete",
   "fastingNotificationCompleteBody": "Your target time has been reached."
 }

--- a/lib/l10n/intl_it.arb
+++ b/lib/l10n/intl_it.arb
@@ -373,9 +373,12 @@
   "notAvailableLabel": "N/D",
   "nothingAddedLabel": "Niente aggiunto",
   "notificationsDailyReminderBody": "Non dimenticare di registrare i tuoi pasti oggi!",
+  "notificationsDailyReminderChannelName": "Promemoria giornalieri",
+  "notificationsDailyReminderChannelDescription": "Promemoria giornaliero per registrare i pasti",
   "notificationsDailyReminderTitle": "OpenNutriTracker",
   "notificationsPermissionDeniedSnack": "Autorizzazione alle notifiche negata.",
   "nutrientPanelAllHiddenLabel": "Tutti i nutrienti nascosti — attivane alcuni in Impostazioni → Nutrienti.",
+  "nutrientPanelLimitLabel": "limite",
   "nutrientPanelDayLabel": "Giorno",
   "nutrientPanelWeekLabel": "Settimana",
   "nutritionInfoLabel": "Informazioni nutrizionali",
@@ -954,6 +957,8 @@
       "remaining": { "type": "String" }
     }
   },
+  "fastingNotificationChannelName": "Timer del digiuno",
+  "fastingNotificationChannelDescription": "Notifiche occasionali quando un digiuno raggiunge il suo obiettivo.",
   "fastingNotificationCompleteTitle": "Sessione di digiuno completata",
   "fastingNotificationCompleteBody": "Il tuo tempo obiettivo è stato raggiunto."
 }

--- a/lib/l10n/intl_pl.arb
+++ b/lib/l10n/intl_pl.arb
@@ -373,9 +373,12 @@
   "notAvailableLabel": "N/D",
   "nothingAddedLabel": "Nic nie dodano",
   "notificationsDailyReminderBody": "Nie zapomnij dziś zapisać swoich posiłków!",
+  "notificationsDailyReminderChannelName": "Codzienne przypomnienia",
+  "notificationsDailyReminderChannelDescription": "Codzienne przypomnienie o zapisaniu posiłków",
   "notificationsDailyReminderTitle": "OpenNutriTracker",
   "notificationsPermissionDeniedSnack": "Odmówiono dostępu do powiadomień.",
   "nutrientPanelAllHiddenLabel": "Wszystkie składniki ukryte — włącz wybrane w Ustawienia → Składniki odżywcze.",
+  "nutrientPanelLimitLabel": "limit",
   "nutrientPanelDayLabel": "Dzień",
   "nutrientPanelWeekLabel": "Tydzień",
   "nutritionInfoLabel": "Informacje odżywcze",
@@ -954,6 +957,8 @@
       "remaining": { "type": "String" }
     }
   },
+  "fastingNotificationChannelName": "Minutnik postu",
+  "fastingNotificationChannelDescription": "Jednorazowe powiadomienia, gdy post osiągnie swój cel.",
   "fastingNotificationCompleteTitle": "Sesja postu zakończona",
   "fastingNotificationCompleteBody": "Czas docelowy został osiągnięty."
 }

--- a/lib/l10n/intl_sk.arb
+++ b/lib/l10n/intl_sk.arb
@@ -420,9 +420,12 @@
   "notAvailableLabel": "neuvedené",
   "nothingAddedLabel": "Nič nepridané",
   "notificationsDailyReminderBody": "Nezabudnite si dnes zapísať svoje jedlá!",
+  "notificationsDailyReminderChannelName": "Denné pripomenutia",
+  "notificationsDailyReminderChannelDescription": "Denné pripomenutie na zaznamenanie jedál",
   "notificationsDailyReminderTitle": "OpenNutriTracker",
   "notificationsPermissionDeniedSnack": "Povolenie pre upozornenia bolo zamietnuté.",
   "nutrientPanelAllHiddenLabel": "Všetky živiny sú skryté — zapnite niektoré v Nastavenia → Živiny.",
+  "nutrientPanelLimitLabel": "limit",
   "nutrientPanelDayLabel": "Deň",
   "nutrientPanelWeekLabel": "Týždeň",
   "nutritionInfoLabel": "Nutričné údaje",
@@ -984,6 +987,8 @@
       "remaining": { "type": "String" }
     }
   },
+  "fastingNotificationChannelName": "Časovač pôstu",
+  "fastingNotificationChannelDescription": "Jednorazové upozornenia, keď pôst dosiahne svoj cieľ.",
   "fastingNotificationCompleteTitle": "Pôst dokončený",
   "fastingNotificationCompleteBody": "Cieľový čas bol dosiahnutý."
 }

--- a/lib/l10n/intl_tr.arb
+++ b/lib/l10n/intl_tr.arb
@@ -404,9 +404,12 @@
   "notAvailableLabel": "Mevcut Değil",
   "nothingAddedLabel": "Hiçbir şey eklenmedi",
   "notificationsDailyReminderBody": "Bugün öğünlerinizi kaydetmeyi unutmayın!",
+  "notificationsDailyReminderChannelName": "Günlük hatırlatıcılar",
+  "notificationsDailyReminderChannelDescription": "Öğünlerinizi kaydetmeniz için günlük hatırlatma",
   "notificationsDailyReminderTitle": "OpenNutriTracker",
   "notificationsPermissionDeniedSnack": "Bildirim izni reddedildi.",
   "nutrientPanelAllHiddenLabel": "Tüm besinler gizli — bazılarını Ayarlar → Besinler bölümünden aç.",
+  "nutrientPanelLimitLabel": "sınır",
   "nutrientPanelDayLabel": "Gün",
   "nutrientPanelWeekLabel": "Hafta",
   "nutritionInfoLabel": "Beslenme Bilgileri",
@@ -985,6 +988,8 @@
       "remaining": { "type": "String" }
     }
   },
+  "fastingNotificationChannelName": "Oruç zamanlayıcısı",
+  "fastingNotificationChannelDescription": "Bir oruç hedefe ulaştığında tek seferlik bildirimler.",
   "fastingNotificationCompleteTitle": "Oruç süresi tamamlandı",
   "fastingNotificationCompleteBody": "Hedef sürene ulaştın."
 }

--- a/lib/l10n/intl_uk.arb
+++ b/lib/l10n/intl_uk.arb
@@ -373,9 +373,12 @@
   "notAvailableLabel": "Н/Д",
   "nothingAddedLabel": "Нічого не додано",
   "notificationsDailyReminderBody": "Не забудьте сьогодні записати свої страви!",
+  "notificationsDailyReminderChannelName": "Щоденні нагадування",
+  "notificationsDailyReminderChannelDescription": "Щоденне нагадування записати прийоми їжі",
   "notificationsDailyReminderTitle": "OpenNutriTracker",
   "notificationsPermissionDeniedSnack": "У дозволі на сповіщення відмовлено.",
   "nutrientPanelAllHiddenLabel": "Усі поживні речовини приховано — увімкни деякі в Налаштування → Поживні речовини.",
+  "nutrientPanelLimitLabel": "ліміт",
   "nutrientPanelDayLabel": "День",
   "nutrientPanelWeekLabel": "Тиждень",
   "nutritionInfoLabel": "Інформація про харчування",
@@ -954,6 +957,8 @@
       "remaining": { "type": "String" }
     }
   },
+  "fastingNotificationChannelName": "Таймер голодування",
+  "fastingNotificationChannelDescription": "Одноразові сповіщення, коли голодування досягає своєї мети.",
   "fastingNotificationCompleteTitle": "Сесія голодування завершена",
   "fastingNotificationCompleteBody": "Цільовий час досягнуто."
 }

--- a/lib/l10n/intl_zh.arb
+++ b/lib/l10n/intl_zh.arb
@@ -374,9 +374,12 @@
   "notAvailableLabel": "不可用",
   "nothingAddedLabel": "未添加任何内容",
   "notificationsDailyReminderBody": "别忘了记录您今天的饮食！",
+  "notificationsDailyReminderChannelName": "每日提醒",
+  "notificationsDailyReminderChannelDescription": "每日记录餐食的提醒",
   "notificationsDailyReminderTitle": "OpenNutriTracker",
   "notificationsPermissionDeniedSnack": "通知权限被拒绝。",
   "nutrientPanelAllHiddenLabel": "所有营养素都已隐藏 — 请到设置 → 营养素中打开。",
+  "nutrientPanelLimitLabel": "上限",
   "nutrientPanelDayLabel": "日",
   "nutrientPanelWeekLabel": "周",
   "nutritionInfoLabel": "营养信息",
@@ -955,6 +958,8 @@
       "remaining": { "type": "String" }
     }
   },
+  "fastingNotificationChannelName": "断食计时器",
+  "fastingNotificationChannelDescription": "断食达到目标时的一次性提醒。",
   "fastingNotificationCompleteTitle": "禁食时间到了",
   "fastingNotificationCompleteBody": "已达到你的目标时间。"
 }

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -56,24 +56,35 @@ Future<void> main() async {
   final isUserInitialized = await locator<UserDataSource>().hasUserData();
   final configRepo = locator<ConfigRepository>();
 
-  // #312: Restore scheduled notifications after app start / device reboot
   final config = await configRepo.getConfig();
+  final savedLocaleCode = await configRepo.getSelectedLocale();
+  final savedLocale =
+      savedLocaleCode != null ? Locale(savedLocaleCode) : null;
+
+  // #312: Restore scheduled notifications after app start / device reboot.
+  // Load the user's localized strings first — there's no widget tree yet, so
+  // S is driven directly off the saved (or device) locale. Android re-applies
+  // the channel name/description on every (re)registration, and they surface
+  // in the OS settings, so this keeps them in the user's language instead of
+  // reverting to English on each launch.
   if (config.notificationsEnabled) {
+    await S.load(
+        savedLocale ?? WidgetsBinding.instance.platformDispatcher.locale);
+    final s = S.current;
     final notificationService = locator<NotificationService>();
     await notificationService.initialize();
     await notificationService.scheduleDailyReminder(
       hour: config.notificationHour,
       minute: config.notificationMinute,
-      title: 'OpenNutriTracker',
-      body: 'Don\'t forget to log your meals today!',
+      title: s.notificationsDailyReminderTitle,
+      body: s.notificationsDailyReminderBody,
+      channelName: s.notificationsDailyReminderChannelName,
+      channelDescription: s.notificationsDailyReminderChannelDescription,
     );
   }
   final hasAcceptedAnonymousData =
       await configRepo.getConfigHasAcceptedAnonymousData();
   final savedAppTheme = await configRepo.getConfigAppTheme();
-  final savedLocaleCode = await configRepo.getSelectedLocale();
-  final savedLocale =
-      savedLocaleCode != null ? Locale(savedLocaleCode) : null;
   final savedUsesKilojoules = config.usesKilojoules;
   final savedUseMaterialYou = config.useMaterialYou;
   final savedAccentColor = config.accentColor;


### PR DESCRIPTION
This works through the review comments Simon left on the v1.4.0 release PR (#459). It targets `develop` so the fixes flow up into that release once merged.

- **Diary nutrient panel:** ceiling rows (sodium, saturated fat, sugar) now carry a small localized "limit" qualifier, so a reference you are meant to stay under no longer reads as a target. It rides on the existing `excessMatters` flag, so the three ceilings stay consistent.
- **DRI citations:** the 2019 IOM sodium/potassium update is now cited inline for the sodium CDRR and potassium AI, and the 2011 calcium/vitamin D report for calcium and vitamin D. I kept the 2011 RDA figures rather than the 1997 AI values, with a note at the line explaining why (see below), so the citation sits where the next reader will look.
- **Low-kcal floor:** the comment now cites the Harvard Health page Simon linked, since the earlier NIH / Mayo Clinic attribution could not be verified.
- **Notification channels:** the channel name and description for the daily reminder and the fasting timer are now localized across all nine languages, including the reboot-restore path in `main()`. They surface in the system settings, so they read in the user's language now.
- **Activity detail:** the "2024 Compendium of Physical Activities" attribution is hidden for custom activities, which are user-entered.

A note on vitamin D and calcium: Simon read the source as listing AI values. Those are the 1997 IOM figures; the 2011 update established an RDA for both (vitamin D 15/20 µg, calcium 1000/1200 mg), which is what NIH ODS publishes today. I kept the 2011 RDA so we are not showing older, lower numbers, and documented the 1997 to 2011 change inline with the source link.

`flutter analyze` is clean and `just test` passes (597 tests).
