### PR TITLE
Navigate to main screen after quick add

### DIFF
--- a/lib/features/add_meal/presentation/widgets/quick_add_bottom_sheet.dart
+++ b/lib/features/add_meal/presentation/widgets/quick_add_bottom_sheet.dart
@@ -111,13 +111,17 @@ class _QuickAddBottomSheetState extends State<QuickAddBottomSheet> {
       if (!mounted) return;
       final mealTypeLabel = _intakeTypeLabel(context, widget.intakeType);
       final scaffoldMessenger = ScaffoldMessenger.of(context);
+      // Resolve the localized message before navigating: the push below
+      // removes every route (including this sheet's), so reading from
+      // context afterwards would be looking up a deactivated widget.
+      final addedMessage = S.of(context).quickAddAddedSnack(mealTypeLabel);
       Navigator.of(context, rootNavigator: true).pushNamedAndRemoveUntil(
         NavigationOptions.mainRoute,
         (route) => false,
       );
       scaffoldMessenger.showSnackBar(
         SnackBar(
-          content: Text(S.of(context).quickAddAddedSnack(mealTypeLabel)),
+          content: Text(addedMessage),
         ),
       );
     } catch (e, st) {

--- a/lib/features/add_meal/presentation/widgets/quick_add_bottom_sheet.dart
+++ b/lib/features/add_meal/presentation/widgets/quick_add_bottom_sheet.dart
@@ -11,6 +11,7 @@ import 'package:opennutritracker/core/utils/calc/unit_calc.dart';
 import 'package:opennutritracker/core/utils/energy_unit_provider.dart';
 import 'package:opennutritracker/core/utils/id_generator.dart';
 import 'package:opennutritracker/core/utils/locator.dart';
+import 'package:opennutritracker/core/utils/navigation_options.dart';
 import 'package:opennutritracker/features/add_meal/domain/entity/meal_entity.dart';
 import 'package:opennutritracker/features/add_meal/domain/entity/meal_nutriments_entity.dart';
 import 'package:opennutritracker/features/diary/presentation/bloc/calendar_day_bloc.dart';
@@ -109,8 +110,12 @@ class _QuickAddBottomSheetState extends State<QuickAddBottomSheet> {
 
       if (!mounted) return;
       final mealTypeLabel = _intakeTypeLabel(context, widget.intakeType);
-      Navigator.of(context).pop();
-      ScaffoldMessenger.of(context).showSnackBar(
+      final scaffoldMessenger = ScaffoldMessenger.of(context);
+      Navigator.of(context, rootNavigator: true).pushNamedAndRemoveUntil(
+        NavigationOptions.mainRoute,
+        (route) => false,
+      );
+      scaffoldMessenger.showSnackBar(
         SnackBar(
           content: Text(S.of(context).quickAddAddedSnack(mealTypeLabel)),
         ),


### PR DESCRIPTION
I'm not sure if this is true for all users, but I'd prefer to navigate back to the main page after adding a meal via 'quick add'. I normally don't add multiple quick entries, but rather calculate a portion in advance so I only have to enter a single number. 

@k4black What do you think, would this be a sensible default?