### PR TITLE
fix(ui): stop AppCard's corner radius clipping its own content

### DIFF
--- a/lib/core/presentation/widgets/app_card.dart
+++ b/lib/core/presentation/widgets/app_card.dart
@@ -38,7 +38,6 @@ class AppCard extends StatelessWidget {
     final tile = Container(
       width: width,
       height: height,
-      padding: padding,
       decoration: BoxDecoration(
         color: color ?? palette.surface,
         borderRadius: radius,
@@ -52,13 +51,24 @@ class AppCard extends StatelessWidget {
       // reaching past the decoration for one further up the tree. Clipped to
       // the card radius so descendant ink splashes/highlights stay within the
       // rounded corners instead of painting square past them.
+      //
+      // The Material must span the whole card, with [padding] applied inside
+      // it — not on the Container around it. Padding the Container instead
+      // shrinks the Material to the content box while the clip keeps the
+      // card's full radius, so the corner arc curves in over the content and
+      // takes a bite out of anything flush against the edge. That clipped the
+      // first glyph of left-aligned text sitting in a card corner, e.g. the
+      // "374/428 g" totals in the home macro tiles.
       child: child == null
           ? null
           : Material(
               color: Colors.transparent,
               borderRadius: radius,
               clipBehavior: Clip.antiAlias,
-              child: child,
+              child: Padding(
+                padding: padding ?? EdgeInsets.zero,
+                child: child,
+              ),
             ),
     );
     if (onTap == null) return tile;

--- a/test/core/presentation/widgets/app_card_test.dart
+++ b/test/core/presentation/widgets/app_card_test.dart
@@ -49,16 +49,17 @@ void main() {
     testWidgets('padding still spaces the child away from the card edge',
         (tester) async {
       const padding = EdgeInsets.all(16);
+      const childKey = Key('app-card-test-child');
 
       await tester.pumpWidget(_wrap(
         const AppCard(
           padding: padding,
-          child: SizedBox(width: 100, height: 40),
+          child: SizedBox(key: childKey, width: 100, height: 40),
         ),
       ));
 
       final card = tester.getRect(find.byType(AppCard));
-      final child = tester.getRect(find.byType(SizedBox).last);
+      final child = tester.getRect(find.byKey(childKey));
       const inset = Dimens.hairline; // the bordered decoration
 
       expect(child.left - card.left, padding.left + inset);

--- a/test/core/presentation/widgets/app_card_test.dart
+++ b/test/core/presentation/widgets/app_card_test.dart
@@ -1,0 +1,70 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:opennutritracker/core/presentation/widgets/app_card.dart';
+import 'package:opennutritracker/core/styles/dimens.dart';
+
+Widget _wrap(Widget child) => MaterialApp(
+      home: Scaffold(body: Center(child: child)),
+    );
+
+void main() {
+  group('AppCard', () {
+    testWidgets(
+        'clipping Material spans the whole card, not the padded content box '
+        '(regression: padding on the Container shrank the Material while the '
+        'clip kept the full corner radius, so the arc curved in over the '
+        'content and sliced the first glyph of text in a card corner — the '
+        'home macro totals rendered "89/79 g" as "39/79 g")',
+        (tester) async {
+      const radius = 20.0;
+      const padding = EdgeInsets.all(16);
+
+      await tester.pumpWidget(_wrap(
+        const AppCard(
+          borderRadius: radius,
+          padding: padding,
+          child: SizedBox(width: 100, height: 40),
+        ),
+      ));
+
+      final cardSize = tester.getSize(find.byType(AppCard));
+      final clipMaterial = find.descendant(
+        of: find.byType(AppCard),
+        matching: find.byWidgetPredicate(
+          (w) => w is Material && w.clipBehavior == Clip.antiAlias,
+        ),
+      );
+
+      expect(clipMaterial, findsOneWidget);
+      // The Material fills the card short of its hairline border. If it were
+      // inside the padding instead it would measure the content box (100x40)
+      // rather than 132x72, and the corner arc would eat into the child.
+      expect(
+        tester.getSize(clipMaterial),
+        Size(cardSize.width - 2 * Dimens.hairline,
+            cardSize.height - 2 * Dimens.hairline),
+      );
+    });
+
+    testWidgets('padding still spaces the child away from the card edge',
+        (tester) async {
+      const padding = EdgeInsets.all(16);
+
+      await tester.pumpWidget(_wrap(
+        const AppCard(
+          padding: padding,
+          child: SizedBox(width: 100, height: 40),
+        ),
+      ));
+
+      final card = tester.getRect(find.byType(AppCard));
+      final child = tester.getRect(find.byType(SizedBox).last);
+      const inset = Dimens.hairline; // the bordered decoration
+
+      expect(child.left - card.left, padding.left + inset);
+      expect(child.top - card.top, padding.top + inset);
+      expect(card.right - child.right, padding.right + inset);
+      expect(card.bottom - child.bottom, padding.bottom + inset);
+    });
+  });
+}


### PR DESCRIPTION
## Summary

`AppCard` applied its `padding` to the decorated `Container` and placed the clipping `Material` *inside* it. The clip therefore carried the card's full corner radius but was applied to the **content box** rather than to the card, so the corner arc curved in over the content and sliced the first glyph of anything sitting flush against the edge.

This is not purely cosmetic. On the home macro tiles the fat total `89/79 g` lost the left of its leading `8` and rendered as `39/79 g` — showing someone **10 g over** their goal as **40 g under** it. Any total whose leading digit is 8, 9, 6 or 0 can misread the same way.

## Type of change
- [x] Bug fix

## Related issues
<!-- none filed; found while re-shooting the README screenshots -->

## Changes

- Move `padding` inside the clipping `Material` so the clip spans the whole card. Layout is unchanged — the content box keeps its size and position — and descendant ink splashes now clip to the card's real corners, which is what the surrounding comment always intended.
- Add `test/core/presentation/widgets/app_card_test.dart` with two tests: one asserting the clip bounds, one asserting padding still spaces the child so a future refactor can't "fix" the clip by dropping the padding.

## Affected surfaces

| Text | Before | After |
| :-- | :-- | :-- |
| Home, carbs total | `374/428 g` with the `3` sliced | `374/428 g` |
| Home, fat total | `39/79 g` (actually `89/79 g`) | `89/79 g` |
| Home, protein total | `92/107 g` with the `9` sliced | `92/107 g` |
| Trends, card titles | `alories`, `aily average` | `Calories`, `Daily average` |

The macro *labels* (`carbs`, `fat`, `protein`) were never affected — a 9px bullet and a 6px gap push them clear of the arc, which is why the bug survived this long.

## Test plan
- [x] Described steps below were followed locally
- [x] Unit / widget tests added or updated (if applicable)
- [x] Manual check on Android
- [ ] Manual check on iOS (if applicable)

### Steps
1. `fvm flutter test test/core/presentation/widgets/app_card_test.dart` — both pass.
2. Revert the `app_card.dart` change and re-run: the clip-bounds test **fails**. Confirmed the test actually catches the regression rather than passing either way.
3. `fvm flutter test test/features/home/presentation/widgets/dashboard_widget_test.dart test/features/settings/presentation/widgets/kcal_goal_info_screen_test.dart test/widget_test/widget_test.dart` — 15 pass.
4. `fvm flutter analyze lib/core/presentation/widgets/app_card.dart` — clean.
5. Built and installed on a Pixel 6 (1080x2400, density 420) and compared the home macro row before/after.

Diagnosis note: the symptom is independent of font, renderer and screen density. It reproduces on a Pixel 6 and on an emulator at densities 420 and 480, with Impeller both enabled and disabled, and is unchanged by swapping Nunito's variable font for static instanced weights. A probe screen rendering the same string in the same style outside an `AppCard` shows no clipping at all.

## Checklist
- [x] Code follows project style (`just format` / 120-char line width)
- [x] New interactive widgets include `Semantics(identifier: '...')` where needed (n/a)
- [x] Localization updated in ARBs **and** `lib/generated/` when user-facing strings change (n/a)
- [x] Codegen ran if DBOs/DTOs/env changed (n/a)
- [x] No secrets or `.env` values committed
- [x] PR title follows conventional commit style