### PR TITLE
fix(ui): keep row titles on one line instead of wrapping

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -213,6 +213,18 @@ DEVICE=1C151FDEE003YJ bash tools/adb/run-branch-tests.sh
 
 Convention, not lint. Reviewers call it out on PRs that touch interactive widgets. New widgets without identifiers aren't a merge blocker — but the per-branch feature verifier that lives alongside each branch's work won't be able to drive them, so the forcing function is downstream rather than upstream.
 
+## Row titles must not overflow
+
+Any title or label placed inside a `Row` has to survive a long localized string (German "Frühstück"/"Abendessen" run much wider than the English "Breakfast") and a large system font setting without wrapping to an extra line or triggering the `RenderFlex` overflow stripes. A short label such as a meal-type header quietly wrapping to two lines looks unpolished, so we guard against the whole class rather than fixing it one screenshot at a time.
+
+Three rules cover it:
+
+1. **Flex-constrain the title.** Wrap it in `Expanded` (or `Flexible`) so it can never overflow its `Row`, and don't let it share flex with a competing `Spacer()`. A `Flexible(title)` + `Spacer()` + `Flexible(value)` arrangement splits the width three ways and starves the title — give the title an `Expanded` and place a fixed `SizedBox` before a trailing value instead.
+2. **Bound the lines.** Set `maxLines` (usually `1` for a title) and `overflow: TextOverflow.ellipsis` so it can never silently wrap.
+3. **Let prominent titles shrink to fit.** For section headers and user-content names, use `AutoSizeText` (already a dependency, `auto_size_text`) with a sensible `minFontSize` rather than a plain `Text`, so a long label scales down to stay on one line and only ellipsizes in the extreme. Plain `Text` with `maxLines` + `ellipsis` is fine for short, secondary numeric labels.
+
+Genuine multi-line body or description copy (disclaimers, helper text) is meant to wrap and is exempt. Like the accessibility-identifier rule above, this is convention rather than lint — reviewers point at it on PRs that add or restructure row-based headers and cards.
+
 ## Architecture
 
 The project follows **Clean Architecture** with a feature-based module structure.

--- a/lib/core/presentation/widgets/activity_card.dart
+++ b/lib/core/presentation/widgets/activity_card.dart
@@ -1,3 +1,4 @@
+import 'package:auto_size_text/auto_size_text.dart';
 import 'package:flutter/material.dart';
 import 'package:opennutritracker/core/domain/entity/user_activity_entity.dart';
 import 'package:opennutritracker/core/presentation/widgets/app_card.dart';
