### PR TITLE
Fix iOS integration test timeouts and disable SPM

### DIFF
--- a/.github/workflows/default_workflow.yml
+++ b/.github/workflows/default_workflow.yml
@@ -283,8 +283,11 @@ jobs:
     runs-on: macos-15
     # Bound the job so a hung test fails fast rather than drifting toward
     # GitHub's 6-hour default. A healthy run is the ~11-12 min Xcode build
-    # plus a few minutes of tests, so 30 leaves comfortable headroom.
-    timeout-minutes: 30
+    # plus a few minutes of tests, but the "Run integration tests" step
+    # retries the whole build+test once on failure, so a single flake needs
+    # room for a second cold build. 30 was too tight for that and got
+    # cancelled mid-retry; 50 covers the retry while still catching hangs.
+    timeout-minutes: 50
     permissions:
       contents: read
     steps:
@@ -293,6 +296,15 @@ jobs:
 
       - name: Setup Flutter + cache packages
         uses: ./.github/actions/setup-flutter-cache
+
+      # Match ios-podfile-lock-guard and ios-build: SPM is enabled by
+      # default on Flutter's stable channel, so `flutter test` would spend
+      # ~150s "Adding Swift Package Manager integration" and resolve plugins
+      # via the SPM graph instead of the CocoaPods one those jobs pin to.
+      # Disable it here too so this job builds the same pinned graph and
+      # skips that avoidable per-build cost.
+      - name: Disable Swift Package Manager
+        run: flutter config --no-enable-swift-package-manager
 
       - name: Cache CocoaPods
         uses: actions/cache@v5
@@ -426,8 +438,11 @@ jobs:
     # android-build (it rebuilds the app itself) nor a file-discovery job.
     runs-on: ubuntu-latest
     # Same bound as iOS so a hung test fails fast rather than running to the
-    # 6-hour default.
-    timeout-minutes: 30
+    # 6-hour default. On a cold cache this job pays an AVD seed boot plus a
+    # test boot, and the "retry once" step adds a third boot + rebuild, so 30
+    # was too tight and got cancelled mid-retry (which also skips the AVD
+    # cache save, keeping the next run cold). 50 covers the retry path.
+    timeout-minutes: 50
     permissions:
       contents: read
     steps:


### PR DESCRIPTION
This pull request introduces several improvements to project infrastructure, CI workflows, and contributor/dependency management for OpenNutriTracker. The main changes include new issue and PR templates, updated CI/CD workflow steps (notably around iOS dependency management and test job timeouts), the addition of dependency update automation, and an upgrade to Flutter 3.44.6.

**Project management and contributor experience:**

