### PR TITLE
feat(profile): add weight history range selector

### DIFF
--- a/lib/features/profile/presentation/weight_history_screen.dart
+++ b/lib/features/profile/presentation/weight_history_screen.dart
@@ -55,7 +55,8 @@ class _WeightHistoryScreenState extends State<WeightHistoryScreen> {
       widget.configRepository ?? locator<ConfigRepository>();
   // Optional in tests so the harness doesn't need to register the
   // user usecase in the locator just to render the chart.
-  late final GetUserUsecase? _getUserUsecase = widget.getUserUsecase ??
+  late final GetUserUsecase? _getUserUsecase =
+      widget.getUserUsecase ??
       (locator.isRegistered<GetUserUsecase>()
           ? locator<GetUserUsecase>()
           : null);
@@ -66,6 +67,7 @@ class _WeightHistoryScreenState extends State<WeightHistoryScreen> {
   // Loaded once at mount time so the chart can draw a dashed reference
   // line for the user's #119 target weight. Null when unset.
   double? _targetWeightKg;
+  _ChartRange _selectedRange = _ChartRange.days30;
 
   @override
   void initState() {
@@ -89,12 +91,91 @@ class _WeightHistoryScreenState extends State<WeightHistoryScreen> {
     });
   }
 
+  int _calculateWindowDays() {
+    switch (_selectedRange) {
+      case _ChartRange.days30:
+        return 30;
+      case _ChartRange.days60:
+        return 60;
+      case _ChartRange.days180:
+        return 180;
+      case _ChartRange.days365:
+        return 365;
+      case _ChartRange.all:
+        final now = DateTime.now();
+        final today = DateTime(now.year, now.month, now.day);
+        final nonFutureEntries = _entries
+            .where((e) => !e.date.isAfter(today))
+            .toList();
+        if (nonFutureEntries.isEmpty) {
+          return 30;
+        }
+        final oldestDate = nonFutureEntries
+            .map((e) => e.date)
+            .reduce((a, b) => a.isBefore(b) ? a : b);
+        final oldestDateOnly = DateTime(
+          oldestDate.year,
+          oldestDate.month,
+          oldestDate.day,
+        );
+        final diffDays = today.difference(oldestDateOnly).inDays + 1;
+        return diffDays < 30 ? 30 : diffDays;
+    }
+  }
+
+  Widget _buildRangeSelector() {
+    return Padding(
+      padding: const EdgeInsets.symmetric(horizontal: 16, vertical: 8),
+      child: Center(
+        child: SingleChildScrollView(
+          scrollDirection: Axis.horizontal,
+          child: Semantics(
+            identifier: 'weight-history-range-selector',
+            child: SegmentedButton<_ChartRange>(
+              showSelectedIcon: false,
+              style: const ButtonStyle(
+                visualDensity: VisualDensity.compact,
+                tapTargetSize: MaterialTapTargetSize.shrinkWrap,
+              ),
+              segments: [
+                const ButtonSegment(
+                  value: _ChartRange.days30,
+                  label: Text('30d'),
+                ),
+                const ButtonSegment(
+                  value: _ChartRange.days60,
+                  label: Text('60d'),
+                ),
+                const ButtonSegment(
+                  value: _ChartRange.days180,
+                  label: Text('180d'),
+                ),
+                const ButtonSegment(
+                  value: _ChartRange.days365,
+                  label: Text('365d'),
+                ),
+                ButtonSegment(
+                  value: _ChartRange.all,
+                  label: Text(S.of(context).allItemsLabel),
+                ),
+              ],
+              selected: {_selectedRange},
+              onSelectionChanged: (set) {
+                setState(() {
+                  _selectedRange = set.first;
+                });
+              },
+            ),
+          ),
+        ),
+      ),
+    );
+  }
+
   @override
   Widget build(BuildContext context) {
     return Scaffold(
-      appBar: AppBar(
-        title: Text(S.of(context).profileWeightHistoryTitle),
-      ),
+      appBar: AppBar(title: Text(S.of(context).profileWeightHistoryTitle)),
       floatingActionButton: Semantics(
         identifier: 'weight-history-add',
         child: FloatingActionButton.extended(
@@ -106,35 +187,42 @@ class _WeightHistoryScreenState extends State<WeightHistoryScreen> {
       body: _loading
           ? const Center(child: CircularProgressIndicator())
           : _entries.isEmpty
-              ? Center(
-                  child: Padding(
-                    padding: const EdgeInsets.all(24.0),
-                    child: Text(
-                      S.of(context).weightHistoryNoEntries,
-                      textAlign: TextAlign.center,
-                      style: Theme.of(context).textTheme.bodyLarge,
-                    ),
-                  ),
-                )
-              : ListView.separated(
-                  padding: const EdgeInsets.only(top: 8, bottom: 96),
-                  itemCount: _entries.length + 1,
-                  separatorBuilder: (context, index) {
-                    // No divider between the chart card and the first list tile.
-                    if (index == 0) return const SizedBox.shrink();
-                    return const Divider(height: 1);
-                  },
-                  itemBuilder: (context, index) {
-                    if (index == 0) {
-                      return WeightTrendChart(
+          ? Center(
+              child: Padding(
+                padding: const EdgeInsets.all(24.0),
+                child: Text(
+                  S.of(context).weightHistoryNoEntries,
+                  textAlign: TextAlign.center,
+                  style: Theme.of(context).textTheme.bodyLarge,
+                ),
+              ),
+            )
+          : ListView.separated(
+              padding: const EdgeInsets.only(top: 8, bottom: 96),
+              itemCount: _entries.length + 1,
+              separatorBuilder: (context, index) {
+                // No divider between the chart card and the first list tile.
+                if (index == 0) return const SizedBox.shrink();
+                return const Divider(height: 1);
+              },
+              itemBuilder: (context, index) {
+                if (index == 0) {
+                  return Column(
+                    mainAxisSize: MainAxisSize.min,
+                    children: [
+                      _buildRangeSelector(),
+                      WeightTrendChart(
                         entries: _entries,
                         bodyWeightUnit: _bodyWeightUnit,
                         targetWeightKg: _targetWeightKg,
-                      );
-                    }
-                    return _buildEntryTile(_entries[index - 1]);
-                  },
-                ),
+                        windowDays: _calculateWindowDays(),
+                      ),
+                    ],
+                  );
+                }
+                return _buildEntryTile(_entries[index - 1]);
+              },
+            ),
     );
   }
 
@@ -153,7 +241,9 @@ class _WeightHistoryScreenState extends State<WeightHistoryScreen> {
     return ListTile(
       title: Text(displayStr),
       subtitle: Text(
-        entry.note?.isNotEmpty == true ? '$dateLabel  •  ${entry.note}' : dateLabel,
+        entry.note?.isNotEmpty == true
+            ? '$dateLabel  •  ${entry.note}'
+            : dateLabel,
       ),
       trailing: IconButton(
         icon: const Icon(Icons.delete_outline),
@@ -163,7 +253,9 @@ class _WeightHistoryScreenState extends State<WeightHistoryScreen> {
   }
 
   Future<void> _onAddEntry() async {
-    final initialWeightKg = _entries.isNotEmpty ? _entries.first.weightKg : 70.0;
+    final initialWeightKg = _entries.isNotEmpty
+        ? _entries.first.weightKg
+        : 70.0;
     final result = await showDialog<_NewWeightEntry>(
       context: context,
       builder: (context) => _AddWeightEntryDialog(
@@ -312,3 +404,5 @@ class _AddWeightEntryDialogState extends State<_AddWeightEntryDialog> {
     );
   }
 }
+
+enum _ChartRange { days30, days60, days180, days365, all }

--- a/lib/features/profile/presentation/widgets/weight_trend_chart.dart
+++ b/lib/features/profile/presentation/widgets/weight_trend_chart.dart
@@ -53,10 +53,13 @@ class WeightTrendChart extends StatelessWidget {
     // how the calorie/water charts window their range.
     final windowStart = today.subtract(Duration(days: windowDays - 1));
 
-    final inWindow = entries
-        .where((e) => !e.date.isBefore(windowStart) && !e.date.isAfter(today))
-        .toList()
-      ..sort((a, b) => a.date.compareTo(b.date));
+    final inWindow =
+        entries
+            .where(
+              (e) => !e.date.isBefore(windowStart) && !e.date.isAfter(today),
+            )
+            .toList()
+          ..sort((a, b) => a.date.compareTo(b.date));
 
     if (inWindow.length < 2) {
       return Padding(
@@ -96,14 +99,18 @@ class WeightTrendChart extends StatelessWidget {
     // Only draw the dashed reference when the target sits within (or just
     // adjacent to) the auto y-range, so a far-off target doesn't autoscale
     // the chart away from the recorded weights.
-    final showTargetLine = targetY != null &&
+    final showTargetLine =
+        targetY != null &&
         targetY >= (minY - yPadding) &&
         targetY <= (maxY + yPadding);
 
     final localeTag = Localizations.localeOf(context).toLanguageTag();
     final dateFormat = DateFormat.MMMd(localeTag);
     // ~5 evenly spaced date labels regardless of window length.
-    final labelInterval = (windowDays / 5).ceilToDouble().clamp(1, 30).toDouble();
+    final labelInterval = (windowDays / 5)
+        .ceilToDouble()
+        .clamp(1.0, double.infinity)
+        .toDouble();
 
     return Padding(
       key: const Key('weightHistoryChart'),
@@ -130,7 +137,9 @@ class WeightTrendChart extends StatelessWidget {
                   showTitles: true,
                   reservedSize: 40,
                   getTitlesWidget: (value, meta) => Text(
-                    value.toStringAsFixed(bodyWeightUnit == BodyWeightUnit.st ? 1 : 0),
+                    value.toStringAsFixed(
+                      bodyWeightUnit == BodyWeightUnit.st ? 1 : 0,
+                    ),
                     style: theme.textTheme.labelSmall,
                   ),
                 ),
@@ -175,10 +184,10 @@ class WeightTrendChart extends StatelessWidget {
                   show: true,
                   getDotPainter: (spot, percent, bar, index) =>
                       FlDotCirclePainter(
-                    radius: 3,
-                    color: lineColor,
-                    strokeWidth: 0,
-                  ),
+                        radius: 3,
+                        color: lineColor,
+                        strokeWidth: 0,
+                      ),
                 ),
               ),
             ],

--- a/test/features/profile/presentation/weight_history_screen_test.dart
+++ b/test/features/profile/presentation/weight_history_screen_test.dart
@@ -45,12 +45,7 @@ class _FakeDeleteWeightLogUsecase extends Fake
 class _FakeConfigRepository extends Fake implements ConfigRepository {
   @override
   Future<ConfigEntity> getConfig() async {
-    return ConfigEntity(
-      false,
-      false,
-      false,
-      AppThemeEntity.system,
-    );
+    return ConfigEntity(false, false, false, AppThemeEntity.system);
   }
 }
 
@@ -78,8 +73,9 @@ Widget _buildScreen(List<WeightLogEntity> entries) {
 
 void main() {
   group('WeightHistoryScreen chart', () {
-    testWidgets('shows the empty-state copy when there are no entries',
-        (tester) async {
+    testWidgets('shows the empty-state copy when there are no entries', (
+      tester,
+    ) async {
       await tester.pumpWidget(_wrap(_buildScreen(const [])));
       await tester.pumpAndSettle();
 
@@ -88,8 +84,9 @@ void main() {
       expect(find.byType(LineChart), findsNothing);
     });
 
-    testWidgets('shows the chart empty-state when there is only one entry',
-        (tester) async {
+    testWidgets('shows the chart empty-state when there is only one entry', (
+      tester,
+    ) async {
       final today = DateTime.now();
       final entries = [
         WeightLogEntity(
@@ -102,14 +99,17 @@ void main() {
       await tester.pumpAndSettle();
 
       // 1 entry: the list shows the row, the chart slot shows the nudge.
-      expect(find.byKey(const Key('weightHistoryChartEmptyState')),
-          findsOneWidget);
+      expect(
+        find.byKey(const Key('weightHistoryChartEmptyState')),
+        findsOneWidget,
+      );
       expect(find.text(S.current.weightHistoryChartEmptyState), findsOneWidget);
       expect(find.byType(LineChart), findsNothing);
     });
 
-    testWidgets('renders the chart when there are three entries',
-        (tester) async {
+    testWidgets('renders the chart when there are three entries', (
+      tester,
+    ) async {
       final today = DateTime.now();
       DateTime day(int daysAgo) {
         final d = today.subtract(Duration(days: daysAgo));
@@ -127,8 +127,60 @@ void main() {
 
       expect(find.byKey(const Key('weightHistoryChart')), findsOneWidget);
       expect(find.byType(LineChart), findsOneWidget);
-      expect(find.byKey(const Key('weightHistoryChartEmptyState')),
-          findsNothing);
+      expect(
+        find.byKey(const Key('weightHistoryChartEmptyState')),
+        findsNothing,
+      );
+    });
+
+    testWidgets('default 30d hides an older point (showing empty state), '
+        'selecting 60d shows chart, and selecting All shows chart '
+        'with very old history', (tester) async {
+      final today = DateTime.now();
+      DateTime day(int daysAgo) {
+        final d = today.subtract(Duration(days: daysAgo));
+        return DateTime(d.year, d.month, d.day);
+      }
+
+      final entries = [
+        WeightLogEntity(date: day(0), weightKg: 70.0),
+        WeightLogEntity(date: day(45), weightKg: 71.0),
+        WeightLogEntity(date: day(200), weightKg: 72.0),
+      ];
+
+      await tester.pumpWidget(_wrap(_buildScreen(entries)));
+      await tester.pumpAndSettle();
+
+      // Default selected is 30d: only 1 point (today) is in window, so chart shows empty state.
+      expect(
+        find.byKey(const Key('weightHistoryChartEmptyState')),
+        findsOneWidget,
+      );
+      expect(find.byKey(const Key('weightHistoryChart')), findsNothing);
+
+      // Tap 60d segment: should now include the 45-day-old point, showing the chart.
+      final button60 = find.text('60d');
+      expect(button60, findsOneWidget);
+      await tester.tap(button60);
+      await tester.pumpAndSettle();
+
+      expect(find.byKey(const Key('weightHistoryChart')), findsOneWidget);
+      expect(
+        find.byKey(const Key('weightHistoryChartEmptyState')),
+        findsNothing,
+      );
+
+      // Tap All segment: should show chart for all history including 200-day-old point.
+      final buttonAll = find.text(S.current.allItemsLabel);
+      expect(buttonAll, findsOneWidget);
+      await tester.tap(buttonAll);
+      await tester.pumpAndSettle();
+
+      expect(find.byKey(const Key('weightHistoryChart')), findsOneWidget);
+      expect(
+        find.byKey(const Key('weightHistoryChartEmptyState')),
+        findsNothing,
+      );
     });
   });
 }


### PR DESCRIPTION
## Summary
- add preset range controls to the Weight History chart: 30d, 60d, 180d, 365d, and all history
- keep the existing 30-day default while letting longer-running users inspect older weight entries
- adjust bottom date label spacing so long chart ranges stay readable

Closes #505

## Test Plan
- `dart format --set-exit-if-changed lib/features/profile/presentation/weight_history_screen.dart lib/features/profile/presentation/widgets/weight_trend_chart.dart test/features/profile/presentation/weight_history_screen_test.dart`
- `flutter test test/features/profile/presentation/weight_history_screen_test.dart`
- `flutter analyze`
- `flutter test`