### PR TITLE
fix(search): stop OFF and FDC cached results leaking across tabs

### DIFF
--- a/lib/features/add_meal/domain/usecase/search_products_usecase.dart
+++ b/lib/features/add_meal/domain/usecase/search_products_usecase.dart
@@ -49,7 +49,8 @@ class SearchProductsUseCase {
     bool skipRemote = false,
   }) async {
     if (skipRemote) {
-      return _buildResult(searchString, const [], remoteSkipped: true);
+      return _buildResult(searchString, const [],
+          remoteSkipped: true, cacheSource: MealSourceEntity.off);
     }
     final remote = await _safeRemoteCall(
       'OFF',
@@ -61,7 +62,8 @@ class SearchProductsUseCase {
     // get their timestamp refreshed and stay until 90 days after the
     // last selection.
     await _cacheRemoteResults(remote);
-    return _buildResult(searchString, remote);
+    return _buildResult(searchString, remote,
+        cacheSource: MealSourceEntity.off);
   }
 
   Future<SearchProductsResult> searchFDCFoodByString(
@@ -69,14 +71,16 @@ class SearchProductsUseCase {
     bool skipRemote = false,
   }) async {
     if (skipRemote) {
-      return _buildResult(searchString, const [], remoteSkipped: true);
+      return _buildResult(searchString, const [],
+          remoteSkipped: true, cacheSource: MealSourceEntity.fdc);
     }
     final remote = await _safeRemoteCall(
       'FDC',
       () => _productsRepository.getSupabaseFDCFoodsByString(searchString),
     );
     await _cacheRemoteResults(remote);
-    return _buildResult(searchString, remote);
+    return _buildResult(searchString, remote,
+        cacheSource: MealSourceEntity.fdc);
   }
 
   Future<void> _cacheRemoteResults(List<MealEntity> remote) async {
@@ -114,6 +118,7 @@ class SearchProductsUseCase {
     String searchString,
     List<MealEntity> remoteResults, {
     bool remoteSkipped = false,
+    required MealSourceEntity cacheSource,
   }) async {
     // When the remote source was deliberately skipped (short query), don't
     // claim it returned nothing — that would show a misleading "no results"
@@ -166,9 +171,17 @@ class SearchProductsUseCase {
     // Sorted with the most recently touched entries first so an item the
     // user just selected (logged) appears at the top of the next search
     // result list, ahead of other cached items they haven't touched.
-    final fromOffCache = _cachedOffMealDataSource
+    //
+    // The cache box holds both OFF and FDC entries (cacheFromSearch writes
+    // whatever either remote returned), so filter to the source of the tab
+    // being built. Without this, a prior OFF search leaks branded products
+    // into the FDC "Food" tab and vice versa, since both tabs share this
+    // helper. Custom meals, recipes and intake history above are the user's
+    // own and are intentionally surfaced in both tabs.
+    final fromCache = _cachedOffMealDataSource
         .getAllByMostRecentlyTouched()
         .map(MealEntity.fromMealDBO)
+        .where((meal) => meal.source == cacheSource)
         .where((meal) => _mealMatchesSearch(meal, normalizedSearchString))
         .toList();
 
@@ -183,7 +196,7 @@ class SearchProductsUseCase {
         ...fromCustomMealBox,
         ...fromRecipes,
         ...fromIntakeHistory,
-        ...fromOffCache,
+        ...fromCache,
         ...remoteResults,
       ]),
       remoteSourceEmpty: remoteSourceEmpty,

--- a/test/unit_test/search_products_usecase_test.dart
+++ b/test/unit_test/search_products_usecase_test.dart
@@ -594,6 +594,57 @@ void main() {
             ['banana-b', 'banana-a', 'banana-c']);
       },
     );
+
+    // The cache box holds both OFF and FDC entries. Each tab must only
+    // surface cached entries from its own source, otherwise a prior search
+    // on one tab leaks results into the other (e.g. branded OFF products
+    // appearing in the FDC "Food" tab).
+    test(
+      'cached OFF product does not leak into the FDC search',
+      () async {
+        cachedOffMealDataSource.meals.add(
+          _offCacheDbo(code: 'off-cached', name: 'Branded Chicken Pie'),
+        );
+        // FDC remote returns its own match for the same query.
+        productsRepository.fdcResults['chicken'] = [
+          _meal(
+              code: 'fdc-1',
+              name: 'Chicken, raw',
+              source: MealSourceEntity.fdc),
+        ];
+
+        final result = await useCase.searchFDCFoodByString('chicken');
+
+        expect(result.meals.map((m) => m.code), ['fdc-1']);
+        expect(
+          result.meals.every((m) => m.source != MealSourceEntity.off),
+          isTrue,
+        );
+      },
+    );
+
+    test(
+      'cached FDC food does not leak into the OFF products search',
+      () async {
+        cachedOffMealDataSource.meals.add(
+          _fdcCacheDbo(code: 'fdc-cached', name: 'Chicken, raw'),
+        );
+        productsRepository.offResults['chicken'] = [
+          _meal(
+              code: 'off-1',
+              name: 'Chicken Pie',
+              source: MealSourceEntity.off),
+        ];
+
+        final result = await useCase.searchOFFProductsByString('chicken');
+
+        expect(result.meals.map((m) => m.code), ['off-1']);
+        expect(
+          result.meals.every((m) => m.source != MealSourceEntity.fdc),
+          isTrue,
+        );
+      },
+    );
   });
 
   group('SearchProductsUseCase recipes integration', () {
@@ -698,6 +749,9 @@ MealDBO _customMealDbo({required String code, required String name}) =>
 
 MealDBO _offCacheDbo({required String code, required String name}) =>
     _meaDboWithSource(code: code, name: name, source: MealSourceDBO.off);
+
+MealDBO _fdcCacheDbo({required String code, required String name}) =>
+    _meaDboWithSource(code: code, name: name, source: MealSourceDBO.fdc);
 
 MealDBO _meaDboWithSource({
   required String code,


### PR DESCRIPTION
While smoke-testing the release I noticed branded Open Food Facts products showing up in the **Food** (FDC) tab, which should only ever show USDA FDC foods.

## Root cause

The local search cache (`CachedOffMealBox`) holds entries from both remote sources, because `cacheFromSearch` writes back whatever either OFF or FDC returned. `_buildResult` is shared by `searchOFFProductsByString` and `searchFDCFoodByString`, and it folded the *entire* cache into the result regardless of which tab asked for it. So once an OFF search had populated the cache, those branded products surfaced in the FDC tab too, and FDC foods would likewise surface under Products.

It's easiest to trigger when FDC is unavailable and the tab leans on cache, which is how it first showed up, but the leak isn't conditional on failure.

## Fix

Filter the cached contribution to the source of the tab being built: Products gets OFF-sourced cached entries, Food gets FDC-sourced ones. Custom meals, recipes and intake history are the user's own creations and are still intentionally surfaced in both tabs.

Two regression tests cover both leak directions.

## Note on scope

This is long-standing, dating to the introduction of local search caching rather than the recent Search-a-licious switchover, so it isn't a 1.5.0 regression. Happy either way on whether it rides this release or the next one.