### PR TITLE
Move OFF text search to Search-a-licious, with hydration, ranking and local prioritisation

### DIFF
--- a/lib/core/data/data_source/remote_search_cache_data_source.dart
+++ b/lib/core/data/data_source/remote_search_cache_data_source.dart
@@ -84,8 +84,15 @@ class RemoteSearchCacheDataSource {
     for (final meal in meals) {
       final existingKey = _lookupExistingKey(meal, index);
       if (existingKey != null) {
-        // Refresh data, leave timestamp alone.
-        await _cacheBox.put(existingKey, meal);
+        // Refresh data, leave timestamp alone — but never let a thin search
+        // result overwrite an entry we've already hydrated to the full
+        // record, or the next open/scan would lose serving + micronutrients.
+        final existing = _cacheBox.get(existingKey);
+        final wouldDowngrade =
+            (existing?.detailed ?? false) && !(meal.detailed ?? false);
+        if (!wouldDowngrade) {
+          await _cacheBox.put(existingKey, meal);
+        }
       } else {
         final newKey = await _cacheBox.add(meal);
         _registerInIndex(meal, newKey, index);
@@ -169,6 +176,17 @@ class RemoteSearchCacheDataSource {
   MealDBO? getByBarcode(String barcode) {
     for (final meal in _cacheBox.values) {
       if (meal.code == barcode) return meal;
+    }
+    return null;
+  }
+
+  /// Look up a cached meal by barcode but only return it when it holds the
+  /// full product record. A thin Search-a-licious search result cached under
+  /// the same code is ignored so the caller fetches (and re-caches) the full
+  /// product instead of serving up macros-only data on a scan or hydration.
+  MealDBO? getDetailedByBarcode(String barcode) {
+    for (final meal in _cacheBox.values) {
+      if (meal.code == barcode && (meal.detailed ?? false)) return meal;
     }
     return null;
   }

--- a/lib/core/data/dbo/meal_dbo.dart
+++ b/lib/core/data/dbo/meal_dbo.dart
@@ -50,6 +50,15 @@ class MealDBO extends HiveObject {
   @HiveField(13)
   final String? localImagePath;
 
+  /// True when this cached entry holds the full product record. Search
+  /// results from Search-a-licious are cached thin (`false` / null on legacy
+  /// rows); barcode and hydrated lookups are cached full (`true`). Used so a
+  /// thin cache entry doesn't satisfy a hydration/barcode lookup and so
+  /// [RemoteSearchCacheDataSource.cacheFromSearch] never downgrades a full
+  /// entry. Nullable for backward compatibility with pre-existing rows.
+  @HiveField(14)
+  final bool? detailed;
+
   MealDBO({
     required this.code,
     required this.name,
@@ -65,6 +74,7 @@ class MealDBO extends HiveObject {
     required this.nutriments,
     required this.source,
     this.localImagePath,
+    this.detailed,
   });
 
   factory MealDBO.fromMealEntity(MealEntity mealEntity) => MealDBO(
@@ -84,6 +94,7 @@ class MealDBO extends HiveObject {
         ),
         source: MealSourceDBO.fromMealSourceEntity(mealEntity.source),
         localImagePath: mealEntity.localImagePath,
+        detailed: mealEntity.detailed,
       );
 
   factory MealDBO.fromJson(Map<String, dynamic> json) =>

--- a/lib/core/data/dbo/meal_dbo.g.dart
+++ b/lib/core/data/dbo/meal_dbo.g.dart
@@ -31,13 +31,14 @@ class MealDBOAdapter extends TypeAdapter<MealDBO> {
       nutriments: fields[11] as MealNutrimentsDBO,
       source: fields[10] as MealSourceDBO,
       localImagePath: fields[13] as String?,
+      detailed: fields[14] as bool?,
     );
   }
 
   @override
   void write(BinaryWriter writer, MealDBO obj) {
     writer
-      ..writeByte(14)
+      ..writeByte(15)
       ..writeByte(0)
       ..write(obj.code)
       ..writeByte(1)
@@ -65,7 +66,9 @@ class MealDBOAdapter extends TypeAdapter<MealDBO> {
       ..writeByte(12)
       ..write(obj.servingSize)
       ..writeByte(13)
-      ..write(obj.localImagePath);
+      ..write(obj.localImagePath)
+      ..writeByte(14)
+      ..write(obj.detailed);
   }
 
   @override
@@ -149,6 +152,7 @@ MealDBO _$MealDBOFromJson(Map<String, dynamic> json) => MealDBO(
   ),
   source: $enumDecode(_$MealSourceDBOEnumMap, json['source']),
   localImagePath: json['localImagePath'] as String?,
+  detailed: json['detailed'] as bool?,
 );
 
 Map<String, dynamic> _$MealDBOToJson(MealDBO instance) => <String, dynamic>{
@@ -166,6 +170,7 @@ Map<String, dynamic> _$MealDBOToJson(MealDBO instance) => <String, dynamic>{
   'source': _$MealSourceDBOEnumMap[instance.source]!,
   'nutriments': instance.nutriments,
   'localImagePath': instance.localImagePath,
+  'detailed': instance.detailed,
 };
 
 const _$MealSourceDBOEnumMap = {

--- a/lib/core/utils/off_const.dart
+++ b/lib/core/utils/off_const.dart
@@ -1,14 +1,31 @@
 class OFFConst {
   static const offWebsiteUrl = "https://world.openfoodfacts.org/";
   static const _offBaseUrl = "world.openfoodfacts.org";
-  static const _offSearchTag = "/cgi/search.pl";
   static const _offProductSearchTag = "/api/v2/product";
+
+  // Text search moved off the deprecated /cgi/search.pl to Open Food Facts'
+  // Elasticsearch-backed Search-a-licious service. Barcode lookups stay on the
+  // still-healthy v2 product endpoint, which also serves as the hydration
+  // source for the thinner Search-a-licious results.
+  static const _salBaseUrl = "search.openfoodfacts.org";
+  static const _salSearchTag = "/search";
+
+  // We fetch a larger relevance-ordered candidate pool than we display so the
+  // repository can re-rank it (fusing relevance position with popularity_key)
+  // before trimming to the shown results. A bare relevance page buries popular,
+  // well-maintained products under near-duplicate and sparse entries.
+  static const searchCandidatePoolSize = 100;
 
   static const offHttpSuccessCode = 200;
   static const offHttpDownCodes = [502, 503, 500];
   static const offProductNotFoundCode = 404;
 
-  static const _offProductSearchTermsTag = "search_terms";
+  static const _salQueryTag = "q";
+  static const _salFieldsTag = "fields";
+  static const _salLangsTag = "langs";
+  static const _salPageSizeTag = "page_size";
+  static const _salPageTag = "page";
+
   static const _offFieldsTag = "fields";
   static const _offJsonTag = "json";
   static const _offJsonValue = "true";
@@ -24,16 +41,36 @@ class OFFConst {
   static const _offImageUrlTag = "image_url";
   static const _offImageThumbUrlTag = "image_front_thumb_url";
   static const _offImageFrontUrlTag = "image_front_url";
-  // static const _offImageNutritionUrlTag = "image_nutrition_url";
-  // static const _offImageIngredientsUrlTag = "image_ingredients_url";
 
   static const _offProductQuantityTag = "product_quantity";
   static const _offQuantityTag = "quantity";
   static const _offServingQuantityTag = "serving_quantity";
   static const _offServingSizeTag = "serving_size";
   static const _offNutrimentsTag = "nutriments";
+  static const _offPopularityKeyTag = "popularity_key";
 
-  static const _returnFields = [
+  // Search-a-licious only indexes a thin projection of each product: the
+  // serving_* and product_quantity fields are absent from its index, so they
+  // are dropped here and recovered on hydration via the full v2 product call.
+  static const _searchReturnFields = [
+    _offCodeTag,
+    _offBrandsTag,
+    _offProductNameTag,
+    _offProductNameENTag,
+    _offProductNameDETag,
+    _offProductNameFRTag,
+    _offUrlTag,
+    _offImageUrlTag,
+    _offImageThumbUrlTag,
+    _offImageFrontUrlTag,
+    _offQuantityTag,
+    _offNutrimentsTag,
+    _offPopularityKeyTag,
+  ];
+
+  // The v2 product endpoint carries the full record, including the serving
+  // fields and micronutrients Search-a-licious omits.
+  static const _productReturnFields = [
     _offCodeTag,
     _offBrandsTag,
     _offProductNameTag,
@@ -51,21 +88,23 @@ class OFFConst {
     _offNutrimentsTag,
   ];
 
-  static String _getReturnFields() => _returnFields.join(",");
+  static String _joinFields(List<String> fields) => fields.join(",");
 
-  static Uri getOffWordSearchUrl(String searchString) {
+  static Uri getOffWordSearchUrl(String searchString, {String langs = 'en'}) {
     final queryParameters = {
-      _offProductSearchTermsTag: searchString,
-      _offFieldsTag: _getReturnFields(),
-      _offJsonTag: _offJsonValue,
+      _salQueryTag: searchString,
+      _salFieldsTag: _joinFields(_searchReturnFields),
+      _salLangsTag: langs,
+      _salPageSizeTag: '$searchCandidatePoolSize',
+      _salPageTag: '1',
     };
 
-    return Uri.https(_offBaseUrl, _offSearchTag, queryParameters);
+    return Uri.https(_salBaseUrl, _salSearchTag, queryParameters);
   }
 
   static Uri getOffBarcodeSearchUri(String barcode) {
     final queryParameters = {
-      _offFieldsTag: _getReturnFields(),
+      _offFieldsTag: _joinFields(_productReturnFields),
       _offJsonTag: _offJsonValue,
     };
 

--- a/lib/core/utils/off_const.dart
+++ b/lib/core/utils/off_const.dart
@@ -48,6 +48,7 @@ class OFFConst {
   static const _offServingSizeTag = "serving_size";
   static const _offNutrimentsTag = "nutriments";
   static const _offPopularityKeyTag = "popularity_key";
+  static const _offCountriesTagsTag = "countries_tags";
 
   // Search-a-licious only indexes a thin projection of each product: the
   // serving_* and product_quantity fields are absent from its index, so they
@@ -66,6 +67,7 @@ class OFFConst {
     _offQuantityTag,
     _offNutrimentsTag,
     _offPopularityKeyTag,
+    _offCountriesTagsTag,
   ];
 
   // The v2 product endpoint carries the full record, including the serving

--- a/lib/core/utils/off_country.dart
+++ b/lib/core/utils/off_country.dart
@@ -1,0 +1,53 @@
+/// Derives the user's Open Food Facts country tag (e.g. `en:united-kingdom`)
+/// from a platform locale name like `en_GB`, so the food search can softly
+/// boost products sold in the user's country up the result ranking.
+///
+/// Returns null when the locale carries no country segment (e.g. `en`, `C`) or
+/// the country isn't in the map — callers then simply skip the boost, which is
+/// the safe default. The tag slugs are OFF's English country-name slugs,
+/// verified against the live Search-a-licious index.
+class OffCountry {
+  OffCountry._();
+
+  static const _isoToOffTag = <String, String>{
+    'GB': 'en:united-kingdom',
+    'US': 'en:united-states',
+    'IE': 'en:ireland',
+    'DE': 'en:germany',
+    'AT': 'en:austria',
+    'CH': 'en:switzerland',
+    'FR': 'en:france',
+    'IT': 'en:italy',
+    'ES': 'en:spain',
+    'PT': 'en:portugal',
+    'NL': 'en:netherlands',
+    'BE': 'en:belgium',
+    'PL': 'en:poland',
+    'CZ': 'en:czech-republic',
+    'SK': 'en:slovakia',
+    'TR': 'en:turkey',
+    'UA': 'en:ukraine',
+    'SE': 'en:sweden',
+    'NO': 'en:norway',
+    'DK': 'en:denmark',
+    'FI': 'en:finland',
+    'CA': 'en:canada',
+    'AU': 'en:australia',
+    'NZ': 'en:new-zealand',
+    'JP': 'en:japan',
+    'CN': 'en:china',
+    'IN': 'en:india',
+    'BR': 'en:brazil',
+    'MX': 'en:mexico',
+    'ZA': 'en:south-africa',
+  };
+
+  /// Maps a platform locale (`Platform.localeName`) to an OFF country tag.
+  /// Handles forms like `en_GB`, `en-GB`, `en_GB.UTF-8`, `en` and `C`.
+  static String? fromLocale(String localeName) {
+    final beforeDot = localeName.split('.').first;
+    final parts = beforeDot.split(RegExp('[_-]'));
+    if (parts.length < 2 || parts[1].isEmpty) return null;
+    return _isoToOffTag[parts[1].toUpperCase()];
+  }
+}

--- a/lib/features/add_meal/data/data_sources/off_data_source.dart
+++ b/lib/features/add_meal/data/data_sources/off_data_source.dart
@@ -1,4 +1,5 @@
 import 'dart:convert';
+import 'dart:io';
 
 import 'package:http/http.dart' as http;
 import 'package:logging/logging.dart';
@@ -6,6 +7,7 @@ import 'package:opennutritracker/core/utils/app_const.dart';
 import 'package:opennutritracker/core/utils/off_const.dart';
 import 'package:opennutritracker/core/utils/ont_http_client.dart';
 import 'package:opennutritracker/core/utils/retry_util.dart';
+import 'package:opennutritracker/core/utils/supported_language.dart';
 import 'package:opennutritracker/features/add_meal/data/dto/off/off_product_response_dto.dart';
 import 'package:opennutritracker/features/add_meal/data/dto/off/off_word_response_dto.dart';
 import 'package:opennutritracker/features/scanner/data/product_not_found_exception.dart';
@@ -15,10 +17,19 @@ class OFFDataSource {
   static const _timeoutDuration = Duration(seconds: 60);
   final log = Logger('OFFDataSource');
 
+  /// The device language as a Search-a-licious relevance context, always with
+  /// English appended as a fallback so non-English locales still match the
+  /// large English-only slice of the catalogue.
+  String _searchLangs() {
+    final lang = SupportedLanguage.fromCode(Platform.localeName).name;
+    return lang == 'en' ? 'en' : '$lang,en';
+  }
+
   Future<OFFWordResponseDTO> fetchSearchWordResults(String searchString) async {
     try {
       return await withRetry(() async {
-        final searchUrlString = OFFConst.getOffWordSearchUrl(searchString);
+        final searchUrlString =
+            OFFConst.getOffWordSearchUrl(searchString, langs: _searchLangs());
         final userAgentString = await AppConst.getUserAgentString();
         final httpClient = ONTHttpClient(userAgentString, http.Client());
         final response =

--- a/lib/features/add_meal/data/dto/off/off_product_dto.dart
+++ b/lib/features/add_meal/data/dto/off/off_product_dto.dart
@@ -61,6 +61,11 @@ class OFFProductDTO {
   // results — the v2 barcode endpoint omits it, which is fine (single product).
   final num? popularity_key;
 
+  // Open Food Facts country tags (e.g. `en:united-kingdom`). Used to softly
+  // boost products sold in the user's country up the search ranking. Only
+  // present on Search-a-licious results.
+  final List<String>? countries_tags;
+
   final OFFProductNutrimentsDTO? nutriments;
 
   String? getLocaleName(SupportedLanguage supportedLanguage) {
@@ -128,6 +133,7 @@ class OFFProductDTO {
     required this.serving_size,
     required this.nutriments,
     this.popularity_key,
+    this.countries_tags,
   });
 
   factory OFFProductDTO.fromJson(Map<String, dynamic> json) =>

--- a/lib/features/add_meal/data/dto/off/off_product_dto.dart
+++ b/lib/features/add_meal/data/dto/off/off_product_dto.dart
@@ -6,6 +6,19 @@ import 'package:opennutritracker/features/add_meal/data/dto/off/off_product_nutr
 
 part 'off_product_dto.g.dart';
 
+String? _brandsFromJson(dynamic value) {
+  if (value == null) return null;
+  if (value is List) {
+    final parts = value
+        .map((e) => e?.toString().trim())
+        .whereType<String>()
+        .where((e) => e.isNotEmpty);
+    return parts.isEmpty ? null : parts.join(', ');
+  }
+  final text = value.toString().trim();
+  return text.isEmpty ? null : text;
+}
+
 @JsonSerializable()
 class OFFProductDTO {
   final String? code;
@@ -23,6 +36,9 @@ class OFFProductDTO {
   final String? product_name_tr;
   final String? product_name_uk;
 
+  // Search-a-licious returns brands as a list, the v2 product endpoint as a
+  // comma-separated string; normalise both to a single display string.
+  @JsonKey(fromJson: _brandsFromJson)
   final String? brands;
 
   final String? image_front_thumb_url;
@@ -37,6 +53,13 @@ class OFFProductDTO {
   final dynamic product_quantity; // Can either be int or String
   final dynamic serving_quantity; // Can either be int or String
   final String? serving_size; // E.g. 2 Tbsp (32 g)
+
+  // Open Food Facts' precomputed ranking key (a composite of scan popularity,
+  // data completeness and quality). Higher is better; null/absent for sparse
+  // or never-scanned products. Used to re-rank text-search results so popular,
+  // well-maintained products surface first. Only present on Search-a-licious
+  // results — the v2 barcode endpoint omits it, which is fine (single product).
+  final num? popularity_key;
 
   final OFFProductNutrimentsDTO? nutriments;
 
@@ -104,6 +127,7 @@ class OFFProductDTO {
     required this.serving_quantity,
     required this.serving_size,
     required this.nutriments,
+    this.popularity_key,
   });
 
   factory OFFProductDTO.fromJson(Map<String, dynamic> json) =>

--- a/lib/features/add_meal/data/dto/off/off_product_dto.g.dart
+++ b/lib/features/add_meal/data/dto/off/off_product_dto.g.dart
@@ -35,6 +35,9 @@ OFFProductDTO _$OFFProductDTOFromJson(Map<String, dynamic> json) =>
               json['nutriments'] as Map<String, dynamic>,
             ),
       popularity_key: json['popularity_key'] as num?,
+      countries_tags: (json['countries_tags'] as List<dynamic>?)
+          ?.map((e) => e as String)
+          .toList(),
     );
 
 Map<String, dynamic> _$OFFProductDTOToJson(OFFProductDTO instance) =>
@@ -61,5 +64,6 @@ Map<String, dynamic> _$OFFProductDTOToJson(OFFProductDTO instance) =>
       'serving_quantity': instance.serving_quantity,
       'serving_size': instance.serving_size,
       'popularity_key': instance.popularity_key,
+      'countries_tags': instance.countries_tags,
       'nutriments': instance.nutriments,
     };

--- a/lib/features/add_meal/data/dto/off/off_product_dto.g.dart
+++ b/lib/features/add_meal/data/dto/off/off_product_dto.g.dart
@@ -18,7 +18,7 @@ OFFProductDTO _$OFFProductDTOFromJson(Map<String, dynamic> json) =>
       product_name_sk: json['product_name_sk'] as String?,
       product_name_tr: json['product_name_tr'] as String?,
       product_name_uk: json['product_name_uk'] as String?,
-      brands: json['brands'] as String?,
+      brands: _brandsFromJson(json['brands']),
       image_front_thumb_url: json['image_front_thumb_url'] as String?,
       image_front_url: json['image_front_url'] as String?,
       image_ingredients_url: json['image_ingredients_url'] as String?,
@@ -34,6 +34,7 @@ OFFProductDTO _$OFFProductDTOFromJson(Map<String, dynamic> json) =>
           : OFFProductNutrimentsDTO.fromJson(
               json['nutriments'] as Map<String, dynamic>,
             ),
+      popularity_key: json['popularity_key'] as num?,
     );
 
 Map<String, dynamic> _$OFFProductDTOToJson(OFFProductDTO instance) =>
@@ -59,5 +60,6 @@ Map<String, dynamic> _$OFFProductDTOToJson(OFFProductDTO instance) =>
       'product_quantity': instance.product_quantity,
       'serving_quantity': instance.serving_quantity,
       'serving_size': instance.serving_size,
+      'popularity_key': instance.popularity_key,
       'nutriments': instance.nutriments,
     };

--- a/lib/features/add_meal/data/dto/off/off_word_response_dto.dart
+++ b/lib/features/add_meal/data/dto/off/off_word_response_dto.dart
@@ -11,6 +11,9 @@ class OFFWordResponseDTO {
   final int? page_count;
   final int? page_size;
 
+  // Search-a-licious returns matches under `hits`; the rest of the app still
+  // reads them as `products`.
+  @JsonKey(name: 'hits')
   final List<OFFProductDTO> products;
 
   OFFWordResponseDTO({

--- a/lib/features/add_meal/data/dto/off/off_word_response_dto.g.dart
+++ b/lib/features/add_meal/data/dto/off/off_word_response_dto.g.dart
@@ -12,7 +12,7 @@ OFFWordResponseDTO _$OFFWordResponseDTOFromJson(Map<String, dynamic> json) =>
       page: json['page'],
       page_count: (json['page_count'] as num?)?.toInt(),
       page_size: (json['page_size'] as num?)?.toInt(),
-      products: (json['products'] as List<dynamic>)
+      products: (json['hits'] as List<dynamic>)
           .map((e) => OFFProductDTO.fromJson(e as Map<String, dynamic>))
           .toList(),
     );
@@ -23,5 +23,5 @@ Map<String, dynamic> _$OFFWordResponseDTOToJson(OFFWordResponseDTO instance) =>
       'page': instance.page,
       'page_count': instance.page_count,
       'page_size': instance.page_size,
-      'products': instance.products,
+      'hits': instance.products,
     };

--- a/lib/features/add_meal/data/repository/products_repository.dart
+++ b/lib/features/add_meal/data/repository/products_repository.dart
@@ -9,6 +9,16 @@ import 'package:sentry_flutter/sentry_flutter.dart';
 class ProductsRepository {
   static final _log = Logger('ProductsRepository');
 
+  // Number of re-ranked OFF results to surface from the larger relevance pool.
+  static const _searchResultLimit = 25;
+
+  // Reciprocal-rank-fusion constant. Lower values let relevance dominate (keeps
+  // specific multi-word queries sharp); higher values let popularity dominate.
+  // 10 keeps exact matches near the top while floating popular, well-maintained
+  // products up and sinking sparse/duplicate entries — validated across brand
+  // ("nutella"), descriptive ("oat milk", "greek yogurt") and specific queries.
+  static const _rankFusionK = 10;
+
   final OFFDataSource _offDataSource;
   final FDCDataSource _fdcDataSource;
   final SpFdcDataSource _spBackendDataSource;
@@ -24,13 +34,56 @@ class ProductsRepository {
       searchString,
     );
 
-    final products = offWordResponse.products
-        .where((offProduct) => offProduct.nutriments != null)
-        .map((offProduct) => MealEntity.fromOFFProduct(offProduct))
-        .where(_keepIfConsistent)
-        .toList();
+    // The API returns hits in relevance order. Keep that as the relevance
+    // signal, drop items without nutriments or that fail plausibility, then
+    // re-rank by fusing relevance position with OFF's popularity_key so
+    // popular, well-maintained products surface first — without letting
+    // popularity drag in off-topic matches the way a hard popularity sort does.
+    final candidates = <_RankedOffProduct>[];
+    for (var i = 0; i < offWordResponse.products.length; i++) {
+      final dto = offWordResponse.products[i];
+      if (dto.nutriments == null) continue;
+      final meal = MealEntity.fromOFFProduct(dto);
+      if (!_keepIfConsistent(meal)) continue;
+      candidates.add(_RankedOffProduct(meal, dto.popularity_key ?? 0, i));
+    }
 
-    return products;
+    return _fuseRelevanceAndPopularity(candidates);
+  }
+
+  /// Re-orders the relevance-ordered candidate pool by reciprocal-rank fusion
+  /// of each item's relevance position and its popularity rank, then trims to
+  /// [_searchResultLimit]. Items with no popularity_key sort to the bottom of
+  /// the popularity dimension, so sparse/never-scanned entries sink.
+  List<MealEntity> _fuseRelevanceAndPopularity(
+    List<_RankedOffProduct> candidates,
+  ) {
+    final byPopularity = [...candidates]
+      ..sort((a, b) => b.popularity.compareTo(a.popularity));
+    final popularityRank = <_RankedOffProduct, int>{};
+    for (var i = 0; i < byPopularity.length; i++) {
+      popularityRank[byPopularity[i]] = i;
+    }
+
+    double score(_RankedOffProduct p) =>
+        1 / (_rankFusionK + p.relevanceRank) +
+        1 / (_rankFusionK + popularityRank[p]!);
+
+    // Soft Atwater demotion: products whose declared energy is incoherent with
+    // their macros sink below all coherent ones (then by fused score within
+    // each group). It is a demotion, not a drop — sparse queries still surface
+    // them — but on a full result page they fall off the visible slice.
+    int consistencyBucket(_RankedOffProduct p) =>
+        isAtwaterConsistent(p.meal.nutriments) ? 0 : 1;
+
+    final ranked = [...candidates]
+      ..sort((a, b) {
+        final byConsistency =
+            consistencyBucket(a).compareTo(consistencyBucket(b));
+        if (byConsistency != 0) return byConsistency;
+        return score(b).compareTo(score(a));
+      });
+    return ranked.take(_searchResultLimit).map((p) => p.meal).toList();
   }
 
   Future<List<MealEntity>> getFDCFoodsByString(String searchString) async {
@@ -60,7 +113,7 @@ class ProductsRepository {
   Future<MealEntity> getOFFProductByBarcode(String barcode) async {
     final productResponse = await _offDataSource.fetchBarcodeResults(barcode);
 
-    return MealEntity.fromOFFProduct(productResponse.product);
+    return MealEntity.fromOFFProduct(productResponse.product, detailed: true);
   }
 
   /// Drops items whose nutriments fail the physical-plausibility rules from
@@ -94,4 +147,15 @@ class ProductsRepository {
     ));
     return false;
   }
+}
+
+/// A search candidate paired with the two ranking signals used to fuse a final
+/// order: its [popularity] (OFF popularity_key, 0 when absent) and its
+/// [relevanceRank] (position in the API's relevance-ordered response).
+class _RankedOffProduct {
+  final MealEntity meal;
+  final num popularity;
+  final int relevanceRank;
+
+  _RankedOffProduct(this.meal, this.popularity, this.relevanceRank);
 }

--- a/lib/features/add_meal/data/repository/products_repository.dart
+++ b/lib/features/add_meal/data/repository/products_repository.dart
@@ -1,4 +1,7 @@
+import 'dart:io';
+
 import 'package:logging/logging.dart';
+import 'package:opennutritracker/core/utils/off_country.dart';
 import 'package:opennutritracker/features/add_meal/data/data_sources/fdc_data_source.dart';
 import 'package:opennutritracker/features/add_meal/data/data_sources/off_data_source.dart';
 import 'package:opennutritracker/features/add_meal/data/data_sources/sp_fdc_data_source.dart';
@@ -18,6 +21,12 @@ class ProductsRepository {
   // products up and sinking sparse/duplicate entries — validated across brand
   // ("nutella"), descriptive ("oat milk", "greek yogurt") and specific queries.
   static const _rankFusionK = 10;
+
+  // Soft multiplier applied to the fused score of products sold in the user's
+  // country. 1.3 lifts locally-available products a clear notch without burying
+  // a much more popular/relevant global match — non-local products still
+  // appear, just lower. Tuned against live results for a GB user.
+  static const _localCountryBoost = 1.3;
 
   final OFFDataSource _offDataSource;
   final FDCDataSource _fdcDataSource;
@@ -39,13 +48,18 @@ class ProductsRepository {
     // re-rank by fusing relevance position with OFF's popularity_key so
     // popular, well-maintained products surface first — without letting
     // popularity drag in off-topic matches the way a hard popularity sort does.
+    final userCountryTag = OffCountry.fromLocale(Platform.localeName);
     final candidates = <_RankedOffProduct>[];
     for (var i = 0; i < offWordResponse.products.length; i++) {
       final dto = offWordResponse.products[i];
       if (dto.nutriments == null) continue;
       final meal = MealEntity.fromOFFProduct(dto);
       if (!_keepIfConsistent(meal)) continue;
-      candidates.add(_RankedOffProduct(meal, dto.popularity_key ?? 0, i));
+      final inUserCountry = userCountryTag != null &&
+          (dto.countries_tags?.contains(userCountryTag) ?? false);
+      candidates.add(
+        _RankedOffProduct(meal, dto.popularity_key ?? 0, i, inUserCountry),
+      );
     }
 
     return _fuseRelevanceAndPopularity(candidates);
@@ -65,9 +79,11 @@ class ProductsRepository {
       popularityRank[byPopularity[i]] = i;
     }
 
-    double score(_RankedOffProduct p) =>
-        1 / (_rankFusionK + p.relevanceRank) +
-        1 / (_rankFusionK + popularityRank[p]!);
+    double score(_RankedOffProduct p) {
+      final fused = 1 / (_rankFusionK + p.relevanceRank) +
+          1 / (_rankFusionK + popularityRank[p]!);
+      return p.inUserCountry ? fused * _localCountryBoost : fused;
+    }
 
     // Soft Atwater demotion: products whose declared energy is incoherent with
     // their macros sink below all coherent ones (then by fused score within
@@ -149,13 +165,20 @@ class ProductsRepository {
   }
 }
 
-/// A search candidate paired with the two ranking signals used to fuse a final
-/// order: its [popularity] (OFF popularity_key, 0 when absent) and its
-/// [relevanceRank] (position in the API's relevance-ordered response).
+/// A search candidate paired with the ranking signals used to fuse a final
+/// order: its [popularity] (OFF popularity_key, 0 when absent), its
+/// [relevanceRank] (position in the API's relevance-ordered response), and
+/// [inUserCountry] (whether it is sold in the user's country, for a soft boost).
 class _RankedOffProduct {
   final MealEntity meal;
   final num popularity;
   final int relevanceRank;
+  final bool inUserCountry;
 
-  _RankedOffProduct(this.meal, this.popularity, this.relevanceRank);
+  _RankedOffProduct(
+    this.meal,
+    this.popularity,
+    this.relevanceRank,
+    this.inUserCountry,
+  );
 }

--- a/lib/features/add_meal/domain/entity/meal_entity.dart
+++ b/lib/features/add_meal/domain/entity/meal_entity.dart
@@ -49,6 +49,15 @@ class MealEntity extends Equatable {
 
   final MealNutrimentsEntity nutriments;
 
+  /// Whether this meal carries the full product record (serving fields and
+  /// micronutrients). Open Food Facts text search now comes from the
+  /// Search-a-licious index, which only returns a thin projection
+  /// (`detailed == false`); opening such a result hydrates it to the full
+  /// record via the v2 product endpoint (`detailed == true`). Barcode scans
+  /// and FDC/custom meals are always full. See [hasServingValues] and the
+  /// hydration step in MealDetailBloc.
+  final bool detailed;
+
   bool get isLiquid => liquidUnits.contains(mealUnit);
 
   bool get isSolid => solidUnits.contains(mealUnit);
@@ -68,6 +77,7 @@ class MealEntity extends Equatable {
     required this.nutriments,
     required this.source,
     this.localImagePath,
+    this.detailed = false,
   });
 
   factory MealEntity.empty() => MealEntity(
@@ -99,9 +109,15 @@ class MealEntity extends Equatable {
             MealNutrimentsEntity.fromMealNutrimentsDBO(mealDBO.nutriments),
         source: MealSourceEntity.fromMealSourceDBO(mealDBO.source),
         localImagePath: mealDBO.localImagePath,
+        detailed: mealDBO.detailed ?? false,
       );
 
-  factory MealEntity.fromOFFProduct(OFFProductDTO offProduct) {
+  /// [detailed] is true for full-product responses (the v2 barcode endpoint),
+  /// false for the thin Search-a-licious text-search projection.
+  factory MealEntity.fromOFFProduct(
+    OFFProductDTO offProduct, {
+    bool detailed = false,
+  }) {
     return MealEntity(
       code: offProduct.code,
       name: offProduct.getLocaleName(
@@ -118,6 +134,7 @@ class MealEntity extends Equatable {
       servingSize: offProduct.serving_size,
       nutriments: MealNutrimentsEntity.fromOffNutriments(offProduct.nutriments),
       source: MealSourceEntity.off,
+      detailed: detailed,
     );
   }
 

--- a/lib/features/add_meal/domain/entity/meal_nutriments_entity.dart
+++ b/lib/features/add_meal/domain/entity/meal_nutriments_entity.dart
@@ -314,3 +314,41 @@ NutrimentsValidationResult validateNutriments(MealNutrimentsEntity nutriments) {
 
   return const NutrimentsValidationResult.ok();
 }
+
+/// Maximum relative gap between declared and Atwater-computed energy before a
+/// product is treated as data-incoherent for ranking. Deliberately generous:
+/// across a sample of ~700 Open Food Facts products the legitimate noise floor
+/// (energy/macro rounding, food-specific Atwater factors, the EU/US fibre-in-
+/// carbs convention) reaches ~10-15%, while genuine data errors are gross
+/// (77% to >20000%). 25% sits in the empty gap between the two, so it demotes
+/// real errors without penalising correctly-entered data.
+const double atwaterEnergyTolerance = 0.25;
+
+/// Relative difference between the declared energy and the energy implied by
+/// the macros via the general Atwater factors (carbs 4, protein 4, fat 9
+/// kcal/g). Fibre is not added separately for the same reason the macro-sum
+/// check omits it — it is already inside the carbohydrate total here.
+///
+/// Returns null when there is nothing to judge (no declared kcal, or none of
+/// the three macros present); callers should treat null as "no opinion" rather
+/// than as inconsistent, so products with sparse data are ranked on the other
+/// signals instead of being penalised.
+double? atwaterEnergyRelativeError(MealNutrimentsEntity nutriments) {
+  final energy = nutriments.energyKcal100;
+  if (energy == null || energy <= 0) return null;
+  final carbs = nutriments.carbohydrates100;
+  final fat = nutriments.fat100;
+  final protein = nutriments.proteins100;
+  if (carbs == null && fat == null && protein == null) return null;
+
+  final computed = 4 * (carbs ?? 0) + 4 * (protein ?? 0) + 9 * (fat ?? 0);
+  return (energy - computed).abs() / energy;
+}
+
+/// True when a product's declared energy is coherent with its macros (within
+/// [atwaterEnergyTolerance]) or cannot be judged. False only for products that
+/// are computable AND diverge beyond the tolerance — the gross-error outliers.
+bool isAtwaterConsistent(MealNutrimentsEntity nutriments) {
+  final error = atwaterEnergyRelativeError(nutriments);
+  return error == null || error <= atwaterEnergyTolerance;
+}

--- a/lib/features/add_meal/domain/usecase/search_products_usecase.dart
+++ b/lib/features/add_meal/domain/usecase/search_products_usecase.dart
@@ -41,9 +41,16 @@ class SearchProductsUseCase {
     this._recipeDataSource,
   );
 
+  /// [skipRemote] limits the search to local matches (custom meals, recipes,
+  /// recent intake, cached results) and does not touch the network — used for
+  /// short as-you-type queries.
   Future<SearchProductsResult> searchOFFProductsByString(
-    String searchString,
-  ) async {
+    String searchString, {
+    bool skipRemote = false,
+  }) async {
+    if (skipRemote) {
+      return _buildResult(searchString, const [], remoteSkipped: true);
+    }
     final remote = await _safeRemoteCall(
       'OFF',
       () => _productsRepository.getOFFProductsByString(searchString),
@@ -57,7 +64,13 @@ class SearchProductsUseCase {
     return _buildResult(searchString, remote);
   }
 
-  Future<SearchProductsResult> searchFDCFoodByString(String searchString) async {
+  Future<SearchProductsResult> searchFDCFoodByString(
+    String searchString, {
+    bool skipRemote = false,
+  }) async {
+    if (skipRemote) {
+      return _buildResult(searchString, const [], remoteSkipped: true);
+    }
     final remote = await _safeRemoteCall(
       'FDC',
       () => _productsRepository.getSupabaseFDCFoodsByString(searchString),
@@ -99,9 +112,13 @@ class SearchProductsUseCase {
 
   Future<SearchProductsResult> _buildResult(
     String searchString,
-    List<MealEntity> remoteResults,
-  ) async {
-    final remoteSourceEmpty = remoteResults.isEmpty;
+    List<MealEntity> remoteResults, {
+    bool remoteSkipped = false,
+  }) async {
+    // When the remote source was deliberately skipped (short query), don't
+    // claim it returned nothing — that would show a misleading "no results"
+    // hint while the user is still typing.
+    final remoteSourceEmpty = !remoteSkipped && remoteResults.isEmpty;
 
     final normalizedSearchString = searchString.trim().toLowerCase();
     if (normalizedSearchString.isEmpty) {

--- a/lib/features/add_meal/presentation/add_meal_screen.dart
+++ b/lib/features/add_meal/presentation/add_meal_screen.dart
@@ -104,6 +104,7 @@ class _AddMealScreenState extends State<AddMealScreen>
               MealSearchBar(
                 searchStringListener: _searchStringListener,
                 onSearchSubmit: _onSearchSubmit,
+                onSearchChanged: _onSearchChanged,
                 onBarcodePressed: _onBarcodeIconPressed,
               ),
               const SizedBox(height: 16.0),
@@ -325,6 +326,17 @@ class _AddMealScreenState extends State<AddMealScreen>
         _foodBloc.add(LoadFoodEvent(searchString: inputText));
       case 2:
         _recentMealBloc.add(LoadRecentMealEvent(searchString: inputText));
+    }
+  }
+
+  /// Debounced search-as-you-type. Recent-added (tab 2) stays submit-only; it
+  /// filters local intake history and has no remote source to debounce.
+  void _onSearchChanged(String inputText) {
+    switch (_tabController.index) {
+      case 0:
+        _productsBloc.add(SearchInputChangedEvent(searchString: inputText));
+      case 1:
+        _foodBloc.add(SearchFoodInputChangedEvent(searchString: inputText));
     }
   }
 

--- a/lib/features/add_meal/presentation/bloc/food_bloc.dart
+++ b/lib/features/add_meal/presentation/bloc/food_bloc.dart
@@ -4,6 +4,7 @@ import 'package:logging/logging.dart';
 import 'package:opennutritracker/core/domain/usecase/get_config_usecase.dart';
 import 'package:opennutritracker/features/add_meal/domain/entity/meal_entity.dart';
 import 'package:opennutritracker/features/add_meal/domain/usecase/search_products_usecase.dart';
+import 'package:opennutritracker/features/add_meal/presentation/bloc/search_debounce.dart';
 
 part 'food_event.dart';
 
@@ -19,29 +20,18 @@ class FoodBloc extends Bloc<FoodEvent, FoodState> {
 
   FoodBloc(this._searchProductUseCase, this._getConfigUsecase)
       : super(FoodInitial()) {
-    on<LoadFoodEvent>((event, emit) async {
-      if (event.searchString != _searchString) {
-        _searchString = event.searchString;
-        emit(FoodLoadingState());
-        try {
-          final result = await _searchProductUseCase.searchFDCFoodByString(
-            _searchString,
-          );
-          final config = await _getConfigUsecase.getConfig();
-
-          emit(
-            FoodLoadedState(
-              food: result.meals,
-              usesImperialUnits: config.usesImperialUnits,
-              remoteSourceEmpty: result.remoteSourceEmpty,
-            ),
-          );
-        } catch (error) {
-          log.severe(error);
-          emit(FoodFailedState());
-        }
-      }
-    });
+    on<LoadFoodEvent>(
+      (event, emit) =>
+          _loadFood(event.searchString, emit, skipRemote: false, force: true),
+    );
+    on<SearchFoodInputChangedEvent>(
+      (event, emit) => _loadFood(
+        event.searchString,
+        emit,
+        skipRemote: event.searchString.trim().length < minRemoteQueryLength,
+      ),
+      transformer: debounceRestartable(searchDebounceDuration),
+    );
     on<RefreshFoodEvent>((event, emit) async {
       emit(FoodLoadingState());
       try {
@@ -57,5 +47,38 @@ class FoodBloc extends Bloc<FoodEvent, FoodState> {
         emit(FoodFailedState());
       }
     });
+  }
+
+  /// Shared search routine for the immediate and debounced events. See
+  /// [ProductsBloc] for the rationale behind [skipRemote], [force], and the
+  /// no-blank behaviour.
+  Future<void> _loadFood(
+    String searchString,
+    Emitter<FoodState> emit, {
+    required bool skipRemote,
+    bool force = false,
+  }) async {
+    if (!force && searchString == _searchString) return;
+    _searchString = searchString;
+    if (state is! FoodLoadedState) {
+      emit(FoodLoadingState());
+    }
+    try {
+      final result = await _searchProductUseCase.searchFDCFoodByString(
+        searchString,
+        skipRemote: skipRemote,
+      );
+      final config = await _getConfigUsecase.getConfig();
+      emit(
+        FoodLoadedState(
+          food: result.meals,
+          usesImperialUnits: config.usesImperialUnits,
+          remoteSourceEmpty: result.remoteSourceEmpty,
+        ),
+      );
+    } catch (error) {
+      log.severe(error);
+      emit(FoodFailedState());
+    }
   }
 }

--- a/lib/features/add_meal/presentation/bloc/food_event.dart
+++ b/lib/features/add_meal/presentation/bloc/food_event.dart
@@ -7,10 +7,22 @@ abstract class FoodEvent extends Equatable {
   List<Object?> get props => [];
 }
 
+/// Immediate search — fired on submit (enter / search button) and tab change.
+/// Bypasses the debounce and always queries the remote source.
 class LoadFoodEvent extends FoodEvent {
   final String searchString;
 
   const LoadFoodEvent({required this.searchString});
+
+  @override
+  List<Object?> get props => [searchString];
+}
+
+/// Search-as-you-type — fired on every keystroke and debounced in the bloc.
+class SearchFoodInputChangedEvent extends FoodEvent {
+  final String searchString;
+
+  const SearchFoodInputChangedEvent({required this.searchString});
 
   @override
   List<Object?> get props => [searchString];

--- a/lib/features/add_meal/presentation/bloc/products_bloc.dart
+++ b/lib/features/add_meal/presentation/bloc/products_bloc.dart
@@ -4,6 +4,7 @@ import 'package:logging/logging.dart';
 import 'package:opennutritracker/core/domain/usecase/get_config_usecase.dart';
 import 'package:opennutritracker/features/add_meal/domain/entity/meal_entity.dart';
 import 'package:opennutritracker/features/add_meal/domain/usecase/search_products_usecase.dart';
+import 'package:opennutritracker/features/add_meal/presentation/bloc/search_debounce.dart';
 
 part 'products_event.dart';
 
@@ -19,29 +20,18 @@ class ProductsBloc extends Bloc<ProductsEvent, ProductsState> {
 
   ProductsBloc(this._searchProductUseCase, this._getConfigUsecase)
       : super(ProductsInitial()) {
-    on<LoadProductsEvent>((event, emit) async {
-      if (event.searchString != _searchString) {
-        _searchString = event.searchString;
-        emit(ProductsLoadingState());
-        try {
-          final result = await _searchProductUseCase.searchOFFProductsByString(
-            _searchString,
-          );
-          final config = await _getConfigUsecase.getConfig();
-
-          emit(
-            ProductsLoadedState(
-              products: result.meals,
-              usesImperialUnits: config.usesImperialUnits,
-              remoteSourceEmpty: result.remoteSourceEmpty,
-            ),
-          );
-        } catch (error) {
-          log.severe(error);
-          emit(ProductsFailedState());
-        }
-      }
-    });
+    on<LoadProductsEvent>(
+      (event, emit) =>
+          _loadProducts(event.searchString, emit, skipRemote: false, force: true),
+    );
+    on<SearchInputChangedEvent>(
+      (event, emit) => _loadProducts(
+        event.searchString,
+        emit,
+        skipRemote: event.searchString.trim().length < minRemoteQueryLength,
+      ),
+      transformer: debounceRestartable(searchDebounceDuration),
+    );
     on<RefreshProductsEvent>((event, emit) async {
       emit(ProductsLoadingState());
       try {
@@ -57,5 +47,43 @@ class ProductsBloc extends Bloc<ProductsEvent, ProductsState> {
         emit(ProductsFailedState());
       }
     });
+  }
+
+  /// Shared search routine for the immediate and debounced events.
+  ///
+  /// [skipRemote] limits the search to local matches (used for short
+  /// as-you-type queries). [force] runs even when the query is unchanged —
+  /// set on the immediate path so an explicit submit always re-queries the
+  /// remote source even if a debounced local-only search ran for the same
+  /// text. A fresh search keeps any existing results on screen rather than
+  /// blanking to a spinner, so typing doesn't flicker.
+  Future<void> _loadProducts(
+    String searchString,
+    Emitter<ProductsState> emit, {
+    required bool skipRemote,
+    bool force = false,
+  }) async {
+    if (!force && searchString == _searchString) return;
+    _searchString = searchString;
+    if (state is! ProductsLoadedState) {
+      emit(ProductsLoadingState());
+    }
+    try {
+      final result = await _searchProductUseCase.searchOFFProductsByString(
+        searchString,
+        skipRemote: skipRemote,
+      );
+      final config = await _getConfigUsecase.getConfig();
+      emit(
+        ProductsLoadedState(
+          products: result.meals,
+          usesImperialUnits: config.usesImperialUnits,
+          remoteSourceEmpty: result.remoteSourceEmpty,
+        ),
+      );
+    } catch (error) {
+      log.severe(error);
+      emit(ProductsFailedState());
+    }
   }
 }

--- a/lib/features/add_meal/presentation/bloc/products_event.dart
+++ b/lib/features/add_meal/presentation/bloc/products_event.dart
@@ -7,10 +7,24 @@ abstract class ProductsEvent extends Equatable {
   List<Object?> get props => [];
 }
 
+/// Immediate search — fired on submit (enter / search button) and tab change.
+/// Bypasses the debounce and always queries the remote source.
 class LoadProductsEvent extends ProductsEvent {
   final String searchString;
 
   const LoadProductsEvent({required this.searchString});
+
+  @override
+  List<Object?> get props => [searchString];
+}
+
+/// Search-as-you-type — fired on every keystroke and debounced in the bloc.
+/// Short queries resolve from local matches only; the remote source is queried
+/// once the trimmed query is long enough.
+class SearchInputChangedEvent extends ProductsEvent {
+  final String searchString;
+
+  const SearchInputChangedEvent({required this.searchString});
 
   @override
   List<Object?> get props => [searchString];

--- a/lib/features/add_meal/presentation/bloc/search_debounce.dart
+++ b/lib/features/add_meal/presentation/bloc/search_debounce.dart
@@ -1,0 +1,19 @@
+import 'package:bloc_concurrency/bloc_concurrency.dart';
+import 'package:flutter_bloc/flutter_bloc.dart';
+import 'package:stream_transform/stream_transform.dart';
+
+/// Shared tuning for search-as-you-type across the product and food blocs.
+const searchDebounceDuration = Duration(milliseconds: 500);
+
+/// Minimum trimmed query length before a debounced search hits the remote
+/// source. Shorter queries still surface local matches (custom meals,
+/// recipes, recent intake, cached results).
+const minRemoteQueryLength = 3;
+
+/// Debounce keystrokes, then run the latest one as a restartable handler so an
+/// in-flight search is cancelled the moment a newer query arrives. Keeps the
+/// remote source to roughly one request per typing pause.
+EventTransformer<E> debounceRestartable<E>(Duration duration) {
+  return (events, mapper) =>
+      restartable<E>().call(events.debounce(duration), mapper);
+}

--- a/lib/features/add_meal/presentation/widgets/meal_search_bar.dart
+++ b/lib/features/add_meal/presentation/widgets/meal_search_bar.dart
@@ -5,6 +5,9 @@ import 'package:opennutritracker/generated/l10n.dart';
 class MealSearchBar extends StatelessWidget {
   final ValueNotifier<String> searchStringListener;
   final Function(String) onSearchSubmit;
+  // Fired on every keystroke for debounced search-as-you-type. Optional so
+  // callers that only want submit-on-enter can omit it.
+  final Function(String)? onSearchChanged;
   // Nullable so callers that don't surface a barcode flow (e.g. the recipe
   // ingredient picker) can omit the suffix icon entirely.
   final Function()? onBarcodePressed;
@@ -16,6 +19,7 @@ class MealSearchBar extends StatelessWidget {
     required this.searchStringListener,
     required this.onSearchSubmit,
     required this.onBarcodePressed,
+    this.onSearchChanged,
   });
 
   @override
@@ -29,6 +33,7 @@ class MealSearchBar extends StatelessWidget {
             textInputAction: TextInputAction.search,
             onChanged: (input) {
               searchStringListener.value = input;
+              onSearchChanged?.call(input);
             },
             onSubmitted: onSearchSubmit,
             decoration: InputDecoration(

--- a/lib/features/meal_detail/meal_detail_screen.dart
+++ b/lib/features/meal_detail/meal_detail_screen.dart
@@ -52,6 +52,9 @@ class _MealDetailScreenState extends State<MealDetailScreen> {
   String _initialUnit = "";
   String _initialQuantity = "";
 
+  bool _hydrationRequested = false;
+  bool _userChangedSelection = false;
+
   @override
   void initState() {
     _mealDetailBloc = locator<MealDetailBloc>();
@@ -77,7 +80,24 @@ class _MealDetailScreenState extends State<MealDetailScreen> {
 
     _mealDetailBloc.add(LoadDailyTotalsEvent(_day));
 
-    // Set initial unit
+    // Thin OFF search results get hydrated to the full product record (serving
+    // fields + micronutrients) once, in the background; the listener in build()
+    // swaps the displayed meal in when it arrives.
+    if (!_hydrationRequested) {
+      _hydrationRequested = true;
+      _mealDetailBloc.add(HydrateMealEvent(meal));
+    }
+
+    _applyInitialSelection();
+
+    super.didChangeDependencies();
+  }
+
+  /// Pick the default unit and quantity from the meal's shape. Serving-based
+  /// meals default to 1 serving; otherwise to 100 g/ml (or 1 oz/fl oz in
+  /// imperial). Guarded so it only runs while the user hasn't chosen yet, and
+  /// re-run after hydration reveals serving values.
+  void _applyInitialSelection() {
     if (_initialUnit == "") {
       if (meal.hasServingValues) {
         _initialUnit = UnitDropdownItem.serving.toString();
@@ -97,7 +117,6 @@ class _MealDetailScreenState extends State<MealDetailScreen> {
       );
     }
 
-    // Set initial quantity
     if (_initialQuantity == "") {
       if (meal.hasServingValues) {
         _initialQuantity = "1";
@@ -113,33 +132,58 @@ class _MealDetailScreenState extends State<MealDetailScreen> {
         UpdateKcalEvent(meal: meal, totalQuantity: quantityTextController.text),
       );
     }
+  }
 
-    super.didChangeDependencies();
+  /// Apply the hydrated full product to the screen. If the user hasn't touched
+  /// the quantity/unit yet, re-pick the defaults (so serving becomes the
+  /// default now that serving data exists); otherwise just recompute totals
+  /// against the fuller nutriments while keeping the user's selection.
+  void _onMealHydrated(MealEntity full) {
+    setState(() => meal = full);
+    if (_userChangedSelection) {
+      _mealDetailBloc.add(
+        UpdateKcalEvent(
+          meal: meal,
+          totalQuantity: quantityTextController.text,
+          selectedUnit: _mealDetailBloc.state.selectedUnit,
+        ),
+      );
+    } else {
+      _initialUnit = "";
+      _initialQuantity = "";
+      _applyInitialSelection();
+    }
   }
 
   @override
   Widget build(BuildContext context) {
-    return SafeArea(
-      child: Scaffold(
-        body: BlocBuilder<MealDetailBloc, MealDetailState>(
-          bloc: _mealDetailBloc,
-          builder: (context, state) {
-            if (state is MealDetailInitial) {
-              return _getLoadedContent(
-                context,
-                state.totalQuantityConverted,
-                state.totalKcal,
-                state.totalCarbs,
-                state.totalFat,
-                state.totalProtein,
-                state.selectedUnit,
-                state.dayKcalConsumed,
-                state.dayKcalGoal,
-              );
-            }
-            return const Center(child: CircularProgressIndicator());
-          },
-        ),
+    return BlocListener<MealDetailBloc, MealDetailState>(
+      bloc: _mealDetailBloc,
+      listenWhen: (prev, curr) =>
+          curr.hydratedMeal != null && curr.hydratedMeal != prev.hydratedMeal,
+      listener: (context, state) => _onMealHydrated(state.hydratedMeal!),
+      child: SafeArea(
+        child: Scaffold(
+          body: BlocBuilder<MealDetailBloc, MealDetailState>(
+            bloc: _mealDetailBloc,
+            builder: (context, state) {
+              if (state is MealDetailInitial) {
+                return _getLoadedContent(
+                  context,
+                  state.totalQuantityConverted,
+                  state.totalKcal,
+                  state.totalCarbs,
+                  state.totalFat,
+                  state.totalProtein,
+                  state.selectedUnit,
+                  state.dayKcalConsumed,
+                  state.dayKcalGoal,
+                  state.isHydrating,
+                );
+              }
+              return const Center(child: CircularProgressIndicator());
+            },
+          ),
         bottomSheet: BlocSelector<MealDetailBloc, MealDetailState, String>(
           bloc: _mealDetailBloc,
           selector: (state) => state.selectedUnit,
@@ -154,6 +198,7 @@ class _MealDetailScreenState extends State<MealDetailScreen> {
               onQuantityOrUnitChanged: onQuantityOrUnitChanged,
             );
           },
+          ),
         ),
       ),
     );
@@ -169,6 +214,7 @@ class _MealDetailScreenState extends State<MealDetailScreen> {
     String selectedUnit,
     double dayKcalConsumed,
     double dayKcalGoal,
+    bool isHydrating,
   ) {
     return CustomScrollView(
       controller: _scrollController,
@@ -306,6 +352,11 @@ class _MealDetailScreenState extends State<MealDetailScreen> {
                   ),
                   const Divider(),
                   const SizedBox(height: 16.0),
+                  if (isHydrating)
+                    const Padding(
+                      padding: EdgeInsets.only(bottom: 16.0),
+                      child: LinearProgressIndicator(minHeight: 2),
+                    ),
                   MealDetailNutrimentsTable(
                     product: meal,
                     usesImperialUnits: _usesImperialUnits,
@@ -334,6 +385,7 @@ class _MealDetailScreenState extends State<MealDetailScreen> {
     if (quantityString == null || unit == null) {
       return;
     }
+    _userChangedSelection = true;
     _mealDetailBloc.add(
       UpdateKcalEvent(
         meal: meal,

--- a/lib/features/meal_detail/presentation/bloc/meal_detail_bloc.dart
+++ b/lib/features/meal_detail/presentation/bloc/meal_detail_bloc.dart
@@ -119,6 +119,38 @@ class MealDetailBloc extends Bloc<MealDetailEvent, MealDetailState> {
         Sentry.captureException(e);
       }
     });
+
+    on<HydrateMealEvent>((event, emit) async {
+      final meal = event.meal;
+      final code = meal.code;
+      if (meal.source != MealSourceEntity.off ||
+          meal.detailed ||
+          code == null ||
+          code.isEmpty) {
+        return;
+      }
+
+      emit(state.copyWith(isHydrating: true));
+      try {
+        // A full cache entry (from an earlier scan/hydration) lets us skip the
+        // network entirely and works offline; otherwise fetch and cache it.
+        final cached = _remoteSearchCacheDataSource.getDetailedByBarcode(code);
+        final full = cached != null
+            ? MealEntity.fromMealDBO(cached)
+            : await _productsRepository.getOFFProductByBarcode(code);
+        if (cached == null) {
+          await _remoteSearchCacheDataSource.cache(
+            MealDBO.fromMealEntity(full),
+          );
+        }
+        emit(state.copyWith(hydratedMeal: full, isHydrating: false));
+      } catch (e, st) {
+        // Soft failure: keep the thin result so the user can still log
+        // macros-only. The Add button is never blocked on hydration.
+        log.warning('OFF hydration failed for $code', e, st);
+        emit(state.copyWith(isHydrating: false));
+      }
+    });
   }
 
   void addIntake(

--- a/lib/features/meal_detail/presentation/bloc/meal_detail_event.dart
+++ b/lib/features/meal_detail/presentation/bloc/meal_detail_event.dart
@@ -40,3 +40,15 @@ class LoadDailyTotalsEvent extends MealDetailEvent {
   @override
   List<Object?> get props => [day];
 }
+
+/// Fetch the full product record for a thin Open Food Facts search result so
+/// the detail view can show serving options and micronutrients. A no-op for
+/// non-OFF meals, already-detailed meals, or meals without a code.
+class HydrateMealEvent extends MealDetailEvent {
+  final MealEntity meal;
+
+  const HydrateMealEvent(this.meal);
+
+  @override
+  List<Object?> get props => [meal];
+}

--- a/lib/features/meal_detail/presentation/bloc/meal_detail_state.dart
+++ b/lib/features/meal_detail/presentation/bloc/meal_detail_state.dart
@@ -12,6 +12,14 @@ abstract class MealDetailState extends Equatable {
   final double dayKcalConsumed;
   final double dayKcalGoal;
 
+  /// Full product record once a thin OFF search result has been hydrated;
+  /// null until then. The screen swaps the displayed meal for this when it
+  /// arrives so serving options and micronutrients appear.
+  final MealEntity? hydratedMeal;
+
+  /// True while the hydration network call is in flight.
+  final bool isHydrating;
+
   const MealDetailState({
     required this.totalQuantityConverted,
     this.totalKcal = 0,
@@ -21,10 +29,12 @@ abstract class MealDetailState extends Equatable {
     required this.selectedUnit,
     this.dayKcalConsumed = 0,
     this.dayKcalGoal = 0,
+    this.hydratedMeal,
+    this.isHydrating = false,
   });
 
   @override
-  List<Object> get props => [
+  List<Object?> get props => [
         totalQuantityConverted,
         totalKcal,
         totalCarbs,
@@ -33,6 +43,8 @@ abstract class MealDetailState extends Equatable {
         selectedUnit,
         dayKcalConsumed,
         dayKcalGoal,
+        hydratedMeal,
+        isHydrating,
       ];
 
   MealDetailInitial copyWith({
@@ -44,6 +56,8 @@ abstract class MealDetailState extends Equatable {
     String? selectedUnit,
     double? dayKcalConsumed,
     double? dayKcalGoal,
+    MealEntity? hydratedMeal,
+    bool? isHydrating,
   }) {
     return MealDetailInitial(
       totalQuantityConverted:
@@ -55,6 +69,8 @@ abstract class MealDetailState extends Equatable {
       selectedUnit: selectedUnit ?? this.selectedUnit,
       dayKcalConsumed: dayKcalConsumed ?? this.dayKcalConsumed,
       dayKcalGoal: dayKcalGoal ?? this.dayKcalGoal,
+      hydratedMeal: hydratedMeal ?? this.hydratedMeal,
+      isHydrating: isHydrating ?? this.isHydrating,
     );
   }
 }
@@ -69,5 +85,7 @@ class MealDetailInitial extends MealDetailState {
     required super.selectedUnit,
     super.dayKcalConsumed,
     super.dayKcalGoal,
+    super.hydratedMeal,
+    super.isHydrating,
   });
 }

--- a/lib/features/recipes/presentation/widgets/food_search_tab_view.dart
+++ b/lib/features/recipes/presentation/widgets/food_search_tab_view.dart
@@ -71,6 +71,7 @@ class _FoodSearchTabViewState extends State<FoodSearchTabView>
           MealSearchBar(
             searchStringListener: _searchStringListener,
             onSearchSubmit: _onSearchSubmit,
+            onSearchChanged: _onSearchChanged,
             onBarcodePressed: widget.onBarcodePressed,
           ),
           const SizedBox(height: 16),
@@ -236,6 +237,17 @@ class _FoodSearchTabViewState extends State<FoodSearchTabView>
         _foodBloc.add(LoadFoodEvent(searchString: inputText));
       case 2:
         _recentMealBloc.add(LoadRecentMealEvent(searchString: inputText));
+    }
+  }
+
+  /// Debounced search-as-you-type for the ingredient picker. Recent-added
+  /// (tab 2) stays submit-only — local-history filter, nothing to debounce.
+  void _onSearchChanged(String inputText) {
+    switch (_tabController.index) {
+      case 0:
+        _productsBloc.add(SearchInputChangedEvent(searchString: inputText));
+      case 1:
+        _foodBloc.add(SearchFoodInputChangedEvent(searchString: inputText));
     }
   }
 }

--- a/lib/features/scanner/domain/usecase/search_product_by_barcode_usecase.dart
+++ b/lib/features/scanner/domain/usecase/search_product_by_barcode_usecase.dart
@@ -10,8 +10,10 @@ import 'package:opennutritracker/features/add_meal/domain/entity/meal_entity.dar
 ///      with a barcode (#167) wins over remote data, because the user
 ///      explicitly created the entry and a matching scan should pull
 ///      that exact saved record back.
-///   2. **Cached OFF lookup** — makes repeat scans instant and works
-///      offline.
+///   2. **Cached full OFF lookup** — makes repeat scans instant and works
+///      offline. Only full (hydrated/scanned) cache entries count; a thin
+///      Search-a-licious search result under the same code is skipped so the
+///      scan still pulls the complete product.
 ///   3. **Live OFF API** — only when nothing local matches. The
 ///      successful result is then written to the cache for next time.
 ///
@@ -40,7 +42,7 @@ class SearchProductByBarcodeUseCase {
       return MealEntity.fromMealDBO(customMatch);
     }
 
-    final cachedMatch = _cachedOffMealDataSource.getByBarcode(barcode);
+    final cachedMatch = _cachedOffMealDataSource.getDetailedByBarcode(barcode);
     if (cachedMatch != null) {
       return MealEntity.fromMealDBO(cachedMatch);
     }

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -97,6 +97,14 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "9.2.0"
+  bloc_concurrency:
+    dependency: "direct main"
+    description:
+      name: bloc_concurrency
+      sha256: "86b7b17a0a78f77fca0d7c030632b59b593b22acea2d96972588f40d4ef53a94"
+      url: "https://pub.dev"
+    source: hosted
+    version: "0.3.0"
   boolean_selector:
     dependency: transitive
     description:
@@ -1442,7 +1450,7 @@ packages:
     source: hosted
     version: "2.1.4"
   stream_transform:
-    dependency: transitive
+    dependency: "direct main"
     description:
       name: stream_transform
       sha256: ad47125e588cfd37a9a7f86c7d6356dde8dfe89d071d293f80ca9e9273a33871

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -54,6 +54,8 @@ dependencies:
   file_picker: ^11.0.2
 
   flutter_bloc: ^9.1.1
+  bloc_concurrency: ^0.3.0
+  stream_transform: ^2.1.1
   equatable: ^2.0.8
 
   percent_indicator: ^4.2.5

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -15,7 +15,7 @@ publish_to: 'none' # Remove this line if you wish to publish to pub.dev
 # In iOS, build-name is used as CFBundleShortVersionString while build-number is used as CFBundleVersion.
 # Read more about iOS versioning at
 # https://developer.apple.com/library/archive/documentation/General/Reference/InfoPlistKeyReference/Articles/CoreFoundationKeys.html
-version: 1.4.1+57
+version: 1.5.0+58
 
 environment:
   sdk: '>=3.11.0 <4.0.0'

--- a/test/features/add_meal/data/repository/products_repository_ranking_test.dart
+++ b/test/features/add_meal/data/repository/products_repository_ranking_test.dart
@@ -1,4 +1,7 @@
+import 'dart:io';
+
 import 'package:flutter_test/flutter_test.dart';
+import 'package:opennutritracker/core/utils/off_country.dart';
 import 'package:opennutritracker/features/add_meal/data/data_sources/fdc_data_source.dart';
 import 'package:opennutritracker/features/add_meal/data/data_sources/off_data_source.dart';
 import 'package:opennutritracker/features/add_meal/data/data_sources/sp_fdc_data_source.dart';
@@ -12,7 +15,12 @@ import 'package:opennutritracker/features/add_meal/data/repository/products_repo
 // [atwaterConsistent] false declares 100 kcal against macros that imply ~33,
 // which is physically plausible (passes _keepIfConsistent) but Atwater-
 // incoherent (>25% energy gap), so it should be demoted in ranking.
-OFFProductDTO _p(String name, {num? popularity, bool atwaterConsistent = true}) =>
+OFFProductDTO _p(
+  String name, {
+  num? popularity,
+  bool atwaterConsistent = true,
+  List<String>? countries,
+}) =>
     OFFProductDTO(
       code: name,
       product_name: name,
@@ -31,6 +39,7 @@ OFFProductDTO _p(String name, {num? popularity, bool atwaterConsistent = true}) 
       serving_quantity: null,
       serving_size: null,
       popularity_key: popularity,
+      countries_tags: countries,
       nutriments: atwaterConsistent
           ? OFFProductNutrimentsDTO(
               energy_kcal_100g: 100,
@@ -155,6 +164,39 @@ void main() {
 
       final result = await repo.getOFFProductsByString('q');
       expect(result.length, lessThanOrEqualTo(25));
+    });
+
+    // The repository derives the user's country from Platform.localeName; these
+    // tests tag the "local" product with whatever that resolves to so they
+    // exercise the real boost path on any host whose locale carries a mapped
+    // country (the typical dev/CI case).
+    final userTag = OffCountry.fromLocale(Platform.localeName);
+
+    test('a product sold in the user country is softly boosted above a '
+        'comparable non-local one', () async {
+      if (userTag == null) return; // host locale has no mappable country
+      final repo = _repoReturning([
+        _p('non-local', popularity: 100),
+        _p('local', popularity: 100, countries: [userTag]),
+      ]);
+
+      final result = await repo.getOFFProductsByString('q');
+      final names = result.map((m) => m.name).toList();
+      expect(names.indexOf('local'), lessThan(names.indexOf('non-local')));
+    });
+
+    test('the country boost is soft: a clearly dominant global product still '
+        'outranks a weak local one', () async {
+      if (userTag == null) return;
+      final items = <OFFProductDTO>[
+        _p('global-strong', popularity: 1000000000),
+        ...List.generate(30, (i) => _p('filler$i', popularity: 500 - i)),
+        _p('local-weak', popularity: 1, countries: [userTag]),
+      ];
+      final repo = _repoReturning(items);
+
+      final result = await repo.getOFFProductsByString('q');
+      expect(result.first.name, 'global-strong');
     });
   });
 }

--- a/test/features/add_meal/data/repository/products_repository_ranking_test.dart
+++ b/test/features/add_meal/data/repository/products_repository_ranking_test.dart
@@ -1,0 +1,160 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:opennutritracker/features/add_meal/data/data_sources/fdc_data_source.dart';
+import 'package:opennutritracker/features/add_meal/data/data_sources/off_data_source.dart';
+import 'package:opennutritracker/features/add_meal/data/data_sources/sp_fdc_data_source.dart';
+import 'package:opennutritracker/features/add_meal/data/dto/off/off_product_dto.dart';
+import 'package:opennutritracker/features/add_meal/data/dto/off/off_product_nutriments_dto.dart';
+import 'package:opennutritracker/features/add_meal/data/dto/off/off_word_response_dto.dart';
+import 'package:opennutritracker/features/add_meal/data/repository/products_repository.dart';
+
+// Builds a plausible product so it survives the consistency filter. The name
+// carries the relevance position so assertions can read the final order back.
+// [atwaterConsistent] false declares 100 kcal against macros that imply ~33,
+// which is physically plausible (passes _keepIfConsistent) but Atwater-
+// incoherent (>25% energy gap), so it should be demoted in ranking.
+OFFProductDTO _p(String name, {num? popularity, bool atwaterConsistent = true}) =>
+    OFFProductDTO(
+      code: name,
+      product_name: name,
+      product_name_en: name,
+      product_name_fr: null,
+      product_name_de: null,
+      brands: null,
+      image_front_thumb_url: null,
+      image_front_url: null,
+      image_ingredients_url: null,
+      image_nutrition_url: null,
+      image_url: null,
+      url: null,
+      quantity: null,
+      product_quantity: null,
+      serving_quantity: null,
+      serving_size: null,
+      popularity_key: popularity,
+      nutriments: atwaterConsistent
+          ? OFFProductNutrimentsDTO(
+              energy_kcal_100g: 100,
+              carbohydrates_100g: 10,
+              fat_100g: 5,
+              proteins_100g: 5,
+              sugars_100g: 2,
+              saturated_fat_100g: 1,
+              fiber_100g: 1,
+            )
+          : OFFProductNutrimentsDTO(
+              energy_kcal_100g: 100, // declared, but macros imply ~33 kcal
+              carbohydrates_100g: 5,
+              fat_100g: 1,
+              proteins_100g: 1,
+              sugars_100g: 1,
+              saturated_fat_100g: 0,
+              fiber_100g: 0,
+            ),
+    );
+
+class _FakeOffDataSource extends OFFDataSource {
+  final OFFWordResponseDTO response;
+  _FakeOffDataSource(this.response);
+  @override
+  Future<OFFWordResponseDTO> fetchSearchWordResults(String searchString) async =>
+      response;
+}
+
+ProductsRepository _repoReturning(List<OFFProductDTO> productsInRelevanceOrder) {
+  final response = OFFWordResponseDTO(
+    count: productsInRelevanceOrder.length,
+    page: 1,
+    page_count: 1,
+    page_size: productsInRelevanceOrder.length,
+    products: productsInRelevanceOrder,
+  );
+  return ProductsRepository(
+    _FakeOffDataSource(response),
+    FDCDataSource(),
+    SpFdcDataSource(),
+  );
+}
+
+void main() {
+  group('ProductsRepository OFF search ranking (relevance + popularity fusion)',
+      () {
+    test(
+        'a popular product ranked low by relevance floats above a more-relevant '
+        'but unpopular one', () async {
+      final repo = _repoReturning([
+        _p('rel0-unpopular', popularity: 0),
+        _p('rel1-mid', popularity: 1000),
+        _p('rel2-unpopular', popularity: 0),
+        _p('rel3-very-popular', popularity: 5000),
+      ]);
+
+      final result = await repo.getOFFProductsByString('q');
+      final names = result.map((m) => m.name).toList();
+
+      expect(names, contains('rel3-very-popular'));
+      expect(
+        names.indexOf('rel3-very-popular'),
+        lessThan(names.indexOf('rel2-unpopular')),
+        reason: 'popularity should lift the popular item above a more-relevant '
+            'but unpopular one',
+      );
+    });
+
+    test('a strong relevance match is not buried by popularity alone', () async {
+      final repo = _repoReturning([
+        _p('top-relevance', popularity: 0),
+        _p('popular-1', popularity: 9000),
+        _p('popular-2', popularity: 8000),
+      ]);
+
+      final result = await repo.getOFFProductsByString('q');
+      final names = result.map((m) => m.name).toList();
+      // The exact top-relevance hit stays near the top rather than sinking
+      // below every popular item (the failure mode of a hard popularity sort).
+      expect(names.indexOf('top-relevance'), lessThan(2));
+    });
+
+    test('null popularity_key (sparse entries) sinks below scanned products',
+        () async {
+      final repo = _repoReturning([
+        _p('sparse-a'), // null popularity
+        _p('sparse-b'), // null popularity
+        _p('scanned', popularity: 4000),
+      ]);
+
+      final result = await repo.getOFFProductsByString('q');
+      expect(
+        result.map((m) => m.name).toList().indexOf('scanned'),
+        lessThan(2),
+        reason: 'a scanned/popular entry should not sit below both sparse ones',
+      );
+    });
+
+    test(
+        'an Atwater-incoherent product is demoted below coherent ones even '
+        'when it is popular and highly relevant', () async {
+      final repo = _repoReturning([
+        _p('incoherent-but-popular', popularity: 9000, atwaterConsistent: false),
+        _p('coherent-a', popularity: 10),
+        _p('coherent-b', popularity: 5),
+      ]);
+
+      final result = await repo.getOFFProductsByString('q');
+      final names = result.map((m) => m.name).toList();
+
+      // Despite top relevance and the highest popularity, the incoherent entry
+      // sinks to the bottom because its declared kcal doesn't match its macros.
+      expect(names.last, 'incoherent-but-popular');
+      expect(names.indexOf('coherent-a'),
+          lessThan(names.indexOf('incoherent-but-popular')));
+    });
+
+    test('result list is trimmed to the display limit', () async {
+      final many = List.generate(60, (i) => _p('item$i', popularity: i));
+      final repo = _repoReturning(many);
+
+      final result = await repo.getOFFProductsByString('q');
+      expect(result.length, lessThanOrEqualTo(25));
+    });
+  });
+}

--- a/test/features/scanner/domain/usecase/search_product_by_barcode_usecase_test.dart
+++ b/test/features/scanner/domain/usecase/search_product_by_barcode_usecase_test.dart
@@ -143,6 +143,33 @@ void main() {
       expect(cachedOffMealDataSource.writes.single.code, '9999');
     });
 
+    test(
+        'a thin (search-only) cache entry does not satisfy the scan; OFF is '
+        'queried for the full product', () async {
+      cachedOffMealDataSource.entries.add(_offCacheDbo(
+        code: '4321',
+        name: 'Thin Cached',
+        detailed: false,
+      ));
+      repo.barcodeResult = MealEntity(
+        code: '4321',
+        name: 'Full OFF',
+        url: null,
+        mealQuantity: '100',
+        mealUnit: 'g',
+        servingQuantity: null,
+        servingUnit: 'g',
+        servingSize: null,
+        nutriments: _emptyNutriments(),
+        source: MealSourceEntity.off,
+      );
+
+      final result = await useCase.searchProductByBarcode('4321');
+
+      expect(result.name, 'Full OFF');
+      expect(repo.getOFFProductByBarcodeCalls, 1);
+    });
+
     test('custom-meal match takes priority over cached match', () async {
       customMealDataSource.meals.add(_customMealDbo(
         code: '5555',
@@ -162,7 +189,11 @@ void main() {
   });
 }
 
-MealDBO _offCacheDbo({required String code, required String name}) =>
+MealDBO _offCacheDbo({
+  required String code,
+  required String name,
+  bool detailed = true,
+}) =>
     MealDBO(
       code: code,
       name: name,
@@ -175,6 +206,7 @@ MealDBO _offCacheDbo({required String code, required String name}) =>
       servingQuantity: null,
       servingUnit: 'g',
       servingSize: null,
+      detailed: detailed,
       source: MealSourceDBO.off,
       nutriments: MealNutrimentsDBO(
         energyKcal100: 0,
@@ -211,6 +243,14 @@ class _FakeRemoteSearchCacheDataSource implements RemoteSearchCacheDataSource {
   MealDBO? getByBarcode(String barcode) {
     for (final m in entries) {
       if (m.code == barcode) return m;
+    }
+    return null;
+  }
+
+  @override
+  MealDBO? getDetailedByBarcode(String barcode) {
+    for (final m in entries) {
+      if (m.code == barcode && (m.detailed ?? false)) return m;
     }
     return null;
   }

--- a/test/unit_test/atwater_consistency_test.dart
+++ b/test/unit_test/atwater_consistency_test.dart
@@ -1,0 +1,61 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:opennutritracker/features/add_meal/domain/entity/meal_nutriments_entity.dart';
+
+MealNutrimentsEntity _n({
+  double? energy,
+  double? carbs,
+  double? fat,
+  double? protein,
+}) =>
+    MealNutrimentsEntity(
+      energyKcal100: energy,
+      carbohydrates100: carbs,
+      fat100: fat,
+      proteins100: protein,
+      sugars100: null,
+      saturatedFat100: null,
+      fiber100: null,
+    );
+
+void main() {
+  group('Atwater energy consistency', () {
+    test('coherent product has a small relative error and is consistent', () {
+      // 4*10 + 4*5 + 9*5 = 105 vs declared 100 -> 5% error.
+      final n = _n(energy: 100, carbs: 10, fat: 5, protein: 5);
+      expect(atwaterEnergyRelativeError(n)! < 0.10, isTrue);
+      expect(isAtwaterConsistent(n), isTrue);
+    });
+
+    test('declared kcal far above macro-implied energy is inconsistent', () {
+      // macros imply 4*5 + 4*1 + 9*1 = 33 vs declared 100 -> 67% error.
+      final n = _n(energy: 100, carbs: 5, fat: 1, protein: 1);
+      expect(atwaterEnergyRelativeError(n)! > atwaterEnergyTolerance, isTrue);
+      expect(isAtwaterConsistent(n), isFalse);
+    });
+
+    test('a unit slip (kJ logged as kcal) is caught', () {
+      // ~2252 kJ stored where kcal expected, against ~540 kcal of macros.
+      final n = _n(energy: 2252, carbs: 57, fat: 31, protein: 6);
+      expect(isAtwaterConsistent(n), isFalse);
+    });
+
+    test('no declared energy -> no opinion (treated as consistent)', () {
+      final n = _n(energy: null, carbs: 10, fat: 5, protein: 5);
+      expect(atwaterEnergyRelativeError(n), isNull);
+      expect(isAtwaterConsistent(n), isTrue);
+    });
+
+    test('no macros at all -> no opinion (treated as consistent)', () {
+      final n = _n(energy: 200);
+      expect(atwaterEnergyRelativeError(n), isNull);
+      expect(isAtwaterConsistent(n), isTrue);
+    });
+
+    test('boundary just under 25% stays consistent', () {
+      // declared 100, macros imply 4*15+4*5+9*5 = 125 -> 25% over; nudge under.
+      final n = _n(energy: 100, carbs: 14, fat: 5, protein: 5);
+      // 4*14+4*5+9*5 = 121 -> 21% -> consistent.
+      expect(isAtwaterConsistent(n), isTrue);
+    });
+  });
+}

--- a/test/unit_test/off_country_test.dart
+++ b/test/unit_test/off_country_test.dart
@@ -1,0 +1,34 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:opennutritracker/core/utils/off_country.dart';
+
+void main() {
+  group('OffCountry.fromLocale', () {
+    test('maps common locales to their OFF country tag', () {
+      expect(OffCountry.fromLocale('en_GB'), 'en:united-kingdom');
+      expect(OffCountry.fromLocale('en_US'), 'en:united-states');
+      expect(OffCountry.fromLocale('de_DE'), 'en:germany');
+      expect(OffCountry.fromLocale('fr_FR'), 'en:france');
+      expect(OffCountry.fromLocale('cs_CZ'), 'en:czech-republic');
+    });
+
+    test('accepts hyphen separators and trailing encodings', () {
+      expect(OffCountry.fromLocale('en-GB'), 'en:united-kingdom');
+      expect(OffCountry.fromLocale('en_GB.UTF-8'), 'en:united-kingdom');
+      expect(OffCountry.fromLocale('de_AT.utf8'), 'en:austria');
+    });
+
+    test('is case-insensitive on the country segment', () {
+      expect(OffCountry.fromLocale('en_gb'), 'en:united-kingdom');
+    });
+
+    test('returns null when there is no country segment', () {
+      expect(OffCountry.fromLocale('en'), isNull);
+      expect(OffCountry.fromLocale('C'), isNull);
+      expect(OffCountry.fromLocale(''), isNull);
+    });
+
+    test('returns null for an unmapped country (graceful no-boost)', () {
+      expect(OffCountry.fromLocale('en_ZZ'), isNull);
+    });
+  });
+}

--- a/test/unit_test/off_product_dto_test.dart
+++ b/test/unit_test/off_product_dto_test.dart
@@ -4,6 +4,7 @@ import 'package:flutter_test/flutter_test.dart';
 import 'package:opennutritracker/core/utils/supported_language.dart';
 import 'package:opennutritracker/features/add_meal/data/dto/off/off_product_dto.dart';
 import 'package:opennutritracker/features/add_meal/data/dto/off/off_product_nutriments_dto.dart';
+import 'package:opennutritracker/features/add_meal/data/dto/off/off_word_response_dto.dart';
 
 void main() {
   group('OFFProductDTO getLocaleName', () {
@@ -177,6 +178,62 @@ void main() {
       final product = _buildProduct(product_name: 'Default name');
       expect(product.getLocaleName(SupportedLanguage.cs),
           equals('Default name'));
+    });
+  });
+
+  group('OFFProductDTO.fromJson brands coercion', () {
+    test('Search-a-licious returns brands as a list; joined to a string', () {
+      final product = OFFProductDTO.fromJson({
+        'code': '1',
+        'brands': ['Gerber', 'Yogurt Melts'],
+      });
+      expect(product.brands, 'Gerber, Yogurt Melts');
+    });
+
+    test('v2 returns brands as a comma-separated string; kept as-is', () {
+      final product = OFFProductDTO.fromJson({
+        'code': '1',
+        'brands': 'Nutella',
+      });
+      expect(product.brands, 'Nutella');
+    });
+
+    test('null / empty brands normalise to null', () {
+      expect(OFFProductDTO.fromJson({'code': '1'}).brands, isNull);
+      expect(OFFProductDTO.fromJson({'code': '1', 'brands': ''}).brands, isNull);
+      expect(
+        OFFProductDTO.fromJson({'code': '1', 'brands': <dynamic>[]}).brands,
+        isNull,
+      );
+    });
+
+    test('blank entries in a brands list are dropped', () {
+      final product = OFFProductDTO.fromJson({
+        'code': '1',
+        'brands': ['', '  ', 'Real'],
+      });
+      expect(product.brands, 'Real');
+    });
+  });
+
+  group('OFFWordResponseDTO.fromJson Search-a-licious envelope', () {
+    test('maps the hits array onto products and reads page metadata', () {
+      final response = OFFWordResponseDTO.fromJson({
+        'count': 631,
+        'page': 1,
+        'page_size': 2,
+        'page_count': 316,
+        'hits': [
+          {'code': '111', 'product_name': 'A', 'brands': ['X']},
+          {'code': '222', 'product_name': 'B'},
+        ],
+      });
+
+      expect(response.products, hasLength(2));
+      expect(response.products.first.code, '111');
+      expect(response.products.first.brands, 'X');
+      expect(response.count, 631);
+      expect(response.page_count, 316);
     });
   });
 }

--- a/test/unit_test/remote_search_cache_data_source_test.dart
+++ b/test/unit_test/remote_search_cache_data_source_test.dart
@@ -20,6 +20,7 @@ MealDBO _meal({
   String? code,
   String? name,
   MealSourceDBO source = MealSourceDBO.off,
+  bool? detailed,
 }) {
   return MealDBO(
     code: code,
@@ -35,6 +36,7 @@ MealDBO _meal({
     servingSize: null,
     nutriments: _emptyNutriments(),
     source: source,
+    detailed: detailed,
   );
 }
 
@@ -198,6 +200,52 @@ void main() {
       expect(ds.getByBarcode('X')?.name, equals('Item X'));
       expect(ds.getByBarcode('Y')?.name, equals('Item Y'));
       expect(ds.getByBarcode('Z'), isNull);
+    });
+
+    group('detailed flag (thin search vs full product)', () {
+      test('getDetailedByBarcode ignores thin entries, returns full ones',
+          () async {
+        await ds.cache(_meal(code: 'THIN', name: 'Thin', detailed: false));
+        await ds.cache(_meal(code: 'FULL', name: 'Full', detailed: true));
+
+        expect(ds.getDetailedByBarcode('THIN'), isNull,
+            reason: 'a thin search result must not satisfy a detailed lookup');
+        expect(ds.getDetailedByBarcode('FULL')?.name, equals('Full'));
+        // getByBarcode still returns either, for callers that accept thin data.
+        expect(ds.getByBarcode('THIN')?.name, equals('Thin'));
+      });
+
+      test('legacy entries with null detailed are treated as thin', () async {
+        await ds.cache(_meal(code: 'OLD', name: 'Legacy')); // detailed == null
+        expect(ds.getDetailedByBarcode('OLD'), isNull);
+      });
+
+      test(
+          'cacheFromSearch does not downgrade a full entry to a thin search '
+          'result', () async {
+        await ds.cache(_meal(code: 'A', name: 'Full', detailed: true));
+
+        await ds.cacheFromSearch([
+          _meal(code: 'A', name: 'Thin from search', detailed: false),
+        ]);
+
+        final entry = ds.getByBarcode('A')!;
+        expect(entry.name, equals('Full'),
+            reason: 'the hydrated full entry must survive a re-search');
+        expect(entry.detailed, isTrue);
+        expect(ds.getDetailedByBarcode('A')?.name, equals('Full'));
+      });
+
+      test('cacheFromSearch still refreshes a thin entry with newer thin data',
+          () async {
+        await ds.cache(_meal(code: 'B', name: 'Thin v1', detailed: false));
+
+        await ds.cacheFromSearch([
+          _meal(code: 'B', name: 'Thin v2', detailed: false),
+        ]);
+
+        expect(ds.getByBarcode('B')?.name, equals('Thin v2'));
+      });
     });
 
     test('touch refreshes the timestamp without changing meal data', () async {


### PR DESCRIPTION
## Why

Open Food Facts is retiring the legacy Perl text-search endpoint (`/cgi/search.pl`), which has been returning 503s. Left alone, OFF text search in the app would eventually fail for everyone. This moves text search onto OFF's Elasticsearch-backed **Search-a-licious** service, and takes the opportunity to make the results genuinely better to use.

If you have ever stood in a supermarket scanning a barcode that would not resolve, or scrolled past twenty near-identical entries to find the one you can actually buy, this is aimed squarely at that experience.

## What changed

**Text search → Search-a-licious.** `/search` replaces `search.pl`. Its `hits` envelope maps onto the existing DTOs, and its `brands` array is normalised back to a string. Barcode scanning is untouched and stays on the still-healthy v2 product endpoint.

**Full-fidelity hydration.** The Search-a-licious index only stores a thin projection of each product (no serving fields, no micronutrients). So opening an OFF search result now hydrates it to the full record via the v2 product endpoint before it is shown or logged. A `detailed` flag on the meal model and cache stops a thin search result from satisfying a scan/hydration lookup or downgrading an already-hydrated entry. Hydration fails softly: if it can't fetch, the macros-only result still logs.

**Result ranking.** A bare relevance order buries popular, well-maintained products under near-duplicate and sparse entries. Results are re-ranked client-side over a larger candidate pool, fusing relevance position with OFF's `popularity_key` (reciprocal-rank fusion), with a soft Atwater demotion that sinks entries whose declared energy is incoherent with their macros (>25%, the edge of the data's natural noise floor). Tuned and validated against live results for brand, descriptive and specific queries.

**Local prioritisation.** Products carry country tags, already in the search response, so a UK user is gently nudged toward products sold in the UK (a 1.3x boost). It is soft: a much more popular or relevant global match still wins, and nothing is filtered out. Locales with no mapped country skip it.

**Search-as-you-type.** Debounced (500ms + restartable) on the product and food tabs, with local matches surfaced under three characters and the result list kept visible rather than blanking between keystrokes.

## Test plan

- [x] `flutter analyze` clean; full suite green (625 tests), including new coverage for the `hits`/`brands` parsing, the thin-vs-detailed cache, the ranking fusion + Atwater demotion, the locale to country mapping and the country boost.
- [x] Manual end-to-end on a Pixel 6 Pro (en-GB): searched 15 varied products (nutella, oat milk, greek yogurt, salmon, olive oil, crisps, ...) and all returned clean, on-topic, brand-complete top results.
- [x] Opened results confirmed hydration (full nutrition panel plus micronutrients that only exist via the v2 fetch), logged intakes, and confirmed barcode scanning still returns full data.
- [x] Country boost confirmed surfacing UK/Irish brands first for an en-GB device.

## Notes for review

- Targets `develop`. Includes a **minor** version bump to `1.5.0+58` (new data-source integration plus user-facing features, no breaking data migration; the new `detailed` Hive field is additive). We're bumping on the feature merge now that releases are smaller and more frequent rather than batched, so the version moves with each merge rather than only at `develop -> main`.
- Two new pure-Dart dependencies (`bloc_concurrency`, `stream_transform`) for the debounce; both support iOS and Android.
