### PR TITLE
ci: name the GitHub release with the pubspec build number

### DIFF
--- a/.github/workflows/default_workflow.yml
+++ b/.github/workflows/default_workflow.yml
@@ -858,8 +858,9 @@ jobs:
         run: |
           APP_VERSION=$(awk '/^version:/ {print $2}' pubspec.yaml)
           VERSION_NO_BUILD="${APP_VERSION%+*}"
+          BUILD_NUMBER="${APP_VERSION##*+}"
           TAG_NAME="v${VERSION_NO_BUILD}"
-          RELEASE_NAME="Release v${VERSION_NO_BUILD} (build ${GITHUB_RUN_NUMBER})"
+          RELEASE_NAME="Release v${VERSION_NO_BUILD} (build ${BUILD_NUMBER})"
           echo "TAG_NAME=$TAG_NAME" >> "$GITHUB_ENV"
           echo "RELEASE_NAME=$RELEASE_NAME" >> "$GITHUB_ENV"
 


### PR DESCRIPTION
On the last release I noticed the GitHub release name showed a build number that didn't match the one our store artifacts carry. The release job tags correctly from pubspec (`v1.5.0`), but its display name built `(build N)` from `GITHUB_RUN_NUMBER`, the CI run counter, rather than the pubspec build number. The iOS `CFBundleVersion` and Android `versionCode` both come from the pubspec `+N`, so the same release read as two different build numbers depending on where you looked.

This derives the build number from the pubspec version so the release name matches the tag and the published artifacts. pubspec stays the single source of truth for the version everywhere. It's the only place the run number leaked in; the builds themselves were already correct.