### PR TITLE
ci: bump to 1.4.0+55 and run ios-deploy on macOS

### DIFF
--- a/.github/workflows/default_workflow.yml
+++ b/.github/workflows/default_workflow.yml
@@ -623,7 +623,12 @@ jobs:
       github.event_name == 'workflow_dispatch'
     needs:
       - ios-package
-    runs-on: ubuntu-latest
+    # Must run on macOS. The TestFlight upload goes through Apple's iTunes
+    # Transporter, which needs the macOS toolchain (xcrun/altool); on
+    # ubuntu it failed with "No such file or directory @ dir_chdir0" as the
+    # transporter couldn't resolve its working directory. The IPA is built
+    # in ios-package and handed off as an artifact, so this job only uploads.
+    runs-on: macos-26
     permissions:
       contents: read
     env:

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -15,7 +15,7 @@ publish_to: 'none' # Remove this line if you wish to publish to pub.dev
 # In iOS, build-name is used as CFBundleShortVersionString while build-number is used as CFBundleVersion.
 # Read more about iOS versioning at
 # https://developer.apple.com/library/archive/documentation/General/Reference/InfoPlistKeyReference/Articles/CoreFoundationKeys.html
-version: 1.4.0+51
+version: 1.4.0+55
 
 environment:
   sdk: '>=3.11.0 <4.0.0'


### PR DESCRIPTION
Follow-ups so the v1.4.0 release pipeline can finish deploying. The last release run got both package jobs green (the iOS precache fix from #474 worked), but both **deploy** jobs failed, for two unrelated reasons:

**android-deploy** — Google Play rejected the upload:
```
Google Api Error: Invalid request - Version code 51 has already been used.
```
The first release run already pushed versionCode 51 (from pubspec) to the internal track, and offline fastlane testing has since used the next few. Bump the build number to **1.4.0+55** so the AAB gets a fresh, unused versionCode. The AAB build takes its versionCode from pubspec (`flutter build appbundle`, no `--build-number`), so the bump is what fixes it; iOS sets `CFBundleVersion` from the CI run number, so it's unaffected by the bump.

**ios-deploy** — the TestFlight upload failed on `ubuntu-latest`:
```
upload_to_testflight -> iTunes Transporter
No such file or directory @ dir_chdir0 -
```
The transporter needs the macOS toolchain (`xcrun`/altool) and can't resolve its working directory on Linux. Move `ios-deploy` back to **macOS**. `ios-package` still builds the IPA and hands it off as an artifact, so this job only downloads + uploads.

Raised **directly into `main`** to unblock the release pipeline now; `develop` will be reconciled with a `main → develop` merge afterward.
