### PR TITLE
fix(a11y): stop dropdown descenders clipping at large text size

### DIFF
--- a/lib/core/presentation/widgets/copy_dialog.dart
+++ b/lib/core/presentation/widgets/copy_dialog.dart
@@ -29,6 +29,7 @@ class CopyDialogState extends State<CopyDialog> {
       title: Text(S.of(context).copyDialogTitle),
       content: DropdownButton<AddMealType>(
         value: _selectedValue,
+        itemHeight: null,
         onChanged: (AddMealType? addMealType) {
           if (addMealType != null) {
             setState(() {

--- a/lib/features/activity_detail/presentation/widget/activity_detail_bottom_sheet.dart
+++ b/lib/features/activity_detail/presentation/widget/activity_detail_bottom_sheet.dart
@@ -221,6 +221,7 @@ class _ActivityDetailBottomSheetState extends State<ActivityDetailBottomSheet> {
                           const SizedBox(width: 16.0),
                           Expanded(
                             child: DropdownButtonFormField(
+                              itemHeight: null,
                               decoration: InputDecoration(
                                 border: const OutlineInputBorder(),
                                 labelText: S.of(context).unitLabel,

--- a/lib/features/meal_detail/presentation/widgets/meal_detail_bottom_sheet.dart
+++ b/lib/features/meal_detail/presentation/widgets/meal_detail_bottom_sheet.dart
@@ -136,6 +136,7 @@ class _MealDetailBottomSheetState extends State<MealDetailBottomSheet> {
                           Expanded(
                             child: DropdownButtonFormField(
                               isExpanded: true,
+                              itemHeight: null,
                               initialValue: widget.selectedUnit,
                               key: ValueKey(widget.selectedUnit),
                               decoration: InputDecoration(

--- a/lib/features/recipes/presentation/widgets/ingredient_quantity_dialog.dart
+++ b/lib/features/recipes/presentation/widgets/ingredient_quantity_dialog.dart
@@ -74,24 +74,28 @@ class _IngredientQuantitySheetState extends State<_IngredientQuantitySheet> {
   List<DropdownMenuItem<String>> _unitItems(BuildContext context) {
     final items = <DropdownMenuItem<String>>[];
     if (widget.meal.hasServingValues) {
-      items.add(const DropdownMenuItem(
-        value: 'serving',
-        child: Text('serving'),
-      ));
+      items.add(_unitItem('serving'));
     }
     if (widget.meal.isSolid ||
         (!widget.meal.isLiquid && !widget.meal.isSolid)) {
-      items.add(const DropdownMenuItem(value: 'g', child: Text('g')));
-      items.add(const DropdownMenuItem(value: 'kg', child: Text('kg')));
-      items.add(const DropdownMenuItem(value: 'oz', child: Text('oz')));
+      items.add(_unitItem('g'));
+      items.add(_unitItem('kg'));
+      items.add(_unitItem('oz'));
     }
     if (widget.meal.isLiquid ||
         (!widget.meal.isLiquid && !widget.meal.isSolid)) {
-      items.add(const DropdownMenuItem(value: 'ml', child: Text('ml')));
-      items.add(const DropdownMenuItem(value: 'l', child: Text('l')));
-      items.add(const DropdownMenuItem(value: 'fl.oz', child: Text('fl.oz')));
+      items.add(_unitItem('ml'));
+      items.add(_unitItem('l'));
+      items.add(_unitItem('fl.oz'));
     }
     return items;
+  }
+
+  DropdownMenuItem<String> _unitItem(String unit) {
+    return DropdownMenuItem(
+      value: unit,
+      child: Text(unit, maxLines: 1, overflow: TextOverflow.ellipsis),
+    );
   }
 
   @override
@@ -145,6 +149,7 @@ class _IngredientQuantitySheetState extends State<_IngredientQuantitySheet> {
                   flex: 2,
                   child: DropdownButtonFormField<String>(
                     isExpanded: true,
+                    itemHeight: null,
                     initialValue: _unit,
                     decoration: InputDecoration(
                       labelText: S.of(context).recipeIngredientUnitLabel,

--- a/lib/features/settings/presentation/widgets/kcal_adjustment_dialog.dart
+++ b/lib/features/settings/presentation/widgets/kcal_adjustment_dialog.dart
@@ -165,6 +165,7 @@ class _KcalAdjustmentDialogState extends State<KcalAdjustmentDialog> {
                   // doesn't feel hidden.
                   DropdownButtonFormField(
                     isExpanded: true,
+                    itemHeight: null,
                     decoration: InputDecoration(
                       enabled: false,
                       filled: false,

--- a/lib/features/settings/settings_screen.dart
+++ b/lib/features/settings/settings_screen.dart
@@ -432,6 +432,7 @@ class _SettingsScreenState extends State<SettingsScreen> {
                   DropdownButtonFormField(
                     initialValue: selectedUnit,
                     key: ValueKey(selectedUnit),
+                    itemHeight: null,
                     decoration: InputDecoration(
                       enabled: true,
                       filled: false,


### PR DESCRIPTION
Closes #107. Thanks to @fuddl for the report and the side-by-side screenshots, which made this easy to pin down.

At a large iOS accessibility Text Size, the descenders of letters like g, y and p were cut off in dropdown menus. The classic Material `DropdownButton` and `DropdownButtonFormField` default each item row to a fixed `itemHeight` of `kMinInteractiveDimension` (48px), and that height does not grow with the text scaler, so scaled glyphs spilled past the row and clipped.

Setting `itemHeight: null` at each of the six call sites lets every row size to its own scaled content instead of being clamped to 48px. This keeps the person's chosen text size intact rather than shrinking it to fit. The recipe ingredient unit picker also gains the `maxLines: 1` plus ellipsis treatment the other pickers already use.

Touched: `settings_screen.dart`, `meal_detail_bottom_sheet.dart`, `ingredient_quantity_dialog.dart`, `kcal_adjustment_dialog.dart`, `activity_detail_bottom_sheet.dart`, `copy_dialog.dart`.

`flutter analyze` clean, `just test` green. The one thing I could not drive automatically is the visual check at large iOS Text Size, so it is worth an eyeball on a device before merge.