@@ -70,10 +71,11 @@ class ActivityCard extends StatelessWidget {
                     mainAxisSize: MainAxisSize.min,
                     crossAxisAlignment: CrossAxisAlignment.start,
                     children: [
-                      Text(
+                      AutoSizeText(
                         activityEntity.physicalActivityEntity.getName(context),
                         style: textTheme.titleSmall?.copyWith(color: palette.textStrong),
                         maxLines: 1,
+                        minFontSize: 11,
                         overflow: TextOverflow.ellipsis,
                       ),
                       const SizedBox(height: 2),

--- a/lib/core/presentation/widgets/activity_vertial_list.dart
+++ b/lib/core/presentation/widgets/activity_vertial_list.dart
@@ -1,3 +1,4 @@
+import 'package:auto_size_text/auto_size_text.dart';
 import 'package:flutter/material.dart';
 import 'package:opennutritracker/core/domain/entity/user_activity_entity.dart';
 import 'package:opennutritracker/core/presentation/widgets/activity_card.dart';
@@ -52,11 +53,16 @@ class _ActivityVerticalListState extends State<ActivityVerticalList> {
                 color: Theme.of(context).colorScheme.onSurface,
               ),
               const SizedBox(width: Dimens.spacing8),
-              Text(
-                widget.title,
-                style: Theme.of(context).textTheme.titleLarge,
+              Expanded(
+                child: AutoSizeText(
+                  widget.title,
+                  maxLines: 1,
+                  minFontSize: 14,
+                  overflow: TextOverflow.ellipsis,
+                  style: Theme.of(context).textTheme.titleLarge,
+                ),
               ),
-              const Spacer(),
+              const SizedBox(width: Dimens.spacing8),
               PopupMenuButton<_ActivityPopupMenuSelection>(
                 onSelected: (_ActivityPopupMenuSelection selection) async {
                   switch (selection) {

--- a/lib/core/presentation/widgets/intake_card.dart
+++ b/lib/core/presentation/widgets/intake_card.dart
@@ -1,5 +1,6 @@
 import 'dart:io';
 
+import 'package:auto_size_text/auto_size_text.dart';
 import 'package:cached_network_image/cached_network_image.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_cache_manager/flutter_cache_manager.dart';
@@ -66,10 +67,11 @@ class IntakeCard extends StatelessWidget {
                     mainAxisSize: MainAxisSize.min,
                     crossAxisAlignment: CrossAxisAlignment.start,
                     children: [
-                      Text(
+                      AutoSizeText(
                         intake.meal.name ?? "?",
                         style: textTheme.titleSmall?.copyWith(color: palette.textStrong),
                         maxLines: 1,
+                        minFontSize: 11,
                         overflow: TextOverflow.ellipsis,
                       ),
                       const SizedBox(height: 2),

--- a/lib/core/presentation/widgets/low_kcal_warning_card.dart
+++ b/lib/core/presentation/widgets/low_kcal_warning_card.dart
@@ -56,6 +56,8 @@ class LowKcalWarningCard extends StatelessWidget {
                   Expanded(
                     child: Text(
                       l10n.lowKcalWarningTitle,
+                      maxLines: 2,
+                      overflow: TextOverflow.ellipsis,
                       style: textTheme.titleSmall?.copyWith(
                         color: palette.textStrong,
                       ),

--- a/lib/core/presentation/widgets/macro_nutriments_widget.dart
+++ b/lib/core/presentation/widgets/macro_nutriments_widget.dart
@@ -99,23 +99,30 @@ class _MacroRing extends StatelessWidget {
           backgroundColor: palette.surfaceMuted,
           circularStrokeCap: CircularStrokeCap.round,
         ),
-        Padding(
-          padding: const EdgeInsets.all(Dimens.spacing4),
-          child: Column(
-            crossAxisAlignment: CrossAxisAlignment.start,
-            children: [
-              Text(
-                '${intake.toInt()}/${goal.toInt()} g',
-                style: textTheme.titleSmall?.copyWith(
-                  color: palette.textStrong,
-                  fontWeight: FontWeight.w700,
+        Flexible(
+          child: Padding(
+            padding: const EdgeInsets.all(Dimens.spacing4),
+            child: Column(
+              crossAxisAlignment: CrossAxisAlignment.start,
+              children: [
+                Text(
+                  '${intake.toInt()}/${goal.toInt()} g',
+                  maxLines: 1,
+                  overflow: TextOverflow.ellipsis,
+                  style: textTheme.titleSmall?.copyWith(
+                    color: palette.textStrong,
+                    fontWeight: FontWeight.w700,
+                  ),
                 ),
-              ),
-              Text(
-                label,
-                style: textTheme.bodySmall?.copyWith(color: palette.textMuted),
-              ),
-            ],
+                Text(
+                  label,
+                  maxLines: 1,
+                  overflow: TextOverflow.ellipsis,
+                  style:
+                      textTheme.bodySmall?.copyWith(color: palette.textMuted),
+                ),
+              ],
+            ),
           ),
         ),
       ],

--- a/lib/features/diary/presentation/widgets/daily_nutrient_panel.dart
+++ b/lib/features/diary/presentation/widgets/daily_nutrient_panel.dart
@@ -1,3 +1,4 @@
+import 'package:auto_size_text/auto_size_text.dart';
 import 'package:flutter/material.dart';
 import 'package:opennutritracker/core/domain/entity/calories_profile_entity.dart';
 import 'package:opennutritracker/core/domain/entity/config_entity.dart';
@@ -432,8 +433,11 @@ class _DailyNutrientPanelState extends State<DailyNutrientPanel> {
             title: Row(
               children: [
                 Expanded(
-                  child: Text(
+                  child: AutoSizeText(
                     s.diaryNutrientPanelTitle,
+                    maxLines: 1,
+                    minFontSize: 12,
+                    overflow: TextOverflow.ellipsis,
                     style: textTheme.titleMedium?.copyWith(fontWeight: FontWeight.w700),
                   ),
                 ),

--- a/lib/features/home/presentation/widgets/dashboard_widget.dart
+++ b/lib/features/home/presentation/widgets/dashboard_widget.dart
@@ -86,11 +86,13 @@ class _DashboardWidgetState extends State<DashboardWidget> {
               children: [
                 Row(
                   children: [
-                    _MiniStat(
-                      icon: Icons.arrow_downward_rounded,
-                      value: '${displaySupplied.toInt()}',
-                      label: S.of(context).suppliedLabel,
-                      color: palette.proteinColor,
+                    Flexible(
+                      child: _MiniStat(
+                        icon: Icons.arrow_downward_rounded,
+                        value: '${displaySupplied.toInt()}',
+                        label: S.of(context).suppliedLabel,
+                        color: palette.proteinColor,
+                      ),
                     ),
                     const Spacer(),
                     GestureDetector(
@@ -100,12 +102,14 @@ class _DashboardWidgetState extends State<DashboardWidget> {
                       child: Icon(Icons.info_outline_rounded, color: palette.textMuted, size: 22),
                     ),
                     const Spacer(),
-                    _MiniStat(
-                      icon: Icons.local_fire_department_rounded,
-                      value: '${displayBurned.toInt()}',
-                      label: S.of(context).burnedLabel,
-                      color: palette.carbsColor,
-                      trailing: true,
+                    Flexible(
+                      child: _MiniStat(
+                        icon: Icons.local_fire_department_rounded,
+                        value: '${displayBurned.toInt()}',
+                        label: S.of(context).burnedLabel,
+                        color: palette.carbsColor,
+                        trailing: true,
+                      ),
                     ),
                   ],
                 ),
@@ -208,8 +212,10 @@ class _MiniStat extends StatelessWidget {
           child: Icon(icon, color: color, size: 20),
         ),
         const SizedBox(height: 6),
-        Text(value, style: textTheme.titleMedium),
-        Text(label, style: textTheme.labelSmall),
+        Text(value,
+            maxLines: 1, overflow: TextOverflow.ellipsis, style: textTheme.titleMedium),
+        Text(label,
+            maxLines: 1, overflow: TextOverflow.ellipsis, style: textTheme.labelSmall),
       ],
     );
   }

--- a/lib/features/home/presentation/widgets/intake_vertical_list.dart
+++ b/lib/features/home/presentation/widgets/intake_vertical_list.dart
@@ -1,3 +1,4 @@
+import 'package:auto_size_text/auto_size_text.dart';
 import 'package:flutter/material.dart';
 import 'package:opennutritracker/core/data/repository/recipe_repository.dart';
 import 'package:opennutritracker/core/domain/entity/intake_entity.dart';
@@ -166,10 +167,11 @@ class _IntakeVerticalListState extends State<IntakeVerticalList> {
                 child: Icon(widget.listIcon, size: 20, color: accent),
               ),
               const SizedBox(width: Dimens.spacing12),
-              Flexible(
-                child: Text(
+              Expanded(
+                child: AutoSizeText(
                   widget.title,
-                  maxLines: 2,
+                  maxLines: 1,
+                  minFontSize: 14,
                   overflow: TextOverflow.ellipsis,
                   style: textTheme.titleLarge?.copyWith(
                     color: palette.textStrong,
@@ -177,7 +179,7 @@ class _IntakeVerticalListState extends State<IntakeVerticalList> {
                   ),
                 ),
               ),
-              const Spacer(),
+              const SizedBox(width: Dimens.spacing8),
               if (_shouldShowHeaderSummary)
                 Flexible(
                   child: Text(

--- a/lib/features/onboarding/presentation/widgets/onboarding_first_page_body.dart
+++ b/lib/features/onboarding/presentation/widgets/onboarding_first_page_body.dart
@@ -1,3 +1,4 @@
+import 'package:auto_size_text/auto_size_text.dart';
 import 'package:flutter/material.dart';
 import 'package:opennutritracker/core/domain/entity/calories_profile_entity.dart';
 import 'package:opennutritracker/core/domain/entity/user_gender_entity.dart';
@@ -104,9 +105,14 @@ class _OnboardingFirstPageBodyState extends State<OnboardingFirstPageBody> {
         children: [
           Row(
             children: [
-              Text(
-                S.of(context).genderLabel,
-                style: Theme.of(context).textTheme.headlineSmall,
+              Expanded(
+                child: AutoSizeText(
+                  S.of(context).genderLabel,
+                  maxLines: 1,
+                  minFontSize: 16,
+                  overflow: TextOverflow.ellipsis,
+                  style: Theme.of(context).textTheme.headlineSmall,
+                ),
               ),
               IconButton(
                 visualDensity: VisualDensity.compact,

--- a/lib/features/profile/presentation/widgets/bmi_overview.dart
+++ b/lib/features/profile/presentation/widgets/bmi_overview.dart
@@ -1,3 +1,4 @@
+import 'package:auto_size_text/auto_size_text.dart';
 import 'package:flutter/material.dart';
 import 'package:opennutritracker/core/domain/entity/user_bmi_entity.dart';
 import 'package:opennutritracker/core/presentation/widgets/info_dialog.dart';
@@ -59,13 +60,18 @@ class BMIOverview extends StatelessWidget {
         Row(
           mainAxisAlignment: MainAxisAlignment.center,
           children: [
-            Text(
-              nutritionalStatus.getName(context),
-              style: text.titleLarge?.copyWith(
-                fontWeight: FontWeight.w700,
-                color: palette.textStrong,
+            Flexible(
+              child: AutoSizeText(
+                nutritionalStatus.getName(context),
+                maxLines: 1,
+                minFontSize: 14,
+                overflow: TextOverflow.ellipsis,
+                style: text.titleLarge?.copyWith(
+                  fontWeight: FontWeight.w700,
+                  color: palette.textStrong,
+                ),
+                textAlign: TextAlign.center,
               ),
-              textAlign: TextAlign.center,
             ),
             const SizedBox(width: Dimens.spacing4),
             InkWell(

--- a/lib/features/profile/presentation/widgets/set_gender_dialog.dart
+++ b/lib/features/profile/presentation/widgets/set_gender_dialog.dart
@@ -12,7 +12,11 @@ class SetGenderDialog extends StatelessWidget {
       title: Row(
         children: [
           Expanded(
-            child: Text(S.of(context).selectGenderDialogLabel),
+            child: Text(
+              S.of(context).selectGenderDialogLabel,
+              maxLines: 2,
+              overflow: TextOverflow.ellipsis,
+            ),
           ),
           IconButton(
             visualDensity: VisualDensity.compact,

--- a/lib/features/recipes/presentation/screens/recipes_page.dart
+++ b/lib/features/recipes/presentation/screens/recipes_page.dart
@@ -366,6 +366,8 @@ class _RecipesPageState extends State<RecipesPage>
           Expanded(
             child: Text(
               s.selectionCountLabel(_selectedIds.length),
+              maxLines: 1,
+              overflow: TextOverflow.ellipsis,
               style: Theme.of(context).textTheme.titleMedium?.copyWith(
                     color: accent,
                     fontWeight: FontWeight.w700,

--- a/lib/features/recipes/presentation/widgets/recipe_list_item.dart
+++ b/lib/features/recipes/presentation/widgets/recipe_list_item.dart
@@ -1,5 +1,6 @@
 import 'dart:io';
 
+import 'package:auto_size_text/auto_size_text.dart';
 import 'package:cached_network_image/cached_network_image.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_cache_manager/flutter_cache_manager.dart';
@@ -67,9 +68,10 @@ class RecipeListItem extends StatelessWidget {
                 child: Column(
                   crossAxisAlignment: CrossAxisAlignment.start,
                   children: [
-                    Text(
+                    AutoSizeText(
                       recipe.name,
                       maxLines: 1,
+                      minFontSize: 12,
                       overflow: TextOverflow.ellipsis,
                       style: textTheme.titleMedium?.copyWith(fontWeight: FontWeight.w700),
                     ),

--- a/lib/features/recipes/presentation/widgets/recipe_nutrition_summary.dart
+++ b/lib/features/recipes/presentation/widgets/recipe_nutrition_summary.dart
@@ -53,29 +53,37 @@ class RecipeNutritionSummary extends StatelessWidget {
           Row(
             mainAxisAlignment: MainAxisAlignment.spaceBetween,
             children: [
-              _NutrientCell(
-                value: energyTotalDisplay,
-                label: energyLabel,
-                color: accent,
-                palette: palette,
+              Expanded(
+                child: _NutrientCell(
+                  value: energyTotalDisplay,
+                  label: energyLabel,
+                  color: accent,
+                  palette: palette,
+                ),
               ),
-              _NutrientCell(
-                value: _total(nutrimentsPer100.carbohydrates100),
-                label: '${s.carbsLabel} g',
-                color: palette.carbs,
-                palette: palette,
+              Expanded(
+                child: _NutrientCell(
+                  value: _total(nutrimentsPer100.carbohydrates100),
+                  label: '${s.carbsLabel} g',
+                  color: palette.carbs,
+                  palette: palette,
+                ),
               ),
-              _NutrientCell(
-                value: _total(nutrimentsPer100.fat100),
-                label: '${s.fatLabel} g',
-                color: palette.fat,
-                palette: palette,
+              Expanded(
+                child: _NutrientCell(
+                  value: _total(nutrimentsPer100.fat100),
+                  label: '${s.fatLabel} g',
+                  color: palette.fat,
+                  palette: palette,
+                ),
               ),
-              _NutrientCell(
-                value: _total(nutrimentsPer100.proteins100),
-                label: '${s.proteinLabel} g',
-                color: palette.protein,
-                palette: palette,
+              Expanded(
+                child: _NutrientCell(
+                  value: _total(nutrimentsPer100.proteins100),
+                  label: '${s.proteinLabel} g',
+                  color: palette.protein,
+                  palette: palette,
+                ),
               ),
             ],
           ),
@@ -114,11 +122,16 @@ class _NutrientCell extends StatelessWidget {
       children: [
         Text(
           value.toStringAsFixed(0),
+          maxLines: 1,
+          overflow: TextOverflow.ellipsis,
           style: textTheme.titleLarge?.copyWith(color: color, fontWeight: FontWeight.w800),
         ),
         const SizedBox(height: 2),
         Text(
           label,
+          maxLines: 1,
+          overflow: TextOverflow.ellipsis,
+          textAlign: TextAlign.center,
           style: textTheme.bodySmall?.copyWith(color: palette.textMuted),
         ),
       ],

--- a/lib/features/settings/presentation/widgets/export_import_dialog.dart
+++ b/lib/features/settings/presentation/widgets/export_import_dialog.dart
@@ -108,7 +108,9 @@ class _ExportImportDialogState extends State<ExportImportDialog> {
                           color: Theme.of(context).colorScheme.primary,
                         ),
                         const SizedBox(width: 8),
-                        Text(S.of(context).exportImportSuccessLabel),
+                        Expanded(
+                          child: Text(S.of(context).exportImportSuccessLabel),
+                        ),
                       ],
                     );
                   } else if (state is ExportImportError) {
@@ -119,7 +121,9 @@ class _ExportImportDialogState extends State<ExportImportDialog> {
                           color: Theme.of(context).colorScheme.error,
                         ),
                         const SizedBox(width: 8),
-                        Text(S.of(context).exportImportErrorLabel),
+                        Expanded(
+                          child: Text(S.of(context).exportImportErrorLabel),
+                        ),
                       ],
                     );
                   }

--- a/lib/features/settings/presentation/widgets/import_custom_food_data_dialog.dart
+++ b/lib/features/settings/presentation/widgets/import_custom_food_data_dialog.dart
@@ -98,7 +98,9 @@ class _ImportCustomFoodDataDialogState
                           color: Theme.of(context).colorScheme.primary,
                         ),
                         const SizedBox(width: 8),
-                        Text(S.of(context).exportImportSuccessLabel),
+                        Expanded(
+                          child: Text(S.of(context).exportImportSuccessLabel),
+                        ),
                       ],
                     );
                   } else if (state is ExportImportError) {
@@ -109,7 +111,9 @@ class _ImportCustomFoodDataDialogState
                           color: Theme.of(context).colorScheme.error,
                         ),
                         const SizedBox(width: 8),
-                        Text(S.of(context).exportImportErrorLabel),
+                        Expanded(
+                          child: Text(S.of(context).exportImportErrorLabel),
+                        ),
                       ],
                     );
                   } else if (state is CsvImportResultState) {

--- a/lib/features/trends/presentation/trends_page.dart
+++ b/lib/features/trends/presentation/trends_page.dart
@@ -1,3 +1,4 @@
+import 'package:auto_size_text/auto_size_text.dart';
 import 'package:fl_chart/fl_chart.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_bloc/flutter_bloc.dart';
@@ -377,8 +378,11 @@ class _WaterTrendCard extends StatelessWidget {
           Row(
             children: [
               Expanded(
-                child: Text(S.of(context).trendsWaterLabel,
-                    style: text.titleMedium),
+                child: AutoSizeText(S.of(context).trendsWaterLabel,
+                    style: text.titleMedium,
+                    maxLines: 1,
+                    minFontSize: 12,
+                    overflow: TextOverflow.ellipsis),
               ),
               Text(
                 S.of(context).waterChipLabel(avg, goalMl),
@@ -482,8 +486,13 @@ class _MacrosTrendCard extends StatelessWidget {
           for (final (label, intake, goal, color) in rows) ...[
             Row(
               children: [
-                Text(label, style: text.labelMedium),
-                const Spacer(),
+                Expanded(
+                  child: Text(label,
+                      style: text.labelMedium,
+                      maxLines: 1,
+                      overflow: TextOverflow.ellipsis),
+                ),
+                const SizedBox(width: Dimens.spacing8),
                 Text('${intake.toInt()} / ${goal.toInt()} g',
                     style: text.bodySmall?.copyWith(color: palette.textStrong, fontWeight: FontWeight.w700)),
               ],
@@ -535,8 +544,11 @@ class _WeightCard extends StatelessWidget {
           Row(
             children: [
               Expanded(
-                child: Text(S.of(context).weightHistoryWeightLabel,
-                    style: text.titleMedium),
+                child: AutoSizeText(S.of(context).weightHistoryWeightLabel,
+                    style: text.titleMedium,
+                    maxLines: 1,
+                    minFontSize: 12,
+                    overflow: TextOverflow.ellipsis),
               ),
               Semantics(
                 identifier: 'trends-log-weight',

--- a/test/features/home/presentation/widgets/intake_vertical_list_test.dart
+++ b/test/features/home/presentation/widgets/intake_vertical_list_test.dart
@@ -1,4 +1,5 @@
 import 'package:flutter/material.dart';
+import 'package:flutter/rendering.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:get_it/get_it.dart';
 import 'package:opennutritracker/core/domain/entity/intake_entity.dart';
@@ -251,6 +252,47 @@ void main() {
       expect(find.text(S.current.deleteAllLabel), findsNothing);
       expect(find.text(S.current.shareMealLabel), findsNothing);
       expect(find.text(S.current.importMealLabel), findsOneWidget);
+    },
+  );
+
+  // Regression: at a phone-width header the title used to be starved of space
+  // by a Spacer competing with the kcal summary for flex, so "Breakfast"
+  // wrapped onto a second line ("Breakfas" / "t"). The title now takes an
+  // Expanded and shrinks to fit, so it must stay on exactly one line.
+  testWidgets(
+    'meal title stays on a single line beside the kcal summary',
+    (WidgetTester tester) async {
+      await tester.pumpWidget(_wrapWithMaterial(
+        Align(
+          alignment: Alignment.topCenter,
+          child: SizedBox(
+            width: 360,
+            child: IntakeVerticalList(
+              day: DateTime(2026, 1, 1),
+              title: 'Breakfast',
+              listIcon: Icons.bakery_dining_outlined,
+              addMealType: AddMealType.breakfastType,
+              intakeList: intakes,
+              usesImperialUnits: false,
+              showMealMacros: false,
+              mealKcalTarget: 583,
+              onDeleteIntakeCallback: (_, _) {},
+            ),
+          ),
+        ),
+      ));
+      await tester.pump();
+
+      // No RenderFlex overflow from the header competing for width.
+      expect(tester.takeException(), isNull);
+
+      final titleFinder = find.text('Breakfast');
+      expect(titleFinder, findsOneWidget);
+      // A single line of titleLarge (21px) renders around one line-height tall;
+      // the old wrapped layout produced two lines (~double). Anything under
+      // this threshold can only be a single line.
+      final paragraph = tester.renderObject<RenderParagraph>(titleFinder);
+      expect(paragraph.size.height, lessThan(35));
     },
   );
 }


### PR DESCRIPTION
## What prompted this

The Breakfast header on the home screen was wrapping onto a second line ("Breakfas" / "t") while the shorter labels sat happily on one. It is a small thing, but the kind of small thing that quietly reads as unpolished every time you open the app, so it felt worth fixing properly rather than in passing.

## The root cause

It was a layout problem, not a missing overflow setting. The header `Row` laid out the title as `Flexible(title)` → `Spacer()` → `Flexible(summary)`. The `Spacer` is an `Expanded`, so the title, the spacer, and the kcal summary all carried equal flex weight and each was capped at a third of the row's free width. "Breakfast" needs more than that third, so it wrapped. The shorter labels fit inside the third and did not.

Giving the title an `Expanded` (so it takes all the leftover width) and swapping the plain `Text` for `AutoSizeText` (so a long or large-font label shrinks to fit before it ever ellipsizes) keeps it on one line, and removing the `Spacer` lets it use the width it needs.

## The wider sweep

Rather than patch only the reported header, this hardens the whole class. Every title or label sitting inside a `Row` now follows one rule: flex-constrain it, cap its lines with an ellipsis, and let the prominent ones scale down before truncating. Alongside the meal header that means:

- the Activity section header (the same bare-`Text` + `Spacer` shape),
- the BMI status name on the profile,
- the Trends macro-label rows and the water/weight card titles,
- the onboarding "Gender" header,
- and a handful of card, panel, dialog, and import/export status rows that could overflow under a long localised string or a large system font.

German is the clearest stress case here, where "Frühstück" and "Abendessen" run a good deal wider than the English "Breakfast". The fix leans entirely on `auto_size_text`, which is already a dependency and already the house pattern for titles that might not fit, so nothing new was introduced.

## Reviewing this confidently

The diff touches 18 widgets, but each change is the same small, mechanical transform, so it reads quickly once you have seen the first one. Two things to lean on:

- A short convention note in `CLAUDE.md` writes the rule down so future row titles follow it and reviewers have something to point at.
- A regression test renders the meal header at phone width and asserts the title stays on a single line. It fails against the old starved-flex layout and passes with the fix, which is what should keep this from creeping back.

`flutter analyze` is clean and the full suite passes (735 tests, one new). I also ran it on the Linux desktop build at phone width and confirmed the home, activity, and dashboard headers all sit on one line.

No version bump, since this targets `develop`.
