### PR TITLE
ci: unblock v1.4.0 iOS packaging (precache iOS Flutter engine)

### DIFF
--- a/.github/workflows/default_workflow.yml
+++ b/.github/workflows/default_workflow.yml
@@ -589,6 +589,15 @@ jobs:
       - name: Generate code
         run: fvm dart run build_runner build --delete-conflicting-outputs
 
+      # The Podfile's Flutter post-install hook needs the iOS engine
+      # artifacts (Flutter.xcframework). The setup-flutter-cache action used
+      # by ios-build precaches them, but this job installs Flutter via FVM
+      # (for parity with local dev) which does not, so `pod install` fails
+      # with "Flutter.xcframework must exist ... run flutter precache --ios
+      # first". Precache the iOS engine before pods.
+      - name: Precache iOS Flutter engine
+        run: fvm flutter precache --ios
+
       - name: Install CocoaPods dependencies
         working-directory: ios
         run: bundle exec pod install


### PR DESCRIPTION
@simonoppowa — a small follow-up to the v1.4.0 release. The release run got through `linux-checks`, both builds, and both integration tests, but `ios-package` failed at `pod install`: the FVM-installed Flutter hadn't precached the iOS engine, so `Flutter.xcframework` was missing. #474 adds `fvm flutter precache --ios` before the pod step.

This carries that one CI fix to `main` so the signed-IPA build and TestFlight upload can finish. **Could you merge and re-cut the iOS build for the App Store?** The Android AAB → Play internal completed on the release run; this is only to get the iOS IPA out.

**Version:** left at `1.4.0+51` (no bump). The app is byte-identical to what v1.4.0 intended to ship, and +51's IPA never actually built (the pipeline died at packaging), so this completes the +51 build rather than starting a new one.

Diff is one workflow file (+9 lines, the precache step) — no app code change.
