### PR TITLE
ci: free runner disk space before the Android emulator

### DIFF
--- a/.github/workflows/default_workflow.yml
+++ b/.github/workflows/default_workflow.yml
@@ -398,6 +398,21 @@ jobs:
       - name: Checkout code
         uses: actions/checkout@v6
 
+      # The hosted ubuntu runner has ~14 GB free after its preinstalled
+      # toolchains, and pulling the android-34 system image plus booting the
+      # emulator can tip it into "No space left on device". That kills the
+      # emulator before it boots, surfacing downstream as the misleading
+      # "could not connect to TCP port 5554". Reclaim ~15 GB by dropping the
+      # large toolchains this job never uses. Deliberately leaves the Flutter
+      # and Java toolcache and the Android SDK dir untouched.
+      - name: Free up disk space for the emulator
+        run: |
+          df -h /
+          sudo rm -rf /usr/share/dotnet /opt/ghc /usr/local/.ghcup \
+            /usr/local/share/boost /usr/share/swift /opt/hostedtoolcache/CodeQL
+          sudo docker image prune --all --force || true
+          df -h /
+
       - name: Setup Java
         uses: actions/setup-java@v5
         with:


### PR DESCRIPTION
The release validation flagged `android-integration-tests` failing, and the root cause turned out to be infrastructure rather than our tests. The job died while downloading the android-34 system image with `No space left on device`, which kills the emulator before it boots and shows up downstream as the misleading `could not connect to TCP port 5554`. It is intermittent because it depends on how full the hosted runner's disk happens to be, which is why some runs (including the current release PR run) pass and others fail.

The hosted ubuntu runner has only around 14 GB free after its preinstalled toolchains, and the system image plus the emulator boot can tip it over. The job's existing retry can't rescue it because the disk stays full across both attempts.

This adds a step at the start of the job that reclaims roughly 15 GB by removing the large toolchains this job never touches (dotnet, GHC/ghcup, boost, swift, the CodeQL bundle) and pruning docker images, before the emulator runs. The Flutter and Java toolcache and the Android SDK directory are deliberately left alone. The `df -h /` lines on either side make the before/after space visible in the log if we ever need to tune it.