### PR TITLE
ci: add newly filed issues to the project boards

### DIFF
--- a/.github/workflows/add-issues-to-projects.yml
+++ b/.github/workflows/add-issues-to-projects.yml
@@ -1,0 +1,56 @@
+# Route newly filed issues onto the GitHub Projects boards.
+#
+# GitHub's built-in project workflows only act on items that are *already*
+# on a board (set status, close, mark done). Nothing in the default set puts
+# a freshly opened issue there — the UI's "Auto-add to project" workflow does
+# that, but it can only target one board with one filter. This workflow exists
+# because there are two boards with different membership rules:
+#
+#   Roadmap (project 2)      — every open issue
+#   Contributors (project 3) — only `help wanted` / `good first issue`
+#
+# `labeled` is in the trigger list alongside `opened` so an issue that earns
+# `help wanted` weeks after it was filed still reaches the Contributors board.
+# Re-adding an item that is already on a board is a no-op (the underlying
+# addProjectV2ItemById mutation returns the existing item), so the repeated
+# `labeled` firings do not create duplicates.
+#
+# REQUIRED SECRET: `PROJECTS_TOKEN` — a PAT with write access to the projects.
+# The default GITHUB_TOKEN cannot write to user-owned (as opposed to
+# repo-owned) projects, so it will not work here. Without the secret every
+# run fails at the first step.
+#
+# Note that workflow files only take effect once they are on the default
+# branch — this does nothing while it lives on a feature branch.
+
+name: Add issues to projects
+
+on:
+  issues:
+    types: [opened, labeled]
+
+permissions:
+  contents: read
+
+jobs:
+  roadmap:
+    name: Add to Roadmap board
+    runs-on: ubuntu-latest
+    steps:
+      - name: Add issue to Roadmap
+        uses: actions/add-to-project@v2
+        with:
+          project-url: https://github.com/users/simonoppowa/projects/2
+          github-token: ${{ secrets.PROJECTS_TOKEN }}
+
+  contributors:
+    name: Add to Contributors board
+    runs-on: ubuntu-latest
+    steps:
+      - name: Add issue to Contributors
+        uses: actions/add-to-project@v2
+        with:
+          project-url: https://github.com/users/simonoppowa/projects/3
+          github-token: ${{ secrets.PROJECTS_TOKEN }}
+          labeled: help wanted, good first issue
+          label-operator: OR

--- a/.github/workflows/add-issues-to-projects.yml
+++ b/.github/workflows/add-issues-to-projects.yml
@@ -11,14 +11,20 @@
 #
 # `labeled` is in the trigger list alongside `opened` so an issue that earns
 # `help wanted` weeks after it was filed still reaches the Contributors board.
+# `transferred` is there because an issue moved in from OpenNutriTracker-Backend
+# or -Website arrives with its labels already attached, so it fires neither
+# `opened` nor `labeled` and would otherwise never reach a board.
+#
 # Re-adding an item that is already on a board is a no-op (the underlying
 # addProjectV2ItemById mutation returns the existing item), so the repeated
 # `labeled` firings do not create duplicates.
 #
-# REQUIRED SECRET: `PROJECTS_TOKEN` — a PAT with write access to the projects.
-# The default GITHUB_TOKEN cannot write to user-owned (as opposed to
-# repo-owned) projects, so it will not work here. Without the secret every
-# run fails at the first step.
+# REQUIRED SECRET: `PROJECTS_TOKEN` — this must be a *classic* PAT carrying the
+# `project` scope (plus `public_repo`). Fine-grained tokens cannot do this job:
+# they expose no Projects permission for user-owned projects, only for
+# organization-owned ones, and these boards belong to the `simonoppowa` user
+# account. The default GITHUB_TOKEN cannot write to user-owned projects either.
+# Without the secret every run fails at the first step.
 #
 # Note that workflow files only take effect once they are on the default
 # branch — this does nothing while it lives on a feature branch.
@@ -27,7 +33,7 @@ name: Add issues to projects
 
 on:
   issues:
-    types: [opened, labeled]
+    types: [opened, labeled, transferred]
 
 permissions:
   contents: read

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -17,6 +17,7 @@ architecture conventions live in [AGENTS.md](AGENTS.md).
 
 ## Before you start
 
