### PR TITLE
fix(add_meal): key FDC nutrients on the id, not the number

### DIFF
--- a/lib/features/add_meal/data/dto/fdc/fdc_const.dart
+++ b/lib/features/add_meal/data/dto/fdc/fdc_const.dart
@@ -177,36 +177,44 @@ class FDCConst {
     return Uri.https(_fdcBaseUrl, _fdcFoodSearchPath, queryParameters);
   }
 
-  // Nutriment codes
+  // Nutriment codes. These are FDC nutrient *ids* (the `nutrient.id` /
+  // `nutrientId` field), not the FDC nutrient *numbers*. Both the Supabase
+  // `fdc_nutrients.nutrient_id` column and the direct FDC search response key
+  // on the id. The Atwater energy ids differ from their numbers (957/958), so
+  // they must be the ids 2047/2048 to match; using the numbers meant Foundation
+  // foods that carry only Atwater energy (no plain Energy 1008) silently
+  // resolved to no kcal and were rejected as "missing required kcal" (#252).
   static const fdcTotalKcalId = 1008;
-  static const fdcKcalAtwaterGeneralId = 957;
-  static const fdcKcalAtwaterSpecificId = 958;
+  static const fdcKcalAtwaterGeneralId = 2047; // number 957
+  static const fdcKcalAtwaterSpecificId = 2048; // number 958
   static const fdcTotalCarbsId = 1005;
   static const fdcTotalFatId = 1004;
   static const fdcTotalProteinsId = 1003;
   static const fdcTotalSugarId = 1063;
   static const fdcTotalSaturatedFatId = 1258;
   static const fdcTotalDietaryFiberId = 1079;
-  // #237: Extended lipid profile
-  static const fdcMonounsaturatedFatId = 645;
-  static const fdcPolyunsaturatedFatId = 646;
-  static const fdcTransFatId = 605;
-  static const fdcCholesterolId = 601;
+  // #237: Extended lipid profile (FDC ids; trailing comment is the number)
+  static const fdcMonounsaturatedFatId = 1292; // number 645, g
+  static const fdcPolyunsaturatedFatId = 1293; // number 646, g
+  static const fdcTransFatId = 1257; // number 605, g
+  static const fdcCholesterolId = 1253; // number 601, mg
   // #237: Minerals
-  static const fdcSodiumId = 307;
-  static const fdcPotassiumId = 306;
-  static const fdcMagnesiumId = 304;
-  static const fdcCalciumId = 301;
-  static const fdcIronId = 303;
-  static const fdcZincId = 309;
-  static const fdcPhosphorusId = 305;
-  // #237: Vitamins
-  static const fdcVitaminAId = 318; // µg RAE
-  static const fdcVitaminCId = 401; // mg
-  static const fdcVitaminDId = 328; // µg
-  static const fdcVitaminB6Id = 415; // mg
-  static const fdcVitaminB12Id = 418; // µg
-  static const fdcNiacinId = 406; // mg (B3)
+  static const fdcSodiumId = 1093; // number 307, mg
+  static const fdcPotassiumId = 1092; // number 306, mg
+  static const fdcMagnesiumId = 1090; // number 304, mg
+  static const fdcCalciumId = 1087; // number 301, mg
+  static const fdcIronId = 1089; // number 303, mg
+  static const fdcZincId = 1095; // number 309, mg
+  static const fdcPhosphorusId = 1091; // number 305, mg
+  // #237: Vitamins. Vitamin A uses the RAE id (1106), not the IU form (1104),
+  // so the value matches the µg RAE the panel expects; Vitamin D uses the µg
+  // id (1114), not the IU form (1110).
+  static const fdcVitaminAId = 1106; // number 320, µg RAE
+  static const fdcVitaminCId = 1162; // number 401, mg
+  static const fdcVitaminDId = 1114; // number 328, µg
+  static const fdcVitaminB6Id = 1175; // number 415, mg
+  static const fdcVitaminB12Id = 1178; // number 418, µg
+  static const fdcNiacinId = 1167; // number 406, mg (B3)
 
   // Measure unit codes
   static const fdcPortionServingId = 1049;

--- a/test/unit_test/meal_nutriments_entity_test.dart
+++ b/test/unit_test/meal_nutriments_entity_test.dart
@@ -29,10 +29,45 @@ void main() {
       expect(entity.fiber100, 2);
     });
 
