### PR TITLE
chore(deps): configure Dependabot to target develop branch

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,30 @@
+version: 2
+
+updates:
+  - package-ecosystem: "bundler"
+    directory: "/ios"
+    schedule:
+      interval: "weekly"
+    target-branch: "develop"
+    open-pull-requests-limit: 10
+
+  - package-ecosystem: "bundler"
+    directory: "/android"
+    schedule:
+      interval: "weekly"
+    target-branch: "develop"
+    open-pull-requests-limit: 10
+
+  - package-ecosystem: "cocoapods"
+    directory: "/ios"
+    schedule:
+      interval: "weekly"
+    target-branch: "develop"
+    open-pull-requests-limit: 10
+
+  - package-ecosystem: "pub"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+    target-branch: "develop"
+    open-pull-requests-limit: 10


### PR DESCRIPTION
Dependabot currently compares against `main` (the default branch), which means PRs like #507 land on a branch that already has those changes merged — resulting in redundant open PRs and merge conflicts.

This configures Dependabot to target `develop` instead for:
- `bundler` in `/ios` and `/android`
- `cocoapods` in `/ios`
- `pub` in `/`

This way Dependabot PRs will go directly to the branch where they belong and can be merged cleanly.