### PR TITLE
fix(scanner): keep the camera preview upright (#165)

### DIFF
--- a/lib/core/data/data_source/config_data_source.dart
+++ b/lib/core/data/data_source/config_data_source.dart
@@ -239,6 +239,10 @@ class ConfigDataSource {
     await _update((c) => c.accentColor = value);
   }
 
+  Future<void> setConfigScannerPortraitLock(bool value) async {
+    await _update((c) => c.scannerPortraitLock = value);
+  }
+
   Future<ConfigDBO> getConfig() async => _readMerged();
 
   Future<bool> getHasAcceptedAnonymousData() async =>

--- a/lib/core/data/dbo/config_dbo.dart
+++ b/lib/core/data/dbo/config_dbo.dart
@@ -94,6 +94,12 @@ class ConfigDBO extends HiveObject {
   // the static palette elsewhere.
   @HiveField(26)
   int? accentColor;
+  // #165: whether the barcode scanner forces portrait. Null means the user
+  // has not made a deliberate choice, which the scanner treats as "follow the
+  // device" — locked on phone-sized screens (so the camera preview can't tip
+  // sideways) and free on tablets (so a landscape tablet isn't forced upright).
+  @HiveField(27)
+  bool? scannerPortraitLock;
 
   ConfigDBO(
     this.hasAcceptedDisclaimer,
@@ -120,6 +126,7 @@ class ConfigDBO extends HiveObject {
     this.fastingWarningAcknowledged,
     this.useMaterialYou,
     this.accentColor,
+    this.scannerPortraitLock,
   });
 
   factory ConfigDBO.empty() =>

--- a/lib/core/data/dbo/config_dbo.g.dart
+++ b/lib/core/data/dbo/config_dbo.g.dart
@@ -41,6 +41,7 @@ class ConfigDBOAdapter extends TypeAdapter<ConfigDBO> {
         fastingWarningAcknowledged: fields[25] as bool?,
         useMaterialYou: fields[20] as bool?,
         accentColor: (fields[26] as num?)?.toInt(),
+        scannerPortraitLock: fields[27] as bool?,
       )
       ..userCarbGoalPct = (fields[6] as num?)?.toDouble()
       ..userProteinGoalPct = (fields[7] as num?)?.toDouble()
@@ -50,7 +51,7 @@ class ConfigDBOAdapter extends TypeAdapter<ConfigDBO> {
   @override
   void write(BinaryWriter writer, ConfigDBO obj) {
     writer
-      ..writeByte(27)
+      ..writeByte(28)
       ..writeByte(0)
       ..write(obj.hasAcceptedDisclaimer)
       ..writeByte(1)
@@ -104,7 +105,9 @@ class ConfigDBOAdapter extends TypeAdapter<ConfigDBO> {
       ..writeByte(25)
       ..write(obj.fastingWarningAcknowledged)
       ..writeByte(26)
-      ..write(obj.accentColor);
+      ..write(obj.accentColor)
+      ..writeByte(27)
+      ..write(obj.scannerPortraitLock);
   }
 
   @override
@@ -155,6 +158,7 @@ ConfigDBO _$ConfigDBOFromJson(Map<String, dynamic> json) =>
         fastingWarningAcknowledged: json['fastingWarningAcknowledged'] as bool?,
         useMaterialYou: json['useMaterialYou'] as bool?,
         accentColor: (json['accentColor'] as num?)?.toInt(),
+        scannerPortraitLock: json['scannerPortraitLock'] as bool?,
       )
       ..userCarbGoalPct = (json['userCarbGoalPct'] as num?)?.toDouble()
       ..userProteinGoalPct = (json['userProteinGoalPct'] as num?)?.toDouble()
@@ -188,6 +192,7 @@ Map<String, dynamic> _$ConfigDBOToJson(ConfigDBO instance) => <String, dynamic>{
   'fastingWarningAcknowledged': instance.fastingWarningAcknowledged,
   'useMaterialYou': instance.useMaterialYou,
   'accentColor': instance.accentColor,
+  'scannerPortraitLock': instance.scannerPortraitLock,
 };
 
 const _$AppThemeDBOEnumMap = {

--- a/lib/core/data/repository/config_repository.dart
+++ b/lib/core/data/repository/config_repository.dart
@@ -150,4 +150,8 @@ class ConfigRepository {
   Future<void> setConfigAccentColor(int? value) async {
     await _configDataSource.setConfigAccentColor(value);
   }
+
+  Future<void> setConfigScannerPortraitLock(bool value) async {
+    await _configDataSource.setConfigScannerPortraitLock(value);
+  }
 }

--- a/lib/core/domain/entity/config_entity.dart
+++ b/lib/core/domain/entity/config_entity.dart
@@ -68,6 +68,11 @@ class ConfigEntity extends Equatable {
   // Material You when set. Null means "use the platform default" — Material
   // You on Android 12+, the static palette elsewhere.
   final int? accentColor;
+  // #165: explicit user override for the scanner's portrait lock. Null means
+  // "follow the device" — the scanner falls back to locking portrait on
+  // phone-sized screens and leaving rotation free on tablets. Once the user
+  // taps the in-scanner toggle, their choice is stored here and sticks.
+  final bool? scannerPortraitLock;
 
   /// Default daily water goal in millilitres for the home chip when the
   /// user has not picked one yet.
@@ -135,6 +140,7 @@ class ConfigEntity extends Equatable {
     this.fastingWarningAcknowledged = false,
     this.useMaterialYou = true,
     this.accentColor,
+    this.scannerPortraitLock,
   });
 
   /// Resolves the daily water goal for the home chip. Returns the user's
@@ -217,6 +223,7 @@ class ConfigEntity extends Equatable {
     fastingWarningAcknowledged: dbo.fastingWarningAcknowledged ?? false,
     useMaterialYou: dbo.useMaterialYou ?? true,
     accentColor: _normaliseAccentColor(dbo.accentColor),
+    scannerPortraitLock: dbo.scannerPortraitLock,
   );
 
   /// Returns the recommended kcal target for [mealKey] given a daily goal.
@@ -295,5 +302,6 @@ class ConfigEntity extends Equatable {
     fastingWarningAcknowledged,
     useMaterialYou,
     accentColor,
+    scannerPortraitLock,
   ];
 }

--- a/lib/core/presentation/scanner_orientation_mixin.dart
+++ b/lib/core/presentation/scanner_orientation_mixin.dart
@@ -1,0 +1,102 @@
+import 'package:flutter/material.dart';
+import 'package:flutter/services.dart';
+import 'package:opennutritracker/core/data/repository/config_repository.dart';
+import 'package:opennutritracker/core/utils/locator.dart';
+import 'package:opennutritracker/generated/l10n.dart';
+
+/// Shared orientation behaviour for the barcode-scanner screens (issue #165).
+///
+/// The live camera preview tips sideways when the phone rotates, so by default
+/// the scanner locks to portrait on phone-sized screens. Tablets are left free
+/// to rotate, because a tablet held in landscape shouldn't be forced upright.
+/// The user can override either way with the in-scanner toggle; that choice is
+/// sticky, persisted via [ConfigRepository.setConfigScannerPortraitLock] so it
+/// survives leaving and reopening the scanner.
+mixin ScannerOrientationMixin<T extends StatefulWidget> on State<T> {
+  /// Material's tablet breakpoint. At or above this shortest-side width we
+  /// treat the device as a tablet and leave rotation free by default.
+  static const _tabletShortestSideDp = 600.0;
+
+  /// Resolved lazily and defensively: production always registers it in
+  /// `initLocator`, but a bare widget-test harness that only exercises the
+  /// scanner's navigation shouldn't have to wire config just to mount the
+  /// screen. When it's absent the scanner simply follows the device default.
+  ConfigRepository? get _configRepository =>
+      locator.isRegistered<ConfigRepository>()
+          ? locator<ConfigRepository>()
+          : null;
+
+  /// Persisted user override. Null until the user taps the toggle, at which
+  /// point the scanner stops following the device default and obeys this.
+  bool? _userOverride;
+
+  @override
+  void initState() {
+    super.initState();
+    _loadOverride();
+  }
+
+  Future<void> _loadOverride() async {
+    final config = await _configRepository?.getConfig();
+    if (!mounted ||
+        config == null ||
+        config.scannerPortraitLock == _userOverride) {
+      return;
+    }
+    setState(() => _userOverride = config.scannerPortraitLock);
+    _applyOrientation();
+  }
+
+  bool get _deviceDefaultsToPortrait =>
+      MediaQuery.of(context).size.shortestSide < _tabletShortestSideDp;
+
+  /// Whether the scanner is currently holding the screen in portrait.
+  bool get isPortraitLocked => _userOverride ?? _deviceDefaultsToPortrait;
+
+  void _applyOrientation() {
+    SystemChrome.setPreferredOrientations(
+      isPortraitLocked
+          ? const [DeviceOrientation.portraitUp]
+          : DeviceOrientation.values,
+    );
+  }
+
+  Future<void> _togglePortraitLock() async {
+    final locked = !isPortraitLocked;
+    setState(() => _userOverride = locked);
+    _applyOrientation();
+    await _configRepository?.setConfigScannerPortraitLock(locked);
+  }
+
+  @override
+  void didChangeDependencies() {
+    super.didChangeDependencies();
+    // MediaQuery is first available here, so this is the earliest point we can
+    // resolve the device default. Re-applying on every call is idempotent.
+    _applyOrientation();
+  }
+
+  @override
+  void dispose() {
+    SystemChrome.setPreferredOrientations(DeviceOrientation.values);
+    super.dispose();
+  }
+
+  /// The appbar action that flips the lock. Each scanner screen drops this
+  /// into its `AppBar.actions`.
+  Widget buildPortraitLockAction(BuildContext context) {
+    final locked = isPortraitLocked;
+    return Semantics(
+      identifier: 'scanner-orientation-lock',
+      child: IconButton(
+        icon: Icon(
+          locked ? Icons.screen_lock_rotation : Icons.screen_rotation,
+        ),
+        tooltip: locked
+            ? S.of(context).scannerUnlockOrientationTooltip
+            : S.of(context).scannerLockOrientationTooltip,
+        onPressed: _togglePortraitLock,
+      ),
+    );
+  }
+}

--- a/lib/features/add_meal/presentation/add_meal_screen.dart
+++ b/lib/features/add_meal/presentation/add_meal_screen.dart
@@ -70,6 +70,10 @@ class _AddMealScreenState extends State<AddMealScreen>
   @override
   Widget build(BuildContext context) {
     return Scaffold(
+      // Let the keyboard overlay the results rather than compress the body.
+      // In landscape the space above the keyboard is shorter than the pinned
+      // search bar + tab bar, which otherwise overflows (issue #165 testing).
+      resizeToAvoidBottomInset: false,
       appBar: AppBar(
         title: Text(_mealType.getTypeName(context)),
         actions: [

--- a/lib/features/home/presentation/screens/import_activity_scanner_screen.dart
+++ b/lib/features/home/presentation/screens/import_activity_scanner_screen.dart
@@ -5,6 +5,7 @@ import 'package:flutter/material.dart';
 import 'package:mobile_scanner/mobile_scanner.dart';
 import 'package:opennutritracker/core/domain/usecase/get_physical_activity_usecase.dart';
 import 'package:opennutritracker/core/domain/usecase/get_user_usecase.dart';
+import 'package:opennutritracker/core/presentation/scanner_orientation_mixin.dart';
 import 'package:opennutritracker/core/utils/calc/met_calc.dart';
 import 'package:opennutritracker/core/utils/locator.dart';
 import 'package:opennutritracker/features/activity_detail/presentation/bloc/activity_detail_bloc.dart';
@@ -32,7 +33,8 @@ class ImportActivityScannerScreen extends StatefulWidget {
 }
 
 class _ImportActivityScannerScreenState
-    extends State<ImportActivityScannerScreen> with WidgetsBindingObserver {
+    extends State<ImportActivityScannerScreen>
+    with WidgetsBindingObserver, ScannerOrientationMixin {
   late ActivityDetailBloc _activityDetailBloc;
   late GetPhysicalActivityUsecase _getPhysicalActivityUsecase;
   late GetUserUsecase _getUserUsecase;
@@ -100,6 +102,7 @@ class _ImportActivityScannerScreenState
             tooltip: S.of(context).pasteCodeLabel,
             onPressed: _showPasteCodeDialog,
           ),
+          buildPortraitLockAction(context),
         ],
       ),
       body: MobileScanner(

--- a/lib/features/home/presentation/screens/import_meal_scanner_screen.dart
+++ b/lib/features/home/presentation/screens/import_meal_scanner_screen.dart
@@ -8,6 +8,7 @@ import 'package:opennutritracker/core/data/data_source/remote_search_cache_data_
 import 'package:opennutritracker/core/data/dbo/meal_dbo.dart';
 import 'package:opennutritracker/core/domain/entity/intake_type_entity.dart';
 import 'package:opennutritracker/core/domain/usecase/save_recipe_usecase.dart';
+import 'package:opennutritracker/core/presentation/scanner_orientation_mixin.dart';
 import 'package:opennutritracker/core/utils/locator.dart';
 import 'package:opennutritracker/core/utils/retry_util.dart';
 import 'package:opennutritracker/features/add_meal/domain/entity/meal_entity.dart';
@@ -51,7 +52,7 @@ class ImportMealScannerScreen extends StatefulWidget {
 }
 
 class _ImportMealScannerScreenState extends State<ImportMealScannerScreen>
-    with WidgetsBindingObserver {
+    with WidgetsBindingObserver, ScannerOrientationMixin {
   late MealDetailBloc _mealDetailBloc;
   late SearchProductByBarcodeUseCase _searchProductByBarcodeUseCase;
   late IntakeTypeEntity _intakeTypeEntity;
@@ -126,6 +127,7 @@ class _ImportMealScannerScreenState extends State<ImportMealScannerScreen>
             tooltip: S.of(context).pasteCodeLabel,
             onPressed: _showPasteCodeDialog,
           ),
+          buildPortraitLockAction(context),
         ],
       ),
       body: MobileScanner(

--- a/lib/features/recipes/presentation/screens/import_recipe_scanner_screen.dart
+++ b/lib/features/recipes/presentation/screens/import_recipe_scanner_screen.dart
@@ -4,6 +4,7 @@ import 'package:collection/collection.dart';
 import 'package:flutter/material.dart';
 import 'package:mobile_scanner/mobile_scanner.dart';
 import 'package:opennutritracker/core/domain/usecase/save_recipe_usecase.dart';
+import 'package:opennutritracker/core/presentation/scanner_orientation_mixin.dart';
 import 'package:opennutritracker/core/utils/locator.dart';
 import 'package:opennutritracker/features/recipes/domain/entity/shared_recipe_payload.dart';
 import 'package:opennutritracker/features/recipes/presentation/bloc/recipes_bloc.dart';
@@ -27,7 +28,7 @@ class ImportRecipeScannerScreen extends StatefulWidget {
 }
 
 class _ImportRecipeScannerScreenState extends State<ImportRecipeScannerScreen>
-    with WidgetsBindingObserver {
+    with WidgetsBindingObserver, ScannerOrientationMixin {
   bool _isProcessing = false;
   bool _handledInitialCode = false;
   late final MobileScannerController _cameraController;
@@ -89,6 +90,7 @@ class _ImportRecipeScannerScreenState extends State<ImportRecipeScannerScreen>
             tooltip: S.of(context).pasteCodeLabel,
             onPressed: _showPasteCodeDialog,
           ),
+          buildPortraitLockAction(context),
         ],
       ),
       body: MobileScanner(

--- a/lib/features/scanner/scanner_screen.dart
+++ b/lib/features/scanner/scanner_screen.dart
@@ -6,6 +6,7 @@ import 'package:flutter_bloc/flutter_bloc.dart';
 import 'package:logging/logging.dart';
 import 'package:mobile_scanner/mobile_scanner.dart';
 import 'package:opennutritracker/core/domain/entity/intake_type_entity.dart';
+import 'package:opennutritracker/core/presentation/scanner_orientation_mixin.dart';
 import 'package:opennutritracker/core/presentation/widgets/error_dialog.dart';
 import 'package:opennutritracker/core/utils/locator.dart';
 import 'package:opennutritracker/core/utils/navigation_options.dart';
@@ -27,7 +28,7 @@ class ScannerScreen extends StatefulWidget {
 }
 
 class _ScannerScreenState extends State<ScannerScreen>
-    with WidgetsBindingObserver {
+    with WidgetsBindingObserver, ScannerOrientationMixin {
   final log = Logger('ScannerScreen');
 
   String? _scannedBarcode;
@@ -177,6 +178,7 @@ class _ScannerScreenState extends State<ScannerScreen>
             icon: const Icon(Icons.flip_camera_android_outlined),
             onPressed: () => _cameraController.switchCamera(),
           ),
+          buildPortraitLockAction(context),
         ],
       ),
       body: Column(

--- a/lib/generated/intl/messages_cs.dart
+++ b/lib/generated/intl/messages_cs.dart
@@ -1072,6 +1072,8 @@ class MessageLookup extends MessageLookupByLibrary {
             MessageLookupByLibrary.simpleMessage("nasycené mastné kyseliny"),
         "scanProductLabel":
             MessageLookupByLibrary.simpleMessage("Skenovat produkt"),
+        "scannerLockOrientationTooltip":
+            MessageLookupByLibrary.simpleMessage("Uzamknout na výšku"),
         "scannerManualEntryButton":
             MessageLookupByLibrary.simpleMessage("Zadat kód ručně"),
         "scannerManualEntryCancel":
@@ -1084,6 +1086,8 @@ class MessageLookup extends MessageLookupByLibrary {
             "Tento čárový kód nevypadá platně. Zkontrolujte prosím číslice a zkuste to znovu."),
         "scannerManualEntrySubmit":
             MessageLookupByLibrary.simpleMessage("Vyhledat"),
+        "scannerUnlockOrientationTooltip":
+            MessageLookupByLibrary.simpleMessage("Povolit otáčení"),
         "searchDefaultLabel": MessageLookupByLibrary.simpleMessage(
             "Zadejte prosím slovo k vyhledání"),
         "searchFoodPage": MessageLookupByLibrary.simpleMessage("Potraviny"),

--- a/lib/generated/intl/messages_de.dart
+++ b/lib/generated/intl/messages_de.dart
@@ -1093,6 +1093,8 @@ class MessageLookup extends MessageLookupByLibrary {
             MessageLookupByLibrary.simpleMessage("gesättigtes Fett"),
         "scanProductLabel":
             MessageLookupByLibrary.simpleMessage("Produkt scannen"),
+        "scannerLockOrientationTooltip":
+            MessageLookupByLibrary.simpleMessage("Auf Hochformat sperren"),
         "scannerManualEntryButton":
             MessageLookupByLibrary.simpleMessage("Code manuell eingeben"),
         "scannerManualEntryCancel":
@@ -1105,6 +1107,8 @@ class MessageLookup extends MessageLookupByLibrary {
             "Dieser Barcode sieht nicht gültig aus. Bitte überprüfe die Ziffern und versuche es erneut."),
         "scannerManualEntrySubmit":
             MessageLookupByLibrary.simpleMessage("Suchen"),
+        "scannerUnlockOrientationTooltip":
+            MessageLookupByLibrary.simpleMessage("Drehung erlauben"),
         "searchDefaultLabel": MessageLookupByLibrary.simpleMessage(
             "Bitte geben Sie ein Suchwort ein"),
         "searchFoodPage": MessageLookupByLibrary.simpleMessage("Lebensmittel"),

--- a/lib/generated/intl/messages_en.dart
+++ b/lib/generated/intl/messages_en.dart
@@ -1065,6 +1065,8 @@ class MessageLookup extends MessageLookupByLibrary {
             MessageLookupByLibrary.simpleMessage("saturated fat"),
         "scanProductLabel":
             MessageLookupByLibrary.simpleMessage("Scan Product"),
+        "scannerLockOrientationTooltip":
+            MessageLookupByLibrary.simpleMessage("Lock to portrait"),
         "scannerManualEntryButton":
             MessageLookupByLibrary.simpleMessage("Type code manually"),
         "scannerManualEntryCancel":
@@ -1077,6 +1079,8 @@ class MessageLookup extends MessageLookupByLibrary {
             "That barcode doesn\'t look valid. Please check the digits and try again."),
         "scannerManualEntrySubmit":
             MessageLookupByLibrary.simpleMessage("Look up"),
+        "scannerUnlockOrientationTooltip":
+            MessageLookupByLibrary.simpleMessage("Allow rotation"),
         "searchDefaultLabel":
             MessageLookupByLibrary.simpleMessage("Please enter a search word"),
         "searchFoodPage": MessageLookupByLibrary.simpleMessage("Food"),

--- a/lib/generated/intl/messages_it.dart
+++ b/lib/generated/intl/messages_it.dart
@@ -1081,6 +1081,8 @@ class MessageLookup extends MessageLookupByLibrary {
             MessageLookupByLibrary.simpleMessage("grassi saturi"),
         "scanProductLabel":
             MessageLookupByLibrary.simpleMessage("Scansiona prodotto"),
+        "scannerLockOrientationTooltip":
+            MessageLookupByLibrary.simpleMessage("Blocca in verticale"),
         "scannerManualEntryButton": MessageLookupByLibrary.simpleMessage(
             "Inserisci il codice manualmente"),
         "scannerManualEntryCancel":
@@ -1093,6 +1095,8 @@ class MessageLookup extends MessageLookupByLibrary {
             "Questo codice a barre non sembra valido. Controlla le cifre e riprova."),
         "scannerManualEntrySubmit":
             MessageLookupByLibrary.simpleMessage("Cerca"),
+        "scannerUnlockOrientationTooltip":
+            MessageLookupByLibrary.simpleMessage("Consenti rotazione"),
         "searchDefaultLabel": MessageLookupByLibrary.simpleMessage(
             "Inserisci una parola da cercare"),
         "searchFoodPage": MessageLookupByLibrary.simpleMessage("Cibo"),

--- a/lib/generated/intl/messages_pl.dart
+++ b/lib/generated/intl/messages_pl.dart
@@ -1078,6 +1078,8 @@ class MessageLookup extends MessageLookupByLibrary {
             MessageLookupByLibrary.simpleMessage("tłuszcze nasycone"),
         "scanProductLabel":
             MessageLookupByLibrary.simpleMessage("Skanuj produkt"),
+        "scannerLockOrientationTooltip":
+            MessageLookupByLibrary.simpleMessage("Zablokuj w pionie"),
         "scannerManualEntryButton":
             MessageLookupByLibrary.simpleMessage("Wpisz kod ręcznie"),
         "scannerManualEntryCancel":
@@ -1090,6 +1092,8 @@ class MessageLookup extends MessageLookupByLibrary {
             "Ten kod kreskowy wygląda na nieprawidłowy. Sprawdź cyfry i spróbuj ponownie."),
         "scannerManualEntrySubmit":
             MessageLookupByLibrary.simpleMessage("Wyszukaj"),
+        "scannerUnlockOrientationTooltip":
+            MessageLookupByLibrary.simpleMessage("Zezwól na obrót"),
         "searchDefaultLabel": MessageLookupByLibrary.simpleMessage(
             "Wprowadź słowo do wyszukania"),
         "searchFoodPage": MessageLookupByLibrary.simpleMessage("Jedzenie"),

--- a/lib/generated/intl/messages_sk.dart
+++ b/lib/generated/intl/messages_sk.dart
@@ -1036,6 +1036,8 @@ class MessageLookup extends MessageLookupByLibrary {
             MessageLookupByLibrary.simpleMessage("nasýtené tuky"),
         "scanProductLabel":
             MessageLookupByLibrary.simpleMessage("Naskenovať produkt"),
+        "scannerLockOrientationTooltip":
+            MessageLookupByLibrary.simpleMessage("Uzamknúť na výšku"),
         "scannerManualEntryButton":
             MessageLookupByLibrary.simpleMessage("Zadať kód ručne"),
         "scannerManualEntryCancel":
@@ -1048,6 +1050,8 @@ class MessageLookup extends MessageLookupByLibrary {
             "Tento čiarový kód nevyzerá platne. Skontrolujte číslice a skúste to znova."),
         "scannerManualEntrySubmit":
             MessageLookupByLibrary.simpleMessage("Vyhľadať"),
+        "scannerUnlockOrientationTooltip":
+            MessageLookupByLibrary.simpleMessage("Povoliť otáčanie"),
         "searchDefaultLabel": MessageLookupByLibrary.simpleMessage(
             "Zadajte prosím hľadané slovo"),
         "searchFoodPage": MessageLookupByLibrary.simpleMessage("Potraviny"),

--- a/lib/generated/intl/messages_tr.dart
+++ b/lib/generated/intl/messages_tr.dart
@@ -1061,6 +1061,8 @@ class MessageLookup extends MessageLookupByLibrary {
         "retryLabel": MessageLookupByLibrary.simpleMessage("Tekrar Dene"),
         "saturatedFatLabel": MessageLookupByLibrary.simpleMessage("doymuş yağ"),
         "scanProductLabel": MessageLookupByLibrary.simpleMessage("Ürünü Tara"),
+        "scannerLockOrientationTooltip":
+            MessageLookupByLibrary.simpleMessage("Dikey kilitle"),
         "scannerManualEntryButton":
             MessageLookupByLibrary.simpleMessage("Kodu elle gir"),
         "scannerManualEntryCancel":
@@ -1072,6 +1074,8 @@ class MessageLookup extends MessageLookupByLibrary {
         "scannerManualEntryInvalid": MessageLookupByLibrary.simpleMessage(
             "Bu barkod geçerli görünmüyor. Lütfen rakamları kontrol edip tekrar deneyin."),
         "scannerManualEntrySubmit": MessageLookupByLibrary.simpleMessage("Ara"),
+        "scannerUnlockOrientationTooltip":
+            MessageLookupByLibrary.simpleMessage("Döndürmeye izin ver"),
         "searchDefaultLabel": MessageLookupByLibrary.simpleMessage(
             "Lütfen bir arama kelimesi girin"),
         "searchFoodPage": MessageLookupByLibrary.simpleMessage("Yiyecek"),

--- a/lib/generated/intl/messages_uk.dart
+++ b/lib/generated/intl/messages_uk.dart
@@ -1082,6 +1082,8 @@ class MessageLookup extends MessageLookupByLibrary {
             MessageLookupByLibrary.simpleMessage("насичені жири"),
         "scanProductLabel":
             MessageLookupByLibrary.simpleMessage("Сканувати продукт"),
+        "scannerLockOrientationTooltip":
+            MessageLookupByLibrary.simpleMessage("Зафіксувати вертикально"),
         "scannerManualEntryButton":
             MessageLookupByLibrary.simpleMessage("Ввести код вручну"),
         "scannerManualEntryCancel":
@@ -1094,6 +1096,8 @@ class MessageLookup extends MessageLookupByLibrary {
             "Цей штрихкод виглядає недійсним. Будь ласка, перевірте цифри та спробуйте знову."),
         "scannerManualEntrySubmit":
             MessageLookupByLibrary.simpleMessage("Знайти"),
+        "scannerUnlockOrientationTooltip":
+            MessageLookupByLibrary.simpleMessage("Дозволити обертання"),
         "searchDefaultLabel":
             MessageLookupByLibrary.simpleMessage("Введіть слово для пошуку"),
         "searchFoodPage": MessageLookupByLibrary.simpleMessage("Їжа"),

--- a/lib/generated/intl/messages_zh.dart
+++ b/lib/generated/intl/messages_zh.dart
@@ -942,6 +942,8 @@ class MessageLookup extends MessageLookupByLibrary {
         "retryLabel": MessageLookupByLibrary.simpleMessage("重试"),
         "saturatedFatLabel": MessageLookupByLibrary.simpleMessage("饱和脂肪"),
         "scanProductLabel": MessageLookupByLibrary.simpleMessage("扫描产品"),
+        "scannerLockOrientationTooltip":
+            MessageLookupByLibrary.simpleMessage("锁定为竖屏"),
         "scannerManualEntryButton":
             MessageLookupByLibrary.simpleMessage("手动输入条码"),
         "scannerManualEntryCancel": MessageLookupByLibrary.simpleMessage("取消"),
@@ -952,6 +954,8 @@ class MessageLookup extends MessageLookupByLibrary {
         "scannerManualEntryInvalid":
             MessageLookupByLibrary.simpleMessage("此条码似乎无效。请检查数字后重试。"),
         "scannerManualEntrySubmit": MessageLookupByLibrary.simpleMessage("查找"),
+        "scannerUnlockOrientationTooltip":
+            MessageLookupByLibrary.simpleMessage("允许旋转"),
         "searchDefaultLabel": MessageLookupByLibrary.simpleMessage("请输入搜索词"),
         "searchFoodPage": MessageLookupByLibrary.simpleMessage("食物"),
         "searchLabel": MessageLookupByLibrary.simpleMessage("搜索"),

--- a/lib/generated/l10n.dart
+++ b/lib/generated/l10n.dart
@@ -4219,6 +4219,26 @@ class S {
     );
   }
 
+  /// `Lock to portrait`
+  String get scannerLockOrientationTooltip {
+    return Intl.message(
+      'Lock to portrait',
+      name: 'scannerLockOrientationTooltip',
+      desc: '',
+      args: [],
+    );
+  }
+
+  /// `Allow rotation`
+  String get scannerUnlockOrientationTooltip {
+    return Intl.message(
+      'Allow rotation',
+      name: 'scannerUnlockOrientationTooltip',
+      desc: '',
+      args: [],
+    );
+  }
+
   /// `Cancel`
   String get scannerManualEntryCancel {
     return Intl.message(

--- a/lib/l10n/intl_cs.arb
+++ b/lib/l10n/intl_cs.arb
@@ -982,5 +982,7 @@
   "quickAddActivityEnergyLabelKcal": "Spálená energie (kcal)",
   "quickAddActivityEnergyLabelKj": "Spálená energie (kJ)",
   "quickAddActivityAddedSnack": "Aktivita přidána",
-  "quickAddActivityNameLabel": "Název (volitelné)"
+  "quickAddActivityNameLabel": "Název (volitelné)",
+  "scannerLockOrientationTooltip": "Uzamknout na výšku",
+  "scannerUnlockOrientationTooltip": "Povolit otáčení"
 }

--- a/lib/l10n/intl_de.arb
+++ b/lib/l10n/intl_de.arb
@@ -1013,5 +1013,7 @@
   "quickAddActivityEnergyLabelKcal": "Verbrannte Energie (kcal)",
   "quickAddActivityEnergyLabelKj": "Verbrannte Energie (kJ)",
   "quickAddActivityAddedSnack": "Aktivität hinzugefügt",
-  "quickAddActivityNameLabel": "Name (optional)"
+  "quickAddActivityNameLabel": "Name (optional)",
+  "scannerLockOrientationTooltip": "Auf Hochformat sperren",
+  "scannerUnlockOrientationTooltip": "Drehung erlauben"
 }

--- a/lib/l10n/intl_en.arb
+++ b/lib/l10n/intl_en.arb
@@ -1054,5 +1054,7 @@
   "quickAddActivityEnergyLabelKcal": "Energy burned (kcal)",
   "quickAddActivityEnergyLabelKj": "Energy burned (kJ)",
   "quickAddActivityAddedSnack": "Activity added",
-  "quickAddActivityNameLabel": "Name (optional)"
+  "quickAddActivityNameLabel": "Name (optional)",
+  "scannerLockOrientationTooltip": "Lock to portrait",
+  "scannerUnlockOrientationTooltip": "Allow rotation"
 }

--- a/lib/l10n/intl_it.arb
+++ b/lib/l10n/intl_it.arb
@@ -982,5 +982,7 @@
   "quickAddActivityEnergyLabelKcal": "Energia bruciata (kcal)",
   "quickAddActivityEnergyLabelKj": "Energia bruciata (kJ)",
   "quickAddActivityAddedSnack": "Attività aggiunta",
-  "quickAddActivityNameLabel": "Nome (facoltativo)"
+  "quickAddActivityNameLabel": "Nome (facoltativo)",
+  "scannerLockOrientationTooltip": "Blocca in verticale",
+  "scannerUnlockOrientationTooltip": "Consenti rotazione"
 }

--- a/lib/l10n/intl_pl.arb
+++ b/lib/l10n/intl_pl.arb
@@ -982,5 +982,7 @@
   "quickAddActivityEnergyLabelKcal": "Spalona energia (kcal)",
   "quickAddActivityEnergyLabelKj": "Spalona energia (kJ)",
   "quickAddActivityAddedSnack": "Dodano aktywność",
-  "quickAddActivityNameLabel": "Nazwa (opcjonalnie)"
+  "quickAddActivityNameLabel": "Nazwa (opcjonalnie)",
+  "scannerLockOrientationTooltip": "Zablokuj w pionie",
+  "scannerUnlockOrientationTooltip": "Zezwól na obrót"
 }

--- a/lib/l10n/intl_sk.arb
+++ b/lib/l10n/intl_sk.arb
@@ -1012,5 +1012,7 @@
   "quickAddActivityEnergyLabelKcal": "Spálená energia (kcal)",
   "quickAddActivityEnergyLabelKj": "Spálená energia (kJ)",
   "quickAddActivityAddedSnack": "Aktivita pridaná",
-  "quickAddActivityNameLabel": "Názov (voliteľné)"
+  "quickAddActivityNameLabel": "Názov (voliteľné)",
+  "scannerLockOrientationTooltip": "Uzamknúť na výšku",
+  "scannerUnlockOrientationTooltip": "Povoliť otáčanie"
 }

--- a/lib/l10n/intl_tr.arb
+++ b/lib/l10n/intl_tr.arb
@@ -1013,5 +1013,7 @@
   "quickAddActivityEnergyLabelKcal": "Yakılan enerji (kcal)",
   "quickAddActivityEnergyLabelKj": "Yakılan enerji (kJ)",
   "quickAddActivityAddedSnack": "Aktivite eklendi",
-  "quickAddActivityNameLabel": "Ad (isteğe bağlı)"
+  "quickAddActivityNameLabel": "Ad (isteğe bağlı)",
+  "scannerLockOrientationTooltip": "Dikey kilitle",
+  "scannerUnlockOrientationTooltip": "Döndürmeye izin ver"
 }

--- a/lib/l10n/intl_uk.arb
+++ b/lib/l10n/intl_uk.arb
@@ -982,5 +982,7 @@
   "quickAddActivityEnergyLabelKcal": "Спалена енергія (ккал)",
   "quickAddActivityEnergyLabelKj": "Спалена енергія (кДж)",
   "quickAddActivityAddedSnack": "Активність додано",
-  "quickAddActivityNameLabel": "Назва (необов'язково)"
+  "quickAddActivityNameLabel": "Назва (необов'язково)",
+  "scannerLockOrientationTooltip": "Зафіксувати вертикально",
+  "scannerUnlockOrientationTooltip": "Дозволити обертання"
 }

--- a/lib/l10n/intl_zh.arb
+++ b/lib/l10n/intl_zh.arb
@@ -983,5 +983,7 @@
   "quickAddActivityEnergyLabelKcal": "消耗能量（kcal）",
   "quickAddActivityEnergyLabelKj": "消耗能量（kJ）",
   "quickAddActivityAddedSnack": "已添加活动",
-  "quickAddActivityNameLabel": "名称（可选）"
+  "quickAddActivityNameLabel": "名称（可选）",
+  "scannerLockOrientationTooltip": "锁定为竖屏",
+  "scannerUnlockOrientationTooltip": "允许旋转"
 }


### PR DESCRIPTION
Closes #165.

## What was wrong

When the phone wasn't held upright while scanning, the camera preview rotated with it, so the scene through the lens no longer matched the real world. It was first reported on an iPhone SE 3 (iOS 18.3.1) and confirmed on Android too. If you have ever tilted your phone over a barcode on a supermarket shelf and watched the live view tip sideways, that is the feeling this fixes.

## The approach

A hybrid lock, decided together rather than a blunt portrait-only rule:

- On phone-sized screens (shortest side < 600dp) the scanner locks to portrait by default, so the preview stays steady however the phone is held.
- Tablets are left free to rotate, because a tablet held in landscape shouldn't be forced upright.
- A toggle in the scanner appbar lets anyone override the choice either way, and it sticks. The preference is persisted on `ConfigDBO` as a nullable `scannerPortraitLock`, where `null` means "follow the device" — the same nullable-default pattern the existing settings use.

A shared `ScannerOrientationMixin` carries the behaviour across all four camera screens (the main scanner and the meal, activity, and recipe QR importers) so they stay consistent and the logic lives in one place. New `scannerLockOrientationTooltip` / `scannerUnlockOrientationTooltip` strings are translated across all nine locales.

## The second commit

While testing the toggle on a device, unlocking the scanner made landscape easy to reach, which surfaced a pre-existing add_meal layout issue: in landscape the space above the keyboard is shorter than the pinned search bar plus tab bar, so focusing the field overflowed the body by 69 pixels. The second commit lets the keyboard overlay the results rather than resizing the body, which keeps the search field where it belongs. It is a separate, self-contained commit, so it is easy to lift out if you would rather it lived in its own PR.

## Verification

- `flutter analyze` clean; all 647 tests pass; `just check_intl` passes.
- Driven on a physical phone via the `tools/adb` helpers: the scanner opens portrait-locked by default (OS reported `SCREEN_ORIENTATION_PORTRAIT`), the toggle unlocks it (`SCREEN_ORIENTATION_FULL_USER`), and reopening the scanner keeps the unlocked choice — proving the preference persists, since a phone would otherwise re-lock.
- The 69px landscape overflow reproduced cleanly before the fix and is gone after it.

The tablet-free path can't be exercised on a phone, so that side rests on the screen-size logic and the `flutter analyze` pass rather than a device check.