### PR TITLE
ci(ios-package): precache the iOS Flutter engine before pod install

### DIFF
--- a/.github/workflows/default_workflow.yml
+++ b/.github/workflows/default_workflow.yml
@@ -589,6 +589,15 @@ jobs:
       - name: Generate code
         run: fvm dart run build_runner build --delete-conflicting-outputs
 
+      # The Podfile's Flutter post-install hook needs the iOS engine
+      # artifacts (Flutter.xcframework). The setup-flutter-cache action used
+      # by ios-build precaches them, but this job installs Flutter via FVM
+      # (for parity with local dev) which does not, so `pod install` fails
+      # with "Flutter.xcframework must exist ... run flutter precache --ios
+      # first". Precache the iOS engine before pods.
+      - name: Precache iOS Flutter engine
+        run: fvm flutter precache --ios
+
       - name: Install CocoaPods dependencies
         working-directory: ios
         run: bundle exec pod install


### PR DESCRIPTION
The v1.4.0 release run's `ios-package` job (signed-IPA build for TestFlight) failed at `bundle exec pod install`:

```
Flutter.xcframework must exist. If you're running pod install manually,
make sure "flutter precache --ios" is executed first
```

**Cause:** the Podfile's Flutter post-install hook needs the iOS engine artifacts (`Flutter.xcframework`). `ios-build` installs Flutter via the `setup-flutter-cache` action, which precaches them; `ios-package` installs Flutter via **FVM** (switched for local-dev parity, #852848d4), which does not. So `pod install` runs against a Flutter with no iOS engine and the hook throws. That's why `ios-build` and the integration jobs are green but packaging dies — only `ios-package` takes the FVM path before a pod install.

**Fix:** add `fvm flutter precache --ios` between code generation and `pod install`, exactly as the error message suggests. One step, unblocks the signed-IPA build and the downstream TestFlight upload on the release path.

This needs to reach `main` to fix the release pipeline, so it goes develop → main like everything else.
