### PR TITLE
Guard link taps in FastingWarningDialog with canLaunchUrl

### DIFF
--- a/lib/features/fasting/presentation/widgets/fasting_warning_dialog.dart
+++ b/lib/features/fasting/presentation/widgets/fasting_warning_dialog.dart
@@ -85,6 +85,9 @@ class FastingWarningDialog extends StatelessWidget {
   }
 
   Future<void> _open(String url) async {
-    await launchUrl(Uri.parse(url), mode: LaunchMode.externalApplication);
+    final uri = Uri.parse(url);
+    if (await canLaunchUrl(uri)) {
+      await launchUrl(uri, mode: LaunchMode.externalApplication);
+    }
   }
 }


### PR DESCRIPTION
This pull request improves the reliability of opening external URLs in the `FastingWarningDialog` widget by adding a safety check before attempting to launch the URL.

Error handling improvement:

* Updated the `_open` method in `fasting_warning_dialog.dart` to check with `canLaunchUrl` before calling `launchUrl`, preventing potential runtime errors if the URL cannot be launched.Tapping the BEAT/NEDA links in FastingWarningDialog called launchUrl directly, so a device with no app able to handle the ACTION_VIEW intent threw an unhandled PlatformException(ACTIVITY_NOT_FOUND) (reported via Sentry). Check canLaunchUrl first, matching the guard already used in sources_screen, bmi_info_screen, and kcal_goal_info_screen.