### PR TITLE
ci: release-pipeline fixes — ssh-keyscan host keys, +56 bump, gate deploys on both packages

### DIFF
--- a/.github/workflows/default_workflow.yml
+++ b/.github/workflows/default_workflow.yml
@@ -544,14 +544,13 @@ jobs:
         if: startsWith(env.MATCH_GIT_URL, 'git@') && env.MATCH_GIT_SSH_PRIVATE_KEY != ''
         run: |
           mkdir -p ~/.ssh
-          ruby -rjson -ropen-uri -e '
-            meta = JSON.parse(URI.open("https://api.github.com/meta", "User-Agent" => "github-actions").read)
-            File.open(File.expand_path("~/.ssh/known_hosts"), "a", 0600) do |file|
-              meta.fetch("ssh_keys").each do |key|
-                file.puts("github.com #{key}")
-              end
-            end
-          '
+          # Fetch github.com's host keys with ssh-keyscan rather than the
+          # api.github.com/meta endpoint. That API is unauthenticated and
+          # rate-limited to 60 requests/hour per IP, and the shared macOS
+          # runner IP exhausts it — the step fails intermittently with
+          # "403 rate limit exceeded". ssh-keyscan talks to github.com:22
+          # directly and has no such limit.
+          ssh-keyscan -t rsa,ecdsa,ed25519 github.com >> ~/.ssh/known_hosts
           chmod 600 ~/.ssh/known_hosts
 
       - name: Cache CocoaPods

--- a/.github/workflows/default_workflow.yml
+++ b/.github/workflows/default_workflow.yml
@@ -620,8 +620,11 @@ jobs:
     if: |
       (github.event_name == 'push' && github.ref == 'refs/heads/main') ||
       github.event_name == 'workflow_dispatch'
+    # Deploy only when BOTH platforms packaged successfully (see android-deploy)
+    # so a one-sided failure never publishes half a release.
     needs:
       - ios-package
+      - android-package
     # Must run on macOS. The TestFlight upload goes through Apple's iTunes
     # Transporter, which needs the macOS toolchain (xcrun/altool); on
     # ubuntu it failed with "No such file or directory @ dir_chdir0" as the
@@ -785,8 +788,13 @@ jobs:
     if: |
       (github.event_name == 'push' && github.ref == 'refs/heads/main') ||
       github.event_name == 'workflow_dispatch'
+    # Deploy only when BOTH platforms packaged successfully. A half-success
+    # (e.g. iOS packaging fails) would otherwise still upload the Android AAB,
+    # consuming a Play versionCode and forcing a build-number bump on the
+    # retry. Gating both deploys on both package jobs keeps a release atomic.
     needs:
       - android-package
+      - ios-package
     runs-on: ubuntu-latest
     permissions:
       contents: read

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -15,7 +15,7 @@ publish_to: 'none' # Remove this line if you wish to publish to pub.dev
 # In iOS, build-name is used as CFBundleShortVersionString while build-number is used as CFBundleVersion.
 # Read more about iOS versioning at
 # https://developer.apple.com/library/archive/documentation/General/Reference/InfoPlistKeyReference/Articles/CoreFoundationKeys.html
-version: 1.4.0+55
+version: 1.4.0+56
 
 environment:
   sdk: '>=3.11.0 <4.0.0'


### PR DESCRIPTION
Release-pipeline fixes, batched so one merge into `main` moves it forward. Each recent main-push run surfaced a new layer; this covers the three currently in the way.

### 1. `ssh-keyscan` for github.com host keys (the failure that triggered this)
`ios-package` died at **"Install GitHub SSH host keys"** with `403 rate limit exceeded`. That step seeded `~/.ssh/known_hosts` (for the fastlane `match` clone) from the **unauthenticated** `https://api.github.com/meta` endpoint — 60 req/hr per IP, exhausted on the shared macOS runner. Replaced with `ssh-keyscan github.com`, which hits `github.com:22` directly and has no API rate limit.

### 2. Bump to `1.4.0+56`
`android-deploy` succeeded on the last run, so versionCode 55 is now used on the Play internal track. Bump so the next AAB gets a fresh code. (Android takes its versionCode from pubspec; iOS uses the CI run number, so it's unaffected.)

### 3. Gate both deploys on both package jobs
The recurring versionCode bumps have a root cause: `android-deploy` only `needs: android-package`, so a half-success — Android packages and **deploys** while iOS packaging fails — uploads the Android AAB and burns a versionCode, forcing a bump on every retry. Now `android-deploy` and `ios-deploy` each `needs` **both** `android-package` and `ios-package`, so a one-sided failure skips both uploads and the version code stays unused. Releases become atomic.

Raised **directly into `main`** to keep the pipeline moving; `develop` will be reconciled with a `main → develop` merge afterward (along with #476 and this).
