### PR TITLE
Add logging of main weight to the weight history

### DIFF
--- a/lib/features/home/presentation/widgets/quick_weight_widget.dart
+++ b/lib/features/home/presentation/widgets/quick_weight_widget.dart
@@ -1,4 +1,6 @@
 import 'package:flutter/material.dart';
+import 'package:opennutritracker/core/domain/entity/weight_log_entity.dart';
+import 'package:opennutritracker/core/domain/usecase/add_weight_log_usecase.dart';
 import 'package:opennutritracker/core/domain/usecase/get_user_usecase.dart';
 import 'package:opennutritracker/core/utils/locator.dart';
 import 'package:opennutritracker/features/profile/presentation/bloc/profile_bloc.dart';
@@ -63,6 +65,14 @@ class QuickWeightWidget extends StatelessWidget {
     if (newWeight == null || !context.mounted) return;
 
     final newWeightKg = usesImperialUnits ? newWeight / 2.20462 : newWeight;
+
+    final now = DateTime.now();
+    await locator<AddWeightLogUsecase>().addEntry(
+      WeightLogEntity(
+        date: DateTime(now.year, now.month, now.day),
+        weightKg: newWeightKg,
+      ),
+    );
 
     final user = await locator<GetUserUsecase>().getUserData();
     user.weightKG = newWeightKg;

--- a/lib/features/home/presentation/widgets/quick_weight_widget.dart
+++ b/lib/features/home/presentation/widgets/quick_weight_widget.dart
@@ -74,13 +74,12 @@ class QuickWeightWidget extends StatelessWidget {
       ),
     );
 
+    // addEntry already persisted today's weight onto the user record, so
+    // re-load it and route through ProfileBloc.updateUser purely so the
+    // profile screen, diary, and home all refresh in one go. Going through
+    // AddUserUsecase directly would update Hive but leave the profile
+    // screen showing the pre-edit weight until the next manual reload.
     final user = await locator<GetUserUsecase>().getUserData();
-    user.weightKG = newWeightKg;
-
-    // Route through ProfileBloc.updateUser so the profile screen, diary,
-    // and home all refresh in one go. Going through AddUserUsecase
-    // directly would update Hive but leave the profile screen showing the
-    // pre-edit weight until the next manual reload.
     await locator<ProfileBloc>().updateUser(user);
   }
 }


### PR DESCRIPTION
This adreses #481. Changing the weight on the home page now creates a history entry. 

I think it would be a great addition that's common in other comparable apps.