+    test('energy ids match the FDC nutrient ids, not the numbers', () {
+      // Regression for #252: the Atwater energy constants must be the FDC
+      // nutrient *ids* (2047/2048), not the numbers (957/958). Foundation
+      // foods such as "Potatoes, russet, without skin, raw" (FDC 2346401)
+      // carry only Atwater energy, so keying on the numbers left them with no
+      // kcal and they were rejected as "missing required kcal".
+      expect(FDCConst.fdcKcalAtwaterGeneralId, 2047);
+      expect(FDCConst.fdcKcalAtwaterSpecificId, 2048);
+      expect(FDCConst.fdcTotalKcalId, 1008);
+    });
+
+    test('micronutrient ids match the FDC nutrient ids, not the numbers', () {
+      // #237 originally used FDC nutrient *numbers* for the lipid / mineral /
+      // vitamin constants, so they never matched the FDC `nutrientId` the data
+      // is keyed on and silently resolved to null. These are the ids. Vitamin A
+      // is the RAE form (1106) and Vitamin D the µg form (1114) so the values
+      // land in the units the entity documents.
+      expect(FDCConst.fdcMonounsaturatedFatId, 1292);
+      expect(FDCConst.fdcPolyunsaturatedFatId, 1293);
+      expect(FDCConst.fdcTransFatId, 1257);
+      expect(FDCConst.fdcCholesterolId, 1253);
+      expect(FDCConst.fdcSodiumId, 1093);
+      expect(FDCConst.fdcPotassiumId, 1092);
+      expect(FDCConst.fdcMagnesiumId, 1090);
+      expect(FDCConst.fdcCalciumId, 1087);
+      expect(FDCConst.fdcIronId, 1089);
+      expect(FDCConst.fdcZincId, 1095);
+      expect(FDCConst.fdcPhosphorusId, 1091);
+      expect(FDCConst.fdcVitaminAId, 1106);
+      expect(FDCConst.fdcVitaminCId, 1162);
+      expect(FDCConst.fdcVitaminDId, 1114);
+      expect(FDCConst.fdcVitaminB6Id, 1175);
+      expect(FDCConst.fdcVitaminB12Id, 1178);
+      expect(FDCConst.fdcNiacinId, 1167);
+    });
+
     test('energy prefers Atwater Specific over General and total', () {
-      // Atwater Specific (958) is the most precise FDC energy value;
-      // when present it should be used in preference to General (957) or
-      // the raw total (1008).
+      // Atwater Specific is the most precise FDC energy value; when present it
+      // should be used in preference to General or the raw total.
       final entity = MealNutrimentsEntity.fromFDCNutriments([
         _fdc(FDCConst.fdcTotalKcalId, 250),
         _fdc(FDCConst.fdcKcalAtwaterGeneralId, 180),


### PR DESCRIPTION
Foods like "Potatoes, russet, without skin, raw" (FDC 2346401) and "Apples, red delicious, with skin, raw" (FDC 1750339) were turned away with "Product missing required kcal or macronutrients information" even though FoodData Central clearly has the numbers. This fixes that, and closes #252.

## What was wrong

FDC nutrients arrive keyed on the nutrient *id* — the `nutrientId` field on the FDC API and the `fdc_nutrients.nutrient_id` column in Supabase, which `docs/supabase-fdc-setup/README.md` loads straight from `food_nutrient.csv`. Several of our constants held the FDC nutrient *number* instead. The two systems only coincide for some nutrients, so the mismatched lookups quietly returned nothing.

The energy lookups used 957/958 (the Atwater General/Specific numbers). Foundation foods often carry only Atwater energy and no plain Energy (1008), so kcal came back null and the food was rejected. The ids are 2047/2048. This is the same case #347 meant to fix; it corrected the fallback order but kept the number form, so it never actually reached these foods.

The #237 lipid, mineral, and vitamin constants had the same slip (sodium 307 rather than id 1093, and so on), so FDC micronutrients silently resolved to null in the diary panel. Those are ids now too. Vitamin A is pinned to the RAE form (1106) rather than IU, and Vitamin D to the µg form (1114), so each value lands in the unit the entity already documents.

## Verification

Confirmed against the live FDC API that 2346401 carries energy only as ids 2047/2048 with no 1008, and that the mineral ids resolve to real values. The Supabase column convention is established by the setup doc mapping and by production macros (keyed on ids 1003/1004/1005) already working.

## Tests

Added regression tests pinning the literal ids. The previous tests referenced the constants symbolically, so they passed regardless of the value, which is how the wrong numbers survived. Full suite green (672 tests).