### PR TITLE
fix(diary): apply day-start offset to entries, not the selected day

### DIFF
--- a/lib/core/data/data_source/intake_data_source.dart
+++ b/lib/core/data/data_source/intake_data_source.dart
@@ -1,5 +1,4 @@
 import 'package:collection/collection.dart';
-import 'package:flutter/material.dart';
 import 'package:hive_ce_flutter/hive_flutter.dart';
 import 'package:logging/logging.dart';
 import 'package:opennutritracker/core/data/dbo/intake_dbo.dart';
@@ -64,33 +63,30 @@ class IntakeDataSource {
     return _intakeBox.values.toList();
   }
 
+  /// Intakes of [intakeType] filed under the calendar day [day].
+  ///
+  /// [day] is a day label — the date the user is looking at — not a
+  /// moment in time. #139: when a non-zero day-start offset is
+  /// configured, an entry logged before that time rolls into the
+  /// previous day; the label itself must stay put (#586). The follow-up
+  /// to #139 adds a minutes companion, which composes additively into a
+  /// single total-minutes value here. A zero total offset reduces to the
+  /// original wall-clock-day behaviour.
   Future<List<IntakeDBO>> getAllIntakesByDate(
     IntakeTypeDBO intakeType,
-    DateTime dateTime, {
+    DateTime day, {
     int dayStartOffsetHours = 0,
     int dayStartOffsetMinutes = 0,
   }) async {
-    // #139: when a non-zero day-start offset is configured, an entry
-    // logged before that hour rolls into the previous wall-clock day.
-    // A zero total offset preserves the original wall-clock behaviour.
-    // The follow-up to #139 adds a minutes companion; both compose
-    // additively into a single total-minutes value here.
-    final totalMinutes = dayStartOffsetHours * 60 +
-        dayStartOffsetMinutes.clamp(0, 59);
-    if (totalMinutes == 0) {
-      return _intakeBox.values
-          .where(
-            (intake) =>
-                DateUtils.isSameDay(dateTime, intake.dateTime) &&
-                intake.type == intakeType,
-          )
-          .toList();
-    }
+    final totalMinutes = DayBoundaryCalc.totalMinutesOf(
+      dayStartOffsetHours,
+      dayStartOffsetMinutes,
+    );
     return _intakeBox.values
         .where(
           (intake) =>
-              DayBoundaryCalc.isSameLogicalDayMinutes(
-                dateTime,
+              DayBoundaryCalc.isMomentInLogicalDayMinutes(
+                day,
                 intake.dateTime,
                 totalMinutes,
               ) &&

--- a/lib/core/data/data_source/user_activity_data_source.dart
+++ b/lib/core/data/data_source/user_activity_data_source.dart
@@ -1,5 +1,4 @@
 import 'package:collection/collection.dart';
-import 'package:flutter/material.dart';
 import 'package:hive_ce_flutter/hive_flutter.dart';
 import 'package:logging/logging.dart';
 import 'package:opennutritracker/core/data/data_source/user_activity_dbo.dart';
@@ -63,25 +62,23 @@ class UserActivityDataSource {
     return _userActivityBox.values.toList();
   }
 
+  /// Activities filed under the calendar day [day].
+  ///
+  /// [day] is a day label, not a moment — see [IntakeDataSource
+  /// .getAllIntakesByDate] for the rationale (#139, #586).
   Future<List<UserActivityDBO>> getAllUserActivitiesByDate(
-    DateTime dateTime, {
+    DateTime day, {
     int dayStartOffsetHours = 0,
     int dayStartOffsetMinutes = 0,
   }) async {
-    // #139: see IntakeDataSource for the rationale — a zero total offset
-    // preserves the original wall-clock day behaviour. The follow-up to
-    // #139 adds the minutes companion which composes additively here.
-    final totalMinutes = dayStartOffsetHours * 60 +
-        dayStartOffsetMinutes.clamp(0, 59);
-    if (totalMinutes == 0) {
-      return _userActivityBox.values
-          .where((activity) => DateUtils.isSameDay(dateTime, activity.date))
-          .toList();
-    }
+    final totalMinutes = DayBoundaryCalc.totalMinutesOf(
+      dayStartOffsetHours,
+      dayStartOffsetMinutes,
+    );
     return _userActivityBox.values
         .where(
-          (activity) => DayBoundaryCalc.isSameLogicalDayMinutes(
-            dateTime,
+          (activity) => DayBoundaryCalc.isMomentInLogicalDayMinutes(
+            day,
             activity.date,
             totalMinutes,
           ),

--- a/lib/core/domain/usecase/get_intake_usecase.dart
+++ b/lib/core/domain/usecase/get_intake_usecase.dart
@@ -1,11 +1,19 @@
 import 'package:opennutritracker/core/data/repository/intake_repository.dart';
 import 'package:opennutritracker/core/domain/entity/intake_entity.dart';
 import 'package:opennutritracker/core/domain/entity/intake_type_entity.dart';
+import 'package:opennutritracker/core/utils/calc/day_boundary_calc.dart';
 
 class GetIntakeUsecase {
   final IntakeRepository _intakeRepository;
 
   GetIntakeUsecase(this._intakeRepository);
+
+  /// The day label the `getToday…` reads below filter on. The queries
+  /// take a label, so the boundary has to be resolved here rather than
+  /// handed a raw `DateTime.now()` — otherwise a 02:00 reading on a
+  /// 06:00 boundary would ask for the wrong day (#586).
+  DateTime _logicalToday(int offsetHours, int offsetMinutes) =>
+      DayBoundaryCalc.currentLogicalDayLabel(offsetHours, offsetMinutes);
 
   Future<List<IntakeEntity>> _getIntakeByDay(
     IntakeTypeEntity type,
@@ -38,7 +46,8 @@ class GetIntakeUsecase {
     int dayStartOffsetHours = 0,
     int dayStartOffsetMinutes = 0,
   }) async =>
-      getBreakfastIntakeByDay(DateTime.now(),
+      getBreakfastIntakeByDay(
+          _logicalToday(dayStartOffsetHours, dayStartOffsetMinutes),
           dayStartOffsetHours: dayStartOffsetHours,
           dayStartOffsetMinutes: dayStartOffsetMinutes);
 
@@ -55,7 +64,8 @@ class GetIntakeUsecase {
     int dayStartOffsetHours = 0,
     int dayStartOffsetMinutes = 0,
   }) async =>
-      await getLunchIntakeByDay(DateTime.now(),
+      await getLunchIntakeByDay(
+          _logicalToday(dayStartOffsetHours, dayStartOffsetMinutes),
           dayStartOffsetHours: dayStartOffsetHours,
           dayStartOffsetMinutes: dayStartOffsetMinutes);
 
@@ -72,7 +82,8 @@ class GetIntakeUsecase {
     int dayStartOffsetHours = 0,
     int dayStartOffsetMinutes = 0,
   }) async =>
-      await getDinnerIntakeByDay(DateTime.now(),
+      await getDinnerIntakeByDay(
+          _logicalToday(dayStartOffsetHours, dayStartOffsetMinutes),
           dayStartOffsetHours: dayStartOffsetHours,
           dayStartOffsetMinutes: dayStartOffsetMinutes);
 
@@ -89,7 +100,8 @@ class GetIntakeUsecase {
     int dayStartOffsetHours = 0,
     int dayStartOffsetMinutes = 0,
   }) async =>
-      await getSnackIntakeByDay(DateTime.now(),
+      await getSnackIntakeByDay(
+          _logicalToday(dayStartOffsetHours, dayStartOffsetMinutes),
           dayStartOffsetHours: dayStartOffsetHours,
           dayStartOffsetMinutes: dayStartOffsetMinutes);
 

--- a/lib/core/domain/usecase/get_kcal_goal_breakdown_usecase.dart
+++ b/lib/core/domain/usecase/get_kcal_goal_breakdown_usecase.dart
@@ -3,6 +3,7 @@ import 'package:opennutritracker/core/data/repository/config_repository.dart';
 import 'package:opennutritracker/core/data/repository/user_activity_repository.dart';
 import 'package:opennutritracker/core/data/repository/user_repository.dart';
 import 'package:opennutritracker/core/domain/entity/kcal_goal_breakdown_entity.dart';
+import 'package:opennutritracker/core/utils/calc/day_boundary_calc.dart';
 
 /// Assembles the full transparency breakdown of today's kcal goal.
 ///
@@ -25,7 +26,13 @@ class GetKcalGoalBreakdownUsecase {
     final config = await _configRepository.getConfig();
     final totalKcalActivities =
         (await _userActivityRepository.getAllUserActivityByDate(
-          DateTime.now(),
+          // Same day label as [GetKcalGoalUsecase] resolves (#586) —
+          // the two must agree or the transparency screen contradicts
+          // the goal it is explaining.
+          DayBoundaryCalc.currentLogicalDayLabel(
+            config.dayStartOffsetHours,
+            config.dayStartOffsetMinutes,
+          ),
           dayStartOffsetHours: config.dayStartOffsetHours,
           dayStartOffsetMinutes: config.dayStartOffsetMinutes,
         )).map((activity) => activity.burnedKcal).toList().sum;

--- a/lib/core/domain/usecase/get_kcal_goal_usecase.dart
+++ b/lib/core/domain/usecase/get_kcal_goal_usecase.dart
@@ -4,6 +4,7 @@ import 'package:opennutritracker/core/data/repository/user_activity_repository.d
 import 'package:opennutritracker/core/data/repository/user_repository.dart';
 import 'package:opennutritracker/core/domain/entity/user_entity.dart';
 import 'package:opennutritracker/core/utils/calc/calorie_goal_calc.dart';
+import 'package:opennutritracker/core/utils/calc/day_boundary_calc.dart';
 
 class GetKcalGoalUsecase {
   final UserRepository _userRepository;
@@ -26,7 +27,16 @@ class GetKcalGoalUsecase {
     final totalKcalActivities =
         totalKcalActivitiesParam ??
         (await _userActivityRepository.getAllUserActivityByDate(
-          DateTime.now(),
+          // #586: the query takes a day label, so "today" has to be
+          // resolved through the boundary first. A raw DateTime.now()
+          // here asks for the wall-clock date, which between midnight
+          // and the boundary is a different day than the one Home's
+          // activity list shows — the goal would silently drop those
+          // burned calories.
+          DayBoundaryCalc.currentLogicalDayLabel(
+            config.dayStartOffsetHours,
+            config.dayStartOffsetMinutes,
+          ),
           dayStartOffsetHours: config.dayStartOffsetHours,
           dayStartOffsetMinutes: config.dayStartOffsetMinutes,
         )).map((activity) => activity.burnedKcal).toList().sum;

--- a/lib/core/domain/usecase/get_user_activity_usecase.dart
+++ b/lib/core/domain/usecase/get_user_activity_usecase.dart
@@ -1,5 +1,6 @@
 import 'package:opennutritracker/core/data/repository/user_activity_repository.dart';
 import 'package:opennutritracker/core/domain/entity/user_activity_entity.dart';
+import 'package:opennutritracker/core/utils/calc/day_boundary_calc.dart';
 
 class GetUserActivityUsecase {
   final UserActivityRepository _userActivityRepository;
@@ -14,8 +15,11 @@ class GetUserActivityUsecase {
     int dayStartOffsetHours = 0,
     int dayStartOffsetMinutes = 0,
   }) {
-    return _userActivityRepository.getAllUserActivityByDate(
-      DateTime.now(),
+    return getUserActivityByDay(
+      DayBoundaryCalc.currentLogicalDayLabel(
+        dayStartOffsetHours,
+        dayStartOffsetMinutes,
+      ),
       dayStartOffsetHours: dayStartOffsetHours,
       dayStartOffsetMinutes: dayStartOffsetMinutes,
     );

--- a/lib/core/utils/calc/day_boundary_calc.dart
+++ b/lib/core/utils/calc/day_boundary_calc.dart
@@ -1,3 +1,5 @@
+import 'package:meta/meta.dart';
+
 /// Helper for the configurable diary day boundary (#139).
 ///
 /// Some reporters live by a 04:00-to-04:00 day rather than the wall-clock
@@ -13,6 +15,16 @@
 /// the entry was created). Notification scheduling has its own timing
 /// logic and is intentionally untouched here.
 class DayBoundaryCalc {
+  /// The clock every "now" below reads.
+  ///
+  /// A boundary only misbehaves between midnight and the offset, so a
+  /// test that reads the real clock silently proves nothing for most of
+  /// the day — which is how the `…Today…` reads went a release without
+  /// anyone noticing they asked for the wrong day (#586). Tests pin this
+  /// and restore it; production never assigns it.
+  @visibleForTesting
+  static DateTime Function() clock = DateTime.now;
+
   /// Returns the wall-clock midnight of the logical day that [moment]
   /// belongs to, given a configured [offsetHours] in the range 0–23.
   ///
@@ -30,7 +42,7 @@ class DayBoundaryCalc {
 
   /// The logical day for "now", given the configured [offsetHours].
   static DateTime currentLogicalDay(int? offsetHours) =>
-      logicalDayOf(DateTime.now(), offsetHours);
+      logicalDayOf(clock(), offsetHours);
 
   /// True when [a] and [b] resolve to the same logical day under
   /// [offsetHours].
@@ -62,7 +74,7 @@ class DayBoundaryCalc {
 
   /// The logical day for "now", given the configured [offsetTotalMinutes].
   static DateTime currentLogicalDayMinutes(int? offsetTotalMinutes) =>
-      logicalDayOfMinutes(DateTime.now(), offsetTotalMinutes);
+      logicalDayOfMinutes(clock(), offsetTotalMinutes);
 
   /// Composes the hours + minutes pair the data layer passes around into
   /// the single total-minutes value the calculations below expect. A

--- a/lib/core/utils/calc/day_boundary_calc.dart
+++ b/lib/core/utils/calc/day_boundary_calc.dart
@@ -106,15 +106,9 @@ class DayBoundaryCalc {
     DateTime moment,
     int? offsetTotalMinutes,
   ) {
-    // Entries added from the diary are stamped with the calendar cell
-    // itself — table_calendar hands out `DateTime.utc(y, m, d)`, which
-    // DayInfoWidget passes through AddMealScreenArguments into
-    // MealDetailBloc.addIntake as the intake's `dateTime`. That value is
-    // a label, not a moment, so it is compared as-is: rolling it back
-    // would file every diary-added entry a day early. Live-logged
-    // entries always come from `DateTime.now()` and so are local, which
-    // is what keeps the two cases distinguishable (hive_ce preserves the
-    // UTC flag across a round trip).
+    // Some stored entries are themselves labels rather than clock
+    // readings, and must be compared as-is: rolling them back would file
+    // them a day early. See [_isDayLabel] for who writes them.
     final momentDay = _isDayLabel(moment)
         ? moment
         : logicalDayOfMinutes(moment, offsetTotalMinutes);
@@ -145,11 +139,25 @@ class DayBoundaryCalc {
     return DateTime(shifted.year, shifted.month, shifted.day);
   }
 
-  /// A UTC midnight is how this app spells "the calendar day named
-  /// y-m-d" (see [isMomentInLogicalDayMinutes]); nothing writes a
-  /// live-logged entry in UTC, so the flag is an unambiguous marker.
+  /// A bare midnight is how this app spells "the calendar day named
+  /// y-m-d" (see [isMomentInLogicalDayMinutes]). Two writers produce
+  /// one, in two different spellings:
+  ///
+  ///  * adding from the diary stamps the calendar cell itself —
+  ///    table_calendar hands out `DateTime.utc(y, m, d)`, which
+  ///    DayInfoWidget passes through AddMealScreenArguments into
+  ///    MealDetailBloc.addIntake as the intake's `dateTime`;
+  ///  * JsonMealImporter dates an entry `DateTime(y, m, d)` — *local*
+  ///    midnight — from the optional `date` field (or today's date when
+  ///    it is omitted), and CSV import can round-trip the same shape.
+  ///
+  /// Hence midnight, not the UTC flag, is the marker: keying off
+  /// `isUtc` alone moved every date-only import back a day as soon as a
+  /// boundary was configured. The cost is that a live entry logged at
+  /// exactly 00:00:00.000000 local stays on its wall-clock day instead
+  /// of rolling back; `DateTime.now()` carries microseconds, so that is
+  /// a rounding error against mis-filing every import.
   static bool _isDayLabel(DateTime value) =>
-      value.isUtc &&
       value.hour == 0 &&
       value.minute == 0 &&
       value.second == 0 &&

--- a/lib/core/utils/calc/day_boundary_calc.dart
+++ b/lib/core/utils/calc/day_boundary_calc.dart
@@ -64,8 +64,58 @@ class DayBoundaryCalc {
   static DateTime currentLogicalDayMinutes(int? offsetTotalMinutes) =>
       logicalDayOfMinutes(DateTime.now(), offsetTotalMinutes);
 
+  /// Composes the hours + minutes pair the data layer passes around into
+  /// the single total-minutes value the calculations below expect. A
+  /// stored minute value outside 0-59 cannot inflate the total.
+  static int totalMinutesOf(int offsetHours, int offsetMinutes) =>
+      offsetHours * 60 + offsetMinutes.clamp(0, 59);
+
+  /// The label of the logical day "now" falls in, from an hours +
+  /// minutes pair.
+  ///
+  /// Queries that mean "today" must resolve the boundary *before* they
+  /// filter, because the query itself takes a day label: on a 06:00
+  /// boundary at 02:00, "today" is yesterday's label (#586).
+  static DateTime currentLogicalDayLabel(int offsetHours, int offsetMinutes) =>
+      currentLogicalDayMinutes(totalMinutesOf(offsetHours, offsetMinutes));
+
+  /// True when the entry logged at [moment] belongs to the logical day
+  /// labelled [dayLabel], given [offsetTotalMinutes].
+  ///
+  /// Use this — not [isSameLogicalDayMinutes] — whenever one side is a
+  /// calendar date the user picked rather than a clock reading. A day
+  /// label names a column in the diary; only its calendar date carries
+  /// meaning, and applying the offset to it shifts the whole selection
+  /// (#586: with a 06:00 boundary, tapping the 20th listed the 19th's
+  /// entries, because subtracting six hours from midnight lands in the
+  /// previous day). Only [moment] is resolved through the boundary.
+  static bool isMomentInLogicalDayMinutes(
+    DateTime dayLabel,
+    DateTime moment,
+    int? offsetTotalMinutes,
+  ) {
+    // Entries added from the diary are stamped with the calendar cell
+    // itself — table_calendar hands out `DateTime.utc(y, m, d)`, which
+    // DayInfoWidget passes through AddMealScreenArguments into
+    // MealDetailBloc.addIntake as the intake's `dateTime`. That value is
+    // a label, not a moment, so it is compared as-is: rolling it back
+    // would file every diary-added entry a day early. Live-logged
+    // entries always come from `DateTime.now()` and so are local, which
+    // is what keeps the two cases distinguishable (hive_ce preserves the
+    // UTC flag across a round trip).
+    final momentDay = _isDayLabel(moment)
+        ? moment
+        : logicalDayOfMinutes(moment, offsetTotalMinutes);
+    return momentDay.year == dayLabel.year &&
+        momentDay.month == dayLabel.month &&
+        momentDay.day == dayLabel.day;
+  }
+
   /// True when [a] and [b] resolve to the same logical day under
   /// [offsetTotalMinutes].
+  ///
+  /// Both arguments must be real timestamps. If either is a user-picked
+  /// calendar date, reach for [isMomentInLogicalDayMinutes] instead.
   static bool isSameLogicalDayMinutes(
     DateTime a,
     DateTime b,
@@ -82,6 +132,17 @@ class DayBoundaryCalc {
     final shifted = moment.subtract(Duration(minutes: totalMinutes));
     return DateTime(shifted.year, shifted.month, shifted.day);
   }
+
+  /// A UTC midnight is how this app spells "the calendar day named
+  /// y-m-d" (see [isMomentInLogicalDayMinutes]); nothing writes a
+  /// live-logged entry in UTC, so the flag is an unambiguous marker.
+  static bool _isDayLabel(DateTime value) =>
+      value.isUtc &&
+      value.hour == 0 &&
+      value.minute == 0 &&
+      value.second == 0 &&
+      value.millisecond == 0 &&
+      value.microsecond == 0;
 
   static int _sanitiseHours(int? offsetHours) {
     if (offsetHours == null) return 0;

--- a/test/unit_test/day_boundary_calc_test.dart
+++ b/test/unit_test/day_boundary_calc_test.dart
@@ -311,6 +311,60 @@ void main() {
         isTrue,
       );
     });
+
+    test('an imported entry dated the 20th is a label, in either spelling',
+        () {
+      // JsonMealImporter dates an entry `DateTime(y, m, d)` — *local*
+      // midnight — from its optional `date` field. Keying "is this a
+      // label?" off the UTC flag alone filed every date-only import a
+      // day early once a boundary was configured.
+      expect(
+        DayBoundaryCalc.isMomentInLogicalDayMinutes(
+          label,
+          DateTime(2026, 7, 20),
+          sixAm,
+        ),
+        isTrue,
+      );
+      expect(
+        DayBoundaryCalc.isMomentInLogicalDayMinutes(
+          DateTime(2026, 7, 20),
+          DateTime(2026, 7, 20),
+          sixAm,
+        ),
+        isTrue,
+      );
+      // ...and it stays off the neighbouring day.
+      expect(
+        DayBoundaryCalc.isMomentInLogicalDayMinutes(
+          DateTime.utc(2026, 7, 19),
+          DateTime(2026, 7, 20),
+          sixAm,
+        ),
+        isFalse,
+      );
+    });
+
+    test('a minute past midnight is a moment again, not a label', () {
+      // The carve-out is deliberately narrow: only a bare midnight reads
+      // as a label, so a genuinely early entry still rolls back.
+      expect(
+        DayBoundaryCalc.isMomentInLogicalDayMinutes(
+          label,
+          DateTime(2026, 7, 21, 0, 1),
+          sixAm,
+        ),
+        isTrue,
+      );
+      expect(
+        DayBoundaryCalc.isMomentInLogicalDayMinutes(
+          DateTime.utc(2026, 7, 21),
+          DateTime(2026, 7, 21, 0, 1),
+          sixAm,
+        ),
+        isFalse,
+      );
+    });
   });
 
   group('ConfigEntity-level clamping (via the minutes companion)', () {

--- a/test/unit_test/day_boundary_calc_test.dart
+++ b/test/unit_test/day_boundary_calc_test.dart
@@ -223,6 +223,96 @@ void main() {
     });
   });
 
+  group('DayBoundaryCalc.isMomentInLogicalDayMinutes (#586)', () {
+    // The day label is what the user tapped in the diary calendar. The
+    // offset must move only the entry, never the label — shifting the
+    // label was #586: selecting the 20th showed the 19th.
+    final label = DateTime.utc(2026, 7, 20);
+    const sixAm = 6 * 60;
+
+    test('a midday entry stays on the day it was logged', () {
+      expect(
+        DayBoundaryCalc.isMomentInLogicalDayMinutes(
+          label,
+          DateTime(2026, 7, 20, 12, 0),
+          sixAm,
+        ),
+        isTrue,
+      );
+    });
+
+    test('an entry logged before the boundary belongs to the previous day', () {
+      // 02:00 on the 21st is still "the 20th" under a 06:00 boundary.
+      expect(
+        DayBoundaryCalc.isMomentInLogicalDayMinutes(
+          label,
+          DateTime(2026, 7, 21, 2, 0),
+          sixAm,
+        ),
+        isTrue,
+      );
+      // ...and by the same token the previous evening is not.
+      expect(
+        DayBoundaryCalc.isMomentInLogicalDayMinutes(
+          label,
+          DateTime(2026, 7, 19, 20, 0),
+          sixAm,
+        ),
+        isFalse,
+      );
+    });
+
+    test('a diary-added entry is a day label and is not rolled back', () {
+      // Entries added from the diary carry the calendar cell itself as
+      // their timestamp, so they must be matched verbatim.
+      expect(
+        DayBoundaryCalc.isMomentInLogicalDayMinutes(label, label, sixAm),
+        isTrue,
+      );
+      expect(
+        DayBoundaryCalc.isMomentInLogicalDayMinutes(
+          label,
+          DateTime.utc(2026, 7, 19),
+          sixAm,
+        ),
+        isFalse,
+      );
+    });
+
+    test('a zero offset matches plain calendar-day semantics', () {
+      expect(
+        DayBoundaryCalc.isMomentInLogicalDayMinutes(
+          label,
+          DateTime(2026, 7, 20, 2, 0),
+          0,
+        ),
+        isTrue,
+      );
+      expect(
+        DayBoundaryCalc.isMomentInLogicalDayMinutes(
+          label,
+          DateTime(2026, 7, 21, 2, 0),
+          0,
+        ),
+        isFalse,
+      );
+    });
+
+    test('a local-midnight label works too (diary before any day is tapped)',
+        () {
+      // _selectedDate starts life as DateTime.now(), so the label handed
+      // to the query is not always UTC.
+      expect(
+        DayBoundaryCalc.isMomentInLogicalDayMinutes(
+          DateTime(2026, 7, 20),
+          DateTime(2026, 7, 20, 12, 0),
+          sixAm,
+        ),
+        isTrue,
+      );
+    });
+  });
+
   group('ConfigEntity-level clamping (via the minutes companion)', () {
     // The actual clamping happens at the entity boundary, but the
     // data-source code path also defends itself. This documents the

--- a/test/unit_test/diary_day_selection_offset_test.dart
+++ b/test/unit_test/diary_day_selection_offset_test.dart
@@ -34,8 +34,14 @@ void main() {
     registerHiveAdaptersOnce();
   });
 
-  tearDown(() {
-    Hive.deleteFromDisk();
+  tearDown(() async {
+    // Awaited: deleteFromDisk is asynchronous, and letting it run loose
+    // lets the deletion land after the next test has already reopened
+    // its box, which fails as a PathNotFoundException on the box file.
+    // Not preceded by Hive.close() either — that deregisters the boxes,
+    // and deleteFromDisk would then have nothing left to delete, so the
+    // next test would inherit this one's entries.
+    await Hive.deleteFromDisk();
   });
 
   group('intakes under a 06:00 day start', () {
@@ -62,6 +68,9 @@ void main() {
       await addLunch('21st-small-hours', DateTime(2026, 7, 21, 2, 0));
       // Added from the diary itself, which stamps the calendar cell.
       await addLunch('20th-diary-added', selectedDay);
+      // Dated by JsonMealImporter, which spells the same calendar cell
+      // as *local* midnight.
+      await addLunch('20th-imported', DateTime(2026, 7, 20));
     });
 
     Future<Set<String>> idsFor(DateTime day, {int offsetHours = 0}) async {
@@ -76,7 +85,12 @@ void main() {
     test('selecting the 20th lists the 20th, not the 19th', () async {
       expect(
         await idsFor(selectedDay, offsetHours: sixAmOffset),
-        {'20th-midday', '20th-diary-added', '21st-small-hours'},
+        {
+          '20th-midday',
+          '20th-diary-added',
+          '20th-imported',
+          '21st-small-hours',
+        },
       );
     });
 
@@ -88,6 +102,8 @@ void main() {
     });
 
     test('the 19th keeps its own evening entry', () async {
+      // Notably it does not also borrow the entry imported for the 20th:
+      // a date-only import is a label too, however it is spelled.
       expect(
         await idsFor(DateTime.utc(2026, 7, 19), offsetHours: sixAmOffset),
         {'19th-evening'},
@@ -97,7 +113,7 @@ void main() {
     test('no offset falls back to plain calendar days', () async {
       expect(
         await idsFor(selectedDay),
-        {'20th-midday', '20th-diary-added'},
+        {'20th-midday', '20th-diary-added', '20th-imported'},
       );
     });
   });

--- a/test/unit_test/diary_day_selection_offset_test.dart
+++ b/test/unit_test/diary_day_selection_offset_test.dart
@@ -1,0 +1,185 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:hive_ce/hive.dart';
+import 'package:opennutritracker/core/data/data_source/intake_data_source.dart';
+import 'package:opennutritracker/core/data/data_source/user_activity_data_source.dart';
+import 'package:opennutritracker/core/data/data_source/user_activity_dbo.dart';
+import 'package:opennutritracker/core/data/dbo/intake_dbo.dart';
+import 'package:opennutritracker/core/data/dbo/intake_type_dbo.dart';
+import 'package:opennutritracker/core/data/dbo/physical_activity_dbo.dart';
+import 'package:opennutritracker/core/data/repository/intake_repository.dart';
+import 'package:opennutritracker/core/domain/entity/intake_entity.dart';
+import 'package:opennutritracker/core/domain/entity/intake_type_entity.dart';
+import 'package:opennutritracker/core/utils/calc/day_boundary_calc.dart';
+
+import '../fixture/meal_entity_fixtures.dart';
+import '../helpers/fake_hive_db_provider.dart';
+import '../helpers/hive_test_setup.dart';
+
+/// #586: a configured day-start offset must shift only the entries, never
+/// the calendar day the user selected. `table_calendar` hands out
+/// `DateTime.utc(y, m, d)` cells, so the day reaching these queries is a
+/// label; subtracting the offset from it moved the whole selection back a
+/// day and the diary listed the previous day's food.
+void main() {
+  // The 20th as the diary's calendar would deliver it.
+  final selectedDay = DateTime.utc(2026, 7, 20);
+  const sixAmOffset = 6;
+
+  setUp(() {
+    TestWidgetsFlutterBinding.ensureInitialized();
+    Hive.init(".");
+    registerHiveAdaptersOnce();
+  });
+
+  tearDown(() {
+    Hive.deleteFromDisk();
+  });
+
+  group('intakes under a 06:00 day start', () {
+    late IntakeDataSource dataSource;
+
+    setUp(() async {
+      final box = await Hive.openBox<IntakeDBO>('intake_offset_test');
+      dataSource = IntakeDataSource(FakeHiveDBProvider(intakeBox: box));
+      final repo = IntakeRepository(dataSource);
+
+      Future<void> addLunch(String id, DateTime when) => repo.addIntake(
+            IntakeEntity(
+              id: id,
+              unit: 'g',
+              amount: 1,
+              type: IntakeTypeEntity.lunch,
+              meal: MealEntityFixtures.mealOne,
+              dateTime: when,
+            ),
+          );
+
+      await addLunch('19th-evening', DateTime(2026, 7, 19, 20, 0));
+      await addLunch('20th-midday', DateTime(2026, 7, 20, 12, 0));
+      await addLunch('21st-small-hours', DateTime(2026, 7, 21, 2, 0));
+      // Added from the diary itself, which stamps the calendar cell.
+      await addLunch('20th-diary-added', selectedDay);
+    });
+
+    Future<Set<String>> idsFor(DateTime day, {int offsetHours = 0}) async {
+      final result = await dataSource.getAllIntakesByDate(
+        IntakeTypeDBO.lunch,
+        day,
+        dayStartOffsetHours: offsetHours,
+      );
+      return result.map((dbo) => dbo.id).toSet();
+    }
+
+    test('selecting the 20th lists the 20th, not the 19th', () async {
+      expect(
+        await idsFor(selectedDay, offsetHours: sixAmOffset),
+        {'20th-midday', '20th-diary-added', '21st-small-hours'},
+      );
+    });
+
+    test('the small hours of the 21st still belong to the 20th', () async {
+      expect(
+        await idsFor(DateTime.utc(2026, 7, 21), offsetHours: sixAmOffset),
+        isNot(contains('21st-small-hours')),
+      );
+    });
+
+    test('the 19th keeps its own evening entry', () async {
+      expect(
+        await idsFor(DateTime.utc(2026, 7, 19), offsetHours: sixAmOffset),
+        {'19th-evening'},
+      );
+    });
+
+    test('no offset falls back to plain calendar days', () async {
+      expect(
+        await idsFor(selectedDay),
+        {'20th-midday', '20th-diary-added'},
+      );
+    });
+  });
+
+  // The Home page asks for "today" rather than a selected day, so it has
+  // to resolve the boundary into a label *before* filtering: on a 06:00
+  // boundary at 02:00, "today" is yesterday's label. Passing a raw
+  // `DateTime.now()` to a label-taking query asks for the wall-clock
+  // date, which is a different day for exactly the hours the offset
+  // exists to handle.
+  //
+  // These usecases read the clock internally, so a test can only observe
+  // the difference between 00:00 and the boundary. What is pinned here is
+  // the composition Home relies on, for a fixed "now".
+  group('a "today" read resolves the boundary before filtering', () {
+    late IntakeDataSource dataSource;
+    late IntakeRepository repo;
+
+    setUp(() async {
+      final box = await Hive.openBox<IntakeDBO>('intake_today_test');
+      dataSource = IntakeDataSource(FakeHiveDBProvider(intakeBox: box));
+      repo = IntakeRepository(dataSource);
+    });
+
+    Future<void> addLunchAt(String id, DateTime when) => repo.addIntake(
+          IntakeEntity(
+            id: id,
+            unit: 'g',
+            amount: 1,
+            type: IntakeTypeEntity.lunch,
+            meal: MealEntityFixtures.mealOne,
+            dateTime: when,
+          ),
+        );
+
+    test('at 02:00 on a 06:00 boundary, "today" is the previous day', () async {
+      const offsetHours = 6;
+      final now = DateTime(2026, 7, 20, 2, 0);
+
+      await addLunchAt('19th-evening', DateTime(2026, 7, 19, 20, 0));
+      await addLunchAt('20th-small-hours', DateTime(2026, 7, 20, 1, 0));
+      await addLunchAt('20th-after-boundary', DateTime(2026, 7, 20, 9, 0));
+
+      // The label a "today" read must resolve to...
+      final label = DayBoundaryCalc.logicalDayOfMinutes(now, offsetHours * 60);
+      expect(label, DateTime(2026, 7, 19));
+
+      // ...and what the diary/home list shows for it: the previous
+      // evening plus the small hours that have not yet crossed 06:00.
+      final result = await dataSource.getAllIntakesByDate(
+        IntakeTypeDBO.lunch,
+        label,
+        dayStartOffsetHours: offsetHours,
+      );
+      expect(
+        result.map((dbo) => dbo.id).toSet(),
+        {'19th-evening', '20th-small-hours'},
+      );
+    });
+  });
+
+  test('activities follow the same rule', () async {
+    final box = await Hive.openBox<UserActivityDBO>('activity_offset_test');
+    final dataSource =
+        UserActivityDataSource(FakeHiveDBProvider(userActivityBox: box));
+
+    final walking = PhysicalActivityDBO(
+      '02020',
+      'Walking',
+      'Walking, leisure',
+      3.5,
+      const [],
+      PhysicalActivityTypeDBO.sport,
+    );
+    await box.addAll([
+      UserActivityDBO('19th-evening', 30, 100,
+          DateTime(2026, 7, 19, 20, 0), walking),
+      UserActivityDBO('20th-midday', 30, 100,
+          DateTime(2026, 7, 20, 12, 0), walking),
+    ]);
+
+    final result = await dataSource.getAllUserActivitiesByDate(
+      selectedDay,
+      dayStartOffsetHours: sixAmOffset,
+    );
+    expect(result.map((dbo) => dbo.id), ['20th-midday']);
+  });
+}

--- a/test/unit_test/diary_day_selection_offset_test.dart
+++ b/test/unit_test/diary_day_selection_offset_test.dart
@@ -7,8 +7,11 @@ import 'package:opennutritracker/core/data/dbo/intake_dbo.dart';
 import 'package:opennutritracker/core/data/dbo/intake_type_dbo.dart';
 import 'package:opennutritracker/core/data/dbo/physical_activity_dbo.dart';
 import 'package:opennutritracker/core/data/repository/intake_repository.dart';
+import 'package:opennutritracker/core/data/repository/user_activity_repository.dart';
 import 'package:opennutritracker/core/domain/entity/intake_entity.dart';
 import 'package:opennutritracker/core/domain/entity/intake_type_entity.dart';
+import 'package:opennutritracker/core/domain/usecase/get_intake_usecase.dart';
+import 'package:opennutritracker/core/domain/usecase/get_user_activity_usecase.dart';
 import 'package:opennutritracker/core/utils/calc/day_boundary_calc.dart';
 
 import '../fixture/meal_entity_fixtures.dart';
@@ -100,23 +103,41 @@ void main() {
   });
 
   // The Home page asks for "today" rather than a selected day, so it has
-  // to resolve the boundary into a label *before* filtering: on a 06:00
-  // boundary at 02:00, "today" is yesterday's label. Passing a raw
-  // `DateTime.now()` to a label-taking query asks for the wall-clock
+  // to resolve the boundary into a label *before* filtering: passing a
+  // raw `DateTime.now()` to a label-taking query asks for the wall-clock
   // date, which is a different day for exactly the hours the offset
-  // exists to handle.
-  //
-  // These usecases read the clock internally, so a test can only observe
-  // the difference between 00:00 and the boundary. What is pinned here is
-  // the composition Home relies on, for a fixed "now".
+  // exists to handle. The clock is pinned inside that window, because
+  // outside it the two spellings of "today" coincide and the test would
+  // pass either way.
   group('a "today" read resolves the boundary before filtering', () {
-    late IntakeDataSource dataSource;
     late IntakeRepository repo;
+    late GetIntakeUsecase intakeUsecase;
+    late GetUserActivityUsecase activityUsecase;
+
+    const offsetHours = 6;
+    // 02:00 — after midnight, before the 06:00 boundary, so the logical
+    // day is still the 19th while the wall-clock date is the 20th.
+    final beforeBoundary = DateTime(2026, 7, 20, 2, 0);
 
     setUp(() async {
-      final box = await Hive.openBox<IntakeDBO>('intake_today_test');
-      dataSource = IntakeDataSource(FakeHiveDBProvider(intakeBox: box));
-      repo = IntakeRepository(dataSource);
+      DayBoundaryCalc.clock = () => beforeBoundary;
+      addTearDown(() => DayBoundaryCalc.clock = DateTime.now);
+
+      final intakeBox = await Hive.openBox<IntakeDBO>('intake_today_test');
+      repo = IntakeRepository(
+        IntakeDataSource(FakeHiveDBProvider(intakeBox: intakeBox)),
+      );
+      intakeUsecase = GetIntakeUsecase(repo);
+
+      final activityBox =
+          await Hive.openBox<UserActivityDBO>('activity_today_test');
+      activityUsecase = GetUserActivityUsecase(
+        UserActivityRepository(
+          UserActivityDataSource(
+            FakeHiveDBProvider(userActivityBox: activityBox),
+          ),
+        ),
+      );
     });
 
     Future<void> addLunchAt(String id, DateTime when) => repo.addIntake(
@@ -130,29 +151,92 @@ void main() {
           ),
         );
 
-    test('at 02:00 on a 06:00 boundary, "today" is the previous day', () async {
-      const offsetHours = 6;
-      final now = DateTime(2026, 7, 20, 2, 0);
-
+    test('at 02:00 on a 06:00 boundary, "today" is still the 19th', () async {
       await addLunchAt('19th-evening', DateTime(2026, 7, 19, 20, 0));
       await addLunchAt('20th-small-hours', DateTime(2026, 7, 20, 1, 0));
+      // Already past the next boundary, so it belongs to the 20th.
       await addLunchAt('20th-after-boundary', DateTime(2026, 7, 20, 9, 0));
 
-      // The label a "today" read must resolve to...
-      final label = DayBoundaryCalc.logicalDayOfMinutes(now, offsetHours * 60);
-      expect(label, DateTime(2026, 7, 19));
-
-      // ...and what the diary/home list shows for it: the previous
-      // evening plus the small hours that have not yet crossed 06:00.
-      final result = await dataSource.getAllIntakesByDate(
-        IntakeTypeDBO.lunch,
-        label,
+      final today = await intakeUsecase.getTodayLunchIntake(
         dayStartOffsetHours: offsetHours,
       );
       expect(
-        result.map((dbo) => dbo.id).toSet(),
+        today.map((e) => e.id).toSet(),
         {'19th-evening', '20th-small-hours'},
       );
+    });
+
+    test('with no offset configured, "today" is the wall-clock day',
+        () async {
+      await addLunchAt('19th-evening', DateTime(2026, 7, 19, 20, 0));
+      await addLunchAt('20th-small-hours', DateTime(2026, 7, 20, 1, 0));
+
+      final today = await intakeUsecase.getTodayLunchIntake();
+      expect(today.map((e) => e.id), ['20th-small-hours']);
+    });
+
+    test('every meal slot agrees on which day "today" is', () async {
+      // A slot reading the wall-clock date while its neighbours read the
+      // logical one would split a single evening across two days.
+      for (final type in IntakeTypeEntity.values) {
+        await repo.addIntake(
+          IntakeEntity(
+            id: 'small-hours-${type.name}',
+            unit: 'g',
+            amount: 1,
+            type: type,
+            meal: MealEntityFixtures.mealOne,
+            dateTime: DateTime(2026, 7, 20, 1, 0),
+          ),
+        );
+        await repo.addIntake(
+          IntakeEntity(
+            id: 'after-boundary-${type.name}',
+            unit: 'g',
+            amount: 1,
+            type: type,
+            meal: MealEntityFixtures.mealOne,
+            dateTime: DateTime(2026, 7, 20, 9, 0),
+          ),
+        );
+      }
+
+      final reads = {
+        IntakeTypeEntity.breakfast: intakeUsecase.getTodayBreakfastIntake,
+        IntakeTypeEntity.lunch: intakeUsecase.getTodayLunchIntake,
+        IntakeTypeEntity.dinner: intakeUsecase.getTodayDinnerIntake,
+        IntakeTypeEntity.snack: intakeUsecase.getTodaySnackIntake,
+      };
+      for (final entry in reads.entries) {
+        final result = await entry.value(dayStartOffsetHours: offsetHours);
+        expect(
+          result.map((e) => e.id),
+          ['small-hours-${entry.key.name}'],
+          reason: '${entry.key.name} disagreed about "today"',
+        );
+      }
+    });
+
+    test('activities resolve "today" the same way', () async {
+      final walking = PhysicalActivityDBO(
+        '02020',
+        'Walking',
+        'Walking, leisure',
+        3.5,
+        const [],
+        PhysicalActivityTypeDBO.sport,
+      );
+      await Hive.box<UserActivityDBO>('activity_today_test').addAll([
+        UserActivityDBO(
+            'small-hours', 30, 100, DateTime(2026, 7, 20, 1, 0), walking),
+        UserActivityDBO(
+            'after-boundary', 30, 100, DateTime(2026, 7, 20, 9, 0), walking),
+      ]);
+
+      final today = await activityUsecase.getTodayUserActivity(
+        dayStartOffsetHours: offsetHours,
+      );
+      expect(today.map((e) => e.id), ['small-hours']);
     });
   });
 

--- a/test/unit_test/kcal_goal_logical_day_test.dart
+++ b/test/unit_test/kcal_goal_logical_day_test.dart
@@ -1,0 +1,166 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:opennutritracker/core/data/repository/config_repository.dart';
+import 'package:opennutritracker/core/data/repository/user_activity_repository.dart';
+import 'package:opennutritracker/core/data/repository/user_repository.dart';
+import 'package:opennutritracker/core/domain/entity/app_theme_entity.dart';
+import 'package:opennutritracker/core/domain/entity/config_entity.dart';
+import 'package:opennutritracker/core/domain/entity/user_activity_entity.dart';
+import 'package:opennutritracker/core/domain/entity/user_entity.dart';
+import 'package:opennutritracker/core/domain/entity/user_gender_entity.dart';
+import 'package:opennutritracker/core/domain/entity/user_pal_entity.dart';
+import 'package:opennutritracker/core/domain/entity/user_weight_goal_entity.dart';
+import 'package:opennutritracker/core/domain/usecase/get_kcal_goal_breakdown_usecase.dart';
+import 'package:opennutritracker/core/domain/usecase/get_kcal_goal_usecase.dart';
+import 'package:opennutritracker/core/utils/calc/day_boundary_calc.dart';
+
+import '../fixture/physical_activity_entity_fixtures.dart';
+
+/// #586: the activity query takes a day *label*, so both kcal-goal reads
+/// have to resolve the boundary before asking. Handing them a raw
+/// `DateTime.now()` asks for the wall-clock date, which between midnight
+/// and the boundary is a different day than the one Home's activity list
+/// shows — the goal would drop those burned calories while the list right
+/// below it still displayed them.
+///
+/// The clock is pinned inside that window on purpose: outside it the two
+/// spellings of "today" coincide and this test would pass either way.
+class _FakeUserRepository extends Fake implements UserRepository {
+  final UserEntity user;
+
+  _FakeUserRepository(this.user);
+
+  @override
+  Future<UserEntity> getUserData() async => user;
+}
+
+class _FakeConfigRepository extends Fake implements ConfigRepository {
+  final ConfigEntity config;
+
+  _FakeConfigRepository(this.config);
+
+  @override
+  Future<ConfigEntity> getConfig() async => config;
+}
+
+/// Records the day it was asked for, so the test can assert on the value
+/// the usecase resolved rather than on a number further downstream.
+class _RecordingUserActivityRepository extends Fake
+    implements UserActivityRepository {
+  final List<UserActivityEntity> activities;
+  DateTime? requestedDay;
+
+  _RecordingUserActivityRepository(this.activities);
+
+  @override
+  Future<List<UserActivityEntity>> getAllUserActivityByDate(
+    DateTime dateTime, {
+    int dayStartOffsetHours = 0,
+    int dayStartOffsetMinutes = 0,
+  }) async {
+    requestedDay = dateTime;
+    return activities
+        .where(
+          (activity) => DayBoundaryCalc.isMomentInLogicalDayMinutes(
+            dateTime,
+            activity.date,
+            DayBoundaryCalc.totalMinutesOf(
+              dayStartOffsetHours,
+              dayStartOffsetMinutes,
+            ),
+          ),
+        )
+        .toList();
+  }
+}
+
+void main() {
+  // 02:00 — after midnight, before the 06:00 boundary, so the logical day
+  // is still the 19th while the wall-clock date is the 20th.
+  final beforeBoundary = DateTime(2026, 7, 20, 2, 0);
+  final logicalToday = DateTime(2026, 7, 19);
+
+  final user = UserEntity(
+    birthday: DateTime(1984, 3, 2),
+    heightCM: 172.0,
+    weightKG: 74.5,
+    gender: UserGenderEntity.female,
+    goal: UserWeightGoalEntity.loseWeight,
+    pal: UserPALEntity.lowActive,
+    weeklyWeightGoalKg: -0.25,
+    targetWeightKg: 70.0,
+    caloriesTaperEnabled: false,
+  );
+
+  const config = ConfigEntity(
+    false,
+    false,
+    false,
+    AppThemeEntity.system,
+    dayStartOffsetHours: 6,
+  );
+
+  // Both belong to the logical 19th: the second was logged after midnight
+  // but before the 06:00 boundary.
+  final activities = [
+    UserActivityEntity(
+      'evening-of-the-19th',
+      45,
+      312.5,
+      DateTime(2026, 7, 19, 20, 0),
+      PhysicalActivityFixtures.moderateBicycling,
+    ),
+    UserActivityEntity(
+      'small-hours-of-the-20th',
+      20,
+      87.25,
+      DateTime(2026, 7, 20, 1, 0),
+      PhysicalActivityFixtures.lightDancing,
+    ),
+  ];
+
+  late _RecordingUserActivityRepository activityRepo;
+  late GetKcalGoalUsecase kcalGoalUsecase;
+  late GetKcalGoalBreakdownUsecase breakdownUsecase;
+
+  setUp(() {
+    DayBoundaryCalc.clock = () => beforeBoundary;
+    addTearDown(() => DayBoundaryCalc.clock = DateTime.now);
+
+    final userRepo = _FakeUserRepository(user);
+    final configRepo = _FakeConfigRepository(config);
+    activityRepo = _RecordingUserActivityRepository(activities);
+    kcalGoalUsecase = GetKcalGoalUsecase(userRepo, configRepo, activityRepo);
+    breakdownUsecase = GetKcalGoalBreakdownUsecase(
+      userRepo,
+      configRepo,
+      activityRepo,
+    );
+  });
+
+  test('the kcal goal asks for the logical day, not the wall-clock one',
+      () async {
+    await kcalGoalUsecase.getKcalGoal();
+
+    expect(activityRepo.requestedDay, logicalToday);
+  });
+
+  test('the breakdown asks for the same logical day', () async {
+    await breakdownUsecase.getBreakdown();
+
+    expect(activityRepo.requestedDay, logicalToday);
+  });
+
+  test('activities from before the boundary still count toward the goal',
+      () async {
+    final breakdown = await breakdownUsecase.getBreakdown();
+
+    expect(breakdown.activityKcal, closeTo(312.5 + 87.25, 0.0001));
+  });
+
+  test('goal and breakdown agree on the activity contribution', () async {
+    final breakdown = await breakdownUsecase.getBreakdown();
+    final goal = await kcalGoalUsecase.getKcalGoal();
+
+    expect(breakdown.totalKcalGoal, goal);
+  });
+}


### PR DESCRIPTION
## Summary

With a day-start offset configured, selecting a day in the diary calendar showed the **previous** day's entries. The offset was being subtracted from the calendar day the user tapped as well as from the stored entries, and subtracting six hours from a midnight day label lands in the day before.

The root cause is one type doing two jobs. A `DateTime` arriving at these queries is sometimes a **day label** (the calendar column the user tapped) and sometimes a **moment** (when an entry was logged). The offset must only ever move the moment.

## Type of change
- [x] Bug fix
- [ ] New feature
- [ ] Refactor / cleanup
- [ ] Documentation
- [ ] CI / tooling
- [ ] Localization
- [ ] Other

## Related issues

Fixes #586

## Changes

- `DayBoundaryCalc.isMomentInLogicalDayMinutes(dayLabel, moment, offset)` resolves only the moment through the boundary; the label names the column and stays put. Both query sites use it — `IntakeDataSource.getAllIntakesByDate` and `UserActivityDataSource.getAllUserActivitiesByDate` (activities had the identical defect).
- Some stored entries are themselves labels and have to be matched verbatim, or this fix would have hidden them a day early — trading one bug for another. Two writers produce them, in two spellings: adding *from the diary* stamps the calendar cell itself (`DateTime.utc(y, m, d)`, via `DayInfoWidget` → `AddMealScreenArguments` → `MealDetailBloc.addIntake`), and `JsonMealImporter` dates a `date`-only entry `DateTime(y, m, d)` — *local* midnight — with CSV import round-tripping the same shape. The marker is therefore a bare midnight rather than the UTC flag; keying off the flag alone moved every date-only import back a day as soon as a boundary was configured, already-stored rows included. The cost is that a live entry logged at exactly `00:00:00.000000` local stays on its wall-clock day, which `DateTime.now()`'s microseconds make a rounding error against mis-filing every import. Confirmed by disk round-trip that `hive_ce` preserves both the instant and the UTC flag, in `Europe/Berlin` and `America/New_York`.
- The `getToday…` reads had the mirror-image defect: they handed a raw `DateTime.now()` to a query that takes a label, which asks for the wall-clock date instead of the logical day. They now resolve the boundary first, so Home agrees with the diary between midnight and the boundary. (Without this, the first half of the fix would have *introduced* a Home-page bug.)
- `GetKcalGoalUsecase` and `GetKcalGoalBreakdownUsecase` read the day's activities the same way, to fold burned calories into the goal, and needed the same resolve. Left on a raw `now`, the goal would have dropped every one of those calories between midnight and the boundary while the activity list directly beneath it still listed them.
- The zero-offset fast paths are gone; the general predicate reduces to plain calendar-day equality when no offset is set. `flutter/material` imports dropped from both data sources with the last `DateUtils` use.
- `DayBoundaryCalc` gains an overridable `clock` (`@visibleForTesting`) so the "today" paths are testable — see the test-plan note below. Production never assigns it.

Deliberately **not** in scope: TrackedDay totals ignore the offset entirely (`CalendarDayBloc` reads `getTrackedDay(day)` with no offset, and the write key differs between adding via `MealDetailBloc` and editing via `HomeBloc`). That is why the pre-fix screenshots below show an empty day *header* above a populated meal list. It needs its own change with care about existing stored data.

Also out of scope, and worth its own issue: storing a label in a field named and typed `dateTime` is what forces the shape-sniffing above, and every new write path is a chance to break it silently. The durable fix is to stamp diary-added entries with a real instant on the selected day and keep the carve-out only as a legacy-data shim.

## Screenshots / recordings

Driven on a real Pixel 6 (Android, `develop` flavour) with day start set to 06:00, against pre-existing data in the app: demo history Jun 30–Jul 20, a real entry on Jul 23, and Jul 21/22/24/25 empty. That asymmetry is what makes the check discriminating, so the pre-fix `develop` APK was built and the identical taps repeated on the same stored data.

| Tapped | Before (develop) | After (this branch) |
|---|---|---|
| Mon **Jul 20** | Aerobic 54 min, Wholegrain bread 808 kcal, Salmon 95 g — *Jul 19's day* | Laufen 26 min, Oatmeal 840 kcal, Salmon 208 kcal ✓ |
| Tue **Jul 21** (no data) | Laufen, Oatmeal, Salmon — *Jul 20's day* | "Nothing added" ✓ |
| Thu **Jul 23** | 0 kcal, all meals empty — *Jul 22's day* | Orange 150 ml, 28 kcal ✓ |
| Fri **Jul 24** (no data) | **Orange 150 ml, 28 kcal** — *Jul 23's entry* | "Nothing added" ✓ |

## Test plan
- [x] Described steps below were followed locally
- [x] Unit / widget tests added or updated (if applicable)
- [x] Manual check on Android
- [ ] Manual check on iOS (if applicable) — not run; the change is in the shared data layer with no platform-specific code

New `test/unit_test/diary_day_selection_offset_test.dart` drives the real Hive-backed data sources with the exact `DateTime.utc(y, m, d)` label `table_calendar` produces, alongside an entry dated the importer's way, plus seven cases added to `day_boundary_calc_test.dart`.

New `test/unit_test/kcal_goal_logical_day_test.dart` covers the two goal usecases. It asserts on the day they hand the repository — through a recording fake — rather than on the calorie total downstream, so it fails both when the boundary is skipped and when the configured offset is ignored.

On the clock seam: the `getToday…` and goal reads only disagree with the wall-clock date between midnight and the boundary, so a test reading the real clock passes for most of the day whether the code is right or wrong. A first attempt at this test did exactly that — it passed against deliberately broken code. Pinning "now" at 02:00 is what makes it load-bearing.

Each of the following mutations was applied, run and reverted, to confirm the tests fail without the fix:

| Mutation | Failing tests |
|---|---|
| `getToday…` passes a raw `now` again | 3 |
| Offset applied to the day label again (the #586 bug) | 7 |
| Day-label carve-out removed | 3 |
| Kcal-goal reads pass a raw `now` again | 2 |
| Day-label carve-out keyed off the UTC flag again | 3 |

One flake fixed along the way: `Hive.deleteFromDisk()` in the new test file's `tearDown` was not awaited, so the deletion could land after the next test had reopened its box and fail it with a `PathNotFoundException`. Awaiting it is the fix — without a preceding `Hive.close()`, which deregisters the boxes and leaves nothing to delete, leaking entries into the next test instead. Several pre-existing test files share the un-awaited pattern and are left alone here.

### Steps
1. Settings → "Day starts at" → set 06:00.
2. Open the diary and select a day that has entries — its own entries are listed, not the previous day's.
3. Select a day with no entries adjacent to one that has them — it stays empty instead of borrowing its neighbour's.
4. Log a meal from the diary on a past day — it lands on the day selected, not the one before.
5. Between midnight and 06:00, check Home: the kcal goal's activity contribution matches the activities listed below it.
6. Reset the day start to 0:00 and confirm behaviour is unchanged from before this PR.

## Checklist
- [ ] Code follows project style (`just format` / 120-char line width) — style matched to the surrounding code, but `just format` was **not** run: the pinned SDK's formatter rewrites these files on `develop` too, so running it would bury the change in unrelated reformatting. CI skips the format pass for this reason (see the comment in `default_workflow.yml`).
- [x] New interactive widgets include `Semantics(identifier: '...')` where needed — no new widgets
- [x] Localization updated in ARBs **and** `lib/generated/` when user-facing strings change — no string changes
- [x] Codegen ran if DBOs/DTOs/env changed (`just build`) — no DBO/DTO/env changes
- [x] No secrets or `.env` values committed
- [x] PR title follows conventional commit style (e.g. `feat:`, `fix:`, `chore:`)

`flutter test` 842 passing, `flutter analyze` clean.