* Added structured issue templates for bugs, features, and questions, along with a PR template to standardize contributions and reporting. [[1]](diffhunk://#diff-637f7b97bba458badb691a1557c3d4648686292e948dbe3e8360564378b653efR1-R153) [[2]](diffhunk://#diff-c6b098646bf32c644234bec14c2675ea2a3d9c2dc2df450a25aa0e7ff02323cdR1-R99) [[3]](diffhunk://#diff-b6087b0ddc2695a819e8199639ea5be88e1352a9a10774c7183eefa682e2dc76R1-R67) [[4]](diffhunk://#diff-18813c86948efc57e661623d7ba48ff94325c9b5421ec9177f724922dd553a35R1-R38)
* Added project links and guidance for non-bug issues in `.github/ISSUE_TEMPLATE/config.yml`.
* Added a Copilot-specific instructions file to clarify commit and co-authoring policies.

**Dependency and update automation:**

* Introduced a `.github/dependabot.yml` configuration to automate dependency update PRs for Bundler, pub, and GitHub Actions.

**CI/CD workflow improvements:**

* Updated the default Flutter version to 3.44.6 across all relevant files and CI steps. [[1]](diffhunk://#diff-9cea93327e1b3783fb81d02be3fd8a69c427d30e1e45725eec4e69c254f15050L2-R2) [[2]](diffhunk://#diff-2b52ac2e798943e0fc92cf175e13ab6164414906687805563082c58541533c5fL7-R7) [[3]](diffhunk://#diff-1df67d2d613b7d5baa19b86fb099a76fca40b520bf33c3288697191262ec9438L610-R648)
* Enhanced iOS workflow reliability by explicitly disabling Swift Package Manager (SPM) in favor of CocoaPods, ensuring consistent dependency resolution and avoiding Xcode signing issues in CI. [[1]](diffhunk://#diff-1df67d2d613b7d5baa19b86fb099a76fca40b520bf33c3288697191262ec9438R117-R130) [[2]](diffhunk://#diff-1df67d2d613b7d5baa19b86fb099a76fca40b520bf33c3288697191262ec9438R194-R200) [[3]](diffhunk://#diff-1df67d2d613b7d5baa19b86fb099a76fca40b520bf33c3288697191262ec9438R300-R308)
* Improved test job reliability by increasing iOS and Android test job timeouts from 30 to 50 minutes to accommodate retries and cold builds. [[1]](diffhunk://#diff-1df67d2d613b7d5baa19b86fb099a76fca40b520bf33c3288697191262ec9438L263-R290) [[2]](diffhunk://#diff-1df67d2d613b7d5baa19b86fb099a76fca40b520bf33c3288697191262ec9438L406-R445)
* Refined workflow steps and documentation, including clearer instructions for localization generation and auto-commit of iOS project files modified during CI. [[1]](diffhunk://#diff-1df67d2d613b7d5baa19b86fb099a76fca40b520bf33c3288697191262ec9438L50-R57) [[2]](diffhunk://#diff-1df67d2d613b7d5baa19b86fb099a76fca40b520bf33c3288697191262ec9438L220-R251)

**Workflow documentation and policy:**

* Updated workflow comments to clarify triggers, direct push policies, and rationale for CI configuration.

These changes collectively improve contributor onboarding, automate maintenance tasks, and make CI runs more robust and consistent.## Summary
<!-- What does this PR change and why? -->

## Type of change
- [ ] Bug fix
- [ ] New feature
- [ ] Refactor / cleanup
- [ ] Documentation
- [ ] CI / tooling
- [ ] Localization
- [ ] Other

## Related issues
<!-- Link issues with Fixes #123 or Refs #123 -->

## Changes
<!-- Bullet list of the main user-facing
This pull request updates the GitHub Actions workflow configuration to improve reliability and consistency for iOS and Android test jobs. The main changes increase the timeout limits to accommodate retry logic and ensure consistent dependency resolution for Flutter builds.

**Workflow timeout adjustments:**

* Increased the `timeout-minutes` for the iOS test job from 30 to 50 minutes to allow enough time for a full retry, preventing jobs from being cancelled mid-retry.
* Increased the `timeout-minutes` for the Android test job from 30 to 50 minutes for the same reason, ensuring retries complete and AVD caches are properly saved.

**Dependency management consistency:**

* Added a step to explicitly disable Swift Package Manager in the iOS test job using `flutter config --no-enable-swift-package-manager`, aligning with other jobs and avoiding unnecessary SPM integration work in favor of the pinned CocoaPods graph. or technical changes -->

## Screenshots / recordings
<!-- UI changes: before/after on Android and/or iOS if practical -->

## Test plan
- [ ] Described steps below were followed locally
- [ ] Unit / widget tests added or updated (if applicable)
- [ ] Manual check on Android
- [ ] Manual check on iOS (if applicable)

### Steps
1.
2.

## Checklist
- [ ] Code follows project style (`just format` / 120-char line width)
- [ ] New interactive widgets include `Semantics(identifier: '...')` where needed
- [ ] Localization updated in ARBs **and** `lib/generated/` when user-facing strings change
- [ ] Codegen ran if DBOs/DTOs/env changed (`just build`)
- [ ] No secrets or `.env` values committed
- [ ] PR title follows conventional commit style (e.g. `feat:`, `fix:`, `chore:`)
This pull request updates the GitHub Actions workflow configuration to improve reliability and consistency of the CI process for both iOS and Android jobs. The main changes are increased timeout limits to accommodate retry logic and disabling Swift Package Manager in iOS jobs to match other workflows and reduce build time.

**iOS workflow improvements:**

* Increased the `timeout-minutes` for the iOS job from 30 to 50 to ensure enough time for a full retry, preventing jobs from being cancelled mid-retry and allowing for a second cold build if needed.
* Added a step to disable Swift Package Manager (`flutter config --no-enable-swift-package-manager`) so that the iOS job uses the same plugin resolution method as other jobs (CocoaPods), avoiding unnecessary SPM integration time and ensuring consistency.

**Android workflow improvements:**

* Increased the `timeout-minutes` for the Android job from 30 to 50 to allow enough time for retries, especially when running on a cold cache, preventing premature cancellation and ensuring the AVD cache can be saved.