### PR TITLE
i18n(en): restore missing additionalInfoLabelRecipe source key

### DIFF
--- a/lib/l10n/intl_en.arb
+++ b/lib/l10n/intl_en.arb
@@ -204,6 +204,7 @@
   "additionalInfoLabelCustom": "Custom Meal Item",
   "additionalInfoLabelFDC": "More Information at\nFoodData Central",
   "additionalInfoLabelOFF": "More Information at\nOpenFoodFacts",
+  "additionalInfoLabelRecipe": "Custom Recipe",
   "additionalInfoLabelUnknown": "Unknown Meal Item",
   "ageLabel": "Age",
   "allItemsLabel": "All",


### PR DESCRIPTION
The English source ARB (`lib/l10n/intl_en.arb`) is missing the `additionalInfoLabelRecipe` key, even though it's live and working everywhere else:

- Called from `S.of(context).additionalInfoLabelRecipe` in `lib/features/add_meal/presentation/widgets/meal_item_card.dart` and `lib/features/meal_detail/presentation/widgets/meal_info_button.dart`.
- Already present with the value "Custom Recipe" in `lib/generated/l10n.dart` and `lib/generated/intl/messages_en.dart`.
- Already present in every other maintained locale ARB (de, cs, it, pl, tr, uk, zh), all using "Custom Recipe" as the English basis for their own translation of this key.

So the key works at runtime but the checked-in English source has drifted out of sync with what's actually shipping. This adds it back to `intl_en.arb` in the same alphabetical slot (`additionalInfoLabelOFF` → `additionalInfoLabelRecipe` → `additionalInfoLabelUnknown`) used by every other locale file, so the source of truth matches reality again.

No change needed to the generated Dart files — they already have the correct entry.