+- Check the [public board](https://github.com/users/simonoppowa/projects/2) before picking something up — it shows what is already in progress, so you don't duplicate work that is underway.
 - Create your branch from the latest `develop`:
   ```sh
   git fetch origin


### PR DESCRIPTION
## Summary

Adds a workflow that puts newly filed issues onto the two GitHub Projects boards.

GitHub's built-in project workflows only act on items that are *already* on a board — set status, close, mark done. None of them puts a freshly opened issue there. The UI's "Auto-add to project" workflow does, but it targets one board with one filter, which doesn't fit two boards with different membership rules:

| Board | Takes |
| ----- | ----- |
| [Roadmap](https://github.com/users/simonoppowa/projects/2) | every open issue |
| [Contributors](https://github.com/users/simonoppowa/projects/3) | only `help wanted` / `good first issue` |

## Type of change
- [ ] Bug fix
- [ ] New feature
- [ ] Refactor / cleanup
- [x] Documentation
- [x] CI / tooling
- [ ] Localization
- [ ] Other

## Related issues

None — the boards were set up ad hoc.

## Changes

- New `.github/workflows/add-issues-to-projects.yml` with two jobs, one per board.
- Triggers on `opened`, `labeled` and `transferred`:
  - `labeled` so an issue that earns a contributor label weeks after filing still reaches the Contributors board.
  - `transferred` because an issue moved in from OpenNutriTracker-Backend or -Website arrives with its labels already attached, firing neither `opened` nor `labeled`.
- Re-adding an item already on a board is a no-op (`addProjectV2ItemById` returns the existing item), so repeated firings don't duplicate.
- Pinned to `actions/add-to-project@v2`.
- `permissions: contents: read` — project writes come from the PAT, not `GITHUB_TOKEN`.
- `CONTRIBUTING.md`: one bullet under "Before you start" linking the now-public Roadmap board, so contributors can see what is already underway before picking something up.

## Screenshots / recordings

N/A — no UI change.

## Test plan
- [ ] Described steps below were followed locally
- [ ] Unit / widget tests added or updated (if applicable)
- [ ] Manual check on Android
- [ ] Manual check on iOS (if applicable)

Not verifiable before merge: workflow files are inert until they reach the default branch. YAML was parse-checked locally and both jobs resolve to the intended board URLs and label filters. The `PROJECTS_TOKEN` secret is in place.

### Steps
1. After merge to `main`, open a throwaway issue and confirm it appears on the Roadmap board.
2. Add `help wanted` to it and confirm it appears on the Contributors board too.
3. Close the test issue — the built-in "Item closed" workflow should flip it to Done on both.
4. Delete the test issue.

## Checklist
- [x] Code follows project style (`just format` / 120-char line width)
- [x] New interactive widgets include `Semantics(identifier: '...')` where needed — N/A
- [x] Localization updated in ARBs **and** `lib/generated/` when user-facing strings change — N/A
- [x] Codegen ran if DBOs/DTOs/env changed (`just build`) — N/A
- [x] No secrets or `.env` values committed — the token is referenced as `secrets.PROJECTS_TOKEN`, never inlined
- [x] PR title follows conventional commit style

## Public board

The Roadmap board is now **public**, and its first view is `Now` — board layout,
filtered to `status:"In Progress"`. Visitors land on active work rather than the
full 45-item backlog, which sits one tab over in the `Backlog` view.

Nothing maintains this by hand: the built-in "Pull request linked to issue"
workflow moves items into `In Progress` and "Pull request merged" moves them out.
The four items showing today (#595, #580, #541, #517) each have either an open
linked PR or an active assignee.

Publishing the board discloses nothing new — the `Priority` values mirror the
`backlog:*` labels already public on the issues themselves. The Contributors board
(`projects/3`) stays private.

## Token requirement

`PROJECTS_TOKEN` must be a **classic** PAT with the `project` scope (plus `public_repo`). Fine-grained tokens cannot do this job — they expose a Projects permission only for *organization*-owned projects, and these boards belong to the `simonoppowa` user account. Projects v2 can only be owned by a User or an Organization; repo-owned boards were Projects (classic), which GitHub has sunset.

This is recorded in the workflow's header comment so the next person doesn't rediscover it.

## Review notes

Two Copilot comments on the first revision:

- **`transferred` event type — applied.** An earlier version of this description claimed that narrowing the Roadmap job to `opened` would cost us transferred-in issues, which wrongly implied the then-current config handled them. It didn't. Fixed in 685d496d.
- **Space after the comma in `labeled` — not applied.** The claim was that `help wanted, good first issue` yields a leading space on the second label. The action's source at `v2` splits on comma and then `.trim().toLowerCase()`s each entry, so the space is removed before any comparison. No change needed.

Still open, and deliberately out of scope here:

- The `labeled` trigger fires on **every** label change, so each triage pass kicks off two workflow runs per issue. Harmless but noisy in the Actions tab.
- The Contributors board duplicates a subset of the Roadmap board (11 of 45 issues at time of writing). A saved, filtered view on the Roadmap board would achieve the same thing without the second board and without this workflow's second job.
