### PR TITLE
Add multiple profiles (#471)

### DIFF
--- a/lib/core/data/data_source/config_data_source.dart
+++ b/lib/core/data/data_source/config_data_source.dart
@@ -2,129 +2,159 @@ import 'package:hive_ce_flutter/hive_flutter.dart';
 import 'package:logging/logging.dart';
 import 'package:opennutritracker/core/data/dbo/app_theme_dbo.dart';
 import 'package:opennutritracker/core/data/dbo/config_dbo.dart';
+import 'package:opennutritracker/core/utils/hive_db_provider.dart';
 
+/// Reads and writes the app config, which is split across two boxes:
+///
+/// - the **shared** [HiveDBProvider.appConfigBox] holds everything that is
+///   a device-wide preference (theme, accent, language, units, energy unit,
+///   notifications, anonymous-data consent, legal acceptances, and the
+///   various view toggles), so it stays consistent whichever profile is
+///   active;
+/// - the **per-profile** [HiveDBProvider.configBox] holds only the personal
+///   nutrition goals (kcal adjustment, macro split, per-meal kcal shares and
+///   the daily water goal), which differ from one profile to the next.
+///
+/// Reads merge the two — shared fields from the app box, personal fields
+/// from the active profile's box. Writes store a detached copy of the merged
+/// config into both boxes; because reads always source each field from its
+/// authoritative box, the redundant copy in the other box is simply ignored,
+/// so the two never disagree on a field that matters.
 class ConfigDataSource {
   static const _configKey = "ConfigKey";
 
   final _log = Logger('ConfigDataSource');
-  final Box<ConfigDBO> _configBox;
+  final HiveDBProvider _db;
 
-  ConfigDataSource(this._configBox);
+  ConfigDataSource(this._db);
 
-  Future<bool> configInitialized() async => _configBox.containsKey(_configKey);
+  Box<ConfigDBO> get _appBox => _db.appConfigBox;
+  Box<ConfigDBO> get _profileBox => _db.configBox;
 
-  Future<void> initializeConfig() async =>
-      _configBox.put(_configKey, ConfigDBO.empty());
+  /// Builds a detached config from the shared app box with the personal
+  /// fields overlaid from the active profile's box. Detached (via JSON) so
+  /// callers can't accidentally mutate a stored instance.
+  ConfigDBO _readMerged() {
+    final app = _appBox.get(_configKey);
+    final profile = _profileBox.get(_configKey);
+    final merged =
+        app != null ? ConfigDBO.fromJson(app.toJson()) : ConfigDBO.empty();
+    if (profile != null) {
+      merged.userKcalAdjustment = profile.userKcalAdjustment;
+      merged.userCarbGoalPct = profile.userCarbGoalPct;
+      merged.userProteinGoalPct = profile.userProteinGoalPct;
+      merged.userFatGoalPct = profile.userFatGoalPct;
+      merged.mealKcalSharesPct = profile.mealKcalSharesPct;
+      merged.dailyWaterGoalMl = profile.dailyWaterGoalMl;
+    }
+    return merged;
+  }
+
+  /// Persists [config] to both boxes. Each box gets its own detached copy so
+  /// the same `HiveObject` instance is never shared between boxes.
+  Future<void> _writeBoth(ConfigDBO config) async {
+    await _appBox.put(_configKey, ConfigDBO.fromJson(config.toJson()));
+    await _profileBox.put(_configKey, ConfigDBO.fromJson(config.toJson()));
+  }
+
+  Future<bool> configInitialized() async =>
+      _appBox.containsKey(_configKey) && _profileBox.containsKey(_configKey);
+
+  Future<void> initializeConfig() async {
+    if (!_appBox.containsKey(_configKey)) {
+      await _appBox.put(_configKey, ConfigDBO.empty());
+    }
+    if (!_profileBox.containsKey(_configKey)) {
+      await _profileBox.put(_configKey, ConfigDBO.empty());
+    }
+  }
+
+  /// One-time upgrade path: an existing single-user install keeps all its
+  /// settings in what is now the default profile's ConfigBox. On first launch
+  /// after the split, seed the shared app box from it so the user's theme,
+  /// language, units and so on carry across untouched.
+  Future<void> migrateAppConfigFromProfile() async {
+    if (_appBox.containsKey(_configKey)) return;
+    final profile = _profileBox.get(_configKey);
+    if (profile != null) {
+      await _appBox.put(_configKey, ConfigDBO.fromJson(profile.toJson()));
+    }
+  }
 
   Future<void> addConfig(ConfigDBO configDBO) async {
     _log.fine('Adding new config item to db');
-    await _configBox.put(_configKey, configDBO);
+    await _writeBoth(configDBO);
+  }
+
+  Future<void> _update(void Function(ConfigDBO config) mutate) async {
+    final config = _readMerged();
+    mutate(config);
+    await _writeBoth(config);
   }
 
   Future<void> setConfigDisclaimer(bool hasAcceptedDisclaimer) async {
-    _log.fine(
-      'Updating config hasAcceptedDisclaimer to $hasAcceptedDisclaimer',
-    );
-    final config = _configBox.get(_configKey);
-    config?.hasAcceptedDisclaimer = hasAcceptedDisclaimer;
-    await config?.save();
+    await _update((c) => c.hasAcceptedDisclaimer = hasAcceptedDisclaimer);
   }
 
   Future<void> setConfigAcceptedAnonymousData(
     bool hasAcceptedAnonymousData,
   ) async {
-    _log.fine(
-      'Updating config hasAcceptedAnonymousData to $hasAcceptedAnonymousData',
+    await _update(
+      (c) => c.hasAcceptedSendAnonymousData = hasAcceptedAnonymousData,
     );
-    final config = _configBox.get(_configKey);
-    config?.hasAcceptedSendAnonymousData = hasAcceptedAnonymousData;
-    await config?.save();
   }
 
-  Future<AppThemeDBO> getAppTheme() async {
-    final config = _configBox.get(_configKey);
-    return config?.selectedAppTheme ?? AppThemeDBO.defaultTheme;
-  }
+  Future<AppThemeDBO> getAppTheme() async =>
+      _readMerged().selectedAppTheme;
 
   Future<void> setConfigAppTheme(AppThemeDBO appTheme) async {
-    _log.fine('Updating config appTheme to $appTheme');
-    final config = _configBox.get(_configKey);
-    config?.selectedAppTheme = appTheme;
-    await config?.save();
+    await _update((c) => c.selectedAppTheme = appTheme);
   }
 
   Future<void> setConfigUsesImperialUnits(bool usesImperialUnits) async {
-    _log.fine('Updating config usesImperialUnits to $usesImperialUnits');
-    final config = _configBox.get(_configKey);
-    config?.usesImperialUnits = usesImperialUnits;
-    await config?.save();
+    await _update((c) => c.usesImperialUnits = usesImperialUnits);
   }
 
-  Future<double> getKcalAdjustment() async {
-    final config = _configBox.get(_configKey);
-    return config?.userKcalAdjustment ?? 0;
-  }
+  Future<double> getKcalAdjustment() async =>
+      _readMerged().userKcalAdjustment ?? 0;
 
   Future<void> setConfigKcalAdjustment(double kcalAdjustment) async {
-    _log.fine('Updating config kcalAdjustment to $kcalAdjustment');
-    final config = _configBox.get(_configKey);
-    config?.userKcalAdjustment = kcalAdjustment;
-    await config?.save();
+    await _update((c) => c.userKcalAdjustment = kcalAdjustment);
   }
 
   Future<void> setConfigCarbGoalPct(double carbGoalPct) async {
-    _log.fine('Updating config carbGoalPct to $carbGoalPct');
-    final config = _configBox.get(_configKey);
-    config?.userCarbGoalPct = carbGoalPct;
-    await config?.save();
+    await _update((c) => c.userCarbGoalPct = carbGoalPct);
   }
 
   Future<void> setConfigProteinGoalPct(double proteinGoalPct) async {
-    _log.fine('Updating config proteinGoalPct to $proteinGoalPct');
-    final config = _configBox.get(_configKey);
-    config?.userProteinGoalPct = proteinGoalPct;
-    await config?.save();
+    await _update((c) => c.userProteinGoalPct = proteinGoalPct);
   }
 
   Future<void> setConfigFatGoalPct(double fatGoalPct) async {
-    _log.fine('Updating config fatGoalPct to $fatGoalPct');
-    final config = _configBox.get(_configKey);
-    config?.userFatGoalPct = fatGoalPct;
-    await config?.save();
+    await _update((c) => c.userFatGoalPct = fatGoalPct);
   }
 
   Future<void> setConfigShowActivityTracking(bool show) async {
-    _log.fine('Updating config showActivityTracking to $show');
-    final config = _configBox.get(_configKey);
-    config?.showActivityTracking = show;
-    await config?.save();
+    await _update((c) => c.showActivityTracking = show);
   }
 
   Future<void> setConfigShowMealMacros(bool show) async {
-    _log.fine('Updating config showMealMacros to $show');
-    final config = _configBox.get(_configKey);
-    config?.showMealMacros = show;
-    await config?.save();
+    await _update((c) => c.showMealMacros = show);
   }
 
   Future<void> setNotificationsEnabled(bool enabled) async {
-    _log.fine('Updating config notificationsEnabled to $enabled');
-    final config = _configBox.get(_configKey);
-    config?.notificationsEnabled = enabled;
-    await config?.save();
+    await _update((c) => c.notificationsEnabled = enabled);
   }
 
   Future<void> setNotificationTime(int hour, int minute) async {
-    _log.fine('Updating config notification time to $hour:$minute');
-    final config = _configBox.get(_configKey);
-    config?.notificationHour = hour;
-    config?.notificationMinute = minute;
-    await config?.save();
+    await _update((c) {
+      c.notificationHour = hour;
+      c.notificationMinute = minute;
+    });
   }
 
   Future<String?> getSelectedLocale() async {
-    final config = _configBox.get(_configKey);
-    final raw = config?.selectedLocale;
+    final raw = _readMerged().selectedLocale;
     // Backward-compat: the project used to ship Czech as 'cz' (non-standard).
     // It was renamed to the BCP-47 code 'cs' so iOS surfaces it correctly in
     // its system language picker. Migrate any stored 'cz' value silently so
@@ -134,132 +164,83 @@ class ConfigDataSource {
   }
 
   Future<void> setSelectedLocale(String? locale) async {
-    _log.fine('Updating config selectedLocale to $locale');
-    final config = _configBox.get(_configKey);
-    config?.selectedLocale = locale;
-    await config?.save();
+    await _update((c) => c.selectedLocale = locale);
   }
 
   Future<void> setConfigShowMicronutrients(bool show) async {
-    _log.fine('Updating config showMicronutrients to $show');
-    final config = _configBox.get(_configKey);
-    config?.showMicronutrients = show;
-    await config?.save();
+    await _update((c) => c.showMicronutrients = show);
   }
 
   Future<void> setConfigUsesKilojoules(bool usesKilojoules) async {
-    _log.fine('Updating config usesKilojoules to $usesKilojoules');
-    final config = _configBox.get(_configKey);
-    config?.usesKilojoules = usesKilojoules;
-    await config?.save();
+    await _update((c) => c.usesKilojoules = usesKilojoules);
   }
 
   Future<void> setConfigMealKcalSharesPct(Map<String, int> shares) async {
-    _log.fine('Updating config mealKcalSharesPct to $shares');
-    final config = _configBox.get(_configKey);
     // Copy into a fresh map so Hive sees a distinct object reference on save.
-    config?.mealKcalSharesPct = Map<String, int>.from(shares);
-    await config?.save();
+    await _update((c) => c.mealKcalSharesPct = Map<String, int>.from(shares));
   }
 
-  Future<String?> getCustomMealFormMode() async {
-    final config = _configBox.get(_configKey);
-    return config?.customMealFormMode;
-  }
+  Future<String?> getCustomMealFormMode() async =>
+      _readMerged().customMealFormMode;
 
   Future<void> setCustomMealFormMode(String mode) async {
-    _log.fine('Updating config customMealFormMode to $mode');
-    final config = _configBox.get(_configKey);
-    config?.customMealFormMode = mode;
-    await config?.save();
+    await _update((c) => c.customMealFormMode = mode);
   }
 
   Future<Map<String, int>?> getDiarySortPreferences() async {
-    final config = _configBox.get(_configKey);
-    final stored = config?.diarySortPreferences;
+    final stored = _readMerged().diarySortPreferences;
     if (stored == null) return null;
-    // The Hive-generated adapter hands us a Map<dynamic, dynamic>.cast<String,
-    // int>() view; eagerly copy into a concrete map so callers see a real
-    // Map<String, int> rather than a lazy cast view that throws on access if
-    // anything unexpected ever lands in the box.
+    // Eagerly copy into a concrete Map<String, int> rather than handing back
+    // a lazy cast view that could throw on access.
     return Map<String, int>.from(stored);
   }
 
   Future<void> setDiarySortPreference(String mealKey, int sortIndex) async {
-    _log.fine('Updating config diarySortPreferences[$mealKey] = $sortIndex');
-    final config = _configBox.get(_configKey);
-    if (config == null) return;
-    final current = config.diarySortPreferences;
-    // Build a fresh Map<String, int> so the write doesn't share storage with
-    // whatever map type Hive handed back, and so the cast lands eagerly
-    // rather than lazily at read time.
-    final next = <String, int>{
-      if (current != null) ...Map<String, int>.from(current),
-      mealKey: sortIndex,
-    };
-    config.diarySortPreferences = next;
-    await config.save();
+    await _update((c) {
+      final current = c.diarySortPreferences;
+      c.diarySortPreferences = <String, int>{
+        if (current != null) ...Map<String, int>.from(current),
+        mealKey: sortIndex,
+      };
+    });
   }
 
   Future<void> setConfigNutrientPanelVisibility(
     Map<String, bool> visibility,
   ) async {
-    _log.fine('Updating nutrientPanelVisibility to $visibility');
-    final config = _configBox.get(_configKey);
-    // Persist a defensive copy — Hive serialises whatever we hand it, and a
-    // caller-owned map mutating later would silently change the saved value.
-    config?.nutrientPanelVisibility = Map<String, bool>.from(visibility);
-    await config?.save();
+    // Persist a defensive copy — a caller-owned map mutating later would
+    // otherwise silently change the saved value.
+    await _update(
+      (c) => c.nutrientPanelVisibility = Map<String, bool>.from(visibility),
+    );
   }
 
   Future<void> setConfigDayStartOffsetHours(int hours) async {
-    _log.fine('Updating config dayStartOffsetHours to $hours');
-    final config = _configBox.get(_configKey);
-    config?.dayStartOffsetHours = hours;
-    await config?.save();
+    await _update((c) => c.dayStartOffsetHours = hours);
   }
 
   Future<void> setConfigDayStartOffsetMinutes(int minutes) async {
-    _log.fine('Updating config dayStartOffsetMinutes to $minutes');
-    final config = _configBox.get(_configKey);
-    config?.dayStartOffsetMinutes = minutes;
-    await config?.save();
+    await _update((c) => c.dayStartOffsetMinutes = minutes);
   }
 
   Future<void> setConfigDailyWaterGoalMl(int goalMl) async {
-    _log.fine('Updating config dailyWaterGoalMl to $goalMl');
-    final config = _configBox.get(_configKey);
-    config?.dailyWaterGoalMl = goalMl;
-    await config?.save();
+    await _update((c) => c.dailyWaterGoalMl = goalMl);
   }
 
   Future<void> setFastingWarningAcknowledged(bool acknowledged) async {
-    _log.fine('Updating config fastingWarningAcknowledged to $acknowledged');
-    final config = _configBox.get(_configKey);
-    config?.fastingWarningAcknowledged = acknowledged;
-    await config?.save();
+    await _update((c) => c.fastingWarningAcknowledged = acknowledged);
   }
 
   Future<void> setConfigUseMaterialYou(bool useMaterialYou) async {
-    _log.fine('Updating config useMaterialYou to $useMaterialYou');
-    final config = _configBox.get(_configKey);
-    config?.useMaterialYou = useMaterialYou;
-    await config?.save();
+    await _update((c) => c.useMaterialYou = useMaterialYou);
   }
 
   Future<void> setConfigAccentColor(int? value) async {
-    _log.fine('Updating config accentColor to $value');
-    final config = _configBox.get(_configKey);
-    config?.accentColor = value;
-    await config?.save();
+    await _update((c) => c.accentColor = value);
   }
 
-  Future<ConfigDBO> getConfig() async {
-    return _configBox.get(_configKey) ?? ConfigDBO.empty();
-  }
+  Future<ConfigDBO> getConfig() async => _readMerged();
 
-  Future<bool> getHasAcceptedAnonymousData() async {
-    final config = _configBox.get(_configKey);
-    return config?.hasAcceptedSendAnonymousData ?? false;
-  }
+  Future<bool> getHasAcceptedAnonymousData() async =>
+      _readMerged().hasAcceptedSendAnonymousData;
 }

--- a/lib/core/data/data_source/custom_activity_template_data_source.dart
+++ b/lib/core/data/data_source/custom_activity_template_data_source.dart
@@ -2,6 +2,7 @@ import 'package:collection/collection.dart';
 import 'package:hive_ce_flutter/hive_flutter.dart';
 import 'package:logging/logging.dart';
 import 'package:opennutritracker/core/data/data_source/custom_activity_template_dbo.dart';
+import 'package:opennutritracker/core/utils/hive_db_provider.dart';
 
 /// Hive-backed store for [CustomActivityTemplateDBO] entries used by the
 /// Custom activity flow (#70 follow-up).
@@ -12,9 +13,11 @@ import 'package:opennutritracker/core/data/data_source/custom_activity_template_
 /// for users who tweak a template's typical kcal over time.
 class CustomActivityTemplateDataSource {
   final log = Logger('CustomActivityTemplateDataSource');
-  final Box<CustomActivityTemplateDBO> _box;
+  final HiveDBProvider _db;
 
-  CustomActivityTemplateDataSource(this._box);
+  CustomActivityTemplateDataSource(this._db);
+
+  Box<CustomActivityTemplateDBO> get _box => _db.customActivityTemplateBox;
 
   Future<void> addTemplate(CustomActivityTemplateDBO template) async {
     log.fine('Saving custom activity template "${template.name}"');

--- a/lib/core/data/data_source/custom_meal_data_source.dart
+++ b/lib/core/data/data_source/custom_meal_data_source.dart
@@ -1,10 +1,13 @@
 import 'package:hive_ce_flutter/hive_flutter.dart';
 import 'package:opennutritracker/core/data/dbo/meal_dbo.dart';
+import 'package:opennutritracker/core/utils/hive_db_provider.dart';
 
 class CustomMealDataSource {
-  final Box<MealDBO> _customMealBox;
+  final HiveDBProvider _db;
 
-  CustomMealDataSource(this._customMealBox);
+  CustomMealDataSource(this._db);
+
+  Box<MealDBO> get _customMealBox => _db.customMealBox;
 
   Future<void> saveCustomMeal(MealDBO mealDBO) async {
     final existing = _customMealBox.values.cast<MealDBO?>().firstWhere(

--- a/lib/core/data/data_source/intake_data_source.dart
+++ b/lib/core/data/data_source/intake_data_source.dart
@@ -6,12 +6,15 @@ import 'package:opennutritracker/core/data/dbo/intake_dbo.dart';
 import 'package:opennutritracker/core/data/dbo/intake_type_dbo.dart';
 import 'package:opennutritracker/core/data/dbo/meal_dbo.dart';
 import 'package:opennutritracker/core/utils/calc/day_boundary_calc.dart';
+import 'package:opennutritracker/core/utils/hive_db_provider.dart';
 
 class IntakeDataSource {
   final log = Logger('IntakeDataSource');
-  final Box<IntakeDBO> _intakeBox;
+  final HiveDBProvider _db;
 
-  IntakeDataSource(this._intakeBox);
+  IntakeDataSource(this._db);
+
+  Box<IntakeDBO> get _intakeBox => _db.intakeBox;
 
   Future<void> addIntake(IntakeDBO intakeDBO) async {
     log.fine('Adding new intake item to db');

--- a/lib/core/data/data_source/profile_data_source.dart
+++ b/lib/core/data/data_source/profile_data_source.dart
@@ -1,0 +1,30 @@
+import 'package:hive_ce_flutter/hive_flutter.dart';
+import 'package:logging/logging.dart';
+import 'package:opennutritracker/core/data/dbo/profile_dbo.dart';
+import 'package:opennutritracker/core/utils/hive_db_provider.dart';
+
+/// Reads and writes the profile registry. The registry is a single global
+/// box keyed by profile id; it never changes when the active profile
+/// changes, so it is always available straight off the provider.
+class ProfileDataSource {
+  final _log = Logger('ProfileDataSource');
+  final HiveDBProvider _db;
+
+  ProfileDataSource(this._db);
+
+  Box<ProfileDBO> get _profileBox => _db.profileBox;
+
+  List<ProfileDBO> getAllProfiles() => _profileBox.values.toList();
+
+  ProfileDBO? getProfile(String id) => _profileBox.get(id);
+
+  Future<void> saveProfile(ProfileDBO profile) async {
+    _log.fine('Saving profile ${profile.id}');
+    await _profileBox.put(profile.id, profile);
+  }
+
+  Future<void> deleteProfile(String id) async {
+    _log.fine('Deleting profile $id');
+    await _profileBox.delete(id);
+  }
+}

--- a/lib/core/data/data_source/recipe_data_source.dart
+++ b/lib/core/data/data_source/recipe_data_source.dart
@@ -1,10 +1,13 @@
 import 'package:hive_ce_flutter/hive_flutter.dart';
 import 'package:opennutritracker/core/data/dbo/recipe_dbo.dart';
+import 'package:opennutritracker/core/utils/hive_db_provider.dart';
 
 class RecipeDataSource {
-  final Box<RecipeDBO> _recipeBox;
+  final HiveDBProvider _db;
 
-  RecipeDataSource(this._recipeBox);
+  RecipeDataSource(this._db);
+
+  Box<RecipeDBO> get _recipeBox => _db.recipeBox;
 
   // Upsert by stable id. Recipe ids are uuids assigned at first save and
   // never change, so we can safely overwrite the matching record.

--- a/lib/core/data/data_source/tracked_day_data_source.dart
+++ b/lib/core/data/data_source/tracked_day_data_source.dart
@@ -2,12 +2,15 @@ import 'package:hive_ce_flutter/hive_flutter.dart';
 import 'package:logging/logging.dart';
 import 'package:opennutritracker/core/data/dbo/tracked_day_dbo.dart';
 import 'package:opennutritracker/core/utils/extensions.dart';
+import 'package:opennutritracker/core/utils/hive_db_provider.dart';
 
 class TrackedDayDataSource {
   final log = Logger('TrackedDayDataSource');
-  final Box<TrackedDayDBO> _trackedDayBox;
+  final HiveDBProvider _db;
 
-  TrackedDayDataSource(this._trackedDayBox);
+  TrackedDayDataSource(this._db);
+
+  Box<TrackedDayDBO> get _trackedDayBox => _db.trackedDayBox;
 
   Future<void> saveTrackedDay(TrackedDayDBO trackedDayDBO) async {
     log.fine('Updating tracked day in db');

--- a/lib/core/data/data_source/user_activity_data_source.dart
+++ b/lib/core/data/data_source/user_activity_data_source.dart
@@ -4,12 +4,15 @@ import 'package:hive_ce_flutter/hive_flutter.dart';
 import 'package:logging/logging.dart';
 import 'package:opennutritracker/core/data/data_source/user_activity_dbo.dart';
 import 'package:opennutritracker/core/utils/calc/day_boundary_calc.dart';
+import 'package:opennutritracker/core/utils/hive_db_provider.dart';
 
 class UserActivityDataSource {
   final log = Logger('UserActivityDataSource');
-  final Box<UserActivityDBO> _userActivityBox;
+  final HiveDBProvider _db;
 
-  UserActivityDataSource(this._userActivityBox);
+  UserActivityDataSource(this._db);
+
+  Box<UserActivityDBO> get _userActivityBox => _db.userActivityBox;
 
   Future<void> addUserActivity(UserActivityDBO userActivityDBO) async {
     log.fine('Adding new user activity to db');

--- a/lib/core/data/data_source/user_data_source.dart
+++ b/lib/core/data/data_source/user_data_source.dart
@@ -1,13 +1,16 @@
 import 'package:hive_ce_flutter/hive_flutter.dart';
 import 'package:logging/logging.dart';
 import 'package:opennutritracker/core/data/dbo/user_dbo.dart';
+import 'package:opennutritracker/core/utils/hive_db_provider.dart';
 
 class UserDataSource {
   static const _userKey = "UserKey";
   final log = Logger('UserDataSource');
-  final Box<UserDBO> _userBox;
+  final HiveDBProvider _db;
 
-  UserDataSource(this._userBox);
+  UserDataSource(this._db);
+
+  Box<UserDBO> get _userBox => _db.userBox;
 
   Future<void> saveUserData(UserDBO userDBO) async {
     log.fine('Updating user in db');

--- a/lib/core/data/data_source/water_intake_data_source.dart
+++ b/lib/core/data/data_source/water_intake_data_source.dart
@@ -1,6 +1,7 @@
 import 'package:hive_ce_flutter/hive_flutter.dart';
 import 'package:logging/logging.dart';
 import 'package:opennutritracker/core/data/dbo/water_intake_dbo.dart';
+import 'package:opennutritracker/core/utils/hive_db_provider.dart';
 
 /// Stores water intake entries — one row per sip. We hold every entry rather
 /// than coalescing to a daily total so the "undo last" affordance can roll a
@@ -8,9 +9,11 @@ import 'package:opennutritracker/core/data/dbo/water_intake_dbo.dart';
 /// so a future "graph of hydration through the day" view is cheap to add.
 class WaterIntakeDataSource {
   final log = Logger('WaterIntakeDataSource');
-  final Box<WaterIntakeDBO> _waterIntakeBox;
+  final HiveDBProvider _db;
 
-  WaterIntakeDataSource(this._waterIntakeBox);
+  WaterIntakeDataSource(this._db);
+
+  Box<WaterIntakeDBO> get _waterIntakeBox => _db.waterIntakeBox;
 
   Future<void> addEntry(WaterIntakeDBO entry) async {
     log.fine('Adding water intake ${entry.amountMl} ml at ${entry.dateTime}');

--- a/lib/core/data/data_source/weight_log_data_source.dart
+++ b/lib/core/data/data_source/weight_log_data_source.dart
@@ -2,12 +2,15 @@ import 'package:hive_ce_flutter/hive_flutter.dart';
 import 'package:logging/logging.dart';
 import 'package:opennutritracker/core/data/dbo/weight_log_dbo.dart';
 import 'package:opennutritracker/core/utils/extensions.dart';
+import 'package:opennutritracker/core/utils/hive_db_provider.dart';
 
 class WeightLogDataSource {
   final log = Logger('WeightLogDataSource');
-  final Box<WeightLogDBO> _weightLogBox;
+  final HiveDBProvider _db;
 
-  WeightLogDataSource(this._weightLogBox);
+  WeightLogDataSource(this._db);
+
+  Box<WeightLogDBO> get _weightLogBox => _db.weightLogBox;
 
   /// Stores a single entry keyed by its day (`yyyy-MM-dd`). Two entries
   /// for the same calendar day overwrite each other so the log carries

--- a/lib/core/data/dbo/profile_dbo.dart
+++ b/lib/core/data/dbo/profile_dbo.dart
@@ -1,0 +1,43 @@
+import 'package:hive_ce_flutter/hive_flutter.dart';
+import 'package:opennutritracker/core/domain/entity/profile_entity.dart';
+
+part 'profile_dbo.g.dart';
+
+@HiveType(typeId: 20)
+class ProfileDBO extends HiveObject {
+  @HiveField(0)
+  String id;
+  @HiveField(1)
+  String name;
+  @HiveField(2)
+  String? imagePath;
+  @HiveField(3)
+  DateTime createdAt;
+
+  /// Suffix appended to this profile's box names. The very first profile
+  /// carries an empty suffix so it adopts the original (unsuffixed) box
+  /// names already on disk — that is what lets a long-time user keep all
+  /// their data with no migration when multi-profile support arrives.
+  /// Every profile created afterwards gets a non-empty suffix and its own
+  /// isolated set of boxes.
+  @HiveField(4)
+  String boxSuffix;
+
+  ProfileDBO({
+    required this.id,
+    required this.name,
+    required this.createdAt,
+    required this.boxSuffix,
+    this.imagePath,
+  });
+
+  factory ProfileDBO.fromProfileEntity(ProfileEntity entity) {
+    return ProfileDBO(
+      id: entity.id,
+      name: entity.name,
+      createdAt: entity.createdAt,
+      boxSuffix: entity.boxSuffix,
+      imagePath: entity.imagePath,
+    );
+  }
+}

--- a/lib/core/data/dbo/profile_dbo.g.dart
+++ b/lib/core/data/dbo/profile_dbo.g.dart
@@ -1,0 +1,53 @@
+// GENERATED CODE - DO NOT MODIFY BY HAND
+
+part of 'profile_dbo.dart';
+
+// **************************************************************************
+// TypeAdapterGenerator
+// **************************************************************************
+
+class ProfileDBOAdapter extends TypeAdapter<ProfileDBO> {
+  @override
+  final typeId = 20;
+
+  @override
+  ProfileDBO read(BinaryReader reader) {
+    final numOfFields = reader.readByte();
+    final fields = <int, dynamic>{
+      for (int i = 0; i < numOfFields; i++) reader.readByte(): reader.read(),
+    };
+    return ProfileDBO(
+      id: fields[0] as String,
+      name: fields[1] as String,
+      createdAt: fields[3] as DateTime,
+      boxSuffix: fields[4] as String,
+      imagePath: fields[2] as String?,
+    );
+  }
+
+  @override
+  void write(BinaryWriter writer, ProfileDBO obj) {
+    writer
+      ..writeByte(5)
+      ..writeByte(0)
+      ..write(obj.id)
+      ..writeByte(1)
+      ..write(obj.name)
+      ..writeByte(2)
+      ..write(obj.imagePath)
+      ..writeByte(3)
+      ..write(obj.createdAt)
+      ..writeByte(4)
+      ..write(obj.boxSuffix);
+  }
+
+  @override
+  int get hashCode => typeId.hashCode;
+
+  @override
+  bool operator ==(Object other) =>
+      identical(this, other) ||
+      other is ProfileDBOAdapter &&
+          runtimeType == other.runtimeType &&
+          typeId == other.typeId;
+}

--- a/lib/core/data/repository/profile_repository.dart
+++ b/lib/core/data/repository/profile_repository.dart
@@ -1,0 +1,27 @@
+import 'package:opennutritracker/core/data/data_source/profile_data_source.dart';
+import 'package:opennutritracker/core/data/dbo/profile_dbo.dart';
+import 'package:opennutritracker/core/domain/entity/profile_entity.dart';
+
+class ProfileRepository {
+  final ProfileDataSource _profileDataSource;
+
+  ProfileRepository(this._profileDataSource);
+
+  List<ProfileEntity> getAllProfiles() => _profileDataSource
+      .getAllProfiles()
+      .map(ProfileEntity.fromProfileDBO)
+      .toList();
+
+  ProfileEntity? getProfile(String id) {
+    final dbo = _profileDataSource.getProfile(id);
+    return dbo == null ? null : ProfileEntity.fromProfileDBO(dbo);
+  }
+
+  Future<void> saveProfile(ProfileEntity profile) async {
+    await _profileDataSource.saveProfile(ProfileDBO.fromProfileEntity(profile));
+  }
+
+  Future<void> deleteProfile(String id) async {
+    await _profileDataSource.deleteProfile(id);
+  }
+}

--- a/lib/core/domain/entity/profile_entity.dart
+++ b/lib/core/domain/entity/profile_entity.dart
@@ -1,0 +1,33 @@
+import 'package:equatable/equatable.dart';
+import 'package:opennutritracker/core/data/dbo/profile_dbo.dart';
+
+class ProfileEntity extends Equatable {
+  final String id;
+  final String name;
+  final String? imagePath;
+  final DateTime createdAt;
+  final String boxSuffix;
+
+  const ProfileEntity({
+    required this.id,
+    required this.name,
+    required this.createdAt,
+    required this.boxSuffix,
+    this.imagePath,
+  });
+
+  bool get isDefault => boxSuffix.isEmpty;
+
+  factory ProfileEntity.fromProfileDBO(ProfileDBO dbo) {
+    return ProfileEntity(
+      id: dbo.id,
+      name: dbo.name,
+      createdAt: dbo.createdAt,
+      boxSuffix: dbo.boxSuffix,
+      imagePath: dbo.imagePath,
+    );
+  }
+
+  @override
+  List<Object?> get props => [id, name, imagePath, createdAt, boxSuffix];
+}

--- a/lib/core/domain/usecase/create_profile_usecase.dart
+++ b/lib/core/domain/usecase/create_profile_usecase.dart
@@ -1,0 +1,29 @@
+import 'package:opennutritracker/core/data/repository/profile_repository.dart';
+import 'package:opennutritracker/core/domain/entity/profile_entity.dart';
+import 'package:opennutritracker/core/utils/id_generator.dart';
+
+class CreateProfileUsecase {
+  final ProfileRepository _profileRepository;
+
+  CreateProfileUsecase(this._profileRepository);
+
+  /// Creates and persists a new profile record. Does not switch to it —
+  /// the caller decides when to activate the new box-set.
+  Future<ProfileEntity> createProfile({
+    required String name,
+    String? imagePath,
+  }) async {
+    final id = IdGenerator.getUniqueID();
+    final profile = ProfileEntity(
+      id: id,
+      name: name,
+      createdAt: DateTime.now(),
+      // Hyphen-free so the suffix is safe as a box-name / filename segment
+      // on every platform.
+      boxSuffix: id.replaceAll('-', ''),
+      imagePath: imagePath,
+    );
+    await _profileRepository.saveProfile(profile);
+    return profile;
+  }
+}

--- a/lib/core/domain/usecase/delete_all_user_data_usecase.dart
+++ b/lib/core/domain/usecase/delete_all_user_data_usecase.dart
@@ -2,12 +2,15 @@ import 'package:logging/logging.dart';
 import 'package:opennutritracker/core/utils/hive_db_provider.dart';
 import 'package:sentry_flutter/sentry_flutter.dart';
 
-/// Wipes every Hive box the app owns, returning the device to a
-/// fresh-install state. Used by the Settings "delete all my data" tile.
+/// Wipes the **active profile's** data, returning that profile to a
+/// fresh, un-onboarded state. Used by the Settings "delete all my data"
+/// tile. Other profiles and the shared Open Food Facts cache are left
+/// untouched — clearing the cache would needlessly slow down food lookups
+/// for everyone else sharing the device.
 ///
-/// After this completes, `UserDataSource.hasUserData()` returns false,
-/// so the next launch (or the explicit navigation back to the onboarding
-/// route the caller performs) will land on the onboarding flow.
+/// After this completes, `UserDataSource.hasUserData()` returns false for
+/// the active profile, so the next launch (or the explicit navigation back
+/// to the onboarding route the caller performs) will land on onboarding.
 class DeleteAllUserDataUsecase {
   final _log = Logger('DeleteAllUserDataUsecase');
   final HiveDBProvider _hiveDBProvider;
@@ -15,26 +18,26 @@ class DeleteAllUserDataUsecase {
   DeleteAllUserDataUsecase(this._hiveDBProvider);
 
   Future<void> deleteAll() async {
-    _log.info('Clearing all Hive boxes on user request');
+    _log.info('Clearing the active profile\'s Hive boxes on user request');
 
     // Closing Sentry first stops any in-flight queue from referencing
     // boxes mid-clear. The user can re-enable crash reporting later from
     // Settings; nothing here re-opens the SDK on its own.
     await Sentry.close();
 
+    // Only the active profile's own data is cleared. The shared content
+    // libraries (custom meals, recipes, activity templates) and the shared
+    // app settings belong to every profile, so they're deliberately left
+    // alone — wiping them here would take them from the other profiles too.
     await Future.wait([
       _hiveDBProvider.configBox.clear(),
       _hiveDBProvider.intakeBox.clear(),
       _hiveDBProvider.userActivityBox.clear(),
       _hiveDBProvider.userBox.clear(),
       _hiveDBProvider.trackedDayBox.clear(),
-      _hiveDBProvider.customMealBox.clear(),
-      _hiveDBProvider.recipeBox.clear(),
-      _hiveDBProvider.cachedOffMealBox.clear(),
-      _hiveDBProvider.cachedOffMealTimestampsBox.clear(),
-      _hiveDBProvider.customActivityTemplateBox.clear(),
       _hiveDBProvider.weightLogBox.clear(),
       _hiveDBProvider.waterIntakeBox.clear(),
+      _hiveDBProvider.fastingBox.clear(),
     ]);
   }
 }

--- a/lib/core/domain/usecase/delete_profile_usecase.dart
+++ b/lib/core/domain/usecase/delete_profile_usecase.dart
@@ -1,0 +1,41 @@
+import 'package:opennutritracker/core/data/repository/profile_repository.dart';
+import 'package:opennutritracker/core/domain/entity/profile_entity.dart';
+import 'package:opennutritracker/core/domain/usecase/switch_profile_usecase.dart';
+import 'package:opennutritracker/core/utils/hive_db_provider.dart';
+import 'package:opennutritracker/core/utils/user_image_storage.dart';
+
+class DeleteProfileUsecase {
+  final ProfileRepository _profileRepository;
+  final HiveDBProvider _hiveDBProvider;
+  final SwitchProfileUsecase _switchProfileUsecase;
+
+  DeleteProfileUsecase(
+    this._profileRepository,
+    this._hiveDBProvider,
+    this._switchProfileUsecase,
+  );
+
+  /// Removes [profile] and its entire box-set from disk.
+  ///
+  /// Refuses to delete the last remaining profile. If the profile being
+  /// deleted is the active one, switches to another first so its boxes are
+  /// closed before they are dropped — Hive cannot delete an open box.
+  Future<void> deleteProfile(ProfileEntity profile) async {
+    final all = _profileRepository.getAllProfiles();
+    if (all.length <= 1) {
+      throw StateError('Cannot delete the last remaining profile.');
+    }
+
+    if (_hiveDBProvider.activeProfileId == profile.id) {
+      final fallback = all.firstWhere((p) => p.id != profile.id);
+      await _switchProfileUsecase.switchProfile(fallback);
+    }
+
+    await _hiveDBProvider.deleteProfileBoxes(profile.boxSuffix);
+    final imagePath = profile.imagePath;
+    if (imagePath != null) {
+      await UserImageStorage.delete(imagePath);
+    }
+    await _profileRepository.deleteProfile(profile.id);
+  }
+}

--- a/lib/core/domain/usecase/get_profiles_usecase.dart
+++ b/lib/core/domain/usecase/get_profiles_usecase.dart
@@ -1,0 +1,17 @@
+import 'package:opennutritracker/core/data/repository/profile_repository.dart';
+import 'package:opennutritracker/core/domain/entity/profile_entity.dart';
+import 'package:opennutritracker/core/utils/hive_db_provider.dart';
+
+class GetProfilesUsecase {
+  final ProfileRepository _profileRepository;
+  final HiveDBProvider _hiveDBProvider;
+
+  GetProfilesUsecase(this._profileRepository, this._hiveDBProvider);
+
+  List<ProfileEntity> getProfiles() => _profileRepository.getAllProfiles();
+
+  String get activeProfileId => _hiveDBProvider.activeProfileId;
+
+  ProfileEntity? getActiveProfile() =>
+      _profileRepository.getProfile(_hiveDBProvider.activeProfileId);
+}

--- a/lib/core/domain/usecase/send_intake_to_profiles_usecase.dart
+++ b/lib/core/domain/usecase/send_intake_to_profiles_usecase.dart
@@ -1,0 +1,122 @@
+import 'package:opennutritracker/core/data/data_source/config_data_source.dart';
+import 'package:opennutritracker/core/data/data_source/intake_data_source.dart';
+import 'package:opennutritracker/core/data/data_source/tracked_day_data_source.dart';
+import 'package:opennutritracker/core/data/data_source/user_activity_data_source.dart';
+import 'package:opennutritracker/core/data/data_source/user_data_source.dart';
+import 'package:opennutritracker/core/data/dbo/config_dbo.dart';
+import 'package:opennutritracker/core/data/data_source/user_activity_dbo.dart';
+import 'package:opennutritracker/core/data/dbo/intake_dbo.dart';
+import 'package:opennutritracker/core/data/dbo/tracked_day_dbo.dart';
+import 'package:opennutritracker/core/data/dbo/user_dbo.dart';
+import 'package:opennutritracker/core/data/repository/config_repository.dart';
+import 'package:opennutritracker/core/data/repository/intake_repository.dart';
+import 'package:opennutritracker/core/data/repository/tracked_day_repository.dart';
+import 'package:opennutritracker/core/data/repository/user_activity_repository.dart';
+import 'package:opennutritracker/core/data/repository/user_repository.dart';
+import 'package:opennutritracker/core/domain/entity/intake_entity.dart';
+import 'package:opennutritracker/core/domain/entity/profile_entity.dart';
+import 'package:opennutritracker/core/domain/usecase/add_tracked_day_usecase.dart';
+import 'package:opennutritracker/core/domain/usecase/get_kcal_goal_usecase.dart';
+import 'package:opennutritracker/core/domain/usecase/get_macro_goal_usecase.dart';
+import 'package:opennutritracker/core/utils/hive_db_provider.dart';
+import 'package:opennutritracker/core/utils/id_generator.dart';
+import 'package:opennutritracker/core/utils/scoped_hive_db_provider.dart';
+
+/// Copies logged intakes into one or more *other* profiles.
+///
+/// Each target profile keeps its own isolated box-set, so this opens the
+/// target's boxes scoped (without making it active) and reuses the normal
+/// add-intake + update-tracked-day flow against them. The intake is
+/// duplicated with a fresh id; the source profile keeps its own copy.
+class SendIntakeToProfilesUsecase {
+  final HiveDBProvider _hiveDBProvider;
+
+  SendIntakeToProfilesUsecase(this._hiveDBProvider);
+
+  Future<void> copyToProfiles(
+    List<IntakeEntity> intakes,
+    List<ProfileEntity> targetProfiles,
+  ) async {
+    for (final target in targetProfiles) {
+      await _copyToProfile(intakes, target);
+    }
+  }
+
+  Future<void> _copyToProfile(
+    List<IntakeEntity> intakes,
+    ProfileEntity target,
+  ) async {
+    final suffix = target.boxSuffix;
+    final scoped = ScopedHiveDBProvider(
+      intakeBox: await _hiveDBProvider.openScopedBox<IntakeDBO>(
+        HiveDBProvider.intakeBoxName,
+        suffix,
+      ),
+      trackedDayBox: await _hiveDBProvider.openScopedBox<TrackedDayDBO>(
+        HiveDBProvider.trackedDayBoxName,
+        suffix,
+      ),
+      userBox: await _hiveDBProvider.openScopedBox<UserDBO>(
+        HiveDBProvider.userBoxName,
+        suffix,
+      ),
+      configBox: await _hiveDBProvider.openScopedBox<ConfigDBO>(
+        HiveDBProvider.configBoxName,
+        suffix,
+      ),
+      userActivityBox: await _hiveDBProvider.openScopedBox<UserActivityDBO>(
+        HiveDBProvider.userActivityBoxName,
+        suffix,
+      ),
+      // App config is shared, so the goal calc reads the same global box.
+      appConfigBox: _hiveDBProvider.appConfigBox,
+    );
+
+    final userRepository = UserRepository(UserDataSource(scoped));
+    // A profile that hasn't finished onboarding has no user data and no
+    // goals to seed a tracked day with — skip it rather than guess.
+    if (!await userRepository.hasUserData()) return;
+
+    final intakeRepository = IntakeRepository(IntakeDataSource(scoped));
+    final addTrackedDay =
+        AddTrackedDayUsecase(TrackedDayRepository(TrackedDayDataSource(scoped)));
+    final configRepository = ConfigRepository(ConfigDataSource(scoped));
+    final getKcalGoal = GetKcalGoalUsecase(
+      userRepository,
+      configRepository,
+      UserActivityRepository(UserActivityDataSource(scoped)),
+    );
+    final getMacroGoal = GetMacroGoalUsecase(configRepository);
+
+    for (final intake in intakes) {
+      final copy = IntakeEntity(
+        id: IdGenerator.getUniqueID(),
+        unit: intake.unit,
+        amount: intake.amount,
+        type: intake.type,
+        meal: intake.meal,
+        dateTime: intake.dateTime,
+      );
+      await intakeRepository.addIntake(copy);
+
+      final day = copy.dateTime;
+      if (!await addTrackedDay.hasTrackedDay(day)) {
+        final kcalGoal = await getKcalGoal.getKcalGoal();
+        await addTrackedDay.addNewTrackedDay(
+          day,
+          kcalGoal,
+          await getMacroGoal.getCarbsGoal(kcalGoal),
+          await getMacroGoal.getFatsGoal(kcalGoal),
+          await getMacroGoal.getProteinsGoal(kcalGoal),
+        );
+      }
+      await addTrackedDay.addDayCaloriesTracked(day, copy.totalKcal);
+      await addTrackedDay.addDayMacrosTracked(
+        day,
+        carbsTracked: copy.totalCarbsGram,
+        fatTracked: copy.totalFatsGram,
+        proteinTracked: copy.totalProteinsGram,
+      );
+    }
+  }
+}

--- a/lib/core/domain/usecase/switch_profile_usecase.dart
+++ b/lib/core/domain/usecase/switch_profile_usecase.dart
@@ -1,0 +1,29 @@
+import 'package:opennutritracker/core/data/data_source/config_data_source.dart';
+import 'package:opennutritracker/core/domain/entity/profile_entity.dart';
+import 'package:opennutritracker/core/utils/config_initializer.dart';
+import 'package:opennutritracker/core/utils/hive_db_provider.dart';
+import 'package:opennutritracker/core/utils/secure_app_storage_provider.dart';
+
+/// Makes [profile] the active profile: swaps the open box-set, persists
+/// the active pointer, and seeds the target's config if it's brand new.
+///
+/// This is the data-layer half of a switch. Reloading the on-screen BLoCs
+/// and routing the user belong to the presentation layer
+/// (`ProfileSwitchCoordinator`).
+class SwitchProfileUsecase {
+  final HiveDBProvider _hiveDBProvider;
+  final SecureAppStorageProvider _secureAppStorageProvider;
+  final ConfigDataSource _configDataSource;
+
+  SwitchProfileUsecase(
+    this._hiveDBProvider,
+    this._secureAppStorageProvider,
+    this._configDataSource,
+  );
+
+  Future<void> switchProfile(ProfileEntity profile) async {
+    await _hiveDBProvider.switchProfile(profile.id, profile.boxSuffix);
+    await _secureAppStorageProvider.setActiveProfileId(profile.id);
+    await ensureConfigInitialized(_configDataSource);
+  }
+}

--- a/lib/core/domain/usecase/update_profile_usecase.dart
+++ b/lib/core/domain/usecase/update_profile_usecase.dart
@@ -1,0 +1,12 @@
+import 'package:opennutritracker/core/data/repository/profile_repository.dart';
+import 'package:opennutritracker/core/domain/entity/profile_entity.dart';
+
+class UpdateProfileUsecase {
+  final ProfileRepository _profileRepository;
+
+  UpdateProfileUsecase(this._profileRepository);
+
+  Future<void> updateProfile(ProfileEntity profile) async {
+    await _profileRepository.saveProfile(profile);
+  }
+}

--- a/lib/core/presentation/widgets/activity_vertial_list.dart
+++ b/lib/core/presentation/widgets/activity_vertial_list.dart
@@ -120,6 +120,7 @@ class _ActivityVerticalListState extends State<ActivityVerticalList> {
                   day: widget.day,
                   onTap: () => _onPlaceholderCardTapped(context),
                   firstListElement: firstListElement,
+                  semanticIdentifier: 'add-activity-placeholder',
                 );
               } else {
                 final userActivity = widget.userActivityList[index];

--- a/lib/core/presentation/widgets/copy_to_profile_sheet.dart
+++ b/lib/core/presentation/widgets/copy_to_profile_sheet.dart
@@ -1,0 +1,128 @@
+import 'package:flutter/material.dart';
+import 'package:opennutritracker/core/domain/entity/intake_entity.dart';
+import 'package:opennutritracker/core/domain/entity/profile_entity.dart';
+import 'package:opennutritracker/core/domain/usecase/get_profiles_usecase.dart';
+import 'package:opennutritracker/core/domain/usecase/send_intake_to_profiles_usecase.dart';
+import 'package:opennutritracker/core/utils/locator.dart';
+import 'package:opennutritracker/features/profile/presentation/utils/profile_display_name.dart';
+import 'package:opennutritracker/features/profile/presentation/widgets/profile_avatar.dart';
+import 'package:opennutritracker/generated/l10n.dart';
+
+/// Bottom sheet that lets the user pick one or more *other* profiles and
+/// copy the given intakes into each. Only profiles other than the active
+/// one are listed. Shows a confirmation snackbar on the calling screen.
+Future<void> showCopyToProfileSheet(
+  BuildContext context,
+  List<IntakeEntity> intakes,
+) async {
+  final getProfiles = locator<GetProfilesUsecase>();
+  final activeId = getProfiles.activeProfileId;
+  final otherProfiles =
+      getProfiles.getProfiles().where((p) => p.id != activeId).toList();
+  if (otherProfiles.isEmpty) return;
+
+  final messenger = ScaffoldMessenger.of(context);
+  final copiedSnackbar = S.of(context).copiedToProfileSnackbar;
+  final copied = await showModalBottomSheet<bool>(
+    context: context,
+    showDragHandle: true,
+    isScrollControlled: true,
+    builder: (sheetContext) =>
+        _CopyToProfileSheet(intakes: intakes, otherProfiles: otherProfiles),
+  );
+
+  if (copied == true) {
+    messenger.showSnackBar(SnackBar(content: Text(copiedSnackbar)));
+  }
+}
+
+class _CopyToProfileSheet extends StatefulWidget {
+  final List<IntakeEntity> intakes;
+  final List<ProfileEntity> otherProfiles;
+
+  const _CopyToProfileSheet({
+    required this.intakes,
+    required this.otherProfiles,
+  });
+
+  @override
+  State<_CopyToProfileSheet> createState() => _CopyToProfileSheetState();
+}
+
+class _CopyToProfileSheetState extends State<_CopyToProfileSheet> {
+  final _selectedIds = <String>{};
+  bool _copying = false;
+
+  @override
+  Widget build(BuildContext context) {
+    final s = S.of(context);
+    return SafeArea(
+      child: Column(
+        mainAxisSize: MainAxisSize.min,
+        crossAxisAlignment: CrossAxisAlignment.stretch,
+        children: [
+          Padding(
+            padding: const EdgeInsets.fromLTRB(16, 0, 16, 8),
+            child: Text(
+              s.copyToProfileLabel,
+              style: Theme.of(context).textTheme.titleLarge,
+            ),
+          ),
+          Flexible(
+            child: ListView(
+              shrinkWrap: true,
+              children: [
+                for (final profile in widget.otherProfiles)
+                  Semantics(
+                    identifier: 'copy-to-profile-item',
+                    child: CheckboxListTile(
+                      value: _selectedIds.contains(profile.id),
+                      onChanged: _copying
+                          ? null
+                          : (checked) => setState(() {
+                                if (checked == true) {
+                                  _selectedIds.add(profile.id);
+                                } else {
+                                  _selectedIds.remove(profile.id);
+                                }
+                              }),
+                      secondary: ProfileAvatar(profile: profile),
+                      title: Text(profileDisplayName(context, profile)),
+                    ),
+                  ),
+              ],
+            ),
+          ),
+          Padding(
+            padding: const EdgeInsets.all(16),
+            child: Semantics(
+              identifier: 'copy-to-profile-confirm',
+              child: FilledButton(
+                onPressed:
+                    _selectedIds.isEmpty || _copying ? null : _onConfirm,
+                child: _copying
+                    ? const SizedBox(
+                        height: 20,
+                        width: 20,
+                        child: CircularProgressIndicator(strokeWidth: 2),
+                      )
+                    : Text(s.copyActionLabel),
+              ),
+            ),
+          ),
+        ],
+      ),
+    );
+  }
+
+  Future<void> _onConfirm() async {
+    setState(() => _copying = true);
+    final targets = widget.otherProfiles
+        .where((p) => _selectedIds.contains(p.id))
+        .toList();
+    await locator<SendIntakeToProfilesUsecase>()
+        .copyToProfiles(widget.intakes, targets);
+    if (!mounted) return;
+    Navigator.of(context).pop(true);
+  }
+}

--- a/lib/core/presentation/widgets/placeholder_card.dart
+++ b/lib/core/presentation/widgets/placeholder_card.dart
@@ -5,11 +5,16 @@ class PlaceholderCard extends StatelessWidget {
   final VoidCallback onTap;
   final bool firstListElement;
 
+  /// Stable handle for UI drivers. Differs per list (meals vs activity) so
+  /// the right "add" card can be targeted unambiguously.
+  final String semanticIdentifier;
+
   const PlaceholderCard({
     super.key,
     required this.day,
     required this.onTap,
     required this.firstListElement,
+    required this.semanticIdentifier,
   });
 
   @override
@@ -29,14 +34,17 @@ class PlaceholderCard extends StatelessWidget {
               shape: RoundedRectangleBorder(
                 borderRadius: BorderRadius.circular(16.0),
               ),
-              child: InkWell(
-                onTap: onTap,
-                child: Icon(
-                  Icons.add,
-                  size: 36,
-                  color: Theme.of(
-                    context,
-                  ).colorScheme.onSurface.withValues(alpha: 0.5),
+              child: Semantics(
+                identifier: semanticIdentifier,
+                child: InkWell(
+                  onTap: onTap,
+                  child: Icon(
+                    Icons.add,
+                    size: 36,
+                    color: Theme.of(
+                      context,
+                    ).colorScheme.onSurface.withValues(alpha: 0.5),
+                  ),
                 ),
               ),
             ),

--- a/lib/core/presentation/widgets/share_qr_dialog.dart
+++ b/lib/core/presentation/widgets/share_qr_dialog.dart
@@ -13,11 +13,17 @@ class ShareQrDialog extends StatefulWidget {
   final String code;
   final String fileBaseName;
 
+  /// Optional "Copy to profile" action shown beneath the share buttons.
+  /// Only the meal-share flow supplies it (and only when more than one
+  /// profile exists); the dialog dismisses itself before invoking it.
+  final VoidCallback? onCopyToProfile;
+
   const ShareQrDialog({
     super.key,
     required this.title,
     required this.code,
     required this.fileBaseName,
+    this.onCopyToProfile,
   });
 
   @override
@@ -73,6 +79,20 @@ class _ShareQrDialogState extends State<ShareQrDialog> {
                 ),
               ],
             ),
+            if (widget.onCopyToProfile != null) ...[
+              const SizedBox(height: 8),
+              Semantics(
+                identifier: 'share-copy-to-profile',
+                child: OutlinedButton.icon(
+                  icon: const Icon(Icons.people_alt_outlined, size: 18),
+                  label: Text(S.of(context).copyToProfileLabel),
+                  onPressed: () {
+                    Navigator.of(context).pop();
+                    widget.onCopyToProfile!();
+                  },
+                ),
+              ),
+            ],
           ],
         ),
       ),

--- a/lib/core/presentation/widgets/user_image_picker_tile.dart
+++ b/lib/core/presentation/widgets/user_image_picker_tile.dart
@@ -36,11 +36,13 @@ class UserImagePickerTile extends StatelessWidget {
   IconData get _fallbackIcon => switch (kind) {
         UserImageKind.recipe => Icons.restaurant_menu,
         UserImageKind.meal => Icons.restaurant_outlined,
+        UserImageKind.profile => Icons.person_outline,
       };
 
   String get _semanticsIdentifier => switch (kind) {
         UserImageKind.recipe => 'recipe-builder-image-picker',
         UserImageKind.meal => 'edit-meal-image-picker',
+        UserImageKind.profile => 'profile-image-picker',
       };
 
   _Strings _stringsFor(BuildContext context) {
@@ -59,6 +61,13 @@ class UserImagePickerTile extends StatelessWidget {
           takePhoto: s.mealImageTakePhoto,
           pickFromGallery: s.mealImagePickFromGallery,
           remove: s.mealImageRemove,
+        ),
+      UserImageKind.profile => _Strings(
+          add: s.profileImageLabel,
+          replace: s.profileImageReplace,
+          takePhoto: s.mealImageTakePhoto,
+          pickFromGallery: s.mealImagePickFromGallery,
+          remove: s.profileImageRemove,
         ),
     };
   }

--- a/lib/core/utils/config_initializer.dart
+++ b/lib/core/utils/config_initializer.dart
@@ -1,0 +1,17 @@
+import 'package:opennutritracker/core/data/data_source/config_data_source.dart';
+
+/// Seeds an empty config with its defaults if it hasn't been seeded yet.
+///
+/// Runs at startup for the active profile and again whenever a new profile
+/// is created or switched to, since every profile owns its own ConfigBox
+/// and a freshly opened one starts empty. The `configInitialized` check
+/// keeps it idempotent, so calling it on an already-seeded profile is a
+/// cheap no-op.
+Future<void> ensureConfigInitialized(ConfigDataSource configDataSource) async {
+  // Carry an existing single-user install's settings into the shared app
+  // config before seeding any defaults.
+  await configDataSource.migrateAppConfigFromProfile();
+  if (!await configDataSource.configInitialized()) {
+    await configDataSource.initializeConfig();
+  }
+}

--- a/lib/core/utils/hive_db_provider.dart
+++ b/lib/core/utils/hive_db_provider.dart
@@ -8,6 +8,7 @@ import 'package:opennutritracker/core/data/dbo/config_dbo.dart';
 import 'package:opennutritracker/core/data/dbo/fasting_session_dbo.dart';
 import 'package:opennutritracker/core/data/dbo/intake_dbo.dart';
 import 'package:opennutritracker/core/data/dbo/meal_dbo.dart';
+import 'package:opennutritracker/core/data/dbo/profile_dbo.dart';
 import 'package:opennutritracker/core/data/dbo/recipe_dbo.dart';
 import 'package:opennutritracker/core/data/dbo/tracked_day_dbo.dart';
 import 'package:opennutritracker/core/data/dbo/user_dbo.dart';
@@ -15,6 +16,23 @@ import 'package:opennutritracker/core/data/dbo/water_intake_dbo.dart';
 import 'package:opennutritracker/core/data/dbo/weight_log_dbo.dart';
 import 'package:opennutritracker/hive_registrar.g.dart';
 
+/// Owns every Hive box the app uses.
+///
+/// Boxes fall into two groups. The **global** ones are shared across every
+/// profile: the Open Food Facts response cache, the profile registry, the
+/// app-wide settings (theme, language, units, notifications, ...), and the
+/// reusable content libraries (custom meals, recipes, activity templates).
+/// The **per-profile** ones are each profile's own private data — the meal,
+/// activity, weight, water and fasting logs, tracked-day totals, the user's
+/// body stats, and the personal nutrition goals in ConfigBox.
+///
+/// Per-profile boxes are named by appending the active profile's
+/// `boxSuffix`. The first profile carries an empty suffix, so it resolves
+/// to the original box names already on disk; that is what lets an
+/// existing user keep all their data untouched when they upgrade into a
+/// multi-profile build. Switching profiles closes the current set and
+/// opens the target's, so the per-profile getters always hand back the
+/// boxes belonging to whoever is active right now.
 class HiveDBProvider extends ChangeNotifier {
   static const configBoxName = 'ConfigBox';
   static const intakeBoxName = 'IntakeBox';
@@ -39,23 +57,103 @@ class HiveDBProvider extends ChangeNotifier {
   // intentionally keeps cancelled and completed sessions side by side with no
   // success/failure label on the record — see `FastingSessionDBO`.
   static const fastingBoxName = 'FastingBox';
+  // #471: registry of profiles. Global — shared across every profile so
+  // the app can enumerate and switch profiles before any one of them is
+  // active.
+  static const profileBoxName = 'ProfileBox';
+  // #471: app-wide settings shared across every profile (theme, language,
+  // units, notifications, anonymous-data consent, view preferences, ...).
+  // Only the genuinely personal nutrition goals live in the per-profile
+  // ConfigBox; everything else is read from here.
+  static const appConfigBoxName = 'AppConfigBox';
 
-  late Box<ConfigDBO> configBox;
-  late Box<IntakeDBO> intakeBox;
-  late Box<UserActivityDBO> userActivityBox;
-  late Box<UserDBO> userBox;
-  late Box<TrackedDayDBO> trackedDayBox;
-  late Box<MealDBO> customMealBox;
-  late Box<RecipeDBO> recipeBox;
-  late Box<MealDBO> cachedOffMealBox;
-  late Box<int> cachedOffMealTimestampsBox;
-  late Box<CustomActivityTemplateDBO> customActivityTemplateBox;
-  late Box<WeightLogDBO> weightLogBox;
-  late Box<WaterIntakeDBO> waterIntakeBox;
-  late Box<FastingSessionDBO> fastingBox;
+  // The base names of every per-profile box, used when opening, closing,
+  // or deleting a profile's box-set. The custom-meal, recipe and
+  // activity-template libraries are deliberately NOT here — they are shared
+  // content (see the global boxes below), not per-profile data.
+  static const perProfileBoxNames = <String>[
+    configBoxName,
+    intakeBoxName,
+    userActivityBoxName,
+    userBoxName,
+    trackedDayBoxName,
+    weightLogBoxName,
+    waterIntakeBoxName,
+    fastingBoxName,
+  ];
 
+  // Global boxes — opened once, never closed on a profile switch.
+  late final Box<MealDBO> cachedOffMealBox;
+  late final Box<int> cachedOffMealTimestampsBox;
+  late final Box<ProfileDBO> profileBox;
+  // Backed by a getter so a scoped provider (cross-profile writes) can point
+  // it at the real shared box without going through initHiveDB.
+  late final Box<ConfigDBO> _appConfigBox;
+  Box<ConfigDBO> get appConfigBox => _appConfigBox;
+  // Shared content libraries — reusable definitions, not personal logs, so
+  // every profile draws from the same set.
+  late final Box<MealDBO> customMealBox;
+  late final Box<RecipeDBO> recipeBox;
+  late final Box<CustomActivityTemplateDBO> customActivityTemplateBox;
+
+  // Per-profile boxes. Nullable rather than `late` so that a read during
+  // the brief close/open window of a profile switch throws a descriptive
+  // error through `_requireBox` instead of Hive's opaque closed-box error.
+  Box<ConfigDBO>? _configBox;
+  Box<IntakeDBO>? _intakeBox;
+  Box<UserActivityDBO>? _userActivityBox;
+  Box<UserDBO>? _userBox;
+  Box<TrackedDayDBO>? _trackedDayBox;
+  Box<WeightLogDBO>? _weightLogBox;
+  Box<WaterIntakeDBO>? _waterIntakeBox;
+  Box<FastingSessionDBO>? _fastingBox;
+
+  late final HiveAesCipher _cipher;
+  String _activeProfileId = '';
+  String _activeBoxSuffix = '';
+  bool _switching = false;
+
+  String get activeProfileId => _activeProfileId;
+
+  Box<ConfigDBO> get configBox => _requireBox(_configBox, configBoxName);
+  Box<IntakeDBO> get intakeBox => _requireBox(_intakeBox, intakeBoxName);
+  Box<UserActivityDBO> get userActivityBox =>
+      _requireBox(_userActivityBox, userActivityBoxName);
+  Box<UserDBO> get userBox => _requireBox(_userBox, userBoxName);
+  Box<TrackedDayDBO> get trackedDayBox =>
+      _requireBox(_trackedDayBox, trackedDayBoxName);
+  Box<WeightLogDBO> get weightLogBox =>
+      _requireBox(_weightLogBox, weightLogBoxName);
+  Box<WaterIntakeDBO> get waterIntakeBox =>
+      _requireBox(_waterIntakeBox, waterIntakeBoxName);
+  Box<FastingSessionDBO> get fastingBox =>
+      _requireBox(_fastingBox, fastingBoxName);
+
+  Box<T> _requireBox<T>(Box<T>? box, String name) {
+    if (_switching) {
+      throw StateError(
+        'Tried to read "$name" while a profile switch was in progress.',
+      );
+    }
+    if (box == null) {
+      throw StateError(
+        'Tried to read "$name" before any profile box-set was opened.',
+      );
+    }
+    return box;
+  }
+
+  /// Resolves a per-profile box name for a given profile suffix. The
+  /// default profile (`suffix == ''`) keeps the legacy unsuffixed name.
+  static String boxNameFor(String base, String suffix) =>
+      suffix.isEmpty ? base : '${base}_$suffix';
+
+  /// Opens the global boxes and registers all adapters. Per-profile
+  /// boxes are opened separately via [openProfileBoxes] once the caller
+  /// (the locator's startup migration) has decided which profile is
+  /// active.
   Future<void> initHiveDB(Uint8List encryptionKey) async {
-    final encryptionCypher = HiveAesCipher(encryptionKey);
+    _cipher = HiveAesCipher(encryptionKey);
     await Hive.initFlutter();
     // Delegate to the generated registrar so any new DBO type added to
     // the project is registered automatically on the next `just build`.
@@ -65,58 +163,137 @@ class HiveDBProvider extends ChangeNotifier {
     // swallowed silently. Result: profile reset to null on app relaunch.
     Hive.registerAdapters();
 
-    configBox = await Hive.openBox(
-      configBoxName,
-      encryptionCipher: encryptionCypher,
-    );
-    intakeBox = await Hive.openBox(
-      intakeBoxName,
-      encryptionCipher: encryptionCypher,
-    );
-    userActivityBox = await Hive.openBox(
-      userActivityBoxName,
-      encryptionCipher: encryptionCypher,
-    );
-    userBox = await Hive.openBox(
-      userBoxName,
-      encryptionCipher: encryptionCypher,
-    );
-    trackedDayBox = await Hive.openBox(
-      trackedDayBoxName,
-      encryptionCipher: encryptionCypher,
-    );
-    customMealBox = await Hive.openBox(
-      customMealBoxName,
-      encryptionCipher: encryptionCypher,
-    );
-    recipeBox = await Hive.openBox(
-      recipeBoxName,
-      encryptionCipher: encryptionCypher,
+    profileBox = await Hive.openBox(
+      profileBoxName,
+      encryptionCipher: _cipher,
     );
     cachedOffMealBox = await Hive.openBox(
       cachedOffMealBoxName,
-      encryptionCipher: encryptionCypher,
+      encryptionCipher: _cipher,
     );
     cachedOffMealTimestampsBox = await Hive.openBox(
       cachedOffMealTimestampsBoxName,
-      encryptionCipher: encryptionCypher,
+      encryptionCipher: _cipher,
+    );
+    _appConfigBox = await Hive.openBox(
+      appConfigBoxName,
+      encryptionCipher: _cipher,
+    );
+    customMealBox = await Hive.openBox(
+      customMealBoxName,
+      encryptionCipher: _cipher,
+    );
+    recipeBox = await Hive.openBox(
+      recipeBoxName,
+      encryptionCipher: _cipher,
     );
     customActivityTemplateBox = await Hive.openBox(
       customActivityTemplateBoxName,
-      encryptionCipher: encryptionCypher,
+      encryptionCipher: _cipher,
     );
-    weightLogBox = await Hive.openBox(
-      weightLogBoxName,
-      encryptionCipher: encryptionCypher,
+  }
+
+  /// Opens the per-profile box-set for [profileId] / [boxSuffix] and
+  /// marks it active. Used once at startup for the active profile.
+  Future<void> openProfileBoxes(String profileId, String boxSuffix) async {
+    _activeProfileId = profileId;
+    _activeBoxSuffix = boxSuffix;
+    await _openActiveProfileBoxes();
+  }
+
+  /// Closes the current profile's box-set and opens [profileId]'s. The
+  /// `_switching` guard makes any racing read fail loudly rather than
+  /// hitting a half-open box.
+  Future<void> switchProfile(String profileId, String boxSuffix) async {
+    if (profileId == _activeProfileId) return;
+    _switching = true;
+    try {
+      await _closeActiveProfileBoxes();
+      _activeProfileId = profileId;
+      _activeBoxSuffix = boxSuffix;
+      await _openActiveProfileBoxes();
+    } finally {
+      _switching = false;
+    }
+    notifyListeners();
+  }
+
+  Future<void> _openActiveProfileBoxes() async {
+    final suffix = _activeBoxSuffix;
+    _configBox = await Hive.openBox(
+      boxNameFor(configBoxName, suffix),
+      encryptionCipher: _cipher,
     );
-    waterIntakeBox = await Hive.openBox(
-      waterIntakeBoxName,
-      encryptionCipher: encryptionCypher,
+    _intakeBox = await Hive.openBox(
+      boxNameFor(intakeBoxName, suffix),
+      encryptionCipher: _cipher,
     );
-    fastingBox = await Hive.openBox(
-      fastingBoxName,
-      encryptionCipher: encryptionCypher,
+    _userActivityBox = await Hive.openBox(
+      boxNameFor(userActivityBoxName, suffix),
+      encryptionCipher: _cipher,
     );
+    _userBox = await Hive.openBox(
+      boxNameFor(userBoxName, suffix),
+      encryptionCipher: _cipher,
+    );
+    _trackedDayBox = await Hive.openBox(
+      boxNameFor(trackedDayBoxName, suffix),
+      encryptionCipher: _cipher,
+    );
+    _weightLogBox = await Hive.openBox(
+      boxNameFor(weightLogBoxName, suffix),
+      encryptionCipher: _cipher,
+    );
+    _waterIntakeBox = await Hive.openBox(
+      boxNameFor(waterIntakeBoxName, suffix),
+      encryptionCipher: _cipher,
+    );
+    _fastingBox = await Hive.openBox(
+      boxNameFor(fastingBoxName, suffix),
+      encryptionCipher: _cipher,
+    );
+  }
+
+  Future<void> _closeActiveProfileBoxes() async {
+    await Future.wait([
+      if (_configBox != null) _configBox!.close(),
+      if (_intakeBox != null) _intakeBox!.close(),
+      if (_userActivityBox != null) _userActivityBox!.close(),
+      if (_userBox != null) _userBox!.close(),
+      if (_trackedDayBox != null) _trackedDayBox!.close(),
+      if (_weightLogBox != null) _weightLogBox!.close(),
+      if (_waterIntakeBox != null) _waterIntakeBox!.close(),
+      if (_fastingBox != null) _fastingBox!.close(),
+    ]);
+    _configBox = null;
+    _intakeBox = null;
+    _userActivityBox = null;
+    _userBox = null;
+    _trackedDayBox = null;
+    _weightLogBox = null;
+    _waterIntakeBox = null;
+    _fastingBox = null;
+  }
+
+  /// Opens (or returns the already-open) box for an arbitrary profile
+  /// suffix, using the shared encryption cipher. Used to read/write a
+  /// profile other than the active one — e.g. copying a meal into another
+  /// profile — without disturbing the active box-set.
+  Future<Box<E>> openScopedBox<E>(String baseName, String boxSuffix) {
+    return Hive.openBox<E>(
+      boxNameFor(baseName, boxSuffix),
+      encryptionCipher: _cipher,
+    );
+  }
+
+  /// Permanently removes the box-set belonging to [boxSuffix] from disk.
+  /// The profile must not be active (close its boxes by switching away
+  /// first). The global cache and profile-registry boxes are never
+  /// touched here.
+  Future<void> deleteProfileBoxes(String boxSuffix) async {
+    for (final base in perProfileBoxNames) {
+      await Hive.deleteBoxFromDisk(boxNameFor(base, boxSuffix));
+    }
   }
 
   static List<int> generateNewHiveEncryptionKey() => Hive.generateSecureKey();

--- a/lib/core/utils/locator.dart
+++ b/lib/core/utils/locator.dart
@@ -7,6 +7,7 @@ import 'package:opennutritracker/core/data/data_source/custom_meal_data_source.d
 import 'package:opennutritracker/core/data/data_source/recipe_data_source.dart';
 import 'package:opennutritracker/core/data/data_source/intake_data_source.dart';
 import 'package:opennutritracker/core/data/data_source/physical_activity_data_source.dart';
+import 'package:opennutritracker/core/data/data_source/profile_data_source.dart';
 import 'package:opennutritracker/core/data/data_source/tracked_day_data_source.dart';
 import 'package:opennutritracker/core/data/data_source/user_activity_data_source.dart';
 import 'package:opennutritracker/core/data/data_source/user_data_source.dart';
@@ -16,6 +17,7 @@ import 'package:opennutritracker/core/data/repository/config_repository.dart';
 import 'package:opennutritracker/core/data/repository/custom_activity_template_repository.dart';
 import 'package:opennutritracker/core/data/repository/intake_repository.dart';
 import 'package:opennutritracker/core/data/repository/physical_activity_repository.dart';
+import 'package:opennutritracker/core/data/repository/profile_repository.dart';
 import 'package:opennutritracker/core/data/repository/recipe_repository.dart';
 import 'package:opennutritracker/core/data/repository/tracked_day_repository.dart';
 import 'package:opennutritracker/core/data/repository/user_activity_repository.dart';
@@ -31,7 +33,9 @@ import 'package:opennutritracker/core/domain/usecase/add_user_usecase.dart';
 import 'package:opennutritracker/core/domain/usecase/add_water_intake_usecase.dart';
 import 'package:opennutritracker/core/domain/usecase/add_weight_log_usecase.dart';
 import 'package:opennutritracker/core/domain/usecase/compute_recipe_nutrition_usecase.dart';
+import 'package:opennutritracker/core/domain/usecase/create_profile_usecase.dart';
 import 'package:opennutritracker/core/domain/usecase/delete_all_user_data_usecase.dart';
+import 'package:opennutritracker/core/domain/usecase/delete_profile_usecase.dart';
 import 'package:opennutritracker/core/domain/usecase/delete_custom_activity_template_usecase.dart';
 import 'package:opennutritracker/core/domain/usecase/delete_intake_usecase.dart';
 import 'package:opennutritracker/core/domain/usecase/delete_recipe_usecase.dart';
@@ -46,6 +50,7 @@ import 'package:opennutritracker/core/domain/usecase/get_intake_usecase.dart';
 import 'package:opennutritracker/core/domain/usecase/get_kcal_goal_usecase.dart';
 import 'package:opennutritracker/core/domain/usecase/get_macro_goal_usecase.dart';
 import 'package:opennutritracker/core/domain/usecase/get_physical_activity_usecase.dart';
+import 'package:opennutritracker/core/domain/usecase/get_profiles_usecase.dart';
 import 'package:opennutritracker/core/domain/usecase/get_recipe_by_id_usecase.dart';
 import 'package:opennutritracker/core/domain/usecase/get_tracked_day_usecase.dart';
 import 'package:opennutritracker/core/domain/usecase/get_user_activity_usecase.dart';
@@ -53,11 +58,16 @@ import 'package:opennutritracker/core/domain/usecase/get_user_usecase.dart';
 import 'package:opennutritracker/core/domain/usecase/get_water_intake_usecase.dart';
 import 'package:opennutritracker/core/domain/usecase/get_weight_log_usecase.dart';
 import 'package:opennutritracker/core/domain/usecase/save_recipe_usecase.dart';
+import 'package:opennutritracker/core/domain/usecase/send_intake_to_profiles_usecase.dart';
+import 'package:opennutritracker/core/domain/usecase/switch_profile_usecase.dart';
 import 'package:opennutritracker/core/domain/usecase/update_intake_usecase.dart';
+import 'package:opennutritracker/core/domain/usecase/update_profile_usecase.dart';
 import 'package:opennutritracker/core/domain/usecase/update_user_activity_usecase.dart';
+import 'package:opennutritracker/core/utils/config_initializer.dart';
 import 'package:opennutritracker/core/utils/env.dart';
 import 'package:opennutritracker/core/utils/hive_db_provider.dart';
 import 'package:opennutritracker/core/utils/notification_service.dart';
+import 'package:opennutritracker/core/utils/profile_bootstrap.dart';
 import 'package:opennutritracker/core/utils/ont_image_cache_manager.dart';
 import 'package:opennutritracker/core/utils/secure_app_storage_provider.dart';
 import 'package:opennutritracker/features/activity_detail/presentation/bloc/activity_detail_bloc.dart';
@@ -87,6 +97,7 @@ import 'package:opennutritracker/features/home/presentation/bloc/home_bloc.dart'
 import 'package:opennutritracker/features/meal_detail/presentation/bloc/meal_detail_bloc.dart';
 import 'package:opennutritracker/features/onboarding/presentation/bloc/onboarding_bloc.dart';
 import 'package:opennutritracker/features/profile/presentation/bloc/profile_bloc.dart';
+import 'package:opennutritracker/features/profile/presentation/utils/profile_switch_coordinator.dart';
 import 'package:opennutritracker/features/recipes/presentation/bloc/recipe_builder_bloc.dart';
 import 'package:opennutritracker/features/recipes/presentation/bloc/recipe_detail_bloc.dart';
 import 'package:opennutritracker/features/recipes/presentation/bloc/recipes_bloc.dart';
@@ -113,6 +124,12 @@ Future<void> initLocator() async {
   final hiveDBProvider = HiveDBProvider();
   await hiveDBProvider.initHiveDB(
     await secureAppStorageProvider.getHiveEncryptionKey(),
+  );
+  // Resolve the active profile and open its box-set (creating the default
+  // profile on first run) before anything reads per-profile data.
+  await bootstrapActiveProfile(hiveDBProvider, secureAppStorageProvider);
+  locator.registerLazySingleton<SecureAppStorageProvider>(
+    () => secureAppStorageProvider,
   );
   locator.registerLazySingleton<HiveDBProvider>(() => hiveDBProvider);
   locator.registerLazySingleton<DeleteAllUserDataUsecase>(
@@ -282,6 +299,29 @@ Future<void> initLocator() async {
   locator.registerLazySingleton<AddUserUsecase>(
     () => AddUserUsecase(locator()),
   );
+
+  // Profiles (#471)
+  locator.registerLazySingleton<GetProfilesUsecase>(
+    () => GetProfilesUsecase(locator(), locator()),
+  );
+  locator.registerLazySingleton<CreateProfileUsecase>(
+    () => CreateProfileUsecase(locator()),
+  );
+  locator.registerLazySingleton<SwitchProfileUsecase>(
+    () => SwitchProfileUsecase(locator(), locator(), locator()),
+  );
+  locator.registerLazySingleton<UpdateProfileUsecase>(
+    () => UpdateProfileUsecase(locator()),
+  );
+  locator.registerLazySingleton<DeleteProfileUsecase>(
+    () => DeleteProfileUsecase(locator(), locator(), locator()),
+  );
+  locator.registerLazySingleton<SendIntakeToProfilesUsecase>(
+    () => SendIntakeToProfilesUsecase(locator()),
+  );
+  locator.registerLazySingleton<ProfileSwitchCoordinator>(
+    () => ProfileSwitchCoordinator(locator(), locator()),
+  );
   locator.registerLazySingleton<SearchProductsUseCase>(
     () => SearchProductsUseCase(
       locator(),
@@ -447,19 +487,23 @@ Future<void> initLocator() async {
   locator.registerLazySingleton<FastingRepository>(
     () => FastingRepository(locator()),
   );
+  locator.registerLazySingleton<ProfileRepository>(
+    () => ProfileRepository(locator()),
+  );
 
   // DataSources
-  locator.registerLazySingleton(
-    () => ConfigDataSource(hiveDBProvider.configBox),
-  );
+  // Per-profile data sources take the provider and resolve the *active*
+  // profile's box on each call (see HiveDBProvider). Only the OFF search
+  // cache is wired to the fixed global boxes.
+  locator.registerLazySingleton(() => ConfigDataSource(hiveDBProvider));
   locator.registerLazySingleton<UserDataSource>(
-    () => UserDataSource(hiveDBProvider.userBox),
+    () => UserDataSource(hiveDBProvider),
   );
   locator.registerLazySingleton<IntakeDataSource>(
-    () => IntakeDataSource(hiveDBProvider.intakeBox),
+    () => IntakeDataSource(hiveDBProvider),
   );
   locator.registerLazySingleton<UserActivityDataSource>(
-    () => UserActivityDataSource(hiveDBProvider.userActivityBox),
+    () => UserActivityDataSource(hiveDBProvider),
   );
   locator.registerLazySingleton<PhysicalActivityDataSource>(
     () => PhysicalActivityDataSource(),
@@ -467,21 +511,15 @@ Future<void> initLocator() async {
   locator.registerLazySingleton<OFFDataSource>(() => OFFDataSource());
   locator.registerLazySingleton<FDCDataSource>(() => FDCDataSource());
   locator.registerLazySingleton<SpFdcDataSource>(() => SpFdcDataSource());
-  locator.registerLazySingleton(
-    () => TrackedDayDataSource(hiveDBProvider.trackedDayBox),
-  );
+  locator.registerLazySingleton(() => TrackedDayDataSource(hiveDBProvider));
   locator.registerLazySingleton<WeightLogDataSource>(
-    () => WeightLogDataSource(hiveDBProvider.weightLogBox),
+    () => WeightLogDataSource(hiveDBProvider),
   );
   locator.registerLazySingleton<WaterIntakeDataSource>(
-    () => WaterIntakeDataSource(hiveDBProvider.waterIntakeBox),
+    () => WaterIntakeDataSource(hiveDBProvider),
   );
-  locator.registerLazySingleton(
-    () => CustomMealDataSource(hiveDBProvider.customMealBox),
-  );
-  locator.registerLazySingleton(
-    () => RecipeDataSource(hiveDBProvider.recipeBox),
-  );
+  locator.registerLazySingleton(() => CustomMealDataSource(hiveDBProvider));
+  locator.registerLazySingleton(() => RecipeDataSource(hiveDBProvider));
   locator.registerLazySingleton(
     () => RemoteSearchCacheDataSource(
       hiveDBProvider.cachedOffMealBox,
@@ -489,19 +527,14 @@ Future<void> initLocator() async {
     ),
   );
   locator.registerLazySingleton<CustomActivityTemplateDataSource>(
-    () => CustomActivityTemplateDataSource(
-      hiveDBProvider.customActivityTemplateBox,
-    ),
+    () => CustomActivityTemplateDataSource(hiveDBProvider),
   );
   locator.registerLazySingleton<FastingDataSource>(
-    () => FastingDataSource(hiveDBProvider.fastingBox),
+    () => FastingDataSource(hiveDBProvider),
+  );
+  locator.registerLazySingleton<ProfileDataSource>(
+    () => ProfileDataSource(hiveDBProvider),
   );
 
-  await _initializeConfig(locator());
-}
-
-Future<void> _initializeConfig(ConfigDataSource configDataSource) async {
-  if (!await configDataSource.configInitialized()) {
-    configDataSource.initializeConfig();
-  }
+  await ensureConfigInitialized(locator());
 }

--- a/lib/core/utils/navigation_options.dart
+++ b/lib/core/utils/navigation_options.dart
@@ -18,4 +18,5 @@ class NavigationOptions {
   static const weightHistoryRoute = "weightHistory";
   static const fastingRoute = "fasting";
   static const accentColourRoute = "accentColour";
+  static const manageProfilesRoute = "manageProfiles";
 }

--- a/lib/core/utils/profile_bootstrap.dart
+++ b/lib/core/utils/profile_bootstrap.dart
@@ -1,0 +1,55 @@
+import 'package:logging/logging.dart';
+import 'package:opennutritracker/core/data/dbo/profile_dbo.dart';
+import 'package:opennutritracker/core/utils/hive_db_provider.dart';
+import 'package:opennutritracker/core/utils/id_generator.dart';
+import 'package:opennutritracker/core/utils/secure_app_storage_provider.dart';
+
+final _log = Logger('ProfileBootstrap');
+
+/// Resolves which profile is active at startup and opens its box-set.
+///
+/// On a fresh install — or the first launch after upgrading from a
+/// single-user build — the registry is empty, so a default profile is
+/// created with an empty box suffix. That empty suffix is the whole trick:
+/// the default profile's boxes resolve to the original, unsuffixed names
+/// already sitting on disk, so a long-time user's meals, weight history and
+/// settings come across untouched, with nothing copied or migrated.
+///
+/// Must run after [HiveDBProvider.initHiveDB] (which opens the global
+/// profile registry) and before any per-profile data is read.
+Future<void> bootstrapActiveProfile(
+  HiveDBProvider hiveDBProvider,
+  SecureAppStorageProvider secureAppStorageProvider,
+) async {
+  final profileBox = hiveDBProvider.profileBox;
+
+  if (profileBox.isEmpty) {
+    _log.info('No profiles found — creating the default profile');
+    final id = IdGenerator.getUniqueID();
+    final defaultProfile = ProfileDBO(
+      id: id,
+      name: '',
+      createdAt: DateTime.now(),
+      boxSuffix: '',
+    );
+    await profileBox.put(id, defaultProfile);
+    await secureAppStorageProvider.setActiveProfileId(id);
+  }
+
+  var activeId = await secureAppStorageProvider.getActiveProfileId();
+  var activeProfile = activeId == null ? null : profileBox.get(activeId);
+
+  // Pointer dangles (profile deleted, storage cleared, downgrade): fall
+  // back to the first registered profile and repair the pointer.
+  if (activeProfile == null) {
+    activeProfile = profileBox.values.first;
+    activeId = activeProfile.id;
+    await secureAppStorageProvider.setActiveProfileId(activeId);
+    _log.info('Active profile pointer was stale — fell back to $activeId');
+  }
+
+  await hiveDBProvider.openProfileBoxes(
+    activeProfile.id,
+    activeProfile.boxSuffix,
+  );
+}

--- a/lib/core/utils/scoped_hive_db_provider.dart
+++ b/lib/core/utils/scoped_hive_db_provider.dart
@@ -1,0 +1,54 @@
+import 'package:hive_ce/hive.dart';
+import 'package:opennutritracker/core/data/data_source/user_activity_dbo.dart';
+import 'package:opennutritracker/core/data/dbo/config_dbo.dart';
+import 'package:opennutritracker/core/data/dbo/intake_dbo.dart';
+import 'package:opennutritracker/core/data/dbo/tracked_day_dbo.dart';
+import 'package:opennutritracker/core/data/dbo/user_dbo.dart';
+import 'package:opennutritracker/core/utils/hive_db_provider.dart';
+
+/// A [HiveDBProvider] that points the per-profile box getters at a
+/// *specific* profile's boxes rather than the active one. It lets the
+/// existing data sources / repositories / use cases run unchanged against
+/// another profile — used when copying a meal into a profile that isn't
+/// currently active.
+///
+/// Only the boxes needed for an intake copy (intake, tracked day, user,
+/// config, user activity) are wired up; touching any other box throws,
+/// which keeps callers honest about scope.
+class ScopedHiveDBProvider extends HiveDBProvider {
+  final Box<IntakeDBO> _intake;
+  final Box<TrackedDayDBO> _trackedDay;
+  final Box<UserDBO> _user;
+  final Box<ConfigDBO> _config;
+  final Box<UserActivityDBO> _userActivity;
+  // The shared app config is global, so it's the real box passed straight
+  // through — the per-profile [configBox] above only holds personal goals.
+  final Box<ConfigDBO> _appConfig;
+
+  ScopedHiveDBProvider({
+    required Box<IntakeDBO> intakeBox,
+    required Box<TrackedDayDBO> trackedDayBox,
+    required Box<UserDBO> userBox,
+    required Box<ConfigDBO> configBox,
+    required Box<UserActivityDBO> userActivityBox,
+    required Box<ConfigDBO> appConfigBox,
+  })  : _intake = intakeBox,
+        _trackedDay = trackedDayBox,
+        _user = userBox,
+        _config = configBox,
+        _userActivity = userActivityBox,
+        _appConfig = appConfigBox;
+
+  @override
+  Box<IntakeDBO> get intakeBox => _intake;
+  @override
+  Box<TrackedDayDBO> get trackedDayBox => _trackedDay;
+  @override
+  Box<UserDBO> get userBox => _user;
+  @override
+  Box<ConfigDBO> get configBox => _config;
+  @override
+  Box<UserActivityDBO> get userActivityBox => _userActivity;
+  @override
+  Box<ConfigDBO> get appConfigBox => _appConfig;
+}

--- a/lib/core/utils/secure_app_storage_provider.dart
+++ b/lib/core/utils/secure_app_storage_provider.dart
@@ -8,6 +8,12 @@ class SecureAppStorageProvider {
   static const _sharedPrefsName = "SharedPrefs";
   static const _hiveEncryptionTag = "HiveEncryptionTag";
 
+  // Pointer to the profile whose box-set is currently active. Lives in
+  // secure storage (not a Hive box) because it has to be read at the very
+  // start of boot, before any per-profile box is open, to decide which
+  // boxes to open in the first place.
+  static const _activeProfileTag = "ActiveProfileTag";
+
   static const _androidOptions = AndroidOptions(
     storageCipherAlgorithm: StorageCipherAlgorithm.AES_CBC_PKCS7Padding,
     sharedPreferencesName: _sharedPrefsName,
@@ -39,5 +45,13 @@ class SecureAppStorageProvider {
       );
     }
     return encryptionKey;
+  }
+
+  Future<String?> getActiveProfileId() async {
+    return _secureStorage.read(key: _activeProfileTag);
+  }
+
+  Future<void> setActiveProfileId(String profileId) async {
+    await _secureStorage.write(key: _activeProfileTag, value: profileId);
   }
 }

--- a/lib/core/utils/user_image_storage.dart
+++ b/lib/core/utils/user_image_storage.dart
@@ -15,7 +15,8 @@ import 'package:path_provider/path_provider.dart';
 /// meals — and the storage layer now reflects that distinction.
 enum UserImageKind {
   recipe('recipe_images'),
-  meal('meal_images');
+  meal('meal_images'),
+  profile('profile_images');
 
   const UserImageKind(this.subdir);
 

--- a/lib/features/fasting/data/data_source/fasting_data_source.dart
+++ b/lib/features/fasting/data/data_source/fasting_data_source.dart
@@ -1,15 +1,18 @@
 import 'package:hive_ce_flutter/hive_flutter.dart';
 import 'package:logging/logging.dart';
 import 'package:opennutritracker/core/data/dbo/fasting_session_dbo.dart';
+import 'package:opennutritracker/core/utils/hive_db_provider.dart';
 
 /// Stores fasting sessions keyed by session id. The data source intentionally
 /// makes no value-judgement about cancellation vs natural completion — both
 /// are simply timestamped on the same record.
 class FastingDataSource {
   final _log = Logger('FastingDataSource');
-  final Box<FastingSessionDBO> _box;
+  final HiveDBProvider _db;
 
-  FastingDataSource(this._box);
+  FastingDataSource(this._db);
+
+  Box<FastingSessionDBO> get _box => _db.fastingBox;
 
   Future<void> addSession(FastingSessionDBO session) async {
     _log.fine('Adding fasting session ${session.id}');

--- a/lib/features/home/presentation/widgets/intake_vertical_list.dart
+++ b/lib/features/home/presentation/widgets/intake_vertical_list.dart
@@ -2,7 +2,9 @@ import 'package:flutter/material.dart';
 import 'package:opennutritracker/core/data/repository/recipe_repository.dart';
 import 'package:opennutritracker/core/domain/entity/intake_entity.dart';
 import 'package:opennutritracker/core/domain/entity/tracked_day_entity.dart';
+import 'package:opennutritracker/core/domain/usecase/get_profiles_usecase.dart';
 import 'package:opennutritracker/core/presentation/widgets/copy_dialog.dart';
+import 'package:opennutritracker/core/presentation/widgets/copy_to_profile_sheet.dart';
 import 'package:opennutritracker/core/presentation/widgets/delete_all_dialog.dart';
 import 'package:opennutritracker/core/presentation/widgets/intake_card.dart';
 import 'package:opennutritracker/core/presentation/widgets/placeholder_card.dart';
@@ -167,7 +169,12 @@ class _IntakeVerticalListState extends State<IntakeVerticalList> {
                 ),
               if (widget.onSortTypeChanged != null && totalKcal > 0)
                 _buildSortMenu(context),
-              PopupMenuButton<VerticalListPopupMenuSelections>(
+              Semantics(
+                  identifier: 'intake-section-menu',
+                  // Tight bounds: without this the node inherits the flex
+                  // Row's full-width box and coordinate taps miss the button.
+                  container: true,
+                  child: PopupMenuButton<VerticalListPopupMenuSelections>(
                     onSelected:
                         (VerticalListPopupMenuSelections selection) async {
                       switch (selection) {
@@ -202,12 +209,23 @@ class _IntakeVerticalListState extends State<IntakeVerticalList> {
                               widget.intakeList,
                               recipeRepository: locator<RecipeRepository>(),
                             ).toJsonString();
+                            final hasOtherProfiles =
+                                locator<GetProfilesUsecase>()
+                                        .getProfiles()
+                                        .length >
+                                    1;
                             await showDialog(
                               context: context,
                               builder: (_) => ShareQrDialog(
                                 title: S.of(context).shareMealLabel,
                                 code: code,
                                 fileBaseName: 'meal_qr',
+                                onCopyToProfile: hasOtherProfiles
+                                    ? () => showCopyToProfileSheet(
+                                          context,
+                                          widget.intakeList,
+                                        )
+                                    : null,
                               ),
                             );
                           }
@@ -242,7 +260,7 @@ class _IntakeVerticalListState extends State<IntakeVerticalList> {
                           PopupMenuItem<VerticalListPopupMenuSelections>(
                               value: VerticalListPopupMenuSelections.onImport,
                               child: Text(S.of(context).importMealLabel)),
-                        ]),
+                        ])),
             ],
           ),
         ),
@@ -263,6 +281,7 @@ class _IntakeVerticalListState extends State<IntakeVerticalList> {
                       day: widget.day,
                       onTap: () => _onPlaceholderCardTapped(context),
                       firstListElement: true,
+                      semanticIdentifier: 'add-meal-placeholder',
                     );
                   }
                   final intakeEntity = widget.intakeList[index - 1];

--- a/lib/features/onboarding/onboarding_screen.dart
+++ b/lib/features/onboarding/onboarding_screen.dart
@@ -2,8 +2,12 @@ import 'package:flutter/material.dart';
 import 'package:flutter_bloc/flutter_bloc.dart';
 import 'package:introduction_screen/introduction_screen.dart';
 import 'package:opennutritracker/core/domain/entity/calories_profile_entity.dart';
+import 'package:opennutritracker/core/domain/entity/profile_entity.dart';
+import 'package:opennutritracker/core/domain/usecase/delete_profile_usecase.dart';
+import 'package:opennutritracker/core/domain/usecase/get_profiles_usecase.dart';
 import 'package:opennutritracker/core/utils/locator.dart';
 import 'package:opennutritracker/core/utils/navigation_options.dart';
+import 'package:opennutritracker/features/profile/presentation/utils/profile_switch_coordinator.dart';
 import 'package:opennutritracker/features/onboarding/domain/entity/user_activity_selection_entity.dart';
 import 'package:opennutritracker/features/onboarding/domain/entity/user_gender_selection_entity.dart';
 import 'package:opennutritracker/features/onboarding/domain/entity/user_goal_selection_entity.dart';
@@ -51,7 +55,14 @@ class _OnboardingScreenState extends State<OnboardingScreen> {
 
   @override
   Widget build(BuildContext context) {
-    return Scaffold(
+    // When onboarding is reached by adding a new profile, the route carries
+    // the id of the profile to return to if the user backs out. First-run
+    // onboarding has no argument, so this stays null and back behaves as
+    // before (exits the app).
+    final cancelToProfileId =
+        ModalRoute.of(context)?.settings.arguments as String?;
+
+    final scaffold = Scaffold(
       body: SafeArea(
         child: BlocBuilder<OnboardingBloc, OnboardingState>(
           bloc: _onboardingBloc,
@@ -69,6 +80,44 @@ class _OnboardingScreenState extends State<OnboardingScreen> {
         ),
       ),
     );
+
+    if (cancelToProfileId == null) return scaffold;
+
+    return PopScope(
+      canPop: false,
+      onPopInvokedWithResult: (didPop, _) {
+        if (!didPop) _onCancelAddProfile(cancelToProfileId);
+      },
+      child: scaffold,
+    );
+  }
+
+  /// Backs out of onboarding for a freshly-added profile: deletes that
+  /// half-created profile and its boxes, then returns to the profile the
+  /// user came from. Keeps an abandoned add from stranding them on an
+  /// empty profile on the next launch.
+  Future<void> _onCancelAddProfile(String cancelToProfileId) async {
+    final getProfiles = locator<GetProfilesUsecase>();
+    final draft = getProfiles.getActiveProfile();
+    ProfileEntity? cancelTo;
+    for (final profile in getProfiles.getProfiles()) {
+      if (profile.id == cancelToProfileId) {
+        cancelTo = profile;
+        break;
+      }
+    }
+
+    if (draft != null && draft.id != cancelToProfileId) {
+      await locator<DeleteProfileUsecase>().deleteProfile(draft);
+    }
+    if (!mounted) return;
+
+    if (cancelTo != null) {
+      await locator<ProfileSwitchCoordinator>().switchTo(context, cancelTo);
+    } else {
+      ProfileSwitchCoordinator.reloadTabBlocs();
+      Navigator.pushReplacementNamed(context, NavigationOptions.mainRoute);
+    }
   }
 
   Widget _getLoadingContent() {
@@ -311,6 +360,11 @@ class _OnboardingScreenState extends State<OnboardingScreen> {
         usesImperialUnits,
       );
       if (!context.mounted) return;
+      // Onboarding can run for a profile added after the app has been in
+      // use, so the screen-persistent tab BLoCs may still hold the previous
+      // profile's data. Refresh them against the now-populated active
+      // profile before landing on the main screen.
+      ProfileSwitchCoordinator.reloadTabBlocs();
       Navigator.pushReplacementNamed(context, NavigationOptions.mainRoute);
     } else {
       // Error with user input

--- a/lib/features/profile/presentation/screens/manage_profiles_screen.dart
+++ b/lib/features/profile/presentation/screens/manage_profiles_screen.dart
@@ -1,0 +1,131 @@
+import 'package:flutter/material.dart';
+import 'package:opennutritracker/core/domain/entity/profile_entity.dart';
+import 'package:opennutritracker/core/domain/usecase/delete_profile_usecase.dart';
+import 'package:opennutritracker/core/domain/usecase/get_profiles_usecase.dart';
+import 'package:opennutritracker/core/utils/locator.dart';
+import 'package:opennutritracker/features/profile/presentation/screens/profile_editor_screen.dart';
+import 'package:opennutritracker/features/profile/presentation/utils/profile_display_name.dart';
+import 'package:opennutritracker/features/profile/presentation/utils/profile_switch_coordinator.dart';
+import 'package:opennutritracker/features/profile/presentation/widgets/profile_avatar.dart';
+import 'package:opennutritracker/features/profile/presentation/widgets/profile_switcher_sheet.dart';
+import 'package:opennutritracker/generated/l10n.dart';
+
+class ManageProfilesScreen extends StatefulWidget {
+  const ManageProfilesScreen({super.key});
+
+  @override
+  State<ManageProfilesScreen> createState() => _ManageProfilesScreenState();
+}
+
+class _ManageProfilesScreenState extends State<ManageProfilesScreen> {
+  late List<ProfileEntity> _profiles;
+  late String _activeId;
+
+  @override
+  void initState() {
+    super.initState();
+    _reload();
+  }
+
+  void _reload() {
+    final getProfiles = locator<GetProfilesUsecase>();
+    _profiles = getProfiles.getProfiles();
+    _activeId = getProfiles.activeProfileId;
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    final s = S.of(context);
+    return Scaffold(
+      appBar: AppBar(title: Text(s.manageProfilesLabel)),
+      floatingActionButton: Semantics(
+        identifier: 'manage-profiles-add',
+        child: FloatingActionButton.extended(
+          onPressed: () async {
+            await showAddProfileDialog(context);
+            if (mounted) setState(_reload);
+          },
+          icon: const Icon(Icons.add),
+          label: Text(s.addProfileLabel),
+        ),
+      ),
+      body: ListView(
+        children: [
+          for (final profile in _profiles)
+            ListTile(
+              leading: ProfileAvatar(profile: profile),
+              title: Text(profileDisplayName(context, profile)),
+              subtitle: profile.id == _activeId
+                  ? Text(s.profileActiveLabel)
+                  : null,
+              trailing: Row(
+                mainAxisSize: MainAxisSize.min,
+                children: [
+                  Semantics(
+                    identifier: 'manage-profiles-edit',
+                    child: IconButton(
+                      icon: const Icon(Icons.edit_outlined),
+                      onPressed: () => _onEdit(profile),
+                    ),
+                  ),
+                  if (_profiles.length > 1)
+                    Semantics(
+                      identifier: 'manage-profiles-delete',
+                      child: IconButton(
+                        icon: const Icon(Icons.delete_outline),
+                        onPressed: () => _onDelete(profile),
+                      ),
+                    ),
+                ],
+              ),
+            ),
+        ],
+      ),
+    );
+  }
+
+  Future<void> _onEdit(ProfileEntity profile) async {
+    final saved = await Navigator.of(context).push<bool>(
+      MaterialPageRoute(
+        builder: (_) => ProfileEditorScreen(profile: profile),
+      ),
+    );
+    if (saved == true && mounted) setState(_reload);
+  }
+
+  Future<void> _onDelete(ProfileEntity profile) async {
+    final s = S.of(context);
+    final confirmed = await showDialog<bool>(
+      context: context,
+      builder: (dialogContext) => AlertDialog(
+        title: Text(s.deleteProfileConfirmTitle),
+        content: Text(s.deleteProfileConfirmContent),
+        actions: [
+          TextButton(
+            onPressed: () => Navigator.of(dialogContext).pop(false),
+            child: Text(s.dialogCancelLabel),
+          ),
+          TextButton(
+            onPressed: () => Navigator.of(dialogContext).pop(true),
+            child: Text(s.dialogDeleteLabel),
+          ),
+        ],
+      ),
+    );
+    if (confirmed != true) return;
+
+    // Deleting the active profile switches to another first, which routes
+    // away from this screen — so let the coordinator take over and stop.
+    final wasActive = profile.id == _activeId;
+    await locator<DeleteProfileUsecase>().deleteProfile(profile);
+    if (!mounted) return;
+    if (wasActive) {
+      final fallback = locator<GetProfilesUsecase>().getActiveProfile();
+      if (fallback != null) {
+        await locator<ProfileSwitchCoordinator>().switchTo(context, fallback);
+        return;
+      }
+    }
+    setState(_reload);
+  }
+}

--- a/lib/features/profile/presentation/screens/profile_editor_screen.dart
+++ b/lib/features/profile/presentation/screens/profile_editor_screen.dart
@@ -1,0 +1,119 @@
+import 'dart:io';
+
+import 'package:flutter/material.dart';
+import 'package:image_picker/image_picker.dart';
+import 'package:opennutritracker/core/domain/entity/profile_entity.dart';
+import 'package:opennutritracker/core/domain/usecase/update_profile_usecase.dart';
+import 'package:opennutritracker/core/utils/locator.dart';
+import 'package:opennutritracker/core/utils/user_image_storage.dart';
+import 'package:opennutritracker/core/presentation/widgets/user_image_picker_tile.dart';
+import 'package:opennutritracker/generated/l10n.dart';
+
+/// Edits a single profile's name and picture. The picture is imported the
+/// moment it's picked (the profile already has an id to key the file by),
+/// mirroring the recipe builder's image flow.
+class ProfileEditorScreen extends StatefulWidget {
+  final ProfileEntity profile;
+
+  const ProfileEditorScreen({super.key, required this.profile});
+
+  @override
+  State<ProfileEditorScreen> createState() => _ProfileEditorScreenState();
+}
+
+class _ProfileEditorScreenState extends State<ProfileEditorScreen> {
+  late final TextEditingController _nameController;
+  late String? _imagePath;
+
+  @override
+  void initState() {
+    super.initState();
+    _nameController = TextEditingController(text: widget.profile.name);
+    _imagePath = widget.profile.imagePath;
+  }
+
+  @override
+  void dispose() {
+    _nameController.dispose();
+    super.dispose();
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    final s = S.of(context);
+    return Scaffold(
+      appBar: AppBar(
+        title: Text(s.editProfileTitle),
+        actions: [
+          Semantics(
+            identifier: 'profile-editor-save',
+            child: TextButton(
+              onPressed: _onSave,
+              child: Text(s.buttonSaveLabel),
+            ),
+          ),
+        ],
+      ),
+      body: ListView(
+        padding: const EdgeInsets.all(16),
+        children: [
+          Center(
+            child: UserImagePickerTile(
+              kind: UserImageKind.profile,
+              imagePath: _imagePath,
+              onPickFromGallery: () =>
+                  _onPickImage(source: ImageSource.gallery),
+              onTakePhoto: () => _onPickImage(source: ImageSource.camera),
+              onRemove: _onRemoveImage,
+            ),
+          ),
+          const SizedBox(height: 16),
+          Semantics(
+            identifier: 'profile-editor-name',
+            child: TextField(
+              controller: _nameController,
+              textCapitalization: TextCapitalization.words,
+              decoration: InputDecoration(
+                labelText: s.profileNameLabel,
+                hintText: s.profileNameHint,
+                border: const OutlineInputBorder(),
+              ),
+            ),
+          ),
+        ],
+      ),
+    );
+  }
+
+  Future<void> _onPickImage({required ImageSource source}) async {
+    final picked = await ImagePicker().pickImage(source: source);
+    if (picked == null) return;
+    final relative = await UserImageStorage.importFrom(
+      kind: UserImageKind.profile,
+      ownerId: widget.profile.id,
+      sourcePath: picked.path,
+    );
+    FileImage(File(await UserImageStorage.absolutePath(relative))).evict();
+    setState(() => _imagePath = relative);
+  }
+
+  Future<void> _onRemoveImage() async {
+    final current = _imagePath;
+    if (current == null) return;
+    await UserImageStorage.delete(current);
+    setState(() => _imagePath = null);
+  }
+
+  Future<void> _onSave() async {
+    final toSave = ProfileEntity(
+      id: widget.profile.id,
+      name: _nameController.text.trim(),
+      createdAt: widget.profile.createdAt,
+      boxSuffix: widget.profile.boxSuffix,
+      imagePath: _imagePath,
+    );
+    await locator<UpdateProfileUsecase>().updateProfile(toSave);
+    if (!mounted) return;
+    Navigator.of(context).pop(true);
+  }
+}

--- a/lib/features/profile/presentation/utils/profile_display_name.dart
+++ b/lib/features/profile/presentation/utils/profile_display_name.dart
@@ -1,0 +1,11 @@
+import 'package:flutter/widgets.dart';
+import 'package:opennutritracker/core/domain/entity/profile_entity.dart';
+import 'package:opennutritracker/generated/l10n.dart';
+
+/// The name to show for a profile. An unnamed profile (e.g. the default
+/// profile auto-created when an existing user upgrades) falls back to a
+/// localised placeholder rather than rendering blank.
+String profileDisplayName(BuildContext context, ProfileEntity profile) {
+  final name = profile.name.trim();
+  return name.isEmpty ? S.of(context).defaultProfileName : name;
+}

--- a/lib/features/profile/presentation/utils/profile_switch_coordinator.dart
+++ b/lib/features/profile/presentation/utils/profile_switch_coordinator.dart
@@ -1,0 +1,70 @@
+import 'package:flutter/material.dart';
+import 'package:opennutritracker/core/data/repository/user_repository.dart';
+import 'package:opennutritracker/core/domain/entity/profile_entity.dart';
+import 'package:opennutritracker/core/domain/usecase/get_profiles_usecase.dart';
+import 'package:opennutritracker/core/domain/usecase/switch_profile_usecase.dart';
+import 'package:opennutritracker/core/utils/locator.dart';
+import 'package:opennutritracker/core/utils/navigation_options.dart';
+import 'package:opennutritracker/features/diary/presentation/bloc/calendar_day_bloc.dart';
+import 'package:opennutritracker/features/diary/presentation/bloc/diary_bloc.dart';
+import 'package:opennutritracker/features/home/presentation/bloc/home_bloc.dart';
+import 'package:opennutritracker/features/profile/presentation/bloc/profile_bloc.dart';
+import 'package:opennutritracker/features/recipes/presentation/bloc/recipes_bloc.dart';
+import 'package:opennutritracker/features/settings/presentation/bloc/custom_meals_bloc.dart';
+import 'package:opennutritracker/features/settings/presentation/bloc/settings_bloc.dart';
+
+/// Owns the ordering of a profile switch so it lives in exactly one place:
+/// swap the open box-set first, then refresh the cached tab BLoCs, then
+/// route. The screen-persistent tab BLoCs are GetIt singletons that hold
+/// the outgoing profile's data, so each must be told to re-read once the
+/// new boxes are open.
+///
+/// Switching to a profile that hasn't finished onboarding (a freshly
+/// created one) routes to onboarding instead and skips the reload — those
+/// BLoCs would throw reading a user that doesn't exist yet. Onboarding
+/// completion calls [reloadTabBlocs] itself before landing on main.
+class ProfileSwitchCoordinator {
+  final SwitchProfileUsecase _switchProfileUsecase;
+  final UserRepository _userRepository;
+
+  ProfileSwitchCoordinator(this._switchProfileUsecase, this._userRepository);
+
+  Future<void> switchTo(BuildContext context, ProfileEntity profile) async {
+    // Remember where we came from. If we end up routing into onboarding
+    // (the target has no user data yet — e.g. a just-added profile), this
+    // is the profile to fall back to if the user backs out before
+    // finishing, so they're never stranded on an empty profile.
+    final previousProfileId = locator<GetProfilesUsecase>().activeProfileId;
+
+    await _switchProfileUsecase.switchProfile(profile);
+    final hasUserData = await _userRepository.hasUserData();
+    if (!context.mounted) return;
+
+    if (hasUserData) {
+      reloadTabBlocs();
+      Navigator.of(context).pushNamedAndRemoveUntil(
+        NavigationOptions.mainRoute,
+        (route) => false,
+      );
+    } else {
+      Navigator.of(context).pushNamedAndRemoveUntil(
+        NavigationOptions.onboardingRoute,
+        (route) => false,
+        arguments: previousProfileId == profile.id ? null : previousProfileId,
+      );
+    }
+  }
+
+  /// Re-reads every screen-persistent tab BLoC against the now-active
+  /// profile's boxes. Safe to call only once the active profile has user
+  /// data (post-onboarding).
+  static void reloadTabBlocs() {
+    locator<HomeBloc>().add(const LoadItemsEvent());
+    locator<DiaryBloc>().add(const LoadDiaryYearEvent());
+    locator<CalendarDayBloc>().add(RefreshCalendarDayEvent());
+    locator<ProfileBloc>().add(LoadProfileEvent());
+    locator<RecipesBloc>().add(LoadRecipesEvent());
+    locator<CustomMealsBloc>().add(LoadCustomMealsEvent());
+    locator<SettingsBloc>().add(LoadSettingsEvent());
+  }
+}

--- a/lib/features/profile/presentation/widgets/profile_avatar.dart
+++ b/lib/features/profile/presentation/widgets/profile_avatar.dart
@@ -1,0 +1,52 @@
+import 'dart:io';
+
+import 'package:flutter/material.dart';
+import 'package:opennutritracker/core/domain/entity/profile_entity.dart';
+import 'package:opennutritracker/core/utils/user_image_storage.dart';
+
+/// Round avatar for a profile: shows the profile picture when one is set,
+/// otherwise the first letter of the name, falling back to a person icon
+/// for an unnamed profile.
+class ProfileAvatar extends StatelessWidget {
+  final ProfileEntity profile;
+  final double radius;
+
+  const ProfileAvatar({super.key, required this.profile, this.radius = 20});
+
+  @override
+  Widget build(BuildContext context) {
+    final theme = Theme.of(context);
+    final imagePath = profile.imagePath;
+
+    if (imagePath != null) {
+      return FutureBuilder<String>(
+        future: UserImageStorage.absolutePath(imagePath),
+        builder: (context, snapshot) {
+          if (!snapshot.hasData) {
+            return CircleAvatar(
+              radius: radius,
+              backgroundColor: theme.colorScheme.primaryContainer,
+            );
+          }
+          return CircleAvatar(
+            radius: radius,
+            backgroundColor: theme.colorScheme.primaryContainer,
+            backgroundImage: FileImage(File(snapshot.data!)),
+          );
+        },
+      );
+    }
+
+    return CircleAvatar(
+      radius: radius,
+      backgroundColor: theme.colorScheme.primaryContainer,
+      foregroundColor: theme.colorScheme.onPrimaryContainer,
+      child: profile.name.trim().isEmpty
+          ? Icon(Icons.person_outline, size: radius)
+          : Text(
+              profile.name.trim().characters.first.toUpperCase(),
+              style: TextStyle(fontSize: radius * 0.9),
+            ),
+    );
+  }
+}

--- a/lib/features/profile/presentation/widgets/profile_switcher_header.dart
+++ b/lib/features/profile/presentation/widgets/profile_switcher_header.dart
@@ -1,0 +1,34 @@
+import 'package:flutter/material.dart';
+import 'package:opennutritracker/core/domain/usecase/get_profiles_usecase.dart';
+import 'package:opennutritracker/core/utils/locator.dart';
+import 'package:opennutritracker/features/profile/presentation/utils/profile_display_name.dart';
+import 'package:opennutritracker/features/profile/presentation/widgets/profile_avatar.dart';
+import 'package:opennutritracker/features/profile/presentation/widgets/profile_switcher_sheet.dart';
+import 'package:opennutritracker/generated/l10n.dart';
+
+/// Tappable header at the top of the Profile tab showing who is active
+/// and opening the switcher sheet.
+class ProfileSwitcherHeader extends StatelessWidget {
+  const ProfileSwitcherHeader({super.key});
+
+  @override
+  Widget build(BuildContext context) {
+    final activeProfile = locator<GetProfilesUsecase>().getActiveProfile();
+    if (activeProfile == null) {
+      return const SizedBox.shrink();
+    }
+    return Semantics(
+      identifier: 'profile-switcher',
+      child: ListTile(
+        leading: ProfileAvatar(profile: activeProfile, radius: 24),
+        title: Text(
+          profileDisplayName(context, activeProfile),
+          style: Theme.of(context).textTheme.titleLarge,
+        ),
+        subtitle: Text(S.of(context).switchProfileLabel),
+        trailing: const Icon(Icons.unfold_more),
+        onTap: () => showProfileSwitcherSheet(context),
+      ),
+    );
+  }
+}

--- a/lib/features/profile/presentation/widgets/profile_switcher_sheet.dart
+++ b/lib/features/profile/presentation/widgets/profile_switcher_sheet.dart
@@ -1,0 +1,137 @@
+import 'package:flutter/material.dart';
+import 'package:opennutritracker/core/domain/usecase/create_profile_usecase.dart';
+import 'package:opennutritracker/core/domain/usecase/get_profiles_usecase.dart';
+import 'package:opennutritracker/core/utils/locator.dart';
+import 'package:opennutritracker/core/utils/navigation_options.dart';
+import 'package:opennutritracker/features/profile/presentation/utils/profile_display_name.dart';
+import 'package:opennutritracker/features/profile/presentation/utils/profile_switch_coordinator.dart';
+import 'package:opennutritracker/features/profile/presentation/widgets/profile_avatar.dart';
+import 'package:opennutritracker/generated/l10n.dart';
+
+/// Bottom sheet that lists every profile, switches to the tapped one, and
+/// offers shortcuts to add a profile or open the management screen.
+Future<void> showProfileSwitcherSheet(BuildContext pageContext) async {
+  await showModalBottomSheet<void>(
+    context: pageContext,
+    showDragHandle: true,
+    builder: (sheetContext) {
+      final getProfiles = locator<GetProfilesUsecase>();
+      final profiles = getProfiles.getProfiles();
+      final activeId = getProfiles.activeProfileId;
+      final s = S.of(sheetContext);
+
+      return SafeArea(
+        child: Column(
+          mainAxisSize: MainAxisSize.min,
+          crossAxisAlignment: CrossAxisAlignment.start,
+          children: [
+            Padding(
+              padding: const EdgeInsets.fromLTRB(16, 0, 16, 8),
+              child: Text(
+                s.switchProfileLabel,
+                style: Theme.of(sheetContext).textTheme.titleLarge,
+              ),
+            ),
+            Flexible(
+              child: ListView(
+                shrinkWrap: true,
+                children: [
+                  for (final profile in profiles)
+                    Semantics(
+                      identifier: 'profile-switcher-item',
+                      child: ListTile(
+                        leading: ProfileAvatar(profile: profile),
+                        title: Text(profileDisplayName(sheetContext, profile)),
+                        trailing: profile.id == activeId
+                            ? const Icon(Icons.check)
+                            : null,
+                        onTap: () {
+                          Navigator.of(sheetContext).pop();
+                          if (profile.id != activeId) {
+                            locator<ProfileSwitchCoordinator>()
+                                .switchTo(pageContext, profile);
+                          }
+                        },
+                      ),
+                    ),
+                ],
+              ),
+            ),
+            const Divider(),
+            Semantics(
+              identifier: 'profile-switcher-add',
+              child: ListTile(
+                leading: const Icon(Icons.add),
+                title: Text(s.addProfileLabel),
+                onTap: () {
+                  Navigator.of(sheetContext).pop();
+                  showAddProfileDialog(pageContext);
+                },
+              ),
+            ),
+            Semantics(
+              identifier: 'profile-switcher-manage',
+              child: ListTile(
+                leading: const Icon(Icons.manage_accounts_outlined),
+                title: Text(s.manageProfilesLabel),
+                onTap: () {
+                  Navigator.of(sheetContext).pop();
+                  Navigator.of(pageContext)
+                      .pushNamed(NavigationOptions.manageProfilesRoute);
+                },
+              ),
+            ),
+          ],
+        ),
+      );
+    },
+  );
+}
+
+/// Prompts for a name, creates the profile, and switches to it — which
+/// routes into onboarding so the new profile's body stats are collected.
+/// A picture can be added afterwards from the management screen.
+Future<void> showAddProfileDialog(BuildContext pageContext) async {
+  final controller = TextEditingController();
+  final created = await showDialog<bool>(
+    context: pageContext,
+    builder: (dialogContext) {
+      final s = S.of(dialogContext);
+      return AlertDialog(
+        title: Text(s.addProfileLabel),
+        content: Semantics(
+          identifier: 'profile-name-field',
+          child: TextField(
+            controller: controller,
+            autofocus: true,
+            textCapitalization: TextCapitalization.words,
+            decoration: InputDecoration(
+              labelText: s.profileNameLabel,
+              hintText: s.profileNameHint,
+            ),
+          ),
+        ),
+        actions: [
+          TextButton(
+            onPressed: () => Navigator.of(dialogContext).pop(false),
+            child: Text(s.dialogCancelLabel),
+          ),
+          Semantics(
+            identifier: 'profile-add-confirm',
+            child: TextButton(
+              onPressed: () => Navigator.of(dialogContext).pop(true),
+              child: Text(s.addLabel),
+            ),
+          ),
+        ],
+      );
+    },
+  );
+
+  if (created != true) return;
+
+  final profile = await locator<CreateProfileUsecase>()
+      .createProfile(name: controller.text.trim());
+  if (!pageContext.mounted) return;
+  await locator<ProfileSwitchCoordinator>().switchTo(pageContext, profile);
+}

--- a/lib/features/profile/profile_page.dart
+++ b/lib/features/profile/profile_page.dart
@@ -12,6 +12,7 @@ import 'package:opennutritracker/core/utils/locator.dart';
 import 'package:opennutritracker/core/utils/navigation_options.dart';
 import 'package:opennutritracker/features/profile/presentation/bloc/profile_bloc.dart';
 import 'package:opennutritracker/features/profile/presentation/widgets/bmi_overview.dart';
+import 'package:opennutritracker/features/profile/presentation/widgets/profile_switcher_header.dart';
 import 'package:opennutritracker/features/profile/presentation/widgets/set_gender_dialog.dart';
 import 'package:opennutritracker/features/profile/presentation/widgets/set_goal_dialog.dart';
 import 'package:opennutritracker/features/profile/presentation/widgets/set_height_dialog.dart';
@@ -78,7 +79,9 @@ class _ProfilePageState extends State<ProfilePage> {
   ) {
     return ListView(
       children: [
-        const SizedBox(height: 32.0),
+        const SizedBox(height: 8.0),
+        const ProfileSwitcherHeader(),
+        const SizedBox(height: 16.0),
         BMIOverview(
           bmiValue: userBMIEntity.bmiValue,
           nutritionalStatus: userBMIEntity.nutritionalStatus,

--- a/lib/generated/intl/messages_cs.dart
+++ b/lib/generated/intl/messages_cs.dart
@@ -108,6 +108,22 @@ class MessageLookup extends MessageLookupByLibrary {
 
   final messages = _notInlinedMessages(_notInlinedMessages);
   static Map<String, Function> _notInlinedMessages(_) => <String, Function>{
+        "copyActionLabel": MessageLookupByLibrary.simpleMessage("Kopírovat"),
+        "copyToProfileLabel": MessageLookupByLibrary.simpleMessage("Kopírovat do profilu"),
+        "copiedToProfileSnackbar": MessageLookupByLibrary.simpleMessage("Jídlo zkopírováno do profilu"),
+        "profileImageLabel": MessageLookupByLibrary.simpleMessage("Přidat fotku"),
+        "profileImageReplace": MessageLookupByLibrary.simpleMessage("Změnit fotku"),
+        "profileImageRemove": MessageLookupByLibrary.simpleMessage("Odebrat fotku"),
+        "switchProfileLabel": MessageLookupByLibrary.simpleMessage("Přepnout profil"),
+        "addProfileLabel": MessageLookupByLibrary.simpleMessage("Přidat profil"),
+        "manageProfilesLabel": MessageLookupByLibrary.simpleMessage("Spravovat profily"),
+        "editProfileTitle": MessageLookupByLibrary.simpleMessage("Upravit profil"),
+        "profileNameLabel": MessageLookupByLibrary.simpleMessage("Jméno"),
+        "profileNameHint": MessageLookupByLibrary.simpleMessage("Název profilu"),
+        "defaultProfileName": MessageLookupByLibrary.simpleMessage("Profil 1"),
+        "profileActiveLabel": MessageLookupByLibrary.simpleMessage("Aktivní"),
+        "deleteProfileConfirmTitle": MessageLookupByLibrary.simpleMessage("Smazat profil?"),
+        "deleteProfileConfirmContent": MessageLookupByLibrary.simpleMessage("Tímto se trvale smaže profil i všechna jeho data. Tuto akci nelze vrátit zpět."),
         "nutrientPanelLimitLabel": MessageLookupByLibrary.simpleMessage("limit"),
         "notificationsDailyReminderChannelName": MessageLookupByLibrary.simpleMessage("Denní připomenutí"),
         "notificationsDailyReminderChannelDescription": MessageLookupByLibrary.simpleMessage("Denní připomenutí k zaznamenání jídel"),

--- a/lib/generated/intl/messages_de.dart
+++ b/lib/generated/intl/messages_de.dart
@@ -110,6 +110,22 @@ class MessageLookup extends MessageLookupByLibrary {
 
   final messages = _notInlinedMessages(_notInlinedMessages);
   static Map<String, Function> _notInlinedMessages(_) => <String, Function>{
+        "copyActionLabel": MessageLookupByLibrary.simpleMessage("Kopieren"),
+        "copyToProfileLabel": MessageLookupByLibrary.simpleMessage("In Profil kopieren"),
+        "copiedToProfileSnackbar": MessageLookupByLibrary.simpleMessage("Mahlzeit ins Profil kopiert"),
+        "profileImageLabel": MessageLookupByLibrary.simpleMessage("Foto hinzufügen"),
+        "profileImageReplace": MessageLookupByLibrary.simpleMessage("Foto ändern"),
+        "profileImageRemove": MessageLookupByLibrary.simpleMessage("Foto entfernen"),
+        "switchProfileLabel": MessageLookupByLibrary.simpleMessage("Profil wechseln"),
+        "addProfileLabel": MessageLookupByLibrary.simpleMessage("Profil hinzufügen"),
+        "manageProfilesLabel": MessageLookupByLibrary.simpleMessage("Profile verwalten"),
+        "editProfileTitle": MessageLookupByLibrary.simpleMessage("Profil bearbeiten"),
+        "profileNameLabel": MessageLookupByLibrary.simpleMessage("Name"),
+        "profileNameHint": MessageLookupByLibrary.simpleMessage("Profilname"),
+        "defaultProfileName": MessageLookupByLibrary.simpleMessage("Profil 1"),
+        "profileActiveLabel": MessageLookupByLibrary.simpleMessage("Aktiv"),
+        "deleteProfileConfirmTitle": MessageLookupByLibrary.simpleMessage("Profil löschen?"),
+        "deleteProfileConfirmContent": MessageLookupByLibrary.simpleMessage("Dadurch werden das Profil und alle seine Daten dauerhaft gelöscht. Dies kann nicht rückgängig gemacht werden."),
         "nutrientPanelLimitLabel": MessageLookupByLibrary.simpleMessage("Limit"),
         "notificationsDailyReminderChannelName": MessageLookupByLibrary.simpleMessage("Tägliche Erinnerungen"),
         "notificationsDailyReminderChannelDescription": MessageLookupByLibrary.simpleMessage("Tägliche Erinnerung zum Erfassen deiner Mahlzeiten"),

--- a/lib/generated/intl/messages_en.dart
+++ b/lib/generated/intl/messages_en.dart
@@ -107,6 +107,22 @@ class MessageLookup extends MessageLookupByLibrary {
 
   final messages = _notInlinedMessages(_notInlinedMessages);
   static Map<String, Function> _notInlinedMessages(_) => <String, Function>{
+        "copyActionLabel": MessageLookupByLibrary.simpleMessage("Copy"),
+        "copyToProfileLabel": MessageLookupByLibrary.simpleMessage("Copy to profile"),
+        "copiedToProfileSnackbar": MessageLookupByLibrary.simpleMessage("Meal copied to profile"),
+        "profileImageLabel": MessageLookupByLibrary.simpleMessage("Add a photo"),
+        "profileImageReplace": MessageLookupByLibrary.simpleMessage("Change photo"),
+        "profileImageRemove": MessageLookupByLibrary.simpleMessage("Remove photo"),
+        "switchProfileLabel": MessageLookupByLibrary.simpleMessage("Switch profile"),
+        "addProfileLabel": MessageLookupByLibrary.simpleMessage("Add profile"),
+        "manageProfilesLabel": MessageLookupByLibrary.simpleMessage("Manage profiles"),
+        "editProfileTitle": MessageLookupByLibrary.simpleMessage("Edit profile"),
+        "profileNameLabel": MessageLookupByLibrary.simpleMessage("Name"),
+        "profileNameHint": MessageLookupByLibrary.simpleMessage("Profile name"),
+        "defaultProfileName": MessageLookupByLibrary.simpleMessage("Profile 1"),
+        "profileActiveLabel": MessageLookupByLibrary.simpleMessage("Active"),
+        "deleteProfileConfirmTitle": MessageLookupByLibrary.simpleMessage("Delete profile?"),
+        "deleteProfileConfirmContent": MessageLookupByLibrary.simpleMessage("This permanently deletes the profile and all of its data and cannot be undone."),
         "nutrientPanelLimitLabel": MessageLookupByLibrary.simpleMessage("limit"),
         "notificationsDailyReminderChannelName": MessageLookupByLibrary.simpleMessage("Daily Reminders"),
         "notificationsDailyReminderChannelDescription": MessageLookupByLibrary.simpleMessage("Daily meal logging reminder"),

--- a/lib/generated/intl/messages_it.dart
+++ b/lib/generated/intl/messages_it.dart
@@ -108,6 +108,22 @@ class MessageLookup extends MessageLookupByLibrary {
 
   final messages = _notInlinedMessages(_notInlinedMessages);
   static Map<String, Function> _notInlinedMessages(_) => <String, Function>{
+        "copyActionLabel": MessageLookupByLibrary.simpleMessage("Copia"),
+        "copyToProfileLabel": MessageLookupByLibrary.simpleMessage("Copia nel profilo"),
+        "copiedToProfileSnackbar": MessageLookupByLibrary.simpleMessage("Pasto copiato nel profilo"),
+        "profileImageLabel": MessageLookupByLibrary.simpleMessage("Aggiungi una foto"),
+        "profileImageReplace": MessageLookupByLibrary.simpleMessage("Cambia foto"),
+        "profileImageRemove": MessageLookupByLibrary.simpleMessage("Rimuovi foto"),
+        "switchProfileLabel": MessageLookupByLibrary.simpleMessage("Cambia profilo"),
+        "addProfileLabel": MessageLookupByLibrary.simpleMessage("Aggiungi profilo"),
+        "manageProfilesLabel": MessageLookupByLibrary.simpleMessage("Gestisci profili"),
+        "editProfileTitle": MessageLookupByLibrary.simpleMessage("Modifica profilo"),
+        "profileNameLabel": MessageLookupByLibrary.simpleMessage("Nome"),
+        "profileNameHint": MessageLookupByLibrary.simpleMessage("Nome profilo"),
+        "defaultProfileName": MessageLookupByLibrary.simpleMessage("Profilo 1"),
+        "profileActiveLabel": MessageLookupByLibrary.simpleMessage("Attivo"),
+        "deleteProfileConfirmTitle": MessageLookupByLibrary.simpleMessage("Eliminare il profilo?"),
+        "deleteProfileConfirmContent": MessageLookupByLibrary.simpleMessage("Questa operazione elimina definitivamente il profilo e tutti i suoi dati e non può essere annullata."),
         "nutrientPanelLimitLabel": MessageLookupByLibrary.simpleMessage("limite"),
         "notificationsDailyReminderChannelName": MessageLookupByLibrary.simpleMessage("Promemoria giornalieri"),
         "notificationsDailyReminderChannelDescription": MessageLookupByLibrary.simpleMessage("Promemoria giornaliero per registrare i pasti"),

--- a/lib/generated/intl/messages_pl.dart
+++ b/lib/generated/intl/messages_pl.dart
@@ -107,6 +107,22 @@ class MessageLookup extends MessageLookupByLibrary {
 
   final messages = _notInlinedMessages(_notInlinedMessages);
   static Map<String, Function> _notInlinedMessages(_) => <String, Function>{
+        "copyActionLabel": MessageLookupByLibrary.simpleMessage("Kopiuj"),
+        "copyToProfileLabel": MessageLookupByLibrary.simpleMessage("Kopiuj do profilu"),
+        "copiedToProfileSnackbar": MessageLookupByLibrary.simpleMessage("Posiłek skopiowany do profilu"),
+        "profileImageLabel": MessageLookupByLibrary.simpleMessage("Dodaj zdjęcie"),
+        "profileImageReplace": MessageLookupByLibrary.simpleMessage("Zmień zdjęcie"),
+        "profileImageRemove": MessageLookupByLibrary.simpleMessage("Usuń zdjęcie"),
+        "switchProfileLabel": MessageLookupByLibrary.simpleMessage("Przełącz profil"),
+        "addProfileLabel": MessageLookupByLibrary.simpleMessage("Dodaj profil"),
+        "manageProfilesLabel": MessageLookupByLibrary.simpleMessage("Zarządzaj profilami"),
+        "editProfileTitle": MessageLookupByLibrary.simpleMessage("Edytuj profil"),
+        "profileNameLabel": MessageLookupByLibrary.simpleMessage("Imię"),
+        "profileNameHint": MessageLookupByLibrary.simpleMessage("Nazwa profilu"),
+        "defaultProfileName": MessageLookupByLibrary.simpleMessage("Profil 1"),
+        "profileActiveLabel": MessageLookupByLibrary.simpleMessage("Aktywny"),
+        "deleteProfileConfirmTitle": MessageLookupByLibrary.simpleMessage("Usunąć profil?"),
+        "deleteProfileConfirmContent": MessageLookupByLibrary.simpleMessage("Spowoduje to trwałe usunięcie profilu i wszystkich jego danych. Tej operacji nie można cofnąć."),
         "nutrientPanelLimitLabel": MessageLookupByLibrary.simpleMessage("limit"),
         "notificationsDailyReminderChannelName": MessageLookupByLibrary.simpleMessage("Codzienne przypomnienia"),
         "notificationsDailyReminderChannelDescription": MessageLookupByLibrary.simpleMessage("Codzienne przypomnienie o zapisaniu posiłków"),

--- a/lib/generated/intl/messages_sk.dart
+++ b/lib/generated/intl/messages_sk.dart
@@ -108,6 +108,22 @@ class MessageLookup extends MessageLookupByLibrary {
 
   final messages = _notInlinedMessages(_notInlinedMessages);
   static Map<String, Function> _notInlinedMessages(_) => <String, Function>{
+        "copyActionLabel": MessageLookupByLibrary.simpleMessage("Kopírovať"),
+        "copyToProfileLabel": MessageLookupByLibrary.simpleMessage("Kopírovať do profilu"),
+        "copiedToProfileSnackbar": MessageLookupByLibrary.simpleMessage("Jedlo skopírované do profilu"),
+        "profileImageLabel": MessageLookupByLibrary.simpleMessage("Pridať fotku"),
+        "profileImageReplace": MessageLookupByLibrary.simpleMessage("Zmeniť fotku"),
+        "profileImageRemove": MessageLookupByLibrary.simpleMessage("Odstrániť fotku"),
+        "switchProfileLabel": MessageLookupByLibrary.simpleMessage("Prepnúť profil"),
+        "addProfileLabel": MessageLookupByLibrary.simpleMessage("Pridať profil"),
+        "manageProfilesLabel": MessageLookupByLibrary.simpleMessage("Spravovať profily"),
+        "editProfileTitle": MessageLookupByLibrary.simpleMessage("Upraviť profil"),
+        "profileNameLabel": MessageLookupByLibrary.simpleMessage("Meno"),
+        "profileNameHint": MessageLookupByLibrary.simpleMessage("Názov profilu"),
+        "defaultProfileName": MessageLookupByLibrary.simpleMessage("Profil 1"),
+        "profileActiveLabel": MessageLookupByLibrary.simpleMessage("Aktívny"),
+        "deleteProfileConfirmTitle": MessageLookupByLibrary.simpleMessage("Odstrániť profil?"),
+        "deleteProfileConfirmContent": MessageLookupByLibrary.simpleMessage("Týmto sa natrvalo odstráni profil aj všetky jeho údaje. Túto akciu nie je možné vrátiť späť."),
         "nutrientPanelLimitLabel": MessageLookupByLibrary.simpleMessage("limit"),
         "notificationsDailyReminderChannelName": MessageLookupByLibrary.simpleMessage("Denné pripomenutia"),
         "notificationsDailyReminderChannelDescription": MessageLookupByLibrary.simpleMessage("Denné pripomenutie na zaznamenanie jedál"),

--- a/lib/generated/intl/messages_tr.dart
+++ b/lib/generated/intl/messages_tr.dart
@@ -110,6 +110,22 @@ class MessageLookup extends MessageLookupByLibrary {
 
   final messages = _notInlinedMessages(_notInlinedMessages);
   static Map<String, Function> _notInlinedMessages(_) => <String, Function>{
+        "copyActionLabel": MessageLookupByLibrary.simpleMessage("Kopyala"),
+        "copyToProfileLabel": MessageLookupByLibrary.simpleMessage("Profile kopyala"),
+        "copiedToProfileSnackbar": MessageLookupByLibrary.simpleMessage("Öğün profile kopyalandı"),
+        "profileImageLabel": MessageLookupByLibrary.simpleMessage("Fotoğraf ekle"),
+        "profileImageReplace": MessageLookupByLibrary.simpleMessage("Fotoğrafı değiştir"),
+        "profileImageRemove": MessageLookupByLibrary.simpleMessage("Fotoğrafı kaldır"),
+        "switchProfileLabel": MessageLookupByLibrary.simpleMessage("Profil değiştir"),
+        "addProfileLabel": MessageLookupByLibrary.simpleMessage("Profil ekle"),
+        "manageProfilesLabel": MessageLookupByLibrary.simpleMessage("Profilleri yönet"),
+        "editProfileTitle": MessageLookupByLibrary.simpleMessage("Profili düzenle"),
+        "profileNameLabel": MessageLookupByLibrary.simpleMessage("Ad"),
+        "profileNameHint": MessageLookupByLibrary.simpleMessage("Profil adı"),
+        "defaultProfileName": MessageLookupByLibrary.simpleMessage("Profil 1"),
+        "profileActiveLabel": MessageLookupByLibrary.simpleMessage("Etkin"),
+        "deleteProfileConfirmTitle": MessageLookupByLibrary.simpleMessage("Profil silinsin mi?"),
+        "deleteProfileConfirmContent": MessageLookupByLibrary.simpleMessage("Bu işlem profili ve tüm verilerini kalıcı olarak siler. Bu geri alınamaz."),
         "nutrientPanelLimitLabel": MessageLookupByLibrary.simpleMessage("sınır"),
         "notificationsDailyReminderChannelName": MessageLookupByLibrary.simpleMessage("Günlük hatırlatıcılar"),
         "notificationsDailyReminderChannelDescription": MessageLookupByLibrary.simpleMessage("Öğünlerinizi kaydetmeniz için günlük hatırlatma"),

--- a/lib/generated/intl/messages_uk.dart
+++ b/lib/generated/intl/messages_uk.dart
@@ -108,6 +108,22 @@ class MessageLookup extends MessageLookupByLibrary {
 
   final messages = _notInlinedMessages(_notInlinedMessages);
   static Map<String, Function> _notInlinedMessages(_) => <String, Function>{
+        "copyActionLabel": MessageLookupByLibrary.simpleMessage("Копіювати"),
+        "copyToProfileLabel": MessageLookupByLibrary.simpleMessage("Копіювати в профіль"),
+        "copiedToProfileSnackbar": MessageLookupByLibrary.simpleMessage("Прийом їжі скопійовано в профіль"),
+        "profileImageLabel": MessageLookupByLibrary.simpleMessage("Додати фото"),
+        "profileImageReplace": MessageLookupByLibrary.simpleMessage("Змінити фото"),
+        "profileImageRemove": MessageLookupByLibrary.simpleMessage("Видалити фото"),
+        "switchProfileLabel": MessageLookupByLibrary.simpleMessage("Змінити профіль"),
+        "addProfileLabel": MessageLookupByLibrary.simpleMessage("Додати профіль"),
+        "manageProfilesLabel": MessageLookupByLibrary.simpleMessage("Керувати профілями"),
+        "editProfileTitle": MessageLookupByLibrary.simpleMessage("Редагувати профіль"),
+        "profileNameLabel": MessageLookupByLibrary.simpleMessage("Ім'я"),
+        "profileNameHint": MessageLookupByLibrary.simpleMessage("Назва профілю"),
+        "defaultProfileName": MessageLookupByLibrary.simpleMessage("Профіль 1"),
+        "profileActiveLabel": MessageLookupByLibrary.simpleMessage("Активний"),
+        "deleteProfileConfirmTitle": MessageLookupByLibrary.simpleMessage("Видалити профіль?"),
+        "deleteProfileConfirmContent": MessageLookupByLibrary.simpleMessage("Це назавжди видалить профіль та всі його дані. Цю дію не можна скасувати."),
         "nutrientPanelLimitLabel": MessageLookupByLibrary.simpleMessage("ліміт"),
         "notificationsDailyReminderChannelName": MessageLookupByLibrary.simpleMessage("Щоденні нагадування"),
         "notificationsDailyReminderChannelDescription": MessageLookupByLibrary.simpleMessage("Щоденне нагадування записати прийоми їжі"),

--- a/lib/generated/intl/messages_zh.dart
+++ b/lib/generated/intl/messages_zh.dart
@@ -105,6 +105,22 @@ class MessageLookup extends MessageLookupByLibrary {
 
   final messages = _notInlinedMessages(_notInlinedMessages);
   static Map<String, Function> _notInlinedMessages(_) => <String, Function>{
+        "copyActionLabel": MessageLookupByLibrary.simpleMessage("复制"),
+        "copyToProfileLabel": MessageLookupByLibrary.simpleMessage("复制到档案"),
+        "copiedToProfileSnackbar": MessageLookupByLibrary.simpleMessage("餐食已复制到档案"),
+        "profileImageLabel": MessageLookupByLibrary.simpleMessage("添加照片"),
+        "profileImageReplace": MessageLookupByLibrary.simpleMessage("更换照片"),
+        "profileImageRemove": MessageLookupByLibrary.simpleMessage("移除照片"),
+        "switchProfileLabel": MessageLookupByLibrary.simpleMessage("切换档案"),
+        "addProfileLabel": MessageLookupByLibrary.simpleMessage("添加档案"),
+        "manageProfilesLabel": MessageLookupByLibrary.simpleMessage("管理档案"),
+        "editProfileTitle": MessageLookupByLibrary.simpleMessage("编辑档案"),
+        "profileNameLabel": MessageLookupByLibrary.simpleMessage("名称"),
+        "profileNameHint": MessageLookupByLibrary.simpleMessage("档案名称"),
+        "defaultProfileName": MessageLookupByLibrary.simpleMessage("档案 1"),
+        "profileActiveLabel": MessageLookupByLibrary.simpleMessage("当前"),
+        "deleteProfileConfirmTitle": MessageLookupByLibrary.simpleMessage("删除档案？"),
+        "deleteProfileConfirmContent": MessageLookupByLibrary.simpleMessage("这将永久删除该档案及其所有数据，此操作无法撤销。"),
         "nutrientPanelLimitLabel": MessageLookupByLibrary.simpleMessage("上限"),
         "notificationsDailyReminderChannelName": MessageLookupByLibrary.simpleMessage("每日提醒"),
         "notificationsDailyReminderChannelDescription": MessageLookupByLibrary.simpleMessage("每日记录餐食的提醒"),

--- a/lib/generated/l10n.dart
+++ b/lib/generated/l10n.dart
@@ -621,6 +621,150 @@ class S {
   }
 
   /// `Add a photo`
+  String get profileImageLabel {
+    return Intl.message(
+      'Add a photo',
+      name: 'profileImageLabel',
+      desc: '',
+      args: [],
+    );
+  }
+
+  String get profileImageReplace {
+    return Intl.message(
+      'Change photo',
+      name: 'profileImageReplace',
+      desc: '',
+      args: [],
+    );
+  }
+
+  String get profileImageRemove {
+    return Intl.message(
+      'Remove photo',
+      name: 'profileImageRemove',
+      desc: '',
+      args: [],
+    );
+  }
+
+  String get switchProfileLabel {
+    return Intl.message(
+      'Switch profile',
+      name: 'switchProfileLabel',
+      desc: '',
+      args: [],
+    );
+  }
+
+  String get addProfileLabel {
+    return Intl.message(
+      'Add profile',
+      name: 'addProfileLabel',
+      desc: '',
+      args: [],
+    );
+  }
+
+  String get manageProfilesLabel {
+    return Intl.message(
+      'Manage profiles',
+      name: 'manageProfilesLabel',
+      desc: '',
+      args: [],
+    );
+  }
+
+  String get editProfileTitle {
+    return Intl.message(
+      'Edit profile',
+      name: 'editProfileTitle',
+      desc: '',
+      args: [],
+    );
+  }
+
+  String get profileNameLabel {
+    return Intl.message(
+      'Name',
+      name: 'profileNameLabel',
+      desc: '',
+      args: [],
+    );
+  }
+
+  String get profileNameHint {
+    return Intl.message(
+      'Profile name',
+      name: 'profileNameHint',
+      desc: '',
+      args: [],
+    );
+  }
+
+  String get defaultProfileName {
+    return Intl.message(
+      'Profile 1',
+      name: 'defaultProfileName',
+      desc: '',
+      args: [],
+    );
+  }
+
+  String get profileActiveLabel {
+    return Intl.message(
+      'Active',
+      name: 'profileActiveLabel',
+      desc: '',
+      args: [],
+    );
+  }
+
+  String get deleteProfileConfirmTitle {
+    return Intl.message(
+      'Delete profile?',
+      name: 'deleteProfileConfirmTitle',
+      desc: '',
+      args: [],
+    );
+  }
+
+  String get deleteProfileConfirmContent {
+    return Intl.message(
+      'This permanently deletes the profile and all of its data and cannot be undone.',
+      name: 'deleteProfileConfirmContent',
+      desc: '',
+      args: [],
+    );
+  }
+
+  String get copyToProfileLabel {
+    return Intl.message(
+      'Copy to profile',
+      name: 'copyToProfileLabel',
+      desc: '',
+      args: [],
+    );
+  }
+
+  String get copiedToProfileSnackbar {
+    return Intl.message(
+      'Meal copied to profile',
+      name: 'copiedToProfileSnackbar',
+      desc: '',
+      args: [],
+    );
+  }
+
+  String get copyActionLabel {
+    return Intl.message(
+      'Copy',
+      name: 'copyActionLabel',
+      desc: '',
+      args: [],
+    );
+  }
+
   String get mealImageLabel {
     return Intl.message(
       'Add a photo',

--- a/lib/hive_registrar.g.dart
+++ b/lib/hive_registrar.g.dart
@@ -14,6 +14,7 @@ import 'package:opennutritracker/core/data/dbo/intake_type_dbo.dart';
 import 'package:opennutritracker/core/data/dbo/meal_dbo.dart';
 import 'package:opennutritracker/core/data/dbo/meal_nutriments_dbo.dart';
 import 'package:opennutritracker/core/data/dbo/physical_activity_dbo.dart';
+import 'package:opennutritracker/core/data/dbo/profile_dbo.dart';
 import 'package:opennutritracker/core/data/dbo/recipe_dbo.dart';
 import 'package:opennutritracker/core/data/dbo/recipe_ingredient_dbo.dart';
 import 'package:opennutritracker/core/data/dbo/tracked_day_dbo.dart';
@@ -38,6 +39,7 @@ extension HiveRegistrar on HiveInterface {
     registerAdapter(MealSourceDBOAdapter());
     registerAdapter(PhysicalActivityDBOAdapter());
     registerAdapter(PhysicalActivityTypeDBOAdapter());
+    registerAdapter(ProfileDBOAdapter());
     registerAdapter(RecipeDBOAdapter());
     registerAdapter(RecipeIngredientDBOAdapter());
     registerAdapter(TrackedDayDBOAdapter());
@@ -65,6 +67,7 @@ extension IsolatedHiveRegistrar on IsolatedHiveInterface {
     registerAdapter(MealSourceDBOAdapter());
     registerAdapter(PhysicalActivityDBOAdapter());
     registerAdapter(PhysicalActivityTypeDBOAdapter());
+    registerAdapter(ProfileDBOAdapter());
     registerAdapter(RecipeDBOAdapter());
     registerAdapter(RecipeIngredientDBOAdapter());
     registerAdapter(TrackedDayDBOAdapter());

--- a/lib/l10n/intl_cs.arb
+++ b/lib/l10n/intl_cs.arb
@@ -960,5 +960,21 @@
   "fastingNotificationChannelName": "Časovač půstu",
   "fastingNotificationChannelDescription": "Jednorázová upozornění, když půst dosáhne svého cíle.",
   "fastingNotificationCompleteTitle": "Půst dokončen",
-  "fastingNotificationCompleteBody": "Cílový čas byl dosažen."
+  "fastingNotificationCompleteBody": "Cílový čas byl dosažen.",
+  "profileImageLabel": "Přidat fotku",
+  "profileImageReplace": "Změnit fotku",
+  "profileImageRemove": "Odebrat fotku",
+  "switchProfileLabel": "Přepnout profil",
+  "addProfileLabel": "Přidat profil",
+  "manageProfilesLabel": "Spravovat profily",
+  "editProfileTitle": "Upravit profil",
+  "profileNameLabel": "Jméno",
+  "profileNameHint": "Název profilu",
+  "defaultProfileName": "Profil 1",
+  "profileActiveLabel": "Aktivní",
+  "deleteProfileConfirmTitle": "Smazat profil?",
+  "deleteProfileConfirmContent": "Tímto se trvale smaže profil i všechna jeho data. Tuto akci nelze vrátit zpět.",
+  "copyToProfileLabel": "Kopírovat do profilu",
+  "copiedToProfileSnackbar": "Jídlo zkopírováno do profilu",
+  "copyActionLabel": "Kopírovat"
 }

--- a/lib/l10n/intl_de.arb
+++ b/lib/l10n/intl_de.arb
@@ -991,5 +991,21 @@
   "fastingNotificationChannelName": "Fasten-Timer",
   "fastingNotificationChannelDescription": "Einmalige Hinweise, wenn eine Fastenphase ihr Ziel erreicht.",
   "fastingNotificationCompleteTitle": "Fastenzeit abgeschlossen",
-  "fastingNotificationCompleteBody": "Deine Zielzeit wurde erreicht."
+  "fastingNotificationCompleteBody": "Deine Zielzeit wurde erreicht.",
+  "profileImageLabel": "Foto hinzufügen",
+  "profileImageReplace": "Foto ändern",
+  "profileImageRemove": "Foto entfernen",
+  "switchProfileLabel": "Profil wechseln",
+  "addProfileLabel": "Profil hinzufügen",
+  "manageProfilesLabel": "Profile verwalten",
+  "editProfileTitle": "Profil bearbeiten",
+  "profileNameLabel": "Name",
+  "profileNameHint": "Profilname",
+  "defaultProfileName": "Profil 1",
+  "profileActiveLabel": "Aktiv",
+  "deleteProfileConfirmTitle": "Profil löschen?",
+  "deleteProfileConfirmContent": "Dadurch werden das Profil und alle seine Daten dauerhaft gelöscht. Dies kann nicht rückgängig gemacht werden.",
+  "copyToProfileLabel": "In Profil kopieren",
+  "copiedToProfileSnackbar": "Mahlzeit ins Profil kopiert",
+  "copyActionLabel": "Kopieren"
 }

--- a/lib/l10n/intl_en.arb
+++ b/lib/l10n/intl_en.arb
@@ -1032,5 +1032,21 @@
   "fastingNotificationChannelName": "Fasting timer",
   "fastingNotificationChannelDescription": "One-off pings when a fasting session reaches its target.",
   "fastingNotificationCompleteTitle": "Fasting session complete",
-  "fastingNotificationCompleteBody": "Your target time has been reached."
+  "fastingNotificationCompleteBody": "Your target time has been reached.",
+  "profileImageLabel": "Add a photo",
+  "profileImageReplace": "Change photo",
+  "profileImageRemove": "Remove photo",
+  "switchProfileLabel": "Switch profile",
+  "addProfileLabel": "Add profile",
+  "manageProfilesLabel": "Manage profiles",
+  "editProfileTitle": "Edit profile",
+  "profileNameLabel": "Name",
+  "profileNameHint": "Profile name",
+  "defaultProfileName": "Profile 1",
+  "profileActiveLabel": "Active",
+  "deleteProfileConfirmTitle": "Delete profile?",
+  "deleteProfileConfirmContent": "This permanently deletes the profile and all of its data and cannot be undone.",
+  "copyToProfileLabel": "Copy to profile",
+  "copiedToProfileSnackbar": "Meal copied to profile",
+  "copyActionLabel": "Copy"
 }

--- a/lib/l10n/intl_it.arb
+++ b/lib/l10n/intl_it.arb
@@ -960,5 +960,21 @@
   "fastingNotificationChannelName": "Timer del digiuno",
   "fastingNotificationChannelDescription": "Notifiche occasionali quando un digiuno raggiunge il suo obiettivo.",
   "fastingNotificationCompleteTitle": "Sessione di digiuno completata",
-  "fastingNotificationCompleteBody": "Il tuo tempo obiettivo è stato raggiunto."
+  "fastingNotificationCompleteBody": "Il tuo tempo obiettivo è stato raggiunto.",
+  "profileImageLabel": "Aggiungi una foto",
+  "profileImageReplace": "Cambia foto",
+  "profileImageRemove": "Rimuovi foto",
+  "switchProfileLabel": "Cambia profilo",
+  "addProfileLabel": "Aggiungi profilo",
+  "manageProfilesLabel": "Gestisci profili",
+  "editProfileTitle": "Modifica profilo",
+  "profileNameLabel": "Nome",
+  "profileNameHint": "Nome profilo",
+  "defaultProfileName": "Profilo 1",
+  "profileActiveLabel": "Attivo",
+  "deleteProfileConfirmTitle": "Eliminare il profilo?",
+  "deleteProfileConfirmContent": "Questa operazione elimina definitivamente il profilo e tutti i suoi dati e non può essere annullata.",
+  "copyToProfileLabel": "Copia nel profilo",
+  "copiedToProfileSnackbar": "Pasto copiato nel profilo",
+  "copyActionLabel": "Copia"
 }

--- a/lib/l10n/intl_pl.arb
+++ b/lib/l10n/intl_pl.arb
@@ -960,5 +960,21 @@
   "fastingNotificationChannelName": "Minutnik postu",
   "fastingNotificationChannelDescription": "Jednorazowe powiadomienia, gdy post osiągnie swój cel.",
   "fastingNotificationCompleteTitle": "Sesja postu zakończona",
-  "fastingNotificationCompleteBody": "Czas docelowy został osiągnięty."
+  "fastingNotificationCompleteBody": "Czas docelowy został osiągnięty.",
+  "profileImageLabel": "Dodaj zdjęcie",
+  "profileImageReplace": "Zmień zdjęcie",
+  "profileImageRemove": "Usuń zdjęcie",
+  "switchProfileLabel": "Przełącz profil",
+  "addProfileLabel": "Dodaj profil",
+  "manageProfilesLabel": "Zarządzaj profilami",
+  "editProfileTitle": "Edytuj profil",
+  "profileNameLabel": "Imię",
+  "profileNameHint": "Nazwa profilu",
+  "defaultProfileName": "Profil 1",
+  "profileActiveLabel": "Aktywny",
+  "deleteProfileConfirmTitle": "Usunąć profil?",
+  "deleteProfileConfirmContent": "Spowoduje to trwałe usunięcie profilu i wszystkich jego danych. Tej operacji nie można cofnąć.",
+  "copyToProfileLabel": "Kopiuj do profilu",
+  "copiedToProfileSnackbar": "Posiłek skopiowany do profilu",
+  "copyActionLabel": "Kopiuj"
 }

--- a/lib/l10n/intl_sk.arb
+++ b/lib/l10n/intl_sk.arb
@@ -990,5 +990,21 @@
   "fastingNotificationChannelName": "Časovač pôstu",
   "fastingNotificationChannelDescription": "Jednorazové upozornenia, keď pôst dosiahne svoj cieľ.",
   "fastingNotificationCompleteTitle": "Pôst dokončený",
-  "fastingNotificationCompleteBody": "Cieľový čas bol dosiahnutý."
+  "fastingNotificationCompleteBody": "Cieľový čas bol dosiahnutý.",
+  "profileImageLabel": "Pridať fotku",
+  "profileImageReplace": "Zmeniť fotku",
+  "profileImageRemove": "Odstrániť fotku",
+  "switchProfileLabel": "Prepnúť profil",
+  "addProfileLabel": "Pridať profil",
+  "manageProfilesLabel": "Spravovať profily",
+  "editProfileTitle": "Upraviť profil",
+  "profileNameLabel": "Meno",
+  "profileNameHint": "Názov profilu",
+  "defaultProfileName": "Profil 1",
+  "profileActiveLabel": "Aktívny",
+  "deleteProfileConfirmTitle": "Odstrániť profil?",
+  "deleteProfileConfirmContent": "Týmto sa natrvalo odstráni profil aj všetky jeho údaje. Túto akciu nie je možné vrátiť späť.",
+  "copyToProfileLabel": "Kopírovať do profilu",
+  "copiedToProfileSnackbar": "Jedlo skopírované do profilu",
+  "copyActionLabel": "Kopírovať"
 }

--- a/lib/l10n/intl_tr.arb
+++ b/lib/l10n/intl_tr.arb
@@ -991,5 +991,21 @@
   "fastingNotificationChannelName": "Oruç zamanlayıcısı",
   "fastingNotificationChannelDescription": "Bir oruç hedefe ulaştığında tek seferlik bildirimler.",
   "fastingNotificationCompleteTitle": "Oruç süresi tamamlandı",
-  "fastingNotificationCompleteBody": "Hedef sürene ulaştın."
+  "fastingNotificationCompleteBody": "Hedef sürene ulaştın.",
+  "profileImageLabel": "Fotoğraf ekle",
+  "profileImageReplace": "Fotoğrafı değiştir",
+  "profileImageRemove": "Fotoğrafı kaldır",
+  "switchProfileLabel": "Profil değiştir",
+  "addProfileLabel": "Profil ekle",
+  "manageProfilesLabel": "Profilleri yönet",
+  "editProfileTitle": "Profili düzenle",
+  "profileNameLabel": "Ad",
+  "profileNameHint": "Profil adı",
+  "defaultProfileName": "Profil 1",
+  "profileActiveLabel": "Etkin",
+  "deleteProfileConfirmTitle": "Profil silinsin mi?",
+  "deleteProfileConfirmContent": "Bu işlem profili ve tüm verilerini kalıcı olarak siler. Bu geri alınamaz.",
+  "copyToProfileLabel": "Profile kopyala",
+  "copiedToProfileSnackbar": "Öğün profile kopyalandı",
+  "copyActionLabel": "Kopyala"
 }

--- a/lib/l10n/intl_uk.arb
+++ b/lib/l10n/intl_uk.arb
@@ -960,5 +960,21 @@
   "fastingNotificationChannelName": "Таймер голодування",
   "fastingNotificationChannelDescription": "Одноразові сповіщення, коли голодування досягає своєї мети.",
   "fastingNotificationCompleteTitle": "Сесія голодування завершена",
-  "fastingNotificationCompleteBody": "Цільовий час досягнуто."
+  "fastingNotificationCompleteBody": "Цільовий час досягнуто.",
+  "profileImageLabel": "Додати фото",
+  "profileImageReplace": "Змінити фото",
+  "profileImageRemove": "Видалити фото",
+  "switchProfileLabel": "Змінити профіль",
+  "addProfileLabel": "Додати профіль",
+  "manageProfilesLabel": "Керувати профілями",
+  "editProfileTitle": "Редагувати профіль",
+  "profileNameLabel": "Ім'я",
+  "profileNameHint": "Назва профілю",
+  "defaultProfileName": "Профіль 1",
+  "profileActiveLabel": "Активний",
+  "deleteProfileConfirmTitle": "Видалити профіль?",
+  "deleteProfileConfirmContent": "Це назавжди видалить профіль та всі його дані. Цю дію не можна скасувати.",
+  "copyToProfileLabel": "Копіювати в профіль",
+  "copiedToProfileSnackbar": "Прийом їжі скопійовано в профіль",
+  "copyActionLabel": "Копіювати"
 }

--- a/lib/l10n/intl_zh.arb
+++ b/lib/l10n/intl_zh.arb
@@ -961,5 +961,21 @@
   "fastingNotificationChannelName": "断食计时器",
   "fastingNotificationChannelDescription": "断食达到目标时的一次性提醒。",
   "fastingNotificationCompleteTitle": "禁食时间到了",
-  "fastingNotificationCompleteBody": "已达到你的目标时间。"
+  "fastingNotificationCompleteBody": "已达到你的目标时间。",
+  "profileImageLabel": "添加照片",
+  "profileImageReplace": "更换照片",
+  "profileImageRemove": "移除照片",
+  "switchProfileLabel": "切换档案",
+  "addProfileLabel": "添加档案",
+  "manageProfilesLabel": "管理档案",
+  "editProfileTitle": "编辑档案",
+  "profileNameLabel": "名称",
+  "profileNameHint": "档案名称",
+  "defaultProfileName": "档案 1",
+  "profileActiveLabel": "当前",
+  "deleteProfileConfirmTitle": "删除档案？",
+  "deleteProfileConfirmContent": "这将永久删除该档案及其所有数据，此操作无法撤销。",
+  "copyToProfileLabel": "复制到档案",
+  "copiedToProfileSnackbar": "餐食已复制到档案",
+  "copyActionLabel": "复制"
 }

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -27,6 +27,7 @@ import 'package:opennutritracker/features/add_activity/presentation/add_activity
 import 'package:opennutritracker/features/edit_meal/presentation/edit_meal_screen.dart';
 import 'package:opennutritracker/features/onboarding/onboarding_screen.dart';
 import 'package:opennutritracker/features/fasting/presentation/fasting_screen.dart';
+import 'package:opennutritracker/features/profile/presentation/screens/manage_profiles_screen.dart';
 import 'package:opennutritracker/features/profile/presentation/weight_history_screen.dart';
 import 'package:opennutritracker/features/recipes/presentation/screens/import_recipe_scanner_screen.dart';
 import 'package:opennutritracker/features/recipes/presentation/screens/recipe_builder_screen.dart';
@@ -249,6 +250,8 @@ class OpenNutriTrackerApp extends StatelessWidget {
         NavigationOptions.weightHistoryRoute: (context) =>
             const WeightHistoryScreen(),
         NavigationOptions.fastingRoute: (context) => const FastingScreen(),
+        NavigationOptions.manageProfilesRoute: (context) =>
+            const ManageProfilesScreen(),
       },
     );
   }

--- a/test/features/home/presentation/widgets/intake_vertical_list_test.dart
+++ b/test/features/home/presentation/widgets/intake_vertical_list_test.dart
@@ -3,6 +3,8 @@ import 'package:flutter_test/flutter_test.dart';
 import 'package:get_it/get_it.dart';
 import 'package:opennutritracker/core/domain/entity/intake_entity.dart';
 import 'package:opennutritracker/core/domain/entity/intake_type_entity.dart';
+import 'package:opennutritracker/core/domain/entity/profile_entity.dart';
+import 'package:opennutritracker/core/domain/usecase/get_profiles_usecase.dart';
 import 'package:opennutritracker/core/utils/energy_unit_provider.dart';
 import 'package:opennutritracker/features/add_meal/domain/entity/meal_entity.dart';
 import 'package:opennutritracker/features/add_meal/domain/entity/meal_nutriments_entity.dart';
@@ -17,6 +19,27 @@ import 'package:provider/provider.dart';
 class _FakeMealDetailBloc extends Fake implements MealDetailBloc {}
 
 class _FakeHomeBloc extends Fake implements HomeBloc {}
+
+/// Single-profile stub: with only one profile the "Copy to profile" menu
+/// item stays hidden, so the section menu matches its pre-multi-profile
+/// shape in these tests.
+class _SingleProfileGetProfilesUsecase implements GetProfilesUsecase {
+  static final _profile = ProfileEntity(
+    id: 'p1',
+    name: 'Me',
+    createdAt: DateTime(2026, 1, 1),
+    boxSuffix: '',
+  );
+
+  @override
+  List<ProfileEntity> getProfiles() => [_profile];
+
+  @override
+  String get activeProfileId => 'p1';
+
+  @override
+  ProfileEntity? getActiveProfile() => _profile;
+}
 
 IntakeEntity _buildIntake({
   required double amount,
@@ -70,6 +93,9 @@ void main() {
     final locator = GetIt.instance;
     locator.registerFactory<MealDetailBloc>(_FakeMealDetailBloc.new);
     locator.registerFactory<HomeBloc>(_FakeHomeBloc.new);
+    locator.registerFactory<GetProfilesUsecase>(
+      _SingleProfileGetProfilesUsecase.new,
+    );
   });
 
   tearDownAll(() {

--- a/test/helpers/fake_hive_db_provider.dart
+++ b/test/helpers/fake_hive_db_provider.dart
@@ -1,0 +1,91 @@
+import 'package:hive_ce/hive.dart';
+import 'package:opennutritracker/core/data/data_source/custom_activity_template_dbo.dart';
+import 'package:opennutritracker/core/data/data_source/user_activity_dbo.dart';
+import 'package:opennutritracker/core/data/dbo/config_dbo.dart';
+import 'package:opennutritracker/core/data/dbo/fasting_session_dbo.dart';
+import 'package:opennutritracker/core/data/dbo/intake_dbo.dart';
+import 'package:opennutritracker/core/data/dbo/meal_dbo.dart';
+import 'package:opennutritracker/core/data/dbo/recipe_dbo.dart';
+import 'package:opennutritracker/core/data/dbo/tracked_day_dbo.dart';
+import 'package:opennutritracker/core/data/dbo/user_dbo.dart';
+import 'package:opennutritracker/core/data/dbo/water_intake_dbo.dart';
+import 'package:opennutritracker/core/data/dbo/weight_log_dbo.dart';
+import 'package:opennutritracker/core/utils/hive_db_provider.dart';
+
+/// Test double for [HiveDBProvider]. Data sources now resolve their box
+/// through the provider, so unit tests inject the box(es) they need here.
+/// Accessing a box that wasn't provided throws, which keeps tests honest
+/// about what they actually touch.
+class FakeHiveDBProvider extends HiveDBProvider {
+  final Box<ConfigDBO>? _configBox;
+  final Box<ConfigDBO>? _appConfigBox;
+  final Box<IntakeDBO>? _intakeBox;
+  final Box<UserActivityDBO>? _userActivityBox;
+  final Box<UserDBO>? _userBox;
+  final Box<TrackedDayDBO>? _trackedDayBox;
+  final Box<MealDBO>? _customMealBox;
+  final Box<RecipeDBO>? _recipeBox;
+  final Box<CustomActivityTemplateDBO>? _customActivityTemplateBox;
+  final Box<WeightLogDBO>? _weightLogBox;
+  final Box<WaterIntakeDBO>? _waterIntakeBox;
+  final Box<FastingSessionDBO>? _fastingBox;
+
+  FakeHiveDBProvider({
+    Box<ConfigDBO>? configBox,
+    Box<ConfigDBO>? appConfigBox,
+    Box<IntakeDBO>? intakeBox,
+    Box<UserActivityDBO>? userActivityBox,
+    Box<UserDBO>? userBox,
+    Box<TrackedDayDBO>? trackedDayBox,
+    Box<MealDBO>? customMealBox,
+    Box<RecipeDBO>? recipeBox,
+    Box<CustomActivityTemplateDBO>? customActivityTemplateBox,
+    Box<WeightLogDBO>? weightLogBox,
+    Box<WaterIntakeDBO>? waterIntakeBox,
+    Box<FastingSessionDBO>? fastingBox,
+  })  : _configBox = configBox,
+        _appConfigBox = appConfigBox ?? configBox,
+        _intakeBox = intakeBox,
+        _userActivityBox = userActivityBox,
+        _userBox = userBox,
+        _trackedDayBox = trackedDayBox,
+        _customMealBox = customMealBox,
+        _recipeBox = recipeBox,
+        _customActivityTemplateBox = customActivityTemplateBox,
+        _weightLogBox = weightLogBox,
+        _waterIntakeBox = waterIntakeBox,
+        _fastingBox = fastingBox;
+
+  T _require<T>(T? box) {
+    if (box == null) {
+      throw StateError('FakeHiveDBProvider: box not provided for this test');
+    }
+    return box;
+  }
+
+  @override
+  Box<ConfigDBO> get configBox => _require(_configBox);
+  @override
+  Box<ConfigDBO> get appConfigBox => _require(_appConfigBox);
+  @override
+  Box<IntakeDBO> get intakeBox => _require(_intakeBox);
+  @override
+  Box<UserActivityDBO> get userActivityBox => _require(_userActivityBox);
+  @override
+  Box<UserDBO> get userBox => _require(_userBox);
+  @override
+  Box<TrackedDayDBO> get trackedDayBox => _require(_trackedDayBox);
+  @override
+  Box<MealDBO> get customMealBox => _require(_customMealBox);
+  @override
+  Box<RecipeDBO> get recipeBox => _require(_recipeBox);
+  @override
+  Box<CustomActivityTemplateDBO> get customActivityTemplateBox =>
+      _require(_customActivityTemplateBox);
+  @override
+  Box<WeightLogDBO> get weightLogBox => _require(_weightLogBox);
+  @override
+  Box<WaterIntakeDBO> get waterIntakeBox => _require(_waterIntakeBox);
+  @override
+  Box<FastingSessionDBO> get fastingBox => _require(_fastingBox);
+}

--- a/test/unit_test/config_data_source_diary_sort_test.dart
+++ b/test/unit_test/config_data_source_diary_sort_test.dart
@@ -6,6 +6,7 @@ import 'package:opennutritracker/core/data/dbo/config_dbo.dart';
 import 'package:opennutritracker/features/diary/presentation/widgets/diary_sort_type.dart';
 
 import '../helpers/hive_test_setup.dart';
+import '../helpers/fake_hive_db_provider.dart';
 
 /// Round-trip test for the persisted per-meal diary sort preference (#82
 /// follow-up). The original sort dropdown stored its choice in widget state
@@ -46,7 +47,7 @@ void main() {
 
     test('breakfast sort preference survives recreating the data source',
         () async {
-      final firstSource = ConfigDataSource(box);
+      final firstSource = ConfigDataSource(FakeHiveDBProvider(configBox: box));
 
       expect(
         await firstSource.getDiarySortPreferences(),
@@ -61,7 +62,7 @@ void main() {
 
       // Simulate the bloc tearing down and a fresh one wiring itself up
       // against the same underlying Hive box on the next app launch.
-      final secondSource = ConfigDataSource(box);
+      final secondSource = ConfigDataSource(FakeHiveDBProvider(configBox: box));
       final prefs = await secondSource.getDiarySortPreferences();
 
       expect(prefs, isNotNull);
@@ -72,7 +73,7 @@ void main() {
 
     test('setting lunch after breakfast preserves the breakfast choice',
         () async {
-      final source = ConfigDataSource(box);
+      final source = ConfigDataSource(FakeHiveDBProvider(configBox: box));
 
       await source.setDiarySortPreference(
         'breakfast',
@@ -99,7 +100,7 @@ void main() {
         ConfigDBO(false, false, false, AppThemeDBO.system),
       );
 
-      final source = ConfigDataSource(box);
+      final source = ConfigDataSource(FakeHiveDBProvider(configBox: box));
       expect(await source.getDiarySortPreferences(), isNull);
     });
   });

--- a/test/unit_test/custom_activity_template_repository_test.dart
+++ b/test/unit_test/custom_activity_template_repository_test.dart
@@ -6,6 +6,7 @@ import 'package:opennutritracker/core/data/repository/custom_activity_template_r
 import 'package:opennutritracker/core/domain/entity/custom_activity_template_entity.dart';
 
 import '../helpers/hive_test_setup.dart';
+import '../helpers/fake_hive_db_provider.dart';
 
 void main() {
   group('CustomActivityTemplateRepository', () {
@@ -34,7 +35,7 @@ void main() {
       );
       await box.clear();
       final repo = CustomActivityTemplateRepository(
-        CustomActivityTemplateDataSource(box),
+        CustomActivityTemplateDataSource(FakeHiveDBProvider(customActivityTemplateBox: box)),
       );
 
       await repo.addTemplate(
@@ -73,7 +74,7 @@ void main() {
       );
       await box.clear();
       final repo = CustomActivityTemplateRepository(
-        CustomActivityTemplateDataSource(box),
+        CustomActivityTemplateDataSource(FakeHiveDBProvider(customActivityTemplateBox: box)),
       );
 
       await repo.addTemplate(
@@ -100,7 +101,7 @@ void main() {
       );
       await box.clear();
       final repo = CustomActivityTemplateRepository(
-        CustomActivityTemplateDataSource(box),
+        CustomActivityTemplateDataSource(FakeHiveDBProvider(customActivityTemplateBox: box)),
       );
 
       await repo.addTemplate(
@@ -131,7 +132,7 @@ void main() {
       );
       await box.clear();
       final repo = CustomActivityTemplateRepository(
-        CustomActivityTemplateDataSource(box),
+        CustomActivityTemplateDataSource(FakeHiveDBProvider(customActivityTemplateBox: box)),
       );
 
       final imported = [

--- a/test/unit_test/custom_meal_data_source_test.dart
+++ b/test/unit_test/custom_meal_data_source_test.dart
@@ -5,6 +5,7 @@ import 'package:opennutritracker/core/data/dbo/meal_dbo.dart';
 import 'package:opennutritracker/core/data/dbo/meal_nutriments_dbo.dart';
 
 import '../helpers/hive_test_setup.dart';
+import '../helpers/fake_hive_db_provider.dart';
 
 MealNutrimentsDBO _emptyNutriments({double? kcal}) => MealNutrimentsDBO(
       energyKcal100: kcal,
@@ -52,7 +53,7 @@ void main() {
     setUp(() async {
       box = await Hive.openBox<MealDBO>(
           'custom_meal_test_${DateTime.now().microsecondsSinceEpoch}');
-      ds = CustomMealDataSource(box);
+      ds = CustomMealDataSource(FakeHiveDBProvider(customMealBox: box));
     });
 
     tearDown(() async {

--- a/test/unit_test/import_meals_json_usecase_test.dart
+++ b/test/unit_test/import_meals_json_usecase_test.dart
@@ -20,6 +20,7 @@ import 'package:opennutritracker/core/domain/usecase/get_macro_goal_usecase.dart
 import 'package:opennutritracker/features/settings/domain/usecase/import_meals_json_usecase.dart';
 
 import '../helpers/hive_test_setup.dart';
+import '../helpers/fake_hive_db_provider.dart';
 
 /// Tracks the intakes the use case wrote without actually touching Hive
 /// for the intake/tracked-day side. The custom-meal side runs against a
@@ -103,19 +104,19 @@ void main() {
       customMealBox = await Hive.openBox<MealDBO>(
         'custom_meal_json_usecase_${DateTime.now().microsecondsSinceEpoch}',
       );
-      customMealDataSource = CustomMealDataSource(customMealBox);
+      customMealDataSource = CustomMealDataSource(FakeHiveDBProvider(customMealBox: customMealBox));
 
       // The super constructors of the use cases require concrete repository
       // instances. The recording/no-op subclasses below never call into
       // those repositories — they short-circuit the public methods — so
       // we pass repositories backed by uninitialised data sources. None of
       // these are ever read.
-      final dummyIntakeRepo = IntakeRepository(IntakeDataSource(_FakeBox()));
-      final dummyTrackedRepo = TrackedDayRepository(TrackedDayDataSource(_FakeBox()));
-      final dummyUserRepo = UserRepository(UserDataSource(_FakeBox()));
-      final dummyConfigRepo = ConfigRepository(ConfigDataSource(_FakeBox()));
+      final dummyIntakeRepo = IntakeRepository(IntakeDataSource(FakeHiveDBProvider()));
+      final dummyTrackedRepo = TrackedDayRepository(TrackedDayDataSource(FakeHiveDBProvider()));
+      final dummyUserRepo = UserRepository(UserDataSource(FakeHiveDBProvider()));
+      final dummyConfigRepo = ConfigRepository(ConfigDataSource(FakeHiveDBProvider()));
       final dummyActivityRepo =
-          UserActivityRepository(UserActivityDataSource(_FakeBox()));
+          UserActivityRepository(UserActivityDataSource(FakeHiveDBProvider()));
 
       addIntake = _RecordingAddIntakeUsecase(dummyIntakeRepo);
       sut = ImportMealsJsonUsecase(
@@ -209,17 +210,4 @@ void main() {
       expect(customMealDataSource.getAllCustomMeals(), hasLength(2));
     });
   });
-}
-
-/// Stand-in for a Hive box used only to satisfy the data-source constructors
-/// in tests where the data source itself is never invoked. Any method call
-/// throws so that misuse fails loudly rather than silently swallowing.
-class _FakeBox<T> implements Box<T> {
-  @override
-  dynamic noSuchMethod(Invocation invocation) {
-    throw UnsupportedError(
-      'Fake Hive box invoked: ${invocation.memberName}. The test should not '
-      'be reaching the underlying data source.',
-    );
-  }
 }

--- a/test/unit_test/intake_repository_test.dart
+++ b/test/unit_test/intake_repository_test.dart
@@ -8,6 +8,7 @@ import 'package:opennutritracker/core/domain/entity/intake_type_entity.dart';
 
 import '../fixture/meal_entity_fixtures.dart';
 import '../helpers/hive_test_setup.dart';
+import '../helpers/fake_hive_db_provider.dart';
 
 void main() {
   group('IntakeRepository test', () {
@@ -24,7 +25,7 @@ void main() {
     test('returns last added first', () async {
       final box = await Hive.openBox<IntakeDBO>('intake_test');
 
-      final repo = IntakeRepository(IntakeDataSource(box));
+      final repo = IntakeRepository(IntakeDataSource(FakeHiveDBProvider(intakeBox: box)));
 
       await repo.addIntake(
         IntakeEntity(

--- a/test/unit_test/merge_custom_meals_usecase_test.dart
+++ b/test/unit_test/merge_custom_meals_usecase_test.dart
@@ -14,6 +14,7 @@ import 'package:opennutritracker/core/domain/usecase/add_tracked_day_usecase.dar
 import 'package:opennutritracker/core/domain/usecase/merge_custom_meals_usecase.dart';
 
 import '../helpers/hive_test_setup.dart';
+import '../helpers/fake_hive_db_provider.dart';
 
 MealNutrimentsDBO _nutriments({double kcal = 100, double protein = 5}) =>
     MealNutrimentsDBO(
@@ -80,10 +81,10 @@ void main() {
       intakeBox = await Hive.openBox<IntakeDBO>('merge_intake_$stamp');
       trackedDayBox =
           await Hive.openBox<TrackedDayDBO>('merge_tracked_$stamp');
-      final customDs = CustomMealDataSource(customBox);
-      final intakeRepo = IntakeRepository(IntakeDataSource(intakeBox));
+      final customDs = CustomMealDataSource(FakeHiveDBProvider(customMealBox: customBox));
+      final intakeRepo = IntakeRepository(IntakeDataSource(FakeHiveDBProvider(intakeBox: intakeBox)));
       final trackedRepo =
-          TrackedDayRepository(TrackedDayDataSource(trackedDayBox));
+          TrackedDayRepository(TrackedDayDataSource(FakeHiveDBProvider(trackedDayBox: trackedDayBox)));
       usecase = MergeCustomMealsUseCase(
         customDs,
         intakeRepo,

--- a/test/unit_test/send_intake_to_profiles_usecase_test.dart
+++ b/test/unit_test/send_intake_to_profiles_usecase_test.dart
@@ -1,0 +1,170 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:hive_ce/hive.dart';
+import 'package:opennutritracker/core/data/data_source/user_activity_dbo.dart';
+import 'package:opennutritracker/core/data/dbo/config_dbo.dart';
+import 'package:opennutritracker/core/data/dbo/intake_dbo.dart';
+import 'package:opennutritracker/core/data/dbo/tracked_day_dbo.dart';
+import 'package:opennutritracker/core/data/dbo/user_dbo.dart';
+import 'package:opennutritracker/core/data/dbo/user_gender_dbo.dart';
+import 'package:opennutritracker/core/data/dbo/user_pal_dbo.dart';
+import 'package:opennutritracker/core/data/dbo/user_weight_goal_dbo.dart';
+import 'package:opennutritracker/core/domain/entity/intake_entity.dart';
+import 'package:opennutritracker/core/domain/entity/intake_type_entity.dart';
+import 'package:opennutritracker/core/domain/entity/profile_entity.dart';
+import 'package:opennutritracker/core/domain/usecase/send_intake_to_profiles_usecase.dart';
+import 'package:opennutritracker/core/utils/hive_db_provider.dart';
+import 'package:opennutritracker/features/add_meal/domain/entity/meal_entity.dart';
+import 'package:opennutritracker/features/add_meal/domain/entity/meal_nutriments_entity.dart';
+
+import '../helpers/hive_test_setup.dart';
+
+/// Returns pre-opened, unencrypted boxes so the usecase can run against a
+/// "target profile" without the full Hive/encryption bootstrap.
+class _TestHiveDBProvider extends HiveDBProvider {
+  final Map<String, Box<dynamic>> _scoped;
+
+  _TestHiveDBProvider(this._scoped);
+
+  @override
+  Future<Box<E>> openScopedBox<E>(String baseName, String boxSuffix) async {
+    return _scoped[baseName] as Box<E>;
+  }
+
+  // App config is global; the goal calc reads it via ConfigDataSource. Reuse
+  // the test's config box so the merge has a valid shared box to read from.
+  @override
+  Box<ConfigDBO> get appConfigBox =>
+      _scoped[HiveDBProvider.configBoxName] as Box<ConfigDBO>;
+}
+
+void main() {
+  TestWidgetsFlutterBinding.ensureInitialized();
+
+  late Box<IntakeDBO> intakeBox;
+  late Box<TrackedDayDBO> trackedDayBox;
+  late Box<UserDBO> userBox;
+  late Box<ConfigDBO> configBox;
+  late Box<UserActivityDBO> activityBox;
+  late SendIntakeToProfilesUsecase sut;
+
+  setUp(() async {
+    Hive.init('.');
+    registerHiveAdaptersOnce();
+    final tag = DateTime.now().microsecondsSinceEpoch;
+    intakeBox = await Hive.openBox<IntakeDBO>('send_intake_$tag');
+    trackedDayBox = await Hive.openBox<TrackedDayDBO>('send_tracked_$tag');
+    userBox = await Hive.openBox<UserDBO>('send_user_$tag');
+    configBox = await Hive.openBox<ConfigDBO>('send_config_$tag');
+    activityBox = await Hive.openBox<UserActivityDBO>('send_activity_$tag');
+
+    // The target profile must be set up (have user data) for a copy to land.
+    await userBox.put(
+      'UserKey',
+      UserDBO(
+        birthday: DateTime(1990, 6, 15),
+        heightCM: 170,
+        weightKG: 70,
+        gender: UserGenderDBO.female,
+        goal: UserWeightGoalDBO.maintainWeight,
+        pal: UserPALDBO.sedentary,
+      ),
+    );
+    await configBox.put('ConfigKey', ConfigDBO.empty());
+
+    sut = SendIntakeToProfilesUsecase(
+      _TestHiveDBProvider({
+        HiveDBProvider.intakeBoxName: intakeBox,
+        HiveDBProvider.trackedDayBoxName: trackedDayBox,
+        HiveDBProvider.userBoxName: userBox,
+        HiveDBProvider.configBoxName: configBox,
+        HiveDBProvider.userActivityBoxName: activityBox,
+      }),
+    );
+  });
+
+  tearDown(() async {
+    await Hive.deleteFromDisk();
+  });
+
+  IntakeEntity buildIntake() => IntakeEntity(
+        id: 'source-intake',
+        unit: 'g',
+        amount: 100,
+        type: IntakeTypeEntity.breakfast,
+        dateTime: DateTime(2026, 1, 1, 8),
+        meal: MealEntity(
+          code: 'meal-1',
+          name: 'Test Meal',
+          url: null,
+          mealQuantity: '100',
+          mealUnit: 'g',
+          servingQuantity: null,
+          servingUnit: 'g',
+          servingSize: '100 g',
+          nutriments: MealNutrimentsEntity(
+            energyKcal100: 200,
+            carbohydrates100: 20,
+            fat100: 10,
+            proteins100: 5,
+            sugars100: null,
+            saturatedFat100: null,
+            fiber100: null,
+          ),
+          source: MealSourceEntity.custom,
+        ),
+      );
+
+  test('copies the intake into the target profile with a fresh id', () async {
+    final intake = buildIntake();
+    final target = ProfileEntity(
+      id: 'target',
+      name: 'Target',
+      createdAt: DateTime(2026, 1, 1),
+      boxSuffix: 'target',
+    );
+
+    await sut.copyToProfiles([intake], [target]);
+
+    expect(intakeBox.length, 1);
+    final copied = intakeBox.values.first;
+    expect(copied.meal.name, 'Test Meal');
+    expect(copied.amount, 100);
+    // The copy must not reuse the source id.
+    expect(copied.id, isNot('source-intake'));
+  });
+
+  test('seeds the target tracked day with the copied calories', () async {
+    final intake = buildIntake();
+    final target = ProfileEntity(
+      id: 'target',
+      name: 'Target',
+      createdAt: DateTime(2026, 1, 1),
+      boxSuffix: 'target',
+    );
+
+    await sut.copyToProfiles([intake], [target]);
+
+    expect(trackedDayBox.isNotEmpty, isTrue);
+    // 100 g * 200 kcal/100g = 200 kcal.
+    expect(trackedDayBox.values.first.caloriesTracked, 200);
+  });
+
+  test('skips a target profile that has no user data', () async {
+    await userBox.delete('UserKey');
+
+    await sut.copyToProfiles(
+      [buildIntake()],
+      [
+        ProfileEntity(
+          id: 'target',
+          name: 'Target',
+          createdAt: DateTime(2026, 1, 1),
+          boxSuffix: 'target',
+        ),
+      ],
+    );
+
+    expect(intakeBox.isEmpty, isTrue);
+    expect(trackedDayBox.isEmpty, isTrue);
+  });
+}

--- a/test/unit_test/tracked_day_data_source_test.dart
+++ b/test/unit_test/tracked_day_data_source_test.dart
@@ -4,6 +4,7 @@ import 'package:opennutritracker/core/data/data_source/tracked_day_data_source.d
 import 'package:opennutritracker/core/data/dbo/tracked_day_dbo.dart';
 
 import '../helpers/hive_test_setup.dart';
+import '../helpers/fake_hive_db_provider.dart';
 
 void main() {
   group('TrackedDayDataSource getTrackedDaysInRange test', () {
@@ -18,7 +19,7 @@ void main() {
     setUp(() async {
       Hive.init('.');
       box = await Hive.openBox<TrackedDayDBO>('tracked_day_test');
-      dataSource = TrackedDayDataSource(box);
+      dataSource = TrackedDayDataSource(FakeHiveDBProvider(trackedDayBox: box));
     });
 
     tearDown(() async {
@@ -157,7 +158,7 @@ void main() {
       Hive.init('.');
       box = await Hive.openBox<TrackedDayDBO>(
           'tracked_day_mut_test_${DateTime.now().microsecondsSinceEpoch}');
-      ds = TrackedDayDataSource(box);
+      ds = TrackedDayDataSource(FakeHiveDBProvider(trackedDayBox: box));
     });
 
     tearDown(() async {

--- a/test/unit_test/user_activity_repository_test.dart
+++ b/test/unit_test/user_activity_repository_test.dart
@@ -8,6 +8,7 @@ import 'package:opennutritracker/core/domain/entity/physical_activity_entity.dar
 import 'package:opennutritracker/core/domain/entity/user_activity_entity.dart';
 
 import '../helpers/hive_test_setup.dart';
+import '../helpers/fake_hive_db_provider.dart';
 
 void main() {
   group('UserActivityRepository', () {
@@ -28,7 +29,7 @@ void main() {
     test('updateUserActivity updates duration and recalculates burnedKcal',
         () async {
       final box = await Hive.openBox<UserActivityDBO>('activity_test');
-      final repo = UserActivityRepository(UserActivityDataSource(box));
+      final repo = UserActivityRepository(UserActivityDataSource(FakeHiveDBProvider(userActivityBox: box)));
 
       final physicalActivity = PhysicalActivityDBO(
         'running_general',
@@ -59,7 +60,7 @@ void main() {
 
     test('updateUserActivity returns null for unknown id', () async {
       final box = await Hive.openBox<UserActivityDBO>('activity_test');
-      final repo = UserActivityRepository(UserActivityDataSource(box));
+      final repo = UserActivityRepository(UserActivityDataSource(FakeHiveDBProvider(userActivityBox: box)));
 
       final result =
           await repo.updateUserActivity('nonexistent', 60.0, 100.0);
@@ -68,7 +69,7 @@ void main() {
 
     test('updateUserActivity preserves the original date', () async {
       final box = await Hive.openBox<UserActivityDBO>('activity_test');
-      final repo = UserActivityRepository(UserActivityDataSource(box));
+      final repo = UserActivityRepository(UserActivityDataSource(FakeHiveDBProvider(userActivityBox: box)));
 
       final originalDate = DateTime.utc(2026, 3, 14, 9, 26, 53);
       final physicalActivity = PhysicalActivityDBO(
@@ -95,7 +96,7 @@ void main() {
     test('updateUserActivity preserves the underlying physical activity',
         () async {
       final box = await Hive.openBox<UserActivityDBO>('activity_test');
-      final repo = UserActivityRepository(UserActivityDataSource(box));
+      final repo = UserActivityRepository(UserActivityDataSource(FakeHiveDBProvider(userActivityBox: box)));
 
       final physicalActivity = PhysicalActivityDBO(
         'walking_brisk',
@@ -121,7 +122,7 @@ void main() {
     test('updateUserActivity accepts a zero duration without crashing',
         () async {
       final box = await Hive.openBox<UserActivityDBO>('activity_test');
-      final repo = UserActivityRepository(UserActivityDataSource(box));
+      final repo = UserActivityRepository(UserActivityDataSource(FakeHiveDBProvider(userActivityBox: box)));
 
       final physicalActivity = PhysicalActivityDBO(
         'running_general',
@@ -148,7 +149,7 @@ void main() {
     test('two consecutive updates both work and the last one wins', () async {
       final box = await Hive.openBox<UserActivityDBO>('activity_test');
       await box.clear();
-      final repo = UserActivityRepository(UserActivityDataSource(box));
+      final repo = UserActivityRepository(UserActivityDataSource(FakeHiveDBProvider(userActivityBox: box)));
 
       final physicalActivity = PhysicalActivityDBO(
         'running_general',
@@ -181,7 +182,7 @@ void main() {
 
     test('deleteUserActivity removes the activity by id', () async {
       final box = await Hive.openBox<UserActivityDBO>('activity_test');
-      final repo = UserActivityRepository(UserActivityDataSource(box));
+      final repo = UserActivityRepository(UserActivityDataSource(FakeHiveDBProvider(userActivityBox: box)));
 
       final physicalActivity = PhysicalActivityDBO(
         'running_general',
@@ -212,7 +213,7 @@ void main() {
         () async {
       final box = await Hive.openBox<UserActivityDBO>('activity_test');
       await box.clear();
-      final repo = UserActivityRepository(UserActivityDataSource(box));
+      final repo = UserActivityRepository(UserActivityDataSource(FakeHiveDBProvider(userActivityBox: box)));
 
       final physicalActivity = PhysicalActivityDBO(
         'walking_brisk',
@@ -250,7 +251,7 @@ void main() {
       // entity should prefer it.
       final box = await Hive.openBox<UserActivityDBO>('activity_test');
       await box.clear();
-      final repo = UserActivityRepository(UserActivityDataSource(box));
+      final repo = UserActivityRepository(UserActivityDataSource(FakeHiveDBProvider(userActivityBox: box)));
 
       final customActivity = PhysicalActivityDBO(
         '99999',
@@ -310,7 +311,7 @@ void main() {
         'most recent first', () async {
       final box = await Hive.openBox<UserActivityDBO>('activity_test');
       await box.clear();
-      final repo = UserActivityRepository(UserActivityDataSource(box));
+      final repo = UserActivityRepository(UserActivityDataSource(FakeHiveDBProvider(userActivityBox: box)));
 
       final running = PhysicalActivityDBO(
         'running_general',

--- a/test/unit_test/user_data_source_test.dart
+++ b/test/unit_test/user_data_source_test.dart
@@ -7,6 +7,7 @@ import 'package:opennutritracker/core/data/dbo/user_pal_dbo.dart';
 import 'package:opennutritracker/core/data/dbo/user_weight_goal_dbo.dart';
 
 import '../helpers/hive_test_setup.dart';
+import '../helpers/fake_hive_db_provider.dart';
 
 void main() {
   group('UserDataSource race-condition guarantees', () {
@@ -37,7 +38,7 @@ void main() {
       // the box during the onboarding race. The data source must now fail
       // loudly so callers can diagnose the race instead of corrupting calcs.
       final box = await Hive.openBox<UserDBO>('user_data_source_test_empty');
-      final source = UserDataSource(box);
+      final source = UserDataSource(FakeHiveDBProvider(userBox: box));
 
       expect(source.getUserData, throwsStateError);
     });
@@ -50,7 +51,7 @@ void main() {
       // OnboardingBloc.saveOnboardingData) could navigate away before the
       // user landed in the box.
       final box = await Hive.openBox<UserDBO>('user_data_source_test_save');
-      final source = UserDataSource(box);
+      final source = UserDataSource(FakeHiveDBProvider(userBox: box));
 
       await source.saveUserData(buildUser());
 

--- a/test/unit_test/weight_log_data_source_test.dart
+++ b/test/unit_test/weight_log_data_source_test.dart
@@ -4,6 +4,7 @@ import 'package:opennutritracker/core/data/data_source/weight_log_data_source.da
 import 'package:opennutritracker/core/data/dbo/weight_log_dbo.dart';
 
 import '../helpers/hive_test_setup.dart';
+import '../helpers/fake_hive_db_provider.dart';
 
 void main() {
   group('WeightLogDataSource', () {
@@ -20,7 +21,7 @@ void main() {
       box = await Hive.openBox<WeightLogDBO>(
         'weight_log_test_${DateTime.now().microsecondsSinceEpoch}',
       );
-      dataSource = WeightLogDataSource(box);
+      dataSource = WeightLogDataSource(FakeHiveDBProvider(weightLogBox: box));
     });
 
     tearDown(() async {


### PR DESCRIPTION
## Summary

This adds support for keeping several people's data side by side on one device, which is what #471 asked for: a parent managing separate profiles for their kids, each with its own diary, weight history and goals, and no one's data bleeding into anyone else's.

Each profile owns an isolated set of Hive boxes. The first profile reuses the existing box names, so anyone upgrading from a single-user install keeps everything they already had with no migration step. New profiles get their own suffixed boxes, and switching closes one set and opens the next.

## What's shared vs per-profile

Device-wide preferences and reusable content are shared rather than duplicated per profile, so switching to a child's profile doesn't flip your theme or lose your recipe library:

- **Shared (app-wide):** theme, accent, Material You, language, units, energy unit, notifications, the anonymous-data consent, and the view toggles (macros/micros, nutrient panel, diary sort, day boundary). Plus the custom-meal, recipe and activity-template libraries, and the existing Open Food Facts search cache.
- **Per-profile:** body stats, the personal nutrition goals (kcal adjustment, macro split, per-meal kcal shares, water goal), and every log (meals, activity, weight, water, fasting, tracked-day totals).

Internally this meant splitting the old `ConfigBox` into a shared app config plus a small per-profile config, merged transparently so the consumers and `ConfigEntity` did not have to change.

## What's included

- Profile registry, isolation, and a switcher on the Profile tab plus a manage-profiles screen (add, rename, set a picture, delete, with last-profile and active-profile guards).
- Adding a profile routes into onboarding for its body stats; backing out cleans up the half-created profile and returns you to where you were.
- A **Copy to profile** action on a meal's share sheet, next to the QR share, to send a logged meal into one or more other profiles at once (with the target's tracked-day totals updated using its own goals).

## Testing

- `flutter analyze` clean; full suite green (647 tests, including new coverage for the cross-profile copy and the config round-trip).
- Verified on a physical device (Pixel 6 Pro):
  - [x] Upgrade over an existing install preserves all prior data (no wipe).
  - [x] Two profiles, switching shows each one's own meals and goals.
  - [x] A shared setting (energy unit) changed on one profile carries to the other; a per-profile goal (water) stays independent.
  - [x] Copy-to-profile lands a meal in the target profile's diary and tracked day.
  - [x] A recipe created on one profile appears on the other.

Closes #471.