### PR TITLE
feat(android): add JSON share intent for AI-assisted meal import

### DIFF
--- a/android/app/src/main/AndroidManifest.xml
+++ b/android/app/src/main/AndroidManifest.xml
@@ -45,6 +45,16 @@
                 <action android:name="android.intent.action.MAIN"/>
                 <category android:name="android.intent.category.LAUNCHER"/>
             </intent-filter>
+            <intent-filter>
+                <action android:name="android.intent.action.SEND"/>
+                <category android:name="android.intent.category.DEFAULT"/>
+                <data android:mimeType="text/plain"/>
+            </intent-filter>
+            <intent-filter>
+                <action android:name="android.intent.action.SEND"/>
+                <category android:name="android.intent.category.DEFAULT"/>
+                <data android:mimeType="application/json"/>
+            </intent-filter>
         </activity>
         <!-- #312: Notification scheduling receivers -->
         <receiver android:exported="false" android:name="com.dexterous.flutterlocalnotifications.ScheduledNotificationReceiver"/>

--- a/android/app/src/main/kotlin/com/opennutritracker/ont/opennutritracker/MainActivity.kt
+++ b/android/app/src/main/kotlin/com/opennutritracker/ont/opennutritracker/MainActivity.kt
@@ -1,6 +1,45 @@
 package com.opennutritracker.ont.opennutritracker
 
+import android.content.Intent
 import io.flutter.embedding.android.FlutterActivity
+import io.flutter.embedding.engine.FlutterEngine
+import io.flutter.plugin.common.MethodChannel
 
