### PR TITLE
ci(ios): align build number to pubspec + bump to 1.4.1+57

### DIFF
--- a/.github/workflows/default_workflow.yml
+++ b/.github/workflows/default_workflow.yml
@@ -523,7 +523,6 @@ jobs:
       MATCH_GIT_SSH_PRIVATE_KEY: ${{ secrets.MATCH_GIT_SSH_PRIVATE_KEY }}
       MATCH_PASSWORD: ${{ secrets.MATCH_PASSWORD }}
       APP_STORE_CONNECT_API_KEY_IS_KEY_CONTENT_BASE64: 'true'
-      CI_BUILD_NUMBER: ${{ github.run_number }}
     steps:
       - name: Checkout code
         uses: actions/checkout@v6

--- a/ios/fastlane/Fastfile
+++ b/ios/fastlane/Fastfile
@@ -16,7 +16,11 @@ platform :ios do
     # production bundle identifier and BUNDLE_DISPLAY_NAME (no .develop
     # suffix). The develop scheme exists for local sideloading and isn't
     # what App Store distribution should ever pick up.
-    sh("cd .. && fvm flutter build ipa --release --flavor full --export-method app-store --build-number=#{ENV.fetch('CI_BUILD_NUMBER', '1')}")
+    #
+    # No --build-number: flutter takes CFBundleVersion from the pubspec build
+    # number (the +N in `version:`), so iOS and Android share one build number
+    # sourced from pubspec instead of iOS using the CI run number.
+    sh('cd .. && fvm flutter build ipa --release --flavor full --export-method app-store')
   end
 
   desc 'Upload the latest IPA to TestFlight'

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -15,7 +15,7 @@ publish_to: 'none' # Remove this line if you wish to publish to pub.dev
 # In iOS, build-name is used as CFBundleShortVersionString while build-number is used as CFBundleVersion.
 # Read more about iOS versioning at
 # https://developer.apple.com/library/archive/documentation/General/Reference/InfoPlistKeyReference/Articles/CoreFoundationKeys.html
-version: 1.4.0+56
+version: 1.4.1+57
 
 environment:
   sdk: '>=3.11.0 <4.0.0'


### PR DESCRIPTION
Aligns the iOS and Android build numbers and moves to a new version so the alignment is store-safe.

**Align the build number to pubspec.** iOS built with `--build-number=CI_BUILD_NUMBER` (`github.run_number`), so it shipped as `1.4.0 (701)` while Android used the pubspec build number (`56`). Drop the override so flutter takes `CFBundleVersion` from the pubspec build number — the same source Android already uses for its versionCode. Both platforms now share one build number managed in `pubspec.yaml`. (Removes the now-unused `CI_BUILD_NUMBER` env from `ios-package`.)

**Bump to `1.4.1+57`.** App Store Connect requires build numbers to increase *within a version name*, and `1.4.0 (701)` is already uploaded — so iOS can't go back to a lower pubspec number under `1.4.0`. Moving to the new version name `1.4.1` resets the iOS build counter, so the pubspec-sourced `57` is accepted; `57` also clears Android's existing versionCode `56`.

Raised **directly into `main`** to keep the pipeline state consistent (main is ahead of develop by the recent release fixes); `develop` gets all of it in the `main → develop` reconcile.
