### PR TITLE
ci: Temurin fallback when Zulu JDK download fails

### DIFF
--- a/.github/workflows/default_workflow.yml
+++ b/.github/workflows/default_workflow.yml
@@ -342,10 +342,23 @@ jobs:
       - name: Checkout code
         uses: actions/checkout@v6
 
-      - name: Setup Java
+      - name: Setup Java (Zulu)
+        id: setup_java_zulu
         uses: actions/setup-java@v5
+        continue-on-error: true
         with:
           distribution: 'zulu'
+          java-version: '17'
+
+      # Azul's download CDN intermittently returns HTTP 520, which fails the
+      # whole job at the JDK-fetch step. Fall back to Temurin only when the
+      # Zulu setup failed, so a single vendor's CDN blip no longer reds the
+      # build. It now takes both vendors being down at once.
+      - name: Setup Java (Temurin fallback)
+        if: steps.setup_java_zulu.outcome == 'failure'
+        uses: actions/setup-java@v5
+        with:
+          distribution: 'temurin'
           java-version: '17'
 
       - name: Setup Flutter + cache packages
@@ -413,10 +426,23 @@ jobs:
           sudo docker image prune --all --force || true
           df -h /
 
-      - name: Setup Java
+      - name: Setup Java (Zulu)
+        id: setup_java_zulu
         uses: actions/setup-java@v5
+        continue-on-error: true
         with:
           distribution: 'zulu'
+          java-version: '17'
+
+      # Azul's download CDN intermittently returns HTTP 520, which fails the
+      # whole job at the JDK-fetch step. Fall back to Temurin only when the
+      # Zulu setup failed, so a single vendor's CDN blip no longer reds the
+      # build. It now takes both vendors being down at once.
+      - name: Setup Java (Temurin fallback)
+        if: steps.setup_java_zulu.outcome == 'failure'
+        uses: actions/setup-java@v5
+        with:
+          distribution: 'temurin'
           java-version: '17'
 
       - name: Setup Flutter + cache packages
@@ -699,10 +725,23 @@ jobs:
       - name: Checkout code
         uses: actions/checkout@v6
 
-      - name: Setup Java
+      - name: Setup Java (Zulu)
+        id: setup_java_zulu
         uses: actions/setup-java@v5
+        continue-on-error: true
         with:
           distribution: 'zulu'
+          java-version: '17'
+
+      # Azul's download CDN intermittently returns HTTP 520, which fails the
+      # whole job at the JDK-fetch step. Fall back to Temurin only when the
+      # Zulu setup failed, so a single vendor's CDN blip no longer reds the
+      # build. It now takes both vendors being down at once.
+      - name: Setup Java (Temurin fallback)
+        if: steps.setup_java_zulu.outcome == 'failure'
+        uses: actions/setup-java@v5
+        with:
+          distribution: 'temurin'
           java-version: '17'
 
       - name: Setup Ruby + Bundler


### PR DESCRIPTION
## Summary

The Android CI jobs fetch the JDK from Azul's CDN through `actions/setup-java`, and that CDN has been intermittently returning HTTP 520. When it does, the job fails at the "Setup Java" step before any of our code is even built, and it has taken several reruns to land a green build on recent PRs (e.g. #489, #490).

This makes the JDK setup resilient. Each of the three Android jobs (`android-build`, `android-integration-tests`, `android-package`) now runs the Zulu setup with `continue-on-error: true` and, only if that step fails, falls back to Temurin (Eclipse Adoptium), whose download CDN is independent of Azul's.

```yaml
- name: Setup Java (Zulu)
  id: setup_java_zulu
  uses: actions/setup-java@v5
  continue-on-error: true
  with:
    distribution: 'zulu'
    java-version: '17'

- name: Setup Java (Temurin fallback)
  if: steps.setup_java_zulu.outcome == 'failure'
  uses: actions/setup-java@v5
  with:
    distribution: 'temurin'
    java-version: '17'
```

The build is identical on either OpenJDK 17 distribution, so the only thing changing is where the JDK comes from when the primary is unreachable. A red build now requires both vendors' CDNs to be down at the same moment.

## Notes

- Zulu stays the default, so nothing changes on a normal run; the fallback only kicks in on a failed primary fetch.
- This is a CI-only change; no app code is touched.
