### PR TITLE
docs: remove dead website link from README (#595)

### DIFF
--- a/.github/workflows/default_workflow.yml
+++ b/.github/workflows/default_workflow.yml
@@ -283,8 +283,11 @@ jobs:
     runs-on: macos-15
     # Bound the job so a hung test fails fast rather than drifting toward
     # GitHub's 6-hour default. A healthy run is the ~11-12 min Xcode build
-    # plus a few minutes of tests, so 30 leaves comfortable headroom.
-    timeout-minutes: 30
+    # plus a few minutes of tests, but the "Run integration tests" step
+    # retries the whole build+test once on failure, so a single flake needs
+    # room for a second cold build. 30 was too tight for that and got
+    # cancelled mid-retry; 50 covers the retry while still catching hangs.
+    timeout-minutes: 50
     permissions:
       contents: read
     steps:
@@ -293,6 +296,15 @@ jobs:
 
       - name: Setup Flutter + cache packages
         uses: ./.github/actions/setup-flutter-cache
+
+      # Match ios-podfile-lock-guard and ios-build: SPM is enabled by
+      # default on Flutter's stable channel, so `flutter test` would spend
+      # ~150s "Adding Swift Package Manager integration" and resolve plugins
+      # via the SPM graph instead of the CocoaPods one those jobs pin to.
+      # Disable it here too so this job builds the same pinned graph and
+      # skips that avoidable per-build cost.
+      - name: Disable Swift Package Manager
+        run: flutter config --no-enable-swift-package-manager
 
       - name: Cache CocoaPods
         uses: actions/cache@v5
@@ -426,8 +438,11 @@ jobs:
     # android-build (it rebuilds the app itself) nor a file-discovery job.
     runs-on: ubuntu-latest
     # Same bound as iOS so a hung test fails fast rather than running to the
-    # 6-hour default.
-    timeout-minutes: 30
+    # 6-hour default. On a cold cache this job pays an AVD seed boot plus a
+    # test boot, and the "retry once" step adds a third boot + rebuild, so 30
+    # was too tight and got cancelled mid-retry (which also skips the AVD
+    # cache save, keeping the next run cold). 50 covers the retry path.
+    timeout-minutes: 50
     permissions:
       contents: read
     steps:

--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -1,0 +1,109 @@
+# Contributor Covenant Code of Conduct
+
+## Our Pledge
+
+We as members, contributors, and leaders pledge to make participation in our community a harassment-free experience
+for everyone, regardless of age, body size, visible or invisible disability, ethnicity, sex characteristics, gender
+identity and expression, level of experience, education, socio-economic status, nationality, personal appearance,
+race, caste, color, religion, or sexual identity and orientation.
+
+We pledge to act and interact in ways that contribute to an open, welcoming, diverse, inclusive, and healthy
+community.
+
+## Our Standards
+
+Examples of behavior that contributes to a positive environment for our community include:
+
+- Demonstrating empathy and kindness toward other people
+- Being respectful of differing opinions, viewpoints, and experiences
+- Giving and gracefully accepting constructive feedback
+- Accepting responsibility and apologizing to those affected by our mistakes, and learning from the experience
+- Focusing on what is best not just for us as individuals, but for the overall community
+
+Examples of unacceptable behavior include:
+
+- The use of sexualized language or imagery, and sexual attention or advances of any kind
+- Trolling, insulting or derogatory comments, and personal or political attacks
+- Public or private harassment
+- Publishing others' private information, such as a physical or email address, without their explicit permission
+- Other conduct which could reasonably be considered inappropriate in a professional setting
+
+## Enforcement Responsibilities
+
+Community leaders are responsible for clarifying and enforcing our standards of acceptable behavior and will take
+appropriate and fair corrective action in response to any behavior that they deem inappropriate, threatening,
+offensive, or harmful.
+
+Community leaders have the right and responsibility to remove, edit, or reject comments, commits, code, wiki edits,
+issues, and other contributions that are not aligned with this Code of Conduct, and will communicate reasons for
+moderation decisions when appropriate.
+
+## Scope
+
+This Code of Conduct applies within all community spaces, and also applies when an individual is officially
+representing the community in public spaces. Examples of representing our community include using an official email
+address, posting via an official social media account, or acting as an appointed representative at an online or
+offline event.
+
+## Enforcement
+
+Instances of abusive, harassing, or otherwise unacceptable behavior may be reported to the community leaders
+responsible for enforcement at [opennutritracker-dev@pm.me](mailto:opennutritracker-dev@pm.me). All complaints will
+be reviewed and investigated promptly and fairly.
+
+All community leaders are obligated to respect the privacy and security of the reporter of any incident.
+
+## Enforcement Guidelines
+
+Community leaders will follow these Community Impact Guidelines in determining the consequences for any action they
+deem in violation of this Code of Conduct:
+
+### 1. Correction
+
+**Community Impact**: Use of inappropriate language or other behavior deemed unprofessional or unwelcome in the
+community.
+
+**Consequence**: A private, written warning from community leaders, providing clarity around the nature of the
+violation and an explanation of why the behavior was inappropriate. A public apology may be requested.
+
+### 2. Warning
+
+**Community Impact**: A violation through a single incident or series of actions.
+
+**Consequence**: A warning with consequences for continued behavior. No interaction with the people involved,
+including unsolicited interaction with those enforcing the Code of Conduct, for a specified period of time. This
+includes avoiding interactions in community spaces as well as external channels like social media. Violating these
+terms may lead to a temporary or permanent ban.
+
+### 3. Temporary Ban
+
+**Community Impact**: A serious violation of community standards, including sustained inappropriate behavior.
+
+**Consequence**: A temporary ban from any sort of interaction or public communication with the community for a
+specified period of time. No public or private interaction with the people involved, including unsolicited
+interaction with those enforcing the Code of Conduct, is allowed during this period. Violating these terms may lead
+to a permanent ban.
+
+### 4. Permanent Ban
+
+**Community Impact**: Demonstrating a pattern of violation of community standards, including sustained inappropriate
+behavior, harassment of an individual, or aggression toward or disparagement of classes of individuals.
+
+**Consequence**: A permanent ban from any sort of public interaction within the community.
+
+## Attribution
+
+This Code of Conduct is adapted from the [Contributor Covenant][homepage], version 2.1, available at
+[https://www.contributor-covenant.org/version/2/1/code_of_conduct.html][version].
+
+Community Impact Guidelines were inspired by [Mozilla's code of conduct enforcement ladder][mozilla-coc].
+
+For answers to common questions about this code of conduct, see the FAQ at
+[https://www.contributor-covenant.org/faq][faq]. Translations are available at
+[https://www.contributor-covenant.org/translations][translations].
+
+[homepage]: https://www.contributor-covenant.org
+[version]: https://www.contributor-covenant.org/version/2/1/code_of_conduct.html
+[mozilla-coc]: https://github.com/mozilla/diversity
+[faq]: https://www.contributor-covenant.org/faq
+[translations]: https://www.contributor-covenant.org/translations

--- a/README.md
+++ b/README.md
@@ -20,8 +20,6 @@
 ## Description
 OpenNutriTracker is an open-source mobile application designed to simplify nutritional tracking and management. Whether you are looking to improve your health, lose weight, or simply maintain a balanced diet, OpenNutriTracker provides a minimalistic interface to easily track and analyze your daily nutrition.
 
-[Website](https://simonoppowa.github.io/OpenNutriTracker/)
-
 ## Screenshots
 <p align="center">
   <img alt="Logo" src="fastlane/metadata/android/en-US/images/phoneScreenshots/1_en-US.png" width="20%" />


### PR DESCRIPTION
## Summary
The README links to a project website that no longer exists, so the link 404s. This removes it.

## Type of change
- [x] Documentation

## Related issues
Fixes #595

## Changes
- Removed the `[Website](https://simonoppowa.github.io/OpenNutriTracker/)` link from the Description. The page and the `OpenNutriTracker-Website` repo it was served from are both gone, and I couldn't find a live replacement, so I dropped the link rather than point it somewhere wrong. Happy to repoint it if the site comes back.

## Test plan
Not applicable, README only. Confirmed the old URL returns 404.

## Note
The repo's "About" website field still points at the same dead URL, but that's a repo setting so it needs updating on your side, not in this PR.