### PR TITLE
fix(export): catch silent 0-byte export writes

### DIFF
--- a/lib/core/utils/export_write_verifier.dart
+++ b/lib/core/utils/export_write_verifier.dart
@@ -4,14 +4,14 @@ import 'dart:io';
 /// actually has bytes on disk.
 ///
 /// FilePicker.saveFile reports success as soon as its Android platform
-/// channel call returns a path — but the path can come from a content://
+/// channel call returns a path - but the path can come from a content://
 /// URI handed out by a document provider (this is the normal case for the
 /// Downloads folder). The plugin's own write silently no-ops if the
 /// provider's output stream can't be opened, and still hands back that
 /// path as if all was well. See simonoppowa/OpenNutriTracker#504, where
 /// exporting to Downloads reported success over a 0-byte zip.
 ///
-/// [savedPath] isn't always something dart:io can open — content:// URIs
+/// [savedPath] isn't always something dart:io can open - content:// URIs
 /// aren't real filesystem paths, so reading them back this way is a
 /// best-effort check, not a guarantee. Where we can read the file back, an
 /// empty result is treated as a real failure. Where we can't stat it at

--- a/lib/core/utils/export_write_verifier.dart
+++ b/lib/core/utils/export_write_verifier.dart
@@ -1,0 +1,42 @@
+import 'dart:io';
+
+/// Double-checks that a file FilePicker.saveFile claims to have written
+/// actually has bytes on disk.
+///
+/// FilePicker.saveFile reports success as soon as its Android platform
+/// channel call returns a path — but the path can come from a content://
+/// URI handed out by a document provider (this is the normal case for the
+/// Downloads folder). The plugin's own write silently no-ops if the
+/// provider's output stream can't be opened, and still hands back that
+/// path as if all was well. See simonoppowa/OpenNutriTracker#504, where
+/// exporting to Downloads reported success over a 0-byte zip.
+///
+/// [savedPath] isn't always something dart:io can open — content:// URIs
+/// aren't real filesystem paths, so reading them back this way is a
+/// best-effort check, not a guarantee. Where we can read the file back, an
+/// empty result is treated as a real failure. Where we can't stat it at
+/// all (the exact Downloads scenario from #504), this can't tell the
+/// difference between "wrote nothing" and "wrote fine, just not a path we
+/// can open" and stays silent rather than reporting a false failure.
+class ExportWriteVerifier {
+  const ExportWriteVerifier._();
+
+  /// Throws a [StateError] if [savedPath] can be statted and turns out to
+  /// be empty despite [expectedByteLength] being greater than zero.
+  static void verify(String savedPath, int expectedByteLength) {
+    late final int writtenLength;
+    try {
+      writtenLength = File(savedPath).lengthSync();
+    } catch (_) {
+      // Not a path we can stat from here - nothing more we can check.
+      return;
+    }
+
+    if (writtenLength == 0 && expectedByteLength > 0) {
+      throw StateError(
+        'Export reported success but the saved file is empty '
+        '(0 bytes written to $savedPath)',
+      );
+    }
+  }
+}

--- a/lib/features/settings/domain/usecase/export_data_usecase.dart
+++ b/lib/features/settings/domain/usecase/export_data_usecase.dart
@@ -12,6 +12,7 @@ import 'package:opennutritracker/core/data/repository/tracked_day_repository.dar
 import 'package:opennutritracker/core/data/repository/user_activity_repository.dart';
 import 'package:opennutritracker/core/data/repository/weight_log_repository.dart';
 import 'package:opennutritracker/core/utils/csv_data_exporter.dart';
+import 'package:opennutritracker/core/utils/export_write_verifier.dart';
 import 'package:opennutritracker/core/utils/user_image_storage.dart';
 
 /// The two export shapes available from Settings → Export / Import App Data.
