### PR TITLE
i18n(sk): add missing additionalInfoLabelRecipe key

### DIFF
--- a/lib/generated/intl/messages_sk.dart
+++ b/lib/generated/intl/messages_sk.dart
@@ -149,6 +149,8 @@ class MessageLookup extends MessageLookupByLibrary {
             "Viac informácií na\nFoodData Central"),
         "additionalInfoLabelOFF": MessageLookupByLibrary.simpleMessage(
             "Viac informácií na\nOpenFoodFacts"),
+        "additionalInfoLabelRecipe":
+            MessageLookupByLibrary.simpleMessage("Vlastný recept"),
         "additionalInfoLabelUnknown":
             MessageLookupByLibrary.simpleMessage("Neznáma položka jedla"),
         "ageLabel": MessageLookupByLibrary.simpleMessage("Vek"),

--- a/lib/l10n/intl_sk.arb
+++ b/lib/l10n/intl_sk.arb
@@ -162,6 +162,7 @@
   "additionalInfoLabelCustom": "Vlastná položka jedla",
   "additionalInfoLabelFDC": "Viac informácií na\nFoodData Central",
   "additionalInfoLabelOFF": "Viac informácií na\nOpenFoodFacts",
+  "additionalInfoLabelRecipe": "Vlastný recept",
   "additionalInfoLabelUnknown": "Neznáma položka jedla",
   "ageLabel": "Vek",
   "allItemsLabel": "Všetky",


### PR DESCRIPTION
Slovak (`lib/l10n/intl_sk.arb`) never got the `additionalInfoLabelRecipe` key. It exists in every other locale ARB (en, de, cs, it, pl, tr, uk, zh) and is called live from `meal_item_card.dart` / `meal_info_button.dart` for meal items that came from a saved recipe, so right now a Slovak user hits English's fallback there instead of a Slovak label.

Added `"additionalInfoLabelRecipe": "Vlastný recept"` in the same alphabetical slot as the other locales, between `additionalInfoLabelOFF` and `additionalInfoLabelUnknown`, plus the matching entry in `lib/generated/intl/messages_sk.dart` per this repo's manually-maintained-generated-file convention (`l10n.dart`'s getter is locale-agnostic and already covers the default).

On "vlastný" vs "vlastná": Slovak `recept` is a masculine inanimate noun, same as its Czech cognate (both borrowed from German *Rezept*, both hard masculine inanimate, genitive `receptu`). This file already relies on that gender elsewhere: `importRecipeErrorLabel`'s "Kód `receptu`" uses the same masculine genitive form, and `settingsDeleteAllDataConfirmContent`'s "všetky vlastné `recepty`" uses the masculine-inanimate-plural adjective ending. So the agreeing singular adjective is "vlastný", not "vlastná" (which would incorrectly agree with a feminine noun). It also matches the already-shipped Czech translation of this identical key, `"Vlastní recept"`, masculine, agreeing with the same cognate noun.