-class MainActivity: FlutterActivity() {
+class MainActivity : FlutterActivity() {
+    private val channelName = "com.opennutritracker/share_intent"
+
+    // Holds text shared to the app until Flutter consumes it.
+    private var pendingSharedText: String? = null
+
+    override fun configureFlutterEngine(flutterEngine: FlutterEngine) {
+        super.configureFlutterEngine(flutterEngine)
+
+        // Capture any text present in the launch intent (cold start).
+        pendingSharedText = extractSharedText(intent)
+
+        MethodChannel(flutterEngine.dartExecutor.binaryMessenger, channelName)
+            .setMethodCallHandler { call, result ->
+                when (call.method) {
+                    "getSharedText" -> {
+                        result.success(pendingSharedText)
+                        pendingSharedText = null
+                    }
+                    else -> result.notImplemented()
+                }
+            }
+    }
+
+    // Called when the app is already running and receives a new share intent
+    // (singleTop behaviour — Android re-uses the existing activity).
+    override fun onNewIntent(intent: Intent) {
+        super.onNewIntent(intent)
+        pendingSharedText = extractSharedText(intent)
+    }
+
+    private fun extractSharedText(intent: Intent?): String? {
+        if (intent?.action != Intent.ACTION_SEND) return null
+        val type = intent.type ?: return null
+        if (!type.startsWith("text/") && type != "application/json") return null
+        return intent.getStringExtra(Intent.EXTRA_TEXT)
+    }
 }

--- a/lib/core/presentation/main_screen.dart
+++ b/lib/core/presentation/main_screen.dart
@@ -3,12 +3,18 @@ import 'package:opennutritracker/core/domain/usecase/get_config_usecase.dart';
 import 'package:opennutritracker/core/presentation/widgets/add_item_bottom_sheet.dart';
 import 'package:opennutritracker/core/presentation/widgets/demo_mode_banner.dart';
 import 'package:opennutritracker/core/styles/app_palette.dart';
+import 'package:opennutritracker/core/utils/json_meal_importer.dart';
 import 'package:opennutritracker/core/utils/locator.dart';
+import 'package:opennutritracker/core/utils/share_intent_service.dart';
 import 'package:opennutritracker/features/diary/diary_page.dart';
+import 'package:opennutritracker/features/diary/presentation/bloc/calendar_day_bloc.dart';
+import 'package:opennutritracker/features/diary/presentation/bloc/diary_bloc.dart';
 import 'package:opennutritracker/core/presentation/widgets/home_appbar.dart';
 import 'package:opennutritracker/features/home/home_page.dart';
+import 'package:opennutritracker/features/home/presentation/bloc/home_bloc.dart';
 import 'package:opennutritracker/core/presentation/widgets/main_appbar.dart';
 import 'package:opennutritracker/features/profile/profile_page.dart';
+import 'package:opennutritracker/features/settings/domain/usecase/import_meals_json_usecase.dart';
 import 'package:opennutritracker/features/trends/presentation/trends_page.dart';
 import 'package:opennutritracker/generated/l10n.dart';
 
@@ -25,11 +31,21 @@ class _MainScreenState extends State<MainScreen> {
 
   late List<Widget> _bodyPages;
   late List<PreferredSizeWidget> _appbarPages;
+  late final AppLifecycleListener _lifecycleListener;
 
   @override
   void initState() {
     super.initState();
     _loadDemoDataFlag();
+    _lifecycleListener = AppLifecycleListener(onResume: _handleSharedMeal);
+    // Check for a share intent that launched the app cold.
+    WidgetsBinding.instance.addPostFrameCallback((_) => _handleSharedMeal());
+  }
+
+  @override
+  void dispose() {
+    _lifecycleListener.dispose();
+    super.dispose();
   }
 
   // Checked once per screen instance rather than kept live — leaving demo
@@ -39,6 +55,60 @@ class _MainScreenState extends State<MainScreen> {
     final config = await locator<GetConfigUsecase>().getConfig();
     if (!mounted) return;
     setState(() => _isDemoData = config.isDemoData);
+  }
+
+  /// Reads any pending share-intent text, validates it as meal JSON, shows a
+  /// confirmation dialog, and imports on approval. Safe to call frequently —
+  /// Kotlin clears the value after the first read so subsequent calls are
+  /// no-ops when nothing was shared.
+  Future<void> _handleSharedMeal() async {
+    if (!mounted) return;
+    final text = await ShareIntentService.consumeSharedText();
+    if (text == null || !mounted) return;
+
+    final parsed = JsonMealImporter.parse(text);
+
+    if (parsed.intakes.isEmpty) {
+      ScaffoldMessenger.of(context).showSnackBar(
+        SnackBar(content: Text(S.of(context).shareJsonImportErrorLabel)),
+      );
+      return;
+    }
+
+    final confirmed = await showDialog<bool>(
+      context: context,
+      builder: (ctx) => AlertDialog(
+        title: Text(S.of(ctx).importMealConfirmTitle(parsed.intakes.length)),
+        content: Text(S.of(ctx).shareJsonImportContent),
+        actions: [
+          TextButton(
+            onPressed: () => Navigator.of(ctx).pop(false),
+            child: Text(S.of(ctx).dialogCancelLabel),
+          ),
+          Semantics(
+            identifier: 'share-json-import-confirm',
+            child: TextButton(
+              onPressed: () => Navigator.of(ctx).pop(true),
+              child: Text(S.of(ctx).dialogOKLabel),
+            ),
+          ),
+        ],
+      ),
+    );
+
+    if (confirmed != true || !mounted) return;
+
+    final result = await locator<ImportMealsJsonUsecase>().importFromJsonString(text);
+    if (!mounted) return;
+
+    locator<HomeBloc>().add(const LoadItemsEvent());
+    locator<DiaryBloc>().add(const LoadDiaryYearEvent());
+    locator<CalendarDayBloc>().add(RefreshCalendarDayEvent());
+
+    final message = result.imported > 0
+        ? S.of(context).csvImportSuccessLabel(result.imported)
+        : S.of(context).shareJsonImportErrorLabel;
+    ScaffoldMessenger.of(context).showSnackBar(SnackBar(content: Text(message)));
   }
 
   @override

--- a/lib/core/utils/share_intent_service.dart
+++ b/lib/core/utils/share_intent_service.dart
@@ -1,0 +1,20 @@
+import 'package:flutter/services.dart';
+
+/// Bridges the Android share-intent MethodChannel. Call [consumeSharedText]
+/// once on startup and once each time the app returns to the foreground —
+/// Kotlin stores the most recent shared text in [pendingSharedText] and
+/// clears it the moment Flutter reads it, so double-import is not possible.
+class ShareIntentService {
+  static const _channel = MethodChannel('com.opennutritracker/share_intent');
+
+  /// Returns the text that another Android app shared to OpenNutriTracker,
+  /// or null when nothing is pending. Consuming the value clears it on the
+  /// native side so a subsequent call returns null until a new share arrives.
+  static Future<String?> consumeSharedText() async {
+    try {
+      return await _channel.invokeMethod<String?>('getSharedText');
+    } on PlatformException {
+      return null;
+    }
+  }
+}

--- a/lib/features/add_meal/util/meal_relevance_ranker.dart
+++ b/lib/features/add_meal/util/meal_relevance_ranker.dart
@@ -121,7 +121,9 @@ String _nearDuplicateKey(MealEntity meal) {
   // would otherwise collapse every unrelated nameless meal into one.
   // meal.code is nullable: fall back to identityHashCode so two distinct
   // nameless meals without codes don't share the same key.
-  if (name.isEmpty) return 'noname:${meal.source.name}:${meal.code ?? identityHashCode(meal)}';
+  if (name.isEmpty) {
+    return 'noname:${meal.source.name}:${meal.code ?? identityHashCode(meal)}';
+  }
   final brand = _normalize(meal.brands);
   return brand.isEmpty ? name : '$name|$brand';
 }

--- a/lib/l10n/intl_cs.arb
+++ b/lib/l10n/intl_cs.arb
@@ -939,6 +939,8 @@
   "settingsVolumeLabel": "Objem",
   "shareActivityLabel": "Sdílet trénink",
   "shareCodeLabel": "Sdílet kód",
+  "shareJsonImportContent": "Tyto pokrmy budou přidány do vašeho deníku.",
+  "shareJsonImportErrorLabel": "Sdílený JSON nelze přečíst. Zkontroluj, zda odpovídá očekávanému formátu.",
   "shareMealLabel": "Sdílet jídlo",
   "shareRecipeLabel": "Sdílet recept",
   "snackExample": "např. jablko, zmrzlina, čokoláda...",

--- a/lib/l10n/intl_de.arb
+++ b/lib/l10n/intl_de.arb
@@ -970,6 +970,8 @@
   "settingsVolumeLabel": "Volumen",
   "shareActivityLabel": "Training teilen",
   "shareCodeLabel": "Code teilen",
+  "shareJsonImportContent": "Diese Mahlzeiten werden deinem Tagebuch hinzugefügt.",
+  "shareJsonImportErrorLabel": "JSON konnte nicht gelesen werden. Überprüfe, ob das Format korrekt ist.",
   "shareMealLabel": "Mahlzeit teilen",
   "shareRecipeLabel": "Rezept teilen",
   "snackExample": "z. B. Apfel, Eiscreme, Schokolade ...",

--- a/lib/l10n/intl_en.arb
+++ b/lib/l10n/intl_en.arb
@@ -1016,6 +1016,8 @@
   "settingsVolumeLabel": "Volume",
   "shareActivityLabel": "Share workout",
   "shareCodeLabel": "Share code",
+  "shareJsonImportContent": "These meals will be added to your diary.",
+  "shareJsonImportErrorLabel": "Could not read shared JSON. Check that it matches the expected format.",
   "shareMealLabel": "Share meal",
   "shareRecipeLabel": "Share recipe",
   "snackExample": "e.g. apple, ice cream, chocolate ...",

--- a/lib/l10n/intl_it.arb
+++ b/lib/l10n/intl_it.arb
@@ -939,6 +939,8 @@
   "settingsVolumeLabel": "Volume",
   "shareActivityLabel": "Condividi allenamento",
   "shareCodeLabel": "Condividi codice",
+  "shareJsonImportContent": "Questi pasti verranno aggiunti al tuo diario.",
+  "shareJsonImportErrorLabel": "Impossibile leggere il JSON condiviso. Verificare che corrisponda al formato previsto.",
   "shareMealLabel": "Condividi pasto",
   "shareRecipeLabel": "Condividi ricetta",
   "snackExample": "es. mela, gelato, cioccolato ...",

--- a/lib/l10n/intl_pl.arb
+++ b/lib/l10n/intl_pl.arb
@@ -939,6 +939,8 @@
   "settingsVolumeLabel": "Objętość",
   "shareActivityLabel": "Udostępnij trening",
   "shareCodeLabel": "Udostępnij kod",
+  "shareJsonImportContent": "Te posiłki zostaną dodane do twojego dziennika.",
+  "shareJsonImportErrorLabel": "Nie można odczytać udostępnionego JSON. Sprawdź, czy odpowiada oczekiwanemu formatowi.",
   "shareMealLabel": "Udostępnij posiłek",
   "shareRecipeLabel": "Udostępnij przepis",
   "snackExample": "np. jabłko, lody, czekolada ...",

--- a/lib/l10n/intl_sk.arb
+++ b/lib/l10n/intl_sk.arb
@@ -970,6 +970,8 @@
   "settingsVolumeLabel": "Objem",
   "shareActivityLabel": "Zdieľať tréning",
   "shareCodeLabel": "Zdieľať kód",
+  "shareJsonImportContent": "Tieto jedlá budú pridané do vášho denníka.",
+  "shareJsonImportErrorLabel": "Zdieľaný JSON sa nedá prečítať. Skontrolujte, či zodpovedá očakávanému formátu.",
   "shareMealLabel": "Zdieľať jedlo",
   "shareRecipeLabel": "Zdieľať recept",
   "snackExample": "napr. jablko, zmrzlina, čokoláda ...",

--- a/lib/l10n/intl_tr.arb
+++ b/lib/l10n/intl_tr.arb
@@ -970,6 +970,8 @@
   "settingsVolumeLabel": "Hacim",
   "shareActivityLabel": "Antrenmanı paylaş",
   "shareCodeLabel": "Kodu paylaş",
+  "shareJsonImportContent": "Bu öğünler günlüğünüze eklenecektir.",
+  "shareJsonImportErrorLabel": "Paylaşılan JSON okunamadı. Beklenen formatla eşleşip eşleşmediğini kontrol edin.",
   "shareMealLabel": "Share meal",
   "shareRecipeLabel": "Tarifi paylaş",
   "snackExample": "ör. elma, dondurma, çikolata ...",

--- a/lib/l10n/intl_uk.arb
+++ b/lib/l10n/intl_uk.arb
@@ -939,6 +939,8 @@
   "settingsVolumeLabel": "Об'єм",
   "shareActivityLabel": "Поділитися тренуванням",
   "shareCodeLabel": "Поділитися кодом",
+  "shareJsonImportContent": "Ці страви буде додано до вашого щоденника.",
+  "shareJsonImportErrorLabel": "Не вдалося прочитати спільний JSON. Перевірте, чи відповідає він очікуваному формату.",
   "shareMealLabel": "Share meal",
   "shareRecipeLabel": "Поділитися рецептом",
   "snackExample": "наприклад, яблуко, морозиво, шоколад ...",

--- a/lib/l10n/intl_zh.arb
+++ b/lib/l10n/intl_zh.arb
@@ -940,6 +940,8 @@
   "settingsVolumeLabel": "体积",
   "shareActivityLabel": "分享运动",
   "shareCodeLabel": "分享代码",
+  "shareJsonImportContent": "这些餐食将被添加到您的日记中。",
+  "shareJsonImportErrorLabel": "无法读取共享的 JSON。请检查其格式是否符合预期。",
   "shareMealLabel": "分享餐食",
   "shareRecipeLabel": "分享食谱",
   "snackExample": "例如：苹果、冰淇淋、巧克力...",


### PR DESCRIPTION
## Summary
Adds Android share intent support so any app — including AI assistants
using the bundled food-tracker skill — can share meal JSON directly to
OpenNutriTracker. The skill accepts natural-language descriptions and
food photos; it generates the app's existing JSON export format and the
user taps Share → OpenNutriTracker, confirms the import dialog, and the
meals land in their diary.

iOS share intent is out of scope for this PR (no Share Extension target
exists yet). The Flutter service returns null on iOS so there is no
regression — tracked as a follow-up.

## Ai Skill
[food-tracker.skill.zip](https://github.com/user-attachments/files/30372804/food-tracker.skill.zip)

## Type of change
- [ ] Bug fix
- [x] New feature
- [ ] Refactor / cleanup
- [ ] Documentation
- [ ] CI / tooling
- [x] Localization
- [ ] Other

## Related issues
<!-- Link issues with Fixes #123 or Refs #123 -->

## Changes
- **Android** — `AndroidManifest.xml` registers `ACTION_SEND` intent-filters
  for `text/plain` and `application/json` so the app appears in the system
  share sheet
- **Android** — `MainActivity.kt` captures the shared text via a
  `MethodChannel` and holds it until Flutter reads it (handles both cold-start
  and singleTop `onNewIntent`)
- **Flutter** — `ShareIntentService` bridges the channel; returns `null` on
  iOS (no-op fallback)
- **Flutter** — `MainScreen` checks for a pending share on cold start and on
  every foreground resume via `AppLifecycleListener`, shows a confirmation
  dialog, and imports approved meals using the existing
  `ImportMealsJsonUsecase`
- **l10n** — two new strings (`shareJsonImportContent`,
  `shareJsonImportErrorLabel`) added to all 9 supported locales (EN + DE, CS,
  IT, PL, SK, TR, UK, ZH)
- **fix** — pre-existing `curly_braces_in_flow_control_structures` lint in
  `meal_relevance_ranker.dart` that blocked CI

## Screenshots / recordings

https://github.com/user-attachments/assets/3f58e1dc-e0ec-4abe-992e-cd1d87f6081f




## Test plan
- [x] Described steps below were followed locally
- [ ] Unit / widget tests added or updated (if applicable)
- [x] Manual check on Android
- [ ] Manual check on iOS (if applicable) — N/A, iOS not yet supported

### Steps
1. Build and install the app (`fvm flutter run --flavor develop`)
2. Use the food-tracker AI skill to generate a meal — it outputs JSON in
   ONT's export format
3. In the AI app, tap Share → OpenNutriTracker
4. Confirm the import dialog — meals appear in today's diary
5. Share invalid/non-JSON text to ONT — error snackbar is shown, no crash

## Checklist
- [x] Code follows project style (`just format` / 120-char line width)
- [x] New interactive widgets include `Semantics(identifier: '...')` where
  needed (`share-json-import-confirm` on the dialog confirm button)
- [x] Localization updated in ARBs **and** `lib/generated/` when user-facing
  strings change
- [ ] Codegen ran if DBOs/DTOs/env changed (`just build`) — no codegen changes
- [x] No secrets or `.env` values committed
- [x] PR title follows conventional commit style (e.g. `feat:`, `fix:`, `chore:`)