### PR TITLE
fix(profile): stop stone weights from showing a full stone of pounds

### DIFF
--- a/lib/core/utils/calc/unit_calc.dart
+++ b/lib/core/utils/calc/unit_calc.dart
@@ -73,10 +73,20 @@ class UnitCalc {
   /// the UK-style "11 st 5.2 lb" display and input. Pounds keep two decimals,
   /// mirroring [lbsToKg], and a value that rounds up to a full 14 lb rolls
   /// into the next stone so we never show "10 st 14.0 lb".
-  static (int stones, double pounds) kgToStLb(double kg) {
+  ///
+  /// [poundsDecimals] is the precision the pounds figure is rounded to, and
+  /// the roll-over is checked against that rounded value. It matters because
+  /// every screen prints one decimal while the default here keeps two: a
+  /// 13.99 lb remainder clears the guard, then renders as "14", which is a
+  /// whole stone shown as a remainder ("9 st 14 lb" for a weight that is
+  /// 10 st). Callers that display the result pass 1; the two-decimal default
+  /// is what [stLbToKg] round-trips against.
+  static (int stones, double pounds) kgToStLb(double kg,
+      {int poundsDecimals = 2}) {
     final totalLbs = kg * 2.20462;
     var stones = totalLbs ~/ 14;
-    var pounds = double.parse((totalLbs - stones * 14).toStringAsFixed(2));
+    var pounds =
+        double.parse((totalLbs - stones * 14).toStringAsFixed(poundsDecimals));
     if (pounds >= 14.0) {
       stones += 1;
       pounds = 0.0;

--- a/lib/features/profile/presentation/utils/profile_display_format.dart
+++ b/lib/features/profile/presentation/utils/profile_display_format.dart
@@ -45,7 +45,9 @@ String formatBodyWeight(
     case BodyWeightUnit.lb:
       return '${formatProfileWeight(UnitCalc.kgToLbs(weightKg))} $lbLabel';
     case BodyWeightUnit.st:
-      final (stones, pounds) = UnitCalc.kgToStLb(weightKg);
+      // One decimal, because that is what formatProfileWeight prints: at the
+      // two-decimal default a 13.99 lb remainder renders as a full stone.
+      final (stones, pounds) = UnitCalc.kgToStLb(weightKg, poundsDecimals: 1);
       return '$stones $stLabel ${formatProfileWeight(pounds)} $lbLabel';
   }
 }

--- a/lib/features/profile/presentation/widgets/body_weight_input.dart
+++ b/lib/features/profile/presentation/widgets/body_weight_input.dart
@@ -70,7 +70,9 @@ class _BodyWeightInputState extends State<BodyWeightInput> {
       case BodyWeightUnit.lb:
         _singleController.text = _trim(UnitCalc.kgToLbs(kg));
       case BodyWeightUnit.st:
-        final (stones, pounds) = UnitCalc.kgToStLb(kg);
+        // _trim prints one decimal, so ask for the split at that precision
+        // rather than seeding the field with a full stone of pounds.
+        final (stones, pounds) = UnitCalc.kgToStLb(kg, poundsDecimals: 1);
         _stonesController.text = stones.toString();
         _poundsController.text = _trim(pounds);
     }

--- a/lib/features/profile/profile_page.dart
+++ b/lib/features/profile/profile_page.dart
@@ -629,7 +629,9 @@ class _ProfilePageState extends State<ProfilePage> {
         formatted =
             '${(deltaKg * 2.20462).toStringAsFixed(1)} ${S.of(context).lbsLabel}';
       case BodyWeightUnit.st:
-        final (stones, pounds) = UnitCalc.kgToStLb(deltaKg);
+        // Split at the one decimal this line prints, so a remainder that
+        // rounds to 14 lb lands as the next whole stone instead.
+        final (stones, pounds) = UnitCalc.kgToStLb(deltaKg, poundsDecimals: 1);
         formatted =
             '$stones ${S.of(context).stLabel} ${pounds.toStringAsFixed(1)} ${S.of(context).lbsLabel}';
     }

--- a/test/unit_test/body_weight_format_test.dart
+++ b/test/unit_test/body_weight_format_test.dart
@@ -91,13 +91,33 @@ void main() {
 
     test('kgToStLb raw pounds value never reaches 14.0', () {
       // The rollover guard in kgToStLb ensures the raw pounds value stays
-      // strictly below 14.0 before formatProfileWeight sees it. Note that
-      // formatProfileWeight may round 13.99 up to 14.0 for display — that is
-      // a separate display concern and not tested here.
+      // strictly below 14.0 before formatProfileWeight sees it.
       for (final kg in const [50.0, 63.5, 70.0, 80.0, 100.0]) {
         final (_, pounds) = UnitCalc.kgToStLb(kg);
         expect(pounds, lessThan(14.0),
             reason: 'raw pounds from kgToStLb($kg) should be less than 14, got $pounds');
+      }
+    });
+
+    test('a remainder that rounds to 14 lb is shown as the next stone', () {
+      // 10 st is 63.5029 kg. Just under that, the raw remainder is 13.97 lb,
+      // which clears the two-decimal rollover guard but prints as '14' once
+      // formatProfileWeight rounds it to one decimal.
+      const justUnderTenStoneKg = 63.49;
+      expect(
+        formatBodyWeight(justUnderTenStoneKg, BodyWeightUnit.st, kgLabel: kgLabel, lbLabel: lbLabel, stLabel: stLabel),
+        equals('10 st 0 lbs'),
+      );
+    });
+
+    test('no weight in the supported range prints 14 lb', () {
+      // Sweep 30-250 kg in 10 g steps: the pounds component must never read
+      // as a whole stone, whatever the stones count is.
+      for (var grams = 30000; grams <= 250000; grams += 10) {
+        final kg = grams / 1000.0;
+        final result =
+            formatBodyWeight(kg, BodyWeightUnit.st, kgLabel: kgLabel, lbLabel: lbLabel, stLabel: stLabel);
+        expect(result, isNot(endsWith(' 14 $lbLabel')), reason: '$kg kg formatted as "$result"');
       }
     });
   });

--- a/test/unit_test/unit_calc_imperial_round_trip_test.dart
+++ b/test/unit_test/unit_calc_imperial_round_trip_test.dart
@@ -196,6 +196,21 @@ void main() {
       expect(pounds, lessThan(14.0),
           reason: 'pounds should never reach 14.0 after rollover guard');
     });
+
+    test('poundsDecimals: 1 rolls over a remainder the default keeps', () {
+      // 63.49 kg is 9 st 13.978 lb. At two decimals that is 13.97, which
+      // clears the guard; at the one decimal every screen prints, it is a
+      // full stone and has to roll over.
+      const kg = 63.49;
+      expect(UnitCalc.kgToStLb(kg), equals((9, 13.97)));
+      expect(UnitCalc.kgToStLb(kg, poundsDecimals: 1), equals((10, 0.0)));
+    });
+
+    test('poundsDecimals: 1 keeps a normal remainder at one decimal', () {
+      final (stones, pounds) = UnitCalc.kgToStLb(70.0, poundsDecimals: 1);
+      expect(stones, equals(11));
+      expect(pounds, closeTo(0.3, 0.05));
+    });
   });
 
   group('UnitCalc.cmToFeetInches / feetInchesToCm', () {


### PR DESCRIPTION
## Summary

With the body weight unit set to stones, some weights render with 14 lb in the pounds slot, which is a whole stone. 63.49 kg shows as "9 st 14 lbs" when it is 10 st.

`UnitCalc.kgToStLb` already guards against this, but at two decimals: it rounds the remainder to 2dp and rolls over when that hits 14.00. Every screen then prints the value at one decimal, and a remainder like 13.97 clears the 2dp guard and rounds to 14 on the way to the label. The existing test in `body_weight_format_test.dart` names this ("formatProfileWeight may round 13.99 up to 14.0 for display") and leaves it as a separate concern, so I picked it up.

Repro on `develop`, calling the real `formatBodyWeight`:

```
31.74 kg -> "4 st 14 lbs"
44.44 kg -> "6 st 14 lbs"
63.49 kg -> "9 st 14 lbs"
76.19 kg -> "11 st 14 lbs"
88.89 kg -> "13 st 14 lbs"
```

Same call with this branch:

```
31.74 kg -> "5 st 0 lbs"
44.44 kg -> "7 st 0 lbs"
63.49 kg -> "10 st 0 lbs"
76.19 kg -> "12 st 0 lbs"
88.89 kg -> "14 st 0 lbs"
```

Sweeping 30 to 250 kg in 10 g steps, 62 values hit it before, 0 after.

## Type of change
- [x] Bug fix
- [ ] New feature
- [ ] Refactor / cleanup
- [ ] Documentation
- [ ] CI / tooling
- [ ] Localization
- [ ] Other

## Related issues

None open that I could find, and no PR touching the st/lb path.

## Changes

- `UnitCalc.kgToStLb` takes an optional `poundsDecimals`, defaulting to the existing 2. The remainder is rounded to that precision and the roll-over guard is checked against the rounded value, so the invariant holds at whatever precision the caller is going to print.
- The three places that display the split pass `poundsDecimals: 1`: `formatBodyWeight` (profile page, home weight chip, weight history), the st/lb seed in `BodyWeightInput`, and the target-weight delta on the profile page. All three print one decimal today.
- `stLbToKg` and `ValueValidator.parseStLbWeightInKg` are untouched. They go through the default, so stored values and the kg round-trip are unchanged.

I kept this as a parameter on the existing function rather than a second helper because the roll-over rule and the rounding it depends on belong together. Splitting them is what let the two drift apart in the first place.

## Screenshots / recordings

Text-only change, no layout difference. The before/after strings above are the user-visible part.

## Test plan
- [x] Described steps below were followed locally
- [x] Unit / widget tests added or updated (if applicable)
- [ ] Manual check on Android
- [ ] Manual check on iOS (if applicable)

I do not have an Android or iOS device set up here, so this is unit-tested only. The three call sites are pure formatting off the same helper, and the test sweep covers the range the app accepts, but flagging that I did not put it on a handset.

### Steps
1. `flutter test test/unit_test/body_weight_format_test.dart test/unit_test/unit_calc_imperial_round_trip_test.dart` - 46 passing.
2. `flutter test` - 966 passing, up from 962 on `develop`.
3. `flutter analyze` - "No issues found!".
4. Mutation check: reverted the `lib/` half and re-ran, which fails "a remainder that rounds to 14 lb is shown as the next stone" and "no weight in the supported range prints 14 lb".

New tests:

- `body_weight_format_test.dart`: 63.49 kg formats as "10 st 0 lbs", plus a sweep of 30 to 250 kg asserting the pounds component never reads as 14.
- `unit_calc_imperial_round_trip_test.dart`: `kgToStLb(63.49)` is still `(9, 13.97)` at the default, and `(10, 0.0)` with `poundsDecimals: 1`. Also a plain case so the new precision is not just testing the boundary.

I also dropped the now-stale note in the existing "raw pounds value never reaches 14.0" test that said the display rounding was out of scope.

## Checklist
- [x] Code follows project style (`just format` / 120-char line width)
- [x] New interactive widgets include `Semantics(identifier: '...')` where needed
- [x] Localization updated in ARBs **and** `lib/generated/` when user-facing strings change
- [x] Codegen ran if DBOs/DTOs/env changed (`just build`)
- [x] No secrets or `.env` values committed
- [x] PR title follows conventional commit style (e.g. `feat:`, `fix:`, `chore:`)

No new strings, no widgets, no DBO or DTO changes, so the localization and codegen boxes are nothing-to-do rather than done. On formatting: I matched the surrounding style by hand instead of running `just format`, since `dart format` on 3.44.6 rewrites 260 files here and the workflow comment says the format pass is deliberately parked for its own PR.