@@ -177,6 +178,14 @@ class ExportDataUsecase {
 
     // Save the zip file to the user-specified location
     final zipBytes = ZipEncoder().encode(archive);
+    if (zipBytes.isEmpty) {
+      // We built the archive ourselves a few lines up, so this should be
+      // unreachable — but if it ever happens, fail loudly rather than
+      // handing FilePicker.saveFile an empty payload and calling that
+      // a successful export.
+      throw StateError('Export archive was empty, refusing to save it');
+    }
+
     final result = await FilePicker.saveFile(
       fileName: exportZipFileName,
       type: FileType.custom,
@@ -184,7 +193,13 @@ class ExportDataUsecase {
       bytes: Uint8List.fromList(zipBytes),
     );
 
-    return result != null && result.isNotEmpty;
+    if (result == null || result.isEmpty) {
+      // User cancelled the save dialog.
+      return false;
+    }
+
+    ExportWriteVerifier.verify(result, zipBytes.length);
+    return true;
   }
 
   Future<void> _addUserImageIfPresent(

--- a/test/unit_test/export_write_verifier_test.dart
+++ b/test/unit_test/export_write_verifier_test.dart
@@ -1,0 +1,61 @@
+import 'dart:io';
+
+import 'package:flutter_test/flutter_test.dart';
+import 'package:opennutritracker/core/utils/export_write_verifier.dart';
+
+void main() {
+  group('ExportWriteVerifier', () {
+    late Directory tempDir;
+
+    setUp(() {
+      tempDir = Directory.systemTemp.createTempSync('export_write_verifier_test');
+    });
+
+    tearDown(() {
+      if (tempDir.existsSync()) {
+        tempDir.deleteSync(recursive: true);
+      }
+    });
+
+    test('does not throw when the saved file has the expected bytes', () {
+      final file = File('${tempDir.path}/export.zip')..writeAsBytesSync([1, 2, 3, 4]);
+
+      expect(
+        () => ExportWriteVerifier.verify(file.path, 4),
+        returnsNormally,
+      );
+    });
+
+    test('throws when the saved file exists but is empty', () {
+      // This is the simonoppowa/OpenNutriTracker#504 case: FilePicker.saveFile
+      // reports a path back but nothing was actually written to it.
+      final file = File('${tempDir.path}/export.zip')..writeAsBytesSync([]);
+
+      expect(
+        () => ExportWriteVerifier.verify(file.path, 4),
+        throwsA(isA<StateError>()),
+      );
+    });
+
+    test('does not throw when the expected length is also zero', () {
+      final file = File('${tempDir.path}/export.zip')..writeAsBytesSync([]);
+
+      expect(
+        () => ExportWriteVerifier.verify(file.path, 0),
+        returnsNormally,
+      );
+    });
+
+    test('does not throw when the path cannot be statted at all', () {
+      // Mirrors an Android content:// URI path segment, which dart:io
+      // can't open. We can't confirm success there, but we also
+      // shouldn't report a false failure.
+      final unreadablePath = '${tempDir.path}/does-not-exist/export.zip';
+
+      expect(
+        () => ExportWriteVerifier.verify(unreadablePath, 4),
+        returnsNormally,
+      );
+    });
+  });
+}


### PR DESCRIPTION
Related to #504.

The report: exporting to the Downloads folder shows the normal success toast, but the zip it writes is 0 bytes. Exporting to any other folder works fine.

This is a partial mitigation, not a full fix, so I'd leave #504 open rather than auto-closing it. The specific case from the report - Android, saving to Downloads - still won't be caught on the Dart side. Details on why below, but wanted that up front.

Root cause is in `file_picker`, not in our code. `FilePicker.saveFile` on Android hands the destination off to whatever document provider owns it (Downloads is `content://com.android.providers.downloads.documents/...`) and calls `ContentResolver.openOutputStream(uri)`. If that call returns null - which can happen depending on the provider and how the URI was granted - the plugin's write method just skips the write and still returns the URI as if it had succeeded:

```kotlin
context.contentResolver.openOutputStream(uri)?.use { output ->
    bytes?.let { output.write(it) }
}
return uri
```

Our `exportData()` then saw a non-null path and reported success, no matter what actually landed on disk.

What I changed: after `saveFile` returns a path, `ExportWriteVerifier.verify()` tries to read that file back and throws if it's there but empty. `ExportImportBloc` already wraps the whole call in a try/catch and shows the existing error state, so that part didn't need to change.

I have to be upfront about the limit here: on Android, the path FilePicker hands back for a content:// URI isn't something `dart:io`'s `File` can open (this is a known Flutter/Android limitation, not specific to this plugin - `File(path).lengthSync()` throws instead of returning 0). So for the exact Downloads case in the original report, this check can't tell "wrote nothing" apart from "wrote fine, just not a path I can stat," and it stays silent rather than firing a false alarm. In practice that means this check gives real coverage on iOS, where `saveFile` hands back an actual file path, plus anywhere else a stat-able path comes back - but on Android, where Downloads and other SAF-backed folders go through a `content://` URI, assume it usually won't fire. Closing that gap for Android means adding a native Kotlin platform channel that queries file size through `ContentResolver` directly - a bigger change, and not something I could verify without an Android device, so I kept this PR to what I could actually reason through and test.

Also added a check that we're not handing `FilePicker` an empty archive to begin with - we build the archive ourselves right before this, so it should be unreachable, but if it ever happened silently, we'd want it to fail loudly rather than round-trip through the same bug.

Testing: no Flutter/Android toolchain on the machine I used, so I couldn't run `flutter test` or `flutter analyze` - I read the relevant `file_picker` source (v11.0.2, matches `pubspec.lock`) to confirm the exact failure path described above, and added `test/unit_test/export_write_verifier_test.dart` covering `ExportWriteVerifier` directly: non-empty file passes, an empty file throws, an empty file with an also-zero expected length doesn't throw (covers a genuinely empty export), and an unreadable/nonexistent path doesn't throw (the content:// fallback case). I traced through the test file by hand against the verifier logic but didn't get to actually run `dart test` - flagging that clearly since I know the project expects `just test` / `flutter test` to pass before merge.
