### PR TITLE
Add quick add for activity (#472)

### DIFF
--- a/lib/core/domain/entity/physical_activity_entity.dart
+++ b/lib/core/domain/entity/physical_activity_entity.dart
@@ -55,10 +55,30 @@ class PhysicalActivityEntity extends Equatable {
     PhysicalActivityTypeEntity.conditioningExercise,
   );
 
+  /// A Custom activity that carries a user-supplied label. The name rides
+  /// in [specificActivity] (persisted on the DBO) and [getName] surfaces it
+  /// instead of the generic "Custom activity" text. The plain [custom]
+  /// sentinel keeps `specificActivity == 'custom'`, so unnamed entries are
+  /// unaffected.
+  factory PhysicalActivityEntity.customNamed(String name) =>
+      PhysicalActivityEntity(
+        customCode,
+        name,
+        'user-entered kcal',
+        0.0,
+        const <String>[],
+        PhysicalActivityTypeEntity.conditioningExercise,
+      );
+
   @override
   List<Object?> get props => [code, specificActivity, description, mets];
 
   String getName(BuildContext context) {
+    // A named Custom activity (e.g. from Quick Add) carries its label in
+    // specificActivity; show that instead of the generic "Custom activity".
+    if (isCustom && specificActivity.isNotEmpty && specificActivity != 'custom') {
+      return specificActivity;
+    }
     final physicalActivityMap = {
       "01015": S.of(context).paBicyclingGeneral,
       "01009": S.of(context).paBicyclingMountainGeneral,

--- a/lib/features/add_activity/presentation/add_activity_screen.dart
+++ b/lib/features/add_activity/presentation/add_activity_screen.dart
@@ -8,6 +8,7 @@ import 'package:opennutritracker/features/activity_detail/activity_detail_screen
 import 'package:opennutritracker/features/add_activity/presentation/bloc/activities_bloc.dart';
 import 'package:opennutritracker/features/add_activity/presentation/bloc/recent_activities_bloc.dart';
 import 'package:opennutritracker/features/add_activity/presentation/widgets/activity_item_card.dart';
+import 'package:opennutritracker/features/add_activity/presentation/widgets/quick_add_activity_bottom_sheet.dart';
 import 'package:opennutritracker/features/add_meal/presentation/widgets/no_results_widget.dart';
 import 'package:opennutritracker/generated/l10n.dart';
 
@@ -55,6 +56,13 @@ class _AddActivityScreenState extends State<AddActivityScreen>
       appBar: AppBar(
         title: Text(S.of(context).activityLabel),
         actions: [
+          Semantics(
+            identifier: 'add-activity-quick-add',
+            child: TextButton(
+              onPressed: _onQuickAddPressed,
+              child: Text(S.of(context).quickAddCardLabel),
+            ),
+          ),
           Semantics(
             identifier: 'add-activity-custom',
             child: IconButton(
@@ -196,6 +204,15 @@ class _AddActivityScreenState extends State<AddActivityScreen>
           ],
         ),
       ),
+    );
+  }
+
+  void _onQuickAddPressed() {
+    showModalBottomSheet<void>(
+      context: context,
+      isScrollControlled: true,
+      showDragHandle: true,
+      builder: (_) => QuickAddActivityBottomSheet(day: _day),
     );
   }
 

--- a/lib/features/add_activity/presentation/widgets/quick_add_activity_bottom_sheet.dart
+++ b/lib/features/add_activity/presentation/widgets/quick_add_activity_bottom_sheet.dart
@@ -1,0 +1,230 @@
+import 'package:flutter/material.dart';
+import 'package:flutter/services.dart';
+import 'package:logging/logging.dart';
+import 'package:opennutritracker/core/domain/entity/physical_activity_entity.dart';
+import 'package:opennutritracker/core/domain/entity/user_activity_entity.dart';
+import 'package:opennutritracker/core/domain/usecase/add_tracked_day_usecase.dart';
+import 'package:opennutritracker/core/domain/usecase/add_user_activity_usercase.dart';
+import 'package:opennutritracker/core/domain/usecase/get_kcal_goal_usecase.dart';
+import 'package:opennutritracker/core/domain/usecase/get_macro_goal_usecase.dart';
+import 'package:opennutritracker/core/utils/calc/macro_calc.dart';
+import 'package:opennutritracker/core/utils/calc/unit_calc.dart';
+import 'package:opennutritracker/core/utils/energy_unit_provider.dart';
+import 'package:opennutritracker/core/utils/id_generator.dart';
+import 'package:opennutritracker/core/utils/locator.dart';
+import 'package:opennutritracker/core/utils/navigation_options.dart';
+import 'package:opennutritracker/features/diary/presentation/bloc/calendar_day_bloc.dart';
+import 'package:opennutritracker/features/diary/presentation/bloc/diary_bloc.dart';
+import 'package:opennutritracker/features/home/presentation/bloc/home_bloc.dart';
+import 'package:opennutritracker/generated/l10n.dart';
+import 'package:provider/provider.dart';
+import 'package:sentry_flutter/sentry_flutter.dart';
+
+/// Fast path for logging an activity by typing the time spent and the
+/// calories burned directly, for people whose tracker (a step counter,
+/// a watch) already gives them a kcal figure that the MET-based presets
+/// don't match (#472). Mirrors the food Quick Add sheet: the burned
+/// energy is required, the duration is an optional note, and the activity
+/// is stored as a Custom one so the entered kcal is used verbatim rather
+/// than recomputed.
+class QuickAddActivityBottomSheet extends StatefulWidget {
+  final DateTime day;
+
+  const QuickAddActivityBottomSheet({super.key, required this.day});
+
+  @override
+  State<QuickAddActivityBottomSheet> createState() =>
+      _QuickAddActivityBottomSheetState();
+}
+
+class _QuickAddActivityBottomSheetState
+    extends State<QuickAddActivityBottomSheet> {
+  final _log = Logger('QuickAddActivityBottomSheet');
+
+  final _durationController = TextEditingController();
+  final _energyController = TextEditingController();
+
+  bool _saving = false;
+
+  @override
+  void initState() {
+    super.initState();
+    _energyController.addListener(_onRequiredFieldChanged);
+  }
+
+  @override
+  void dispose() {
+    _energyController.removeListener(_onRequiredFieldChanged);
+    _durationController.dispose();
+    _energyController.dispose();
+    super.dispose();
+  }
+
+  void _onRequiredFieldChanged() => setState(() {});
+
+  double? _parsed(TextEditingController c) {
+    final raw = c.text.trim().replaceAll(',', '.');
+    if (raw.isEmpty) return null;
+    final value = double.tryParse(raw);
+    if (value == null || value < 0) return null;
+    return value;
+  }
+
+  bool get _canSubmit {
+    final energy = _parsed(_energyController);
+    return !_saving && energy != null && energy > 0;
+  }
+
+  Future<void> _onSubmit() async {
+    if (!_canSubmit) return;
+    setState(() => _saving = true);
+
+    final usesKj = context.read<EnergyUnitProvider>().usesKilojoules;
+    final enteredEnergy = _parsed(_energyController)!;
+    final kcal = usesKj ? UnitCalc.kjToKcal(enteredEnergy) : enteredEnergy;
+    final duration = _parsed(_durationController) ?? 0;
+
+    try {
+      final activity = UserActivityEntity(
+        IdGenerator.getUniqueID(),
+        duration,
+        kcal,
+        widget.day,
+        PhysicalActivityEntity.custom,
+        userKcal: kcal,
+      );
+      await locator<AddUserActivityUsecase>().addUserActivity(activity);
+      await _updateTrackedDay(kcal);
+
+      locator<HomeBloc>().add(const LoadItemsEvent());
+      locator<DiaryBloc>().add(const LoadDiaryYearEvent());
+      locator<CalendarDayBloc>().add(RefreshCalendarDayEvent());
+
+      if (!mounted) return;
+      final scaffoldMessenger = ScaffoldMessenger.of(context);
+      // Resolve the message before navigating: the push below tears down
+      // this sheet, so reading from context afterwards is unsafe.
+      final addedMessage = S.of(context).quickAddActivityAddedSnack;
+      Navigator.of(context, rootNavigator: true).pushNamedAndRemoveUntil(
+        NavigationOptions.mainRoute,
+        (route) => false,
+      );
+      scaffoldMessenger.showSnackBar(SnackBar(content: Text(addedMessage)));
+    } catch (e, st) {
+      _log.severe('Quick Add activity save failed', e, st);
+      Sentry.captureException(e, stackTrace: st);
+      if (!mounted) return;
+      setState(() => _saving = false);
+    }
+  }
+
+  /// Burned calories raise the day's goal ceiling, mirroring
+  /// `ActivityDetailBloc._updateTrackedDay`.
+  Future<void> _updateTrackedDay(double caloriesBurned) async {
+    final addTrackedDay = locator<AddTrackedDayUsecase>();
+    final hasTrackedDay = await addTrackedDay.hasTrackedDay(widget.day);
+    if (!hasTrackedDay) {
+      final kcalGoal = await locator<GetKcalGoalUsecase>().getKcalGoal(
+        totalKcalActivitiesParam: 0,
+      );
+      final macroGoal = locator<GetMacroGoalUsecase>();
+      await addTrackedDay.addNewTrackedDay(
+        widget.day,
+        kcalGoal,
+        await macroGoal.getCarbsGoal(kcalGoal),
+        await macroGoal.getFatsGoal(kcalGoal),
+        await macroGoal.getProteinsGoal(kcalGoal),
+      );
+    }
+    await addTrackedDay.increaseDayCalorieGoal(widget.day, caloriesBurned);
+    await addTrackedDay.increaseDayMacroGoals(
+      widget.day,
+      carbsAmount: MacroCalc.getTotalCarbsGoal(caloriesBurned),
+      fatAmount: MacroCalc.getTotalFatsGoal(caloriesBurned),
+      proteinAmount: MacroCalc.getTotalProteinsGoal(caloriesBurned),
+    );
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    final usesKj = context.watch<EnergyUnitProvider>().usesKilojoules;
+    final s = S.of(context);
+
+    return Padding(
+      padding: EdgeInsets.only(bottom: MediaQuery.of(context).viewInsets.bottom),
+      child: SingleChildScrollView(
+        padding: const EdgeInsets.fromLTRB(24, 8, 24, 24),
+        child: Column(
+          crossAxisAlignment: CrossAxisAlignment.stretch,
+          mainAxisSize: MainAxisSize.min,
+          children: [
+            Padding(
+              padding: const EdgeInsets.only(bottom: 16),
+              child: Text(
+                s.quickAddActivityTitleLabel,
+                style: Theme.of(context).textTheme.titleLarge,
+                textAlign: TextAlign.center,
+              ),
+            ),
+            _field(
+              controller: _energyController,
+              identifier: 'quick-add-activity-energy',
+              label: usesKj
+                  ? s.quickAddActivityEnergyLabelKj
+                  : s.quickAddActivityEnergyLabelKcal,
+              isRequired: true,
+              autofocus: true,
+            ),
+            _field(
+              controller: _durationController,
+              identifier: 'quick-add-activity-duration',
+              label: s.quickAddActivityDurationLabel,
+              isRequired: false,
+            ),
+            const SizedBox(height: 16),
+            Semantics(
+              identifier: 'quick-add-activity-submit',
+              child: FilledButton(
+                onPressed: _canSubmit ? _onSubmit : null,
+                child: _saving
+                    ? const SizedBox(
+                        height: 18,
+                        width: 18,
+                        child: CircularProgressIndicator(strokeWidth: 2),
+                      )
+                    : Text(s.quickAddSubmitLabel),
+              ),
+            ),
+          ],
+        ),
+      ),
+    );
+  }
+
+  Widget _field({
+    required TextEditingController controller,
+    required String identifier,
+    required String label,
+    required bool isRequired,
+    bool autofocus = false,
+  }) {
+    return Padding(
+      padding: const EdgeInsets.only(bottom: 12),
+      child: Semantics(
+        identifier: identifier,
+        child: TextField(
+          controller: controller,
+          autofocus: autofocus,
+          keyboardType: const TextInputType.numberWithOptions(decimal: true),
+          inputFormatters: [
+            FilteringTextInputFormatter.allow(RegExp(r'[0-9.,]')),
+          ],
+          decoration: InputDecoration(
+            labelText: isRequired ? '$label *' : label,
+            border: const OutlineInputBorder(),
+          ),
+        ),
+      ),
+    );
+  }
+}

--- a/lib/features/add_activity/presentation/widgets/quick_add_activity_bottom_sheet.dart
+++ b/lib/features/add_activity/presentation/widgets/quick_add_activity_bottom_sheet.dart
@@ -41,6 +41,7 @@ class _QuickAddActivityBottomSheetState
     extends State<QuickAddActivityBottomSheet> {
   final _log = Logger('QuickAddActivityBottomSheet');
 
+  final _nameController = TextEditingController();
   final _durationController = TextEditingController();
   final _energyController = TextEditingController();
 
@@ -55,6 +56,7 @@ class _QuickAddActivityBottomSheetState
   @override
   void dispose() {
     _energyController.removeListener(_onRequiredFieldChanged);
+    _nameController.dispose();
     _durationController.dispose();
     _energyController.dispose();
     super.dispose();
@@ -83,6 +85,7 @@ class _QuickAddActivityBottomSheetState
     final enteredEnergy = _parsed(_energyController)!;
     final kcal = usesKj ? UnitCalc.kjToKcal(enteredEnergy) : enteredEnergy;
     final duration = _parsed(_durationController) ?? 0;
+    final name = _nameController.text.trim();
 
     try {
       final activity = UserActivityEntity(
@@ -90,7 +93,9 @@ class _QuickAddActivityBottomSheetState
         duration,
         kcal,
         widget.day,
-        PhysicalActivityEntity.custom,
+        name.isEmpty
+            ? PhysicalActivityEntity.custom
+            : PhysicalActivityEntity.customNamed(name),
         userKcal: kcal,
       );
       await locator<AddUserActivityUsecase>().addUserActivity(activity);
@@ -167,13 +172,20 @@ class _QuickAddActivityBottomSheetState
               ),
             ),
             _field(
+              controller: _nameController,
+              identifier: 'quick-add-activity-name',
+              label: s.quickAddActivityNameLabel,
+              isRequired: false,
+              numeric: false,
+              autofocus: true,
+            ),
+            _field(
               controller: _energyController,
               identifier: 'quick-add-activity-energy',
               label: usesKj
                   ? s.quickAddActivityEnergyLabelKj
                   : s.quickAddActivityEnergyLabelKcal,
               isRequired: true,
-              autofocus: true,
             ),
             _field(
               controller: _durationController,
@@ -206,6 +218,7 @@ class _QuickAddActivityBottomSheetState
     required String identifier,
     required String label,
     required bool isRequired,
+    bool numeric = true,
     bool autofocus = false,
   }) {
     return Padding(
@@ -215,10 +228,14 @@ class _QuickAddActivityBottomSheetState
         child: TextField(
           controller: controller,
           autofocus: autofocus,
-          keyboardType: const TextInputType.numberWithOptions(decimal: true),
-          inputFormatters: [
-            FilteringTextInputFormatter.allow(RegExp(r'[0-9.,]')),
-          ],
+          textCapitalization:
+              numeric ? TextCapitalization.none : TextCapitalization.sentences,
+          keyboardType: numeric
+              ? const TextInputType.numberWithOptions(decimal: true)
+              : TextInputType.text,
+          inputFormatters: numeric
+              ? [FilteringTextInputFormatter.allow(RegExp(r'[0-9.,]'))]
+              : null,
           decoration: InputDecoration(
             labelText: isRequired ? '$label *' : label,
             border: const OutlineInputBorder(),

--- a/lib/generated/intl/messages_cs.dart
+++ b/lib/generated/intl/messages_cs.dart
@@ -108,6 +108,11 @@ class MessageLookup extends MessageLookupByLibrary {
 
   final messages = _notInlinedMessages(_notInlinedMessages);
   static Map<String, Function> _notInlinedMessages(_) => <String, Function>{
+        "quickAddActivityTitleLabel": MessageLookupByLibrary.simpleMessage("Rychlé přidání aktivity"),
+        "quickAddActivityDurationLabel": MessageLookupByLibrary.simpleMessage("Doba trvání (min, volitelné)"),
+        "quickAddActivityEnergyLabelKcal": MessageLookupByLibrary.simpleMessage("Spálená energie (kcal)"),
+        "quickAddActivityEnergyLabelKj": MessageLookupByLibrary.simpleMessage("Spálená energie (kJ)"),
+        "quickAddActivityAddedSnack": MessageLookupByLibrary.simpleMessage("Aktivita přidána"),
         "copyActionLabel": MessageLookupByLibrary.simpleMessage("Kopírovat"),
         "copyToProfileLabel": MessageLookupByLibrary.simpleMessage("Kopírovat do profilu"),
         "copiedToProfileSnackbar": MessageLookupByLibrary.simpleMessage("Jídlo zkopírováno do profilu"),

--- a/lib/generated/intl/messages_cs.dart
+++ b/lib/generated/intl/messages_cs.dart
@@ -108,6 +108,7 @@ class MessageLookup extends MessageLookupByLibrary {
 
   final messages = _notInlinedMessages(_notInlinedMessages);
   static Map<String, Function> _notInlinedMessages(_) => <String, Function>{
+        "quickAddActivityNameLabel": MessageLookupByLibrary.simpleMessage("Název (volitelné)"),
         "quickAddActivityTitleLabel": MessageLookupByLibrary.simpleMessage("Rychlé přidání aktivity"),
         "quickAddActivityDurationLabel": MessageLookupByLibrary.simpleMessage("Doba trvání (min, volitelné)"),
         "quickAddActivityEnergyLabelKcal": MessageLookupByLibrary.simpleMessage("Spálená energie (kcal)"),

--- a/lib/generated/intl/messages_de.dart
+++ b/lib/generated/intl/messages_de.dart
@@ -110,6 +110,11 @@ class MessageLookup extends MessageLookupByLibrary {
 
   final messages = _notInlinedMessages(_notInlinedMessages);
   static Map<String, Function> _notInlinedMessages(_) => <String, Function>{
+        "quickAddActivityTitleLabel": MessageLookupByLibrary.simpleMessage("Aktivität schnell hinzufügen"),
+        "quickAddActivityDurationLabel": MessageLookupByLibrary.simpleMessage("Dauer (Min., optional)"),
+        "quickAddActivityEnergyLabelKcal": MessageLookupByLibrary.simpleMessage("Verbrannte Energie (kcal)"),
+        "quickAddActivityEnergyLabelKj": MessageLookupByLibrary.simpleMessage("Verbrannte Energie (kJ)"),
+        "quickAddActivityAddedSnack": MessageLookupByLibrary.simpleMessage("Aktivität hinzugefügt"),
         "copyActionLabel": MessageLookupByLibrary.simpleMessage("Kopieren"),
         "copyToProfileLabel": MessageLookupByLibrary.simpleMessage("In Profil kopieren"),
         "copiedToProfileSnackbar": MessageLookupByLibrary.simpleMessage("Mahlzeit ins Profil kopiert"),

--- a/lib/generated/intl/messages_de.dart
+++ b/lib/generated/intl/messages_de.dart
@@ -110,6 +110,7 @@ class MessageLookup extends MessageLookupByLibrary {
 
   final messages = _notInlinedMessages(_notInlinedMessages);
   static Map<String, Function> _notInlinedMessages(_) => <String, Function>{
+        "quickAddActivityNameLabel": MessageLookupByLibrary.simpleMessage("Name (optional)"),
         "quickAddActivityTitleLabel": MessageLookupByLibrary.simpleMessage("Aktivität schnell hinzufügen"),
         "quickAddActivityDurationLabel": MessageLookupByLibrary.simpleMessage("Dauer (Min., optional)"),
         "quickAddActivityEnergyLabelKcal": MessageLookupByLibrary.simpleMessage("Verbrannte Energie (kcal)"),

--- a/lib/generated/intl/messages_en.dart
+++ b/lib/generated/intl/messages_en.dart
@@ -107,6 +107,11 @@ class MessageLookup extends MessageLookupByLibrary {
 
   final messages = _notInlinedMessages(_notInlinedMessages);
   static Map<String, Function> _notInlinedMessages(_) => <String, Function>{
+        "quickAddActivityTitleLabel": MessageLookupByLibrary.simpleMessage("Quick add activity"),
+        "quickAddActivityDurationLabel": MessageLookupByLibrary.simpleMessage("Duration (min, optional)"),
+        "quickAddActivityEnergyLabelKcal": MessageLookupByLibrary.simpleMessage("Energy burned (kcal)"),
+        "quickAddActivityEnergyLabelKj": MessageLookupByLibrary.simpleMessage("Energy burned (kJ)"),
+        "quickAddActivityAddedSnack": MessageLookupByLibrary.simpleMessage("Activity added"),
         "copyActionLabel": MessageLookupByLibrary.simpleMessage("Copy"),
         "copyToProfileLabel": MessageLookupByLibrary.simpleMessage("Copy to profile"),
         "copiedToProfileSnackbar": MessageLookupByLibrary.simpleMessage("Meal copied to profile"),

--- a/lib/generated/intl/messages_en.dart
+++ b/lib/generated/intl/messages_en.dart
@@ -107,6 +107,7 @@ class MessageLookup extends MessageLookupByLibrary {
 
   final messages = _notInlinedMessages(_notInlinedMessages);
   static Map<String, Function> _notInlinedMessages(_) => <String, Function>{
+        "quickAddActivityNameLabel": MessageLookupByLibrary.simpleMessage("Name (optional)"),
         "quickAddActivityTitleLabel": MessageLookupByLibrary.simpleMessage("Quick add activity"),
         "quickAddActivityDurationLabel": MessageLookupByLibrary.simpleMessage("Duration (min, optional)"),
         "quickAddActivityEnergyLabelKcal": MessageLookupByLibrary.simpleMessage("Energy burned (kcal)"),

--- a/lib/generated/intl/messages_it.dart
+++ b/lib/generated/intl/messages_it.dart
@@ -108,6 +108,11 @@ class MessageLookup extends MessageLookupByLibrary {
 
   final messages = _notInlinedMessages(_notInlinedMessages);
   static Map<String, Function> _notInlinedMessages(_) => <String, Function>{
+        "quickAddActivityTitleLabel": MessageLookupByLibrary.simpleMessage("Aggiunta rapida attività"),
+        "quickAddActivityDurationLabel": MessageLookupByLibrary.simpleMessage("Durata (min, facoltativo)"),
+        "quickAddActivityEnergyLabelKcal": MessageLookupByLibrary.simpleMessage("Energia bruciata (kcal)"),
+        "quickAddActivityEnergyLabelKj": MessageLookupByLibrary.simpleMessage("Energia bruciata (kJ)"),
+        "quickAddActivityAddedSnack": MessageLookupByLibrary.simpleMessage("Attività aggiunta"),
         "copyActionLabel": MessageLookupByLibrary.simpleMessage("Copia"),
         "copyToProfileLabel": MessageLookupByLibrary.simpleMessage("Copia nel profilo"),
         "copiedToProfileSnackbar": MessageLookupByLibrary.simpleMessage("Pasto copiato nel profilo"),

--- a/lib/generated/intl/messages_it.dart
+++ b/lib/generated/intl/messages_it.dart
@@ -108,6 +108,7 @@ class MessageLookup extends MessageLookupByLibrary {
 
   final messages = _notInlinedMessages(_notInlinedMessages);
   static Map<String, Function> _notInlinedMessages(_) => <String, Function>{
+        "quickAddActivityNameLabel": MessageLookupByLibrary.simpleMessage("Nome (facoltativo)"),
         "quickAddActivityTitleLabel": MessageLookupByLibrary.simpleMessage("Aggiunta rapida attività"),
         "quickAddActivityDurationLabel": MessageLookupByLibrary.simpleMessage("Durata (min, facoltativo)"),
         "quickAddActivityEnergyLabelKcal": MessageLookupByLibrary.simpleMessage("Energia bruciata (kcal)"),

--- a/lib/generated/intl/messages_pl.dart
+++ b/lib/generated/intl/messages_pl.dart
@@ -107,6 +107,11 @@ class MessageLookup extends MessageLookupByLibrary {
 
   final messages = _notInlinedMessages(_notInlinedMessages);
   static Map<String, Function> _notInlinedMessages(_) => <String, Function>{
+        "quickAddActivityTitleLabel": MessageLookupByLibrary.simpleMessage("Szybkie dodawanie aktywności"),
+        "quickAddActivityDurationLabel": MessageLookupByLibrary.simpleMessage("Czas trwania (min, opcjonalnie)"),
+        "quickAddActivityEnergyLabelKcal": MessageLookupByLibrary.simpleMessage("Spalona energia (kcal)"),
+        "quickAddActivityEnergyLabelKj": MessageLookupByLibrary.simpleMessage("Spalona energia (kJ)"),
+        "quickAddActivityAddedSnack": MessageLookupByLibrary.simpleMessage("Dodano aktywność"),
         "copyActionLabel": MessageLookupByLibrary.simpleMessage("Kopiuj"),
         "copyToProfileLabel": MessageLookupByLibrary.simpleMessage("Kopiuj do profilu"),
         "copiedToProfileSnackbar": MessageLookupByLibrary.simpleMessage("Posiłek skopiowany do profilu"),

--- a/lib/generated/intl/messages_pl.dart
+++ b/lib/generated/intl/messages_pl.dart
@@ -107,6 +107,7 @@ class MessageLookup extends MessageLookupByLibrary {
 
   final messages = _notInlinedMessages(_notInlinedMessages);
   static Map<String, Function> _notInlinedMessages(_) => <String, Function>{
+        "quickAddActivityNameLabel": MessageLookupByLibrary.simpleMessage("Nazwa (opcjonalnie)"),
         "quickAddActivityTitleLabel": MessageLookupByLibrary.simpleMessage("Szybkie dodawanie aktywności"),
         "quickAddActivityDurationLabel": MessageLookupByLibrary.simpleMessage("Czas trwania (min, opcjonalnie)"),
         "quickAddActivityEnergyLabelKcal": MessageLookupByLibrary.simpleMessage("Spalona energia (kcal)"),

--- a/lib/generated/intl/messages_sk.dart
+++ b/lib/generated/intl/messages_sk.dart
@@ -108,6 +108,11 @@ class MessageLookup extends MessageLookupByLibrary {
 
   final messages = _notInlinedMessages(_notInlinedMessages);
   static Map<String, Function> _notInlinedMessages(_) => <String, Function>{
+        "quickAddActivityTitleLabel": MessageLookupByLibrary.simpleMessage("Rýchle pridanie aktivity"),
+        "quickAddActivityDurationLabel": MessageLookupByLibrary.simpleMessage("Trvanie (min, voliteľné)"),
+        "quickAddActivityEnergyLabelKcal": MessageLookupByLibrary.simpleMessage("Spálená energia (kcal)"),
+        "quickAddActivityEnergyLabelKj": MessageLookupByLibrary.simpleMessage("Spálená energia (kJ)"),
+        "quickAddActivityAddedSnack": MessageLookupByLibrary.simpleMessage("Aktivita pridaná"),
         "copyActionLabel": MessageLookupByLibrary.simpleMessage("Kopírovať"),
         "copyToProfileLabel": MessageLookupByLibrary.simpleMessage("Kopírovať do profilu"),
         "copiedToProfileSnackbar": MessageLookupByLibrary.simpleMessage("Jedlo skopírované do profilu"),

--- a/lib/generated/intl/messages_sk.dart
+++ b/lib/generated/intl/messages_sk.dart
@@ -108,6 +108,7 @@ class MessageLookup extends MessageLookupByLibrary {
 
   final messages = _notInlinedMessages(_notInlinedMessages);
   static Map<String, Function> _notInlinedMessages(_) => <String, Function>{
+        "quickAddActivityNameLabel": MessageLookupByLibrary.simpleMessage("Názov (voliteľné)"),
         "quickAddActivityTitleLabel": MessageLookupByLibrary.simpleMessage("Rýchle pridanie aktivity"),
         "quickAddActivityDurationLabel": MessageLookupByLibrary.simpleMessage("Trvanie (min, voliteľné)"),
         "quickAddActivityEnergyLabelKcal": MessageLookupByLibrary.simpleMessage("Spálená energia (kcal)"),

--- a/lib/generated/intl/messages_tr.dart
+++ b/lib/generated/intl/messages_tr.dart
@@ -110,6 +110,11 @@ class MessageLookup extends MessageLookupByLibrary {
 
   final messages = _notInlinedMessages(_notInlinedMessages);
   static Map<String, Function> _notInlinedMessages(_) => <String, Function>{
+        "quickAddActivityTitleLabel": MessageLookupByLibrary.simpleMessage("Hızlı aktivite ekle"),
+        "quickAddActivityDurationLabel": MessageLookupByLibrary.simpleMessage("Süre (dk, isteğe bağlı)"),
+        "quickAddActivityEnergyLabelKcal": MessageLookupByLibrary.simpleMessage("Yakılan enerji (kcal)"),
+        "quickAddActivityEnergyLabelKj": MessageLookupByLibrary.simpleMessage("Yakılan enerji (kJ)"),
+        "quickAddActivityAddedSnack": MessageLookupByLibrary.simpleMessage("Aktivite eklendi"),
         "copyActionLabel": MessageLookupByLibrary.simpleMessage("Kopyala"),
         "copyToProfileLabel": MessageLookupByLibrary.simpleMessage("Profile kopyala"),
         "copiedToProfileSnackbar": MessageLookupByLibrary.simpleMessage("Öğün profile kopyalandı"),

--- a/lib/generated/intl/messages_tr.dart
+++ b/lib/generated/intl/messages_tr.dart
@@ -110,6 +110,7 @@ class MessageLookup extends MessageLookupByLibrary {
 
   final messages = _notInlinedMessages(_notInlinedMessages);
   static Map<String, Function> _notInlinedMessages(_) => <String, Function>{
+        "quickAddActivityNameLabel": MessageLookupByLibrary.simpleMessage("Ad (isteğe bağlı)"),
         "quickAddActivityTitleLabel": MessageLookupByLibrary.simpleMessage("Hızlı aktivite ekle"),
         "quickAddActivityDurationLabel": MessageLookupByLibrary.simpleMessage("Süre (dk, isteğe bağlı)"),
         "quickAddActivityEnergyLabelKcal": MessageLookupByLibrary.simpleMessage("Yakılan enerji (kcal)"),

--- a/lib/generated/intl/messages_uk.dart
+++ b/lib/generated/intl/messages_uk.dart
@@ -108,6 +108,11 @@ class MessageLookup extends MessageLookupByLibrary {
 
   final messages = _notInlinedMessages(_notInlinedMessages);
   static Map<String, Function> _notInlinedMessages(_) => <String, Function>{
+        "quickAddActivityTitleLabel": MessageLookupByLibrary.simpleMessage("Швидке додавання активності"),
+        "quickAddActivityDurationLabel": MessageLookupByLibrary.simpleMessage("Тривалість (хв, необов'язково)"),
+        "quickAddActivityEnergyLabelKcal": MessageLookupByLibrary.simpleMessage("Спалена енергія (ккал)"),
+        "quickAddActivityEnergyLabelKj": MessageLookupByLibrary.simpleMessage("Спалена енергія (кДж)"),
+        "quickAddActivityAddedSnack": MessageLookupByLibrary.simpleMessage("Активність додано"),
         "copyActionLabel": MessageLookupByLibrary.simpleMessage("Копіювати"),
         "copyToProfileLabel": MessageLookupByLibrary.simpleMessage("Копіювати в профіль"),
         "copiedToProfileSnackbar": MessageLookupByLibrary.simpleMessage("Прийом їжі скопійовано в профіль"),

--- a/lib/generated/intl/messages_uk.dart
+++ b/lib/generated/intl/messages_uk.dart
@@ -108,6 +108,7 @@ class MessageLookup extends MessageLookupByLibrary {
 
   final messages = _notInlinedMessages(_notInlinedMessages);
   static Map<String, Function> _notInlinedMessages(_) => <String, Function>{
+        "quickAddActivityNameLabel": MessageLookupByLibrary.simpleMessage("Назва (необов'язково)"),
         "quickAddActivityTitleLabel": MessageLookupByLibrary.simpleMessage("Швидке додавання активності"),
         "quickAddActivityDurationLabel": MessageLookupByLibrary.simpleMessage("Тривалість (хв, необов'язково)"),
         "quickAddActivityEnergyLabelKcal": MessageLookupByLibrary.simpleMessage("Спалена енергія (ккал)"),

--- a/lib/generated/intl/messages_zh.dart
+++ b/lib/generated/intl/messages_zh.dart
@@ -105,6 +105,11 @@ class MessageLookup extends MessageLookupByLibrary {
 
   final messages = _notInlinedMessages(_notInlinedMessages);
   static Map<String, Function> _notInlinedMessages(_) => <String, Function>{
+        "quickAddActivityTitleLabel": MessageLookupByLibrary.simpleMessage("快速添加活动"),
+        "quickAddActivityDurationLabel": MessageLookupByLibrary.simpleMessage("时长（分钟，可选）"),
+        "quickAddActivityEnergyLabelKcal": MessageLookupByLibrary.simpleMessage("消耗能量（kcal）"),
+        "quickAddActivityEnergyLabelKj": MessageLookupByLibrary.simpleMessage("消耗能量（kJ）"),
+        "quickAddActivityAddedSnack": MessageLookupByLibrary.simpleMessage("已添加活动"),
         "copyActionLabel": MessageLookupByLibrary.simpleMessage("复制"),
         "copyToProfileLabel": MessageLookupByLibrary.simpleMessage("复制到档案"),
         "copiedToProfileSnackbar": MessageLookupByLibrary.simpleMessage("餐食已复制到档案"),

--- a/lib/generated/intl/messages_zh.dart
+++ b/lib/generated/intl/messages_zh.dart
@@ -105,6 +105,7 @@ class MessageLookup extends MessageLookupByLibrary {
 
   final messages = _notInlinedMessages(_notInlinedMessages);
   static Map<String, Function> _notInlinedMessages(_) => <String, Function>{
+        "quickAddActivityNameLabel": MessageLookupByLibrary.simpleMessage("名称（可选）"),
         "quickAddActivityTitleLabel": MessageLookupByLibrary.simpleMessage("快速添加活动"),
         "quickAddActivityDurationLabel": MessageLookupByLibrary.simpleMessage("时长（分钟，可选）"),
         "quickAddActivityEnergyLabelKcal": MessageLookupByLibrary.simpleMessage("消耗能量（kcal）"),

--- a/lib/generated/l10n.dart
+++ b/lib/generated/l10n.dart
@@ -765,6 +765,51 @@ class S {
     );
   }
 
+  String get quickAddActivityTitleLabel {
+    return Intl.message(
+      'Quick add activity',
+      name: 'quickAddActivityTitleLabel',
+      desc: '',
+      args: [],
+    );
+  }
+
+  String get quickAddActivityDurationLabel {
+    return Intl.message(
+      'Duration (min, optional)',
+      name: 'quickAddActivityDurationLabel',
+      desc: '',
+      args: [],
+    );
+  }
+
+  String get quickAddActivityEnergyLabelKcal {
+    return Intl.message(
+      'Energy burned (kcal)',
+      name: 'quickAddActivityEnergyLabelKcal',
+      desc: '',
+      args: [],
+    );
+  }
+
+  String get quickAddActivityEnergyLabelKj {
+    return Intl.message(
+      'Energy burned (kJ)',
+      name: 'quickAddActivityEnergyLabelKj',
+      desc: '',
+      args: [],
+    );
+  }
+
+  String get quickAddActivityAddedSnack {
+    return Intl.message(
+      'Activity added',
+      name: 'quickAddActivityAddedSnack',
+      desc: '',
+      args: [],
+    );
+  }
+
   String get mealImageLabel {
     return Intl.message(
       'Add a photo',

--- a/lib/generated/l10n.dart
+++ b/lib/generated/l10n.dart
@@ -810,6 +810,15 @@ class S {
     );
   }
 
+  String get quickAddActivityNameLabel {
+    return Intl.message(
+      'Name (optional)',
+      name: 'quickAddActivityNameLabel',
+      desc: '',
+      args: [],
+    );
+  }
+
   String get mealImageLabel {
     return Intl.message(
       'Add a photo',

--- a/lib/l10n/intl_cs.arb
+++ b/lib/l10n/intl_cs.arb
@@ -976,5 +976,10 @@
   "deleteProfileConfirmContent": "Tímto se trvale smaže profil i všechna jeho data. Tuto akci nelze vrátit zpět.",
   "copyToProfileLabel": "Kopírovat do profilu",
   "copiedToProfileSnackbar": "Jídlo zkopírováno do profilu",
-  "copyActionLabel": "Kopírovat"
+  "copyActionLabel": "Kopírovat",
+  "quickAddActivityTitleLabel": "Rychlé přidání aktivity",
+  "quickAddActivityDurationLabel": "Doba trvání (min, volitelné)",
+  "quickAddActivityEnergyLabelKcal": "Spálená energie (kcal)",
+  "quickAddActivityEnergyLabelKj": "Spálená energie (kJ)",
+  "quickAddActivityAddedSnack": "Aktivita přidána"
 }

--- a/lib/l10n/intl_cs.arb
+++ b/lib/l10n/intl_cs.arb
@@ -981,5 +981,6 @@
   "quickAddActivityDurationLabel": "Doba trvání (min, volitelné)",
   "quickAddActivityEnergyLabelKcal": "Spálená energie (kcal)",
   "quickAddActivityEnergyLabelKj": "Spálená energie (kJ)",
-  "quickAddActivityAddedSnack": "Aktivita přidána"
+  "quickAddActivityAddedSnack": "Aktivita přidána",
+  "quickAddActivityNameLabel": "Název (volitelné)"
 }

--- a/lib/l10n/intl_de.arb
+++ b/lib/l10n/intl_de.arb
@@ -1007,5 +1007,10 @@
   "deleteProfileConfirmContent": "Dadurch werden das Profil und alle seine Daten dauerhaft gelöscht. Dies kann nicht rückgängig gemacht werden.",
   "copyToProfileLabel": "In Profil kopieren",
   "copiedToProfileSnackbar": "Mahlzeit ins Profil kopiert",
-  "copyActionLabel": "Kopieren"
+  "copyActionLabel": "Kopieren",
+  "quickAddActivityTitleLabel": "Aktivität schnell hinzufügen",
+  "quickAddActivityDurationLabel": "Dauer (Min., optional)",
+  "quickAddActivityEnergyLabelKcal": "Verbrannte Energie (kcal)",
+  "quickAddActivityEnergyLabelKj": "Verbrannte Energie (kJ)",
+  "quickAddActivityAddedSnack": "Aktivität hinzugefügt"
 }

--- a/lib/l10n/intl_de.arb
+++ b/lib/l10n/intl_de.arb
@@ -1012,5 +1012,6 @@
   "quickAddActivityDurationLabel": "Dauer (Min., optional)",
   "quickAddActivityEnergyLabelKcal": "Verbrannte Energie (kcal)",
   "quickAddActivityEnergyLabelKj": "Verbrannte Energie (kJ)",
-  "quickAddActivityAddedSnack": "Aktivität hinzugefügt"
+  "quickAddActivityAddedSnack": "Aktivität hinzugefügt",
+  "quickAddActivityNameLabel": "Name (optional)"
 }

--- a/lib/l10n/intl_en.arb
+++ b/lib/l10n/intl_en.arb
@@ -1048,5 +1048,10 @@
   "deleteProfileConfirmContent": "This permanently deletes the profile and all of its data and cannot be undone.",
   "copyToProfileLabel": "Copy to profile",
   "copiedToProfileSnackbar": "Meal copied to profile",
-  "copyActionLabel": "Copy"
+  "copyActionLabel": "Copy",
+  "quickAddActivityTitleLabel": "Quick add activity",
+  "quickAddActivityDurationLabel": "Duration (min, optional)",
+  "quickAddActivityEnergyLabelKcal": "Energy burned (kcal)",
+  "quickAddActivityEnergyLabelKj": "Energy burned (kJ)",
+  "quickAddActivityAddedSnack": "Activity added"
 }

--- a/lib/l10n/intl_en.arb
+++ b/lib/l10n/intl_en.arb
@@ -1053,5 +1053,6 @@
   "quickAddActivityDurationLabel": "Duration (min, optional)",
   "quickAddActivityEnergyLabelKcal": "Energy burned (kcal)",
   "quickAddActivityEnergyLabelKj": "Energy burned (kJ)",
-  "quickAddActivityAddedSnack": "Activity added"
+  "quickAddActivityAddedSnack": "Activity added",
+  "quickAddActivityNameLabel": "Name (optional)"
 }

--- a/lib/l10n/intl_it.arb
+++ b/lib/l10n/intl_it.arb
@@ -976,5 +976,10 @@
   "deleteProfileConfirmContent": "Questa operazione elimina definitivamente il profilo e tutti i suoi dati e non può essere annullata.",
   "copyToProfileLabel": "Copia nel profilo",
   "copiedToProfileSnackbar": "Pasto copiato nel profilo",
-  "copyActionLabel": "Copia"
+  "copyActionLabel": "Copia",
+  "quickAddActivityTitleLabel": "Aggiunta rapida attività",
+  "quickAddActivityDurationLabel": "Durata (min, facoltativo)",
+  "quickAddActivityEnergyLabelKcal": "Energia bruciata (kcal)",
+  "quickAddActivityEnergyLabelKj": "Energia bruciata (kJ)",
+  "quickAddActivityAddedSnack": "Attività aggiunta"
 }

--- a/lib/l10n/intl_it.arb
+++ b/lib/l10n/intl_it.arb
@@ -981,5 +981,6 @@
   "quickAddActivityDurationLabel": "Durata (min, facoltativo)",
   "quickAddActivityEnergyLabelKcal": "Energia bruciata (kcal)",
   "quickAddActivityEnergyLabelKj": "Energia bruciata (kJ)",
-  "quickAddActivityAddedSnack": "Attività aggiunta"
+  "quickAddActivityAddedSnack": "Attività aggiunta",
+  "quickAddActivityNameLabel": "Nome (facoltativo)"
 }

--- a/lib/l10n/intl_pl.arb
+++ b/lib/l10n/intl_pl.arb
@@ -976,5 +976,10 @@
   "deleteProfileConfirmContent": "Spowoduje to trwałe usunięcie profilu i wszystkich jego danych. Tej operacji nie można cofnąć.",
   "copyToProfileLabel": "Kopiuj do profilu",
   "copiedToProfileSnackbar": "Posiłek skopiowany do profilu",
-  "copyActionLabel": "Kopiuj"
+  "copyActionLabel": "Kopiuj",
+  "quickAddActivityTitleLabel": "Szybkie dodawanie aktywności",
+  "quickAddActivityDurationLabel": "Czas trwania (min, opcjonalnie)",
+  "quickAddActivityEnergyLabelKcal": "Spalona energia (kcal)",
+  "quickAddActivityEnergyLabelKj": "Spalona energia (kJ)",
+  "quickAddActivityAddedSnack": "Dodano aktywność"
 }

--- a/lib/l10n/intl_pl.arb
+++ b/lib/l10n/intl_pl.arb
@@ -981,5 +981,6 @@
   "quickAddActivityDurationLabel": "Czas trwania (min, opcjonalnie)",
   "quickAddActivityEnergyLabelKcal": "Spalona energia (kcal)",
   "quickAddActivityEnergyLabelKj": "Spalona energia (kJ)",
-  "quickAddActivityAddedSnack": "Dodano aktywność"
+  "quickAddActivityAddedSnack": "Dodano aktywność",
+  "quickAddActivityNameLabel": "Nazwa (opcjonalnie)"
 }

--- a/lib/l10n/intl_sk.arb
+++ b/lib/l10n/intl_sk.arb
@@ -1006,5 +1006,10 @@
   "deleteProfileConfirmContent": "Týmto sa natrvalo odstráni profil aj všetky jeho údaje. Túto akciu nie je možné vrátiť späť.",
   "copyToProfileLabel": "Kopírovať do profilu",
   "copiedToProfileSnackbar": "Jedlo skopírované do profilu",
-  "copyActionLabel": "Kopírovať"
+  "copyActionLabel": "Kopírovať",
+  "quickAddActivityTitleLabel": "Rýchle pridanie aktivity",
+  "quickAddActivityDurationLabel": "Trvanie (min, voliteľné)",
+  "quickAddActivityEnergyLabelKcal": "Spálená energia (kcal)",
+  "quickAddActivityEnergyLabelKj": "Spálená energia (kJ)",
+  "quickAddActivityAddedSnack": "Aktivita pridaná"
 }

--- a/lib/l10n/intl_sk.arb
+++ b/lib/l10n/intl_sk.arb
@@ -1011,5 +1011,6 @@
   "quickAddActivityDurationLabel": "Trvanie (min, voliteľné)",
   "quickAddActivityEnergyLabelKcal": "Spálená energia (kcal)",
   "quickAddActivityEnergyLabelKj": "Spálená energia (kJ)",
-  "quickAddActivityAddedSnack": "Aktivita pridaná"
+  "quickAddActivityAddedSnack": "Aktivita pridaná",
+  "quickAddActivityNameLabel": "Názov (voliteľné)"
 }

--- a/lib/l10n/intl_tr.arb
+++ b/lib/l10n/intl_tr.arb
@@ -1007,5 +1007,10 @@
   "deleteProfileConfirmContent": "Bu işlem profili ve tüm verilerini kalıcı olarak siler. Bu geri alınamaz.",
   "copyToProfileLabel": "Profile kopyala",
   "copiedToProfileSnackbar": "Öğün profile kopyalandı",
-  "copyActionLabel": "Kopyala"
+  "copyActionLabel": "Kopyala",
+  "quickAddActivityTitleLabel": "Hızlı aktivite ekle",
+  "quickAddActivityDurationLabel": "Süre (dk, isteğe bağlı)",
+  "quickAddActivityEnergyLabelKcal": "Yakılan enerji (kcal)",
+  "quickAddActivityEnergyLabelKj": "Yakılan enerji (kJ)",
+  "quickAddActivityAddedSnack": "Aktivite eklendi"
 }

--- a/lib/l10n/intl_tr.arb
+++ b/lib/l10n/intl_tr.arb
@@ -1012,5 +1012,6 @@
   "quickAddActivityDurationLabel": "Süre (dk, isteğe bağlı)",
   "quickAddActivityEnergyLabelKcal": "Yakılan enerji (kcal)",
   "quickAddActivityEnergyLabelKj": "Yakılan enerji (kJ)",
-  "quickAddActivityAddedSnack": "Aktivite eklendi"
+  "quickAddActivityAddedSnack": "Aktivite eklendi",
+  "quickAddActivityNameLabel": "Ad (isteğe bağlı)"
 }

--- a/lib/l10n/intl_uk.arb
+++ b/lib/l10n/intl_uk.arb
@@ -976,5 +976,10 @@
   "deleteProfileConfirmContent": "Це назавжди видалить профіль та всі його дані. Цю дію не можна скасувати.",
   "copyToProfileLabel": "Копіювати в профіль",
   "copiedToProfileSnackbar": "Прийом їжі скопійовано в профіль",
-  "copyActionLabel": "Копіювати"
+  "copyActionLabel": "Копіювати",
+  "quickAddActivityTitleLabel": "Швидке додавання активності",
+  "quickAddActivityDurationLabel": "Тривалість (хв, необов'язково)",
+  "quickAddActivityEnergyLabelKcal": "Спалена енергія (ккал)",
+  "quickAddActivityEnergyLabelKj": "Спалена енергія (кДж)",
+  "quickAddActivityAddedSnack": "Активність додано"
 }

--- a/lib/l10n/intl_uk.arb
+++ b/lib/l10n/intl_uk.arb
@@ -981,5 +981,6 @@
   "quickAddActivityDurationLabel": "Тривалість (хв, необов'язково)",
   "quickAddActivityEnergyLabelKcal": "Спалена енергія (ккал)",
   "quickAddActivityEnergyLabelKj": "Спалена енергія (кДж)",
-  "quickAddActivityAddedSnack": "Активність додано"
+  "quickAddActivityAddedSnack": "Активність додано",
+  "quickAddActivityNameLabel": "Назва (необов'язково)"
 }

--- a/lib/l10n/intl_zh.arb
+++ b/lib/l10n/intl_zh.arb
@@ -977,5 +977,10 @@
   "deleteProfileConfirmContent": "这将永久删除该档案及其所有数据，此操作无法撤销。",
   "copyToProfileLabel": "复制到档案",
   "copiedToProfileSnackbar": "餐食已复制到档案",
-  "copyActionLabel": "复制"
+  "copyActionLabel": "复制",
+  "quickAddActivityTitleLabel": "快速添加活动",
+  "quickAddActivityDurationLabel": "时长（分钟，可选）",
+  "quickAddActivityEnergyLabelKcal": "消耗能量（kcal）",
+  "quickAddActivityEnergyLabelKj": "消耗能量（kJ）",
+  "quickAddActivityAddedSnack": "已添加活动"
 }

--- a/lib/l10n/intl_zh.arb
+++ b/lib/l10n/intl_zh.arb
@@ -982,5 +982,6 @@
   "quickAddActivityDurationLabel": "时长（分钟，可选）",
   "quickAddActivityEnergyLabelKcal": "消耗能量（kcal）",
   "quickAddActivityEnergyLabelKj": "消耗能量（kJ）",
-  "quickAddActivityAddedSnack": "已添加活动"
+  "quickAddActivityAddedSnack": "已添加活动",
+  "quickAddActivityNameLabel": "名称（可选）"
 }


### PR DESCRIPTION
## Summary

@ferkulat noted in #472 that their step counter already estimates the calories a walk burns, but the MET-based presets never quite match that number when you enter the time, so the figure is always a little off. They asked to enter the time spent and the calories burned themselves.

This adds the activity counterpart to the food Quick Add. A "Quick add" button in the Add Activity app bar (right next to the existing custom-activity "+") opens a small bottom sheet with three fields: an optional name, the energy burned (required) and the time spent (optional). It logs the entry as a Custom activity, so the kcal you typed is used verbatim rather than recomputed from METs, and the day's burned total updates exactly as it does when logging an activity the long way.

The optional name means an entry can read "Morning walk" on the home and diary cards instead of the generic "Custom activity"; the label rides in the Custom activity's `specificActivity` (already persisted) and `getName` surfaces it, leaving unnamed entries showing the localised default as before.

It mirrors the food `QuickAddBottomSheet` closely: same sheet/validation shape, energy shown in the user's chosen unit (kcal or kJ), `Home`/`Diary`/`CalendarDay` refreshed on save, and a confirmation snackbar.

## Testing

- `flutter analyze` clean; full suite green (647 tests).
- Verified on a physical device (Pixel 6 Pro): logged a named entry and an unnamed one; the named card shows its label, the unnamed one shows "Custom activity", and the day's burned total rises by the entered kcal each time.

Closes #472.
