### PR TITLE
feat(add-meal): deterministic meal-text parser

### DIFF
--- a/lib/features/add_meal/util/meal_text_parser.dart
+++ b/lib/features/add_meal/util/meal_text_parser.dart
@@ -137,6 +137,22 @@ String? _normalizeUnitSymbol(String raw) {
   }
 }
 
+/// The app's [UnitDropdownItem] (`meal_detail_bloc.dart`) has no `kg` or
+/// `l` — its `fromString` falls through to `g/ml` for anything it doesn't
+/// recognize, so emitting `kg`/`l` unchanged would silently turn `1,5 l
+/// milk` into 1.5 g/ml instead of 1500 ml. Converting here, before the
+/// value ever reaches that code, is what avoids the silent 1000x error.
+(double, String) _normalizeUnitAndQuantity(double quantity, String unit) {
+  switch (unit) {
+    case 'kg':
+      return (quantity * 1000, 'g');
+    case 'l':
+      return (quantity * 1000, 'ml');
+    default:
+      return (quantity, unit);
+  }
+}
+
 /// Turns one line of free text into a list of search intents. Pure and
 /// dependency-free: no I/O, no UI. See the class docs on [ParsedMealItem]
 /// and [MealTextParseResult] for the shape, and the doc comments on the
@@ -149,11 +165,18 @@ MealTextParseResult parseMealText(String input) {
 
   for (var i = 0; i < segments.length; i++) {
     final extracted = _extractQuantityAndUnit(segments[i]);
+
+    var quantity = extracted.quantity;
+    var unit = extracted.unit;
+    if (quantity != null && unit != null) {
+      (quantity, unit) = _normalizeUnitAndQuantity(quantity, unit);
+    }
+
     items.add(
       ParsedMealItem(
         query: extracted.query.trim(),
-        quantity: extracted.quantity,
-        unit: extracted.unit,
+        quantity: quantity,
+        unit: unit,
       ),
     );
   }

--- a/lib/features/add_meal/util/meal_text_parser.dart
+++ b/lib/features/add_meal/util/meal_text_parser.dart
@@ -73,7 +73,14 @@ const _unitSymbol = r'(?:kg|ml|oz|g|l)';
 
 /// A number, accepting either decimal separator. `JsonMealImporter` takes
 /// both the same way; [_parseQuantity] does the conversion.
-const _number = r'\d+(?:[.,]\d+)?';
+///
+/// The leading `-` is matched deliberately even though a negative quantity
+/// is never valid. Refusing it here does not reject the input — it just
+/// stops the number being recognized as a quantity at all, so `-5g sugar`
+/// would fall through to the food search as a literal query and the user
+/// would silently get the default amount instead of the bounds error that
+/// `0g water` produces. Matching it lets the `> 0` check below do its job.
+const _number = r'-?\d+(?:[.,]\d+)?';
 
 /// A quantity+unit token immediately before or after the food name, e.g.
 /// `100g toast` or `toast 100g`. `\s*` (not `\s+`) between the number and

--- a/lib/features/add_meal/util/meal_text_parser.dart
+++ b/lib/features/add_meal/util/meal_text_parser.dart
@@ -69,6 +69,74 @@ bool _isDigit(String char) {
   return code >= 0x30 && code <= 0x39;
 }
 
+/// A quantity+unit token immediately before or after the food name, e.g.
+/// `100g toast` or `toast 100g`. `\s*` (not `\s+`) between the number and
+/// the unit letters is what lets `1.5 l milk` — number, space, unit — match
+/// the same way as the no-space `100g toast` does.
+final _leadingQuantity = RegExp(r'^(\d+(?:\.\d+)?)\s*([a-zA-Z]*)\s+(.+)$');
+final _trailingQuantity = RegExp(r'^(.+?)\s+(\d+(?:\.\d+)?)\s*([a-zA-Z]*)\s*$');
+
+/// The result of attempting to pull a quantity+unit out of one segment.
+/// [unit] is the raw matched letters (not yet normalized/validated) or
+/// `null` when no unit token was present.
+class _Extracted {
+  final String query;
+  final double? quantity;
+  final String? unit;
+
+  const _Extracted({required this.query, this.quantity, this.unit});
+}
+
+/// Tries [_leadingQuantity] then [_trailingQuantity]. A unit token that
+/// doesn't match a recognized symbol (see [_normalizeUnitSymbol]) is
+/// treated as part of the food name instead of a unit, since a run of
+/// letters glued to a number is more often a product code than a unit
+/// this parser doesn't know — leaving it in the query keeps the segment
+/// searchable rather than silently discarding it.
+_Extracted _extractQuantityAndUnit(String segment) {
+  final leading = _leadingQuantity.firstMatch(segment);
+  if (leading != null) {
+    final rawUnit = leading.group(2)!;
+    if (rawUnit.isEmpty || _normalizeUnitSymbol(rawUnit) != null) {
+      return _Extracted(
+        query: leading.group(3)!,
+        quantity: double.parse(leading.group(1)!),
+        unit: rawUnit.isEmpty ? null : rawUnit.toLowerCase(),
+      );
+    }
+  }
+
+  final trailing = _trailingQuantity.firstMatch(segment);
+  if (trailing != null) {
+    final rawUnit = trailing.group(3)!;
+    if (rawUnit.isEmpty || _normalizeUnitSymbol(rawUnit) != null) {
+      return _Extracted(
+        query: trailing.group(1)!,
+        quantity: double.parse(trailing.group(2)!),
+        unit: rawUnit.isEmpty ? null : rawUnit.toLowerCase(),
+      );
+    }
+  }
+
+  return _Extracted(query: segment);
+}
+
+/// `null` when [raw] (case-insensitive) isn't one of the five symbols this
+/// parser recognizes as input. Deliberately just `g`/`kg`/`ml`/`l`/`oz` —
+/// see the file doc comment for why word-based units are out of scope.
+String? _normalizeUnitSymbol(String raw) {
+  switch (raw.toLowerCase()) {
+    case 'g':
+    case 'kg':
+    case 'ml':
+    case 'l':
+    case 'oz':
+      return raw.toLowerCase();
+    default:
+      return null;
+  }
+}
+
 /// Turns one line of free text into a list of search intents. Pure and
 /// dependency-free: no I/O, no UI. See the class docs on [ParsedMealItem]
 /// and [MealTextParseResult] for the shape, and the doc comments on the
@@ -80,7 +148,14 @@ MealTextParseResult parseMealText(String input) {
   final errors = <String>[];
 
   for (var i = 0; i < segments.length; i++) {
-    items.add(ParsedMealItem(query: segments[i]));
+    final extracted = _extractQuantityAndUnit(segments[i]);
+    items.add(
+      ParsedMealItem(
+        query: extracted.query.trim(),
+        quantity: extracted.quantity,
+        unit: extracted.unit,
+      ),
+    );
   }
 
   return MealTextParseResult(items: items, errors: errors);

--- a/lib/features/add_meal/util/meal_text_parser.dart
+++ b/lib/features/add_meal/util/meal_text_parser.dart
@@ -4,6 +4,11 @@ import 'package:opennutritracker/core/utils/food_name_validator.dart';
 /// meal_detail_bottom_sheet.dart.
 const _maxQuantity = 10000;
 
+/// The exact set of `UnitDropdownItem.toString()` values (meal_detail_bloc
+/// .dart). [ParsedMealItem.unit] must always be `null` or one of these —
+/// see the assert in [parseMealText] and the dedicated invariant test.
+const _validUnits = {'g', 'ml', 'g/ml', 'oz', 'fl.oz', 'serving'};
+
 /// One item extracted from a free-text meal description. [query] is what
 /// gets handed to the existing food search; [quantity] and [unit] are
 /// `null` when the input didn't state an amount, in which case the review
@@ -202,6 +207,13 @@ MealTextParseResult parseMealText(String input) {
         continue;
       }
     }
+
+    // This is the invariant that stops a future unit addition reintroducing
+    // the silent kg/l coercion _normalizeUnitAndQuantity exists to prevent.
+    assert(
+      unit == null || _validUnits.contains(unit),
+      'parseMealText emitted unrecognized unit "$unit"',
+    );
 
     items.add(ParsedMealItem(query: query, quantity: quantity, unit: unit));
   }

--- a/lib/features/add_meal/util/meal_text_parser.dart
+++ b/lib/features/add_meal/util/meal_text_parser.dart
@@ -1,0 +1,87 @@
+/// One item extracted from a free-text meal description. [query] is what
+/// gets handed to the existing food search; [quantity] and [unit] are
+/// `null` when the input didn't state an amount, in which case the review
+/// row downstream falls back to the defaults `MealDetailScreen
+/// ._applyInitialSelection` already uses.
+class ParsedMealItem {
+  final String query;
+  final double? quantity;
+  final String? unit;
+
+  const ParsedMealItem({required this.query, this.quantity, this.unit});
+
+  @override
+  String toString() =>
+      'ParsedMealItem(query: $query, quantity: $quantity, unit: $unit)';
+}
+
+/// Result of [parseMealText]. [errors] holds a one-line, item-indexed
+/// reason for each segment that could not be turned into a [ParsedMealItem]
+/// — empty segments (e.g. a trailing comma) are skipped silently and never
+/// produce an error.
+class MealTextParseResult {
+  final List<ParsedMealItem> items;
+  final List<String> errors;
+
+  const MealTextParseResult({required this.items, required this.errors});
+
+  bool get hasErrors => errors.isNotEmpty;
+}
+
+/// Splits [input] on `,` / `;` / newline / `+`, subject to the comma rule
+/// below, and returns the trimmed, non-empty pieces in order.
+List<String> _segment(String input) {
+  final normalized = _normalizeDecimalCommas(input);
+  return normalized
+      .split(RegExp(r'[,;+\n]'))
+      .map((s) => s.trim())
+      .where((s) => s.isNotEmpty)
+      .toList();
+}
+
+/// A comma with a digit immediately before it and a digit immediately
+/// after it is a decimal point; every other comma is a separator. This
+/// rewrites decimal commas to `.` in place so the later split on `,` only
+/// ever cuts on separator commas.
+///
+/// `1,5 l milk` → `1.5 l milk` (digits on both sides, one item).
+/// `100g toast, 2 eggs` → unchanged (space follows the comma, two items).
+/// `toast,2 eggs` → unchanged (no digit before the comma, two items).
+String _normalizeDecimalCommas(String input) {
+  final buffer = StringBuffer();
+  for (var i = 0; i < input.length; i++) {
+    final char = input[i];
+    if (char == ',') {
+      final before = i > 0 ? input[i - 1] : '';
+      final after = i < input.length - 1 ? input[i + 1] : '';
+      final isDecimal = _isDigit(before) && _isDigit(after);
+      buffer.write(isDecimal ? '.' : ',');
+    } else {
+      buffer.write(char);
+    }
+  }
+  return buffer.toString();
+}
+
+bool _isDigit(String char) {
+  if (char.isEmpty) return false;
+  final code = char.codeUnitAt(0);
+  return code >= 0x30 && code <= 0x39;
+}
+
+/// Turns one line of free text into a list of search intents. Pure and
+/// dependency-free: no I/O, no UI. See the class docs on [ParsedMealItem]
+/// and [MealTextParseResult] for the shape, and the doc comments on the
+/// private helpers below for the segmentation and unit-normalization rules.
+MealTextParseResult parseMealText(String input) {
+  final segments = _segment(input.trim());
+
+  final items = <ParsedMealItem>[];
+  final errors = <String>[];
+
+  for (var i = 0; i < segments.length; i++) {
+    items.add(ParsedMealItem(query: segments[i]));
+  }
+
+  return MealTextParseResult(items: items, errors: errors);
+}

--- a/lib/features/add_meal/util/meal_text_parser.dart
+++ b/lib/features/add_meal/util/meal_text_parser.dart
@@ -1,5 +1,9 @@
 import 'package:opennutritracker/core/utils/food_name_validator.dart';
 
+/// Upper bound for a parsed quantity, matching the manual-entry check in
+/// meal_detail_bottom_sheet.dart.
+const _maxQuantity = 10000;
+
 /// One item extracted from a free-text meal description. [query] is what
 /// gets handed to the existing food search; [quantity] and [unit] are
 /// `null` when the input didn't state an amount, in which case the review
@@ -183,6 +187,20 @@ MealTextParseResult parseMealText(String input) {
     var unit = extracted.unit;
     if (quantity != null && unit != null) {
       (quantity, unit) = _normalizeUnitAndQuantity(quantity, unit);
+    }
+
+    // Bounds match meal_detail_bottom_sheet.dart's manual-entry check.
+    // Applied after kg/l conversion, so '15 kg' is rejected as 15000 g
+    // rather than silently becoming a valid-looking 15.
+    if (quantity != null) {
+      if (quantity <= 0) {
+        errors.add('Item $itemNum: quantity must be greater than 0');
+        continue;
+      }
+      if (quantity > _maxQuantity) {
+        errors.add('Item $itemNum: quantity must be $_maxQuantity or less');
+        continue;
+      }
     }
 
     items.add(ParsedMealItem(query: query, quantity: quantity, unit: unit));

--- a/lib/features/add_meal/util/meal_text_parser.dart
+++ b/lib/features/add_meal/util/meal_text_parser.dart
@@ -164,10 +164,36 @@ String? _normalizeUnitSymbol(String raw) {
   }
 }
 
-/// Turns one line of free text into a list of search intents. Pure and
-/// dependency-free: no I/O, no UI. See the class docs on [ParsedMealItem]
-/// and [MealTextParseResult] for the shape, and the doc comments on the
-/// private helpers below for the segmentation and unit-normalization rules.
+/// Turns one line of free text into a list of search intents — the tier-0
+/// half of #599's AI-assisted meal logging: a deterministic parser, no
+/// model, so it ships free and runs offline. Pure and dependency-free: no
+/// I/O, no UI, fully unit-testable.
+///
+/// ```
+/// parseMealText('100g toast, 2 eggs; 1,5 l milk')
+/// // -> items: [
+/// //      ParsedMealItem(query: 'toast', quantity: 100, unit: 'g'),
+/// //      ParsedMealItem(query: 'eggs', quantity: 2, unit: null),
+/// //      ParsedMealItem(query: 'milk', quantity: 1500, unit: 'ml'),
+/// //    ]
+/// ```
+///
+/// Each `,` / `;` / newline / `+`-separated segment becomes one
+/// [ParsedMealItem], resolved independently against the existing food
+/// search downstream (this parser never invents nutrient estimates — see
+/// #599 for why that constraint matters to the project's privacy/citation
+/// claims). A segment with no recognizable quantity — `black coffee` —
+/// still becomes an item, just with `quantity` and `unit` left `null` for
+/// the review row to default. A segment that fails validation (no letters,
+/// quantity out of bounds) produces an indexed entry in [errors] instead
+/// and is dropped from [items]; it never silently disappears.
+///
+/// Locale-independent by construction: this keys off digits and the unit
+/// symbols `g`/`kg`/`ml`/`l`/`oz`, never number-words, so it needs no
+/// per-locale word list across the app's 9 supported locales. See the doc
+/// comments on the private helpers below for the segmentation and
+/// unit-normalization rules, and the class docs on [ParsedMealItem] and
+/// [MealTextParseResult] for the result shape.
 MealTextParseResult parseMealText(String input) {
   final segments = _segment(input.trim());
 

--- a/lib/features/add_meal/util/meal_text_parser.dart
+++ b/lib/features/add_meal/util/meal_text_parser.dart
@@ -1,3 +1,5 @@
+import 'package:opennutritracker/core/utils/food_name_validator.dart';
+
 /// One item extracted from a free-text meal description. [query] is what
 /// gets handed to the existing food search; [quantity] and [unit] are
 /// `null` when the input didn't state an amount, in which case the review
@@ -163,8 +165,19 @@ MealTextParseResult parseMealText(String input) {
   final items = <ParsedMealItem>[];
   final errors = <String>[];
 
-  for (var i = 0; i < segments.length; i++) {
-    final extracted = _extractQuantityAndUnit(segments[i]);
+  // Numbers only the segments actually attempted, matching "empty segments
+  // are skipped, not errors" — a trailing comma doesn't consume an index.
+  var itemNum = 0;
+
+  for (final segment in segments) {
+    itemNum++;
+    final extracted = _extractQuantityAndUnit(segment);
+    final query = extracted.query.trim();
+
+    if (!FoodNameValidator.isValid(query)) {
+      errors.add('Item $itemNum: not a valid food name');
+      continue;
+    }
 
     var quantity = extracted.quantity;
     var unit = extracted.unit;
@@ -172,13 +185,7 @@ MealTextParseResult parseMealText(String input) {
       (quantity, unit) = _normalizeUnitAndQuantity(quantity, unit);
     }
 
-    items.add(
-      ParsedMealItem(
-        query: extracted.query.trim(),
-        quantity: quantity,
-        unit: unit,
-      ),
-    );
+    items.add(ParsedMealItem(query: query, quantity: quantity, unit: unit));
   }
 
   return MealTextParseResult(items: items, errors: errors);

--- a/lib/features/add_meal/util/meal_text_parser.dart
+++ b/lib/features/add_meal/util/meal_text_parser.dart
@@ -39,57 +39,69 @@ class MealTextParseResult {
   bool get hasErrors => errors.isNotEmpty;
 }
 
-/// Splits [input] on `,` / `;` / newline / `+`, subject to the comma rule
-/// below, and returns the trimmed, non-empty pieces in order.
-List<String> _segment(String input) {
-  final normalized = _normalizeDecimalCommas(input);
-  return normalized
-      .split(RegExp(r'[,;+\n]'))
-      .map((s) => s.trim())
-      .where((s) => s.isNotEmpty)
-      .toList();
-}
-
-/// A comma with a digit immediately before it and a digit immediately
-/// after it is a decimal point; every other comma is a separator. This
-/// rewrites decimal commas to `.` in place so the later split on `,` only
-/// ever cuts on separator commas.
+/// A comma with a digit immediately before it *and* immediately after it
+/// is a decimal point; every other comma separates items. The lookarounds
+/// express that as "a comma not preceded by a digit, or not followed by
+/// one", so a decimal comma is simply never matched as a separator.
 ///
-/// `1,5 l milk` → `1.5 l milk` (digits on both sides, one item).
-/// `100g toast, 2 eggs` → unchanged (space follows the comma, two items).
-/// `toast,2 eggs` → unchanged (no digit before the comma, two items).
-String _normalizeDecimalCommas(String input) {
-  final buffer = StringBuffer();
-  for (var i = 0; i < input.length; i++) {
-    final char = input[i];
-    if (char == ',') {
-      final before = i > 0 ? input[i - 1] : '';
-      final after = i < input.length - 1 ? input[i + 1] : '';
-      final isDecimal = _isDigit(before) && _isDigit(after);
-      buffer.write(isDecimal ? '.' : ',');
-    } else {
-      buffer.write(char);
-    }
-  }
-  return buffer.toString();
-}
+/// `1,5 l milk` → one segment (digits on both sides).
+/// `100g toast, 2 eggs` → two segments (a space follows the comma).
+/// `toast,2 eggs` → two segments (no digit precedes the comma).
+///
+/// Splitting rather than rewriting matters: an earlier version replaced
+/// every decimal comma with `.` across the whole input before splitting,
+/// which also rewrote commas inside food names — `yoghurt 3,5% fat` and
+/// `Omega 3,6,9 capsules` reached the food search with characters the user
+/// never typed. The decimal comma is now converted only inside the number
+/// actually parsed, in [_parseQuantity].
+final _separator = RegExp(r'[;+\n]|(?<!\d),|,(?!\d)');
 
-bool _isDigit(String char) {
-  if (char.isEmpty) return false;
-  final code = char.codeUnitAt(0);
-  return code >= 0x30 && code <= 0x39;
-}
+/// Splits [input] into trimmed, non-empty pieces on `,` / `;` / newline /
+/// `+`, subject to the comma rule on [_separator].
+List<String> _segment(String input) => input
+    .split(_separator)
+    .map((s) => s.trim())
+    .where((s) => s.isNotEmpty)
+    .toList();
+
+/// The five unit symbols this parser recognizes as *input*, longest-first
+/// so a two-character symbol is never shadowed by its first letter. Naming
+/// them explicitly (rather than matching any run of letters) is what lets
+/// the regex engine backtrack to the no-unit reading when the word after
+/// the number simply belongs to the food name — see [_leadingQuantity].
+const _unitSymbol = r'(?:kg|ml|oz|g|l)';
+
+/// A number, accepting either decimal separator. `JsonMealImporter` takes
+/// both the same way; [_parseQuantity] does the conversion.
+const _number = r'\d+(?:[.,]\d+)?';
 
 /// A quantity+unit token immediately before or after the food name, e.g.
 /// `100g toast` or `toast 100g`. `\s*` (not `\s+`) between the number and
-/// the unit letters is what lets `1.5 l milk` — number, space, unit — match
-/// the same way as the no-space `100g toast` does.
-final _leadingQuantity = RegExp(r'^(\d+(?:\.\d+)?)\s*([a-zA-Z]*)\s+(.+)$');
-final _trailingQuantity = RegExp(r'^(.+?)\s+(\d+(?:\.\d+)?)\s*([a-zA-Z]*)\s*$');
+/// the unit is what lets `1.5 l milk` — number, space, unit — match the
+/// same way as the no-space `100g toast` does.
+///
+/// The unit group is optional *and* restricted to [_unitSymbol]. Both
+/// halves matter: with a bare `([a-zA-Z]*)` the group greedily swallowed
+/// the first word of a multi-word food, and because that word is not a
+/// unit the whole match was then discarded — so `2 chicken breasts` lost
+/// its quantity entirely while `2 eggs` kept it, purely because a single
+/// trailing word forced the engine to backtrack. Restricting the group
+/// makes the engine find the no-unit reading itself.
+final _leadingQuantity = RegExp(
+  '^($_number)\\s*($_unitSymbol)?\\s+(.+)\$',
+  caseSensitive: false,
+);
+final _trailingQuantity = RegExp(
+  '^(.+?)\\s+($_number)\\s*($_unitSymbol)?\\s*\$',
+  caseSensitive: false,
+);
+
+/// Both decimal separators reach here; `double.parse` only accepts `.`.
+double _parseQuantity(String raw) => double.parse(raw.replaceAll(',', '.'));
 
 /// The result of attempting to pull a quantity+unit out of one segment.
-/// [unit] is the raw matched letters (not yet normalized/validated) or
-/// `null` when no unit token was present.
+/// [unit] is one of the [_unitSymbol] symbols, lower-cased, or `null` when
+/// the segment stated no unit.
 class _Extracted {
   final String query;
   final double? quantity;
@@ -98,56 +110,32 @@ class _Extracted {
   const _Extracted({required this.query, this.quantity, this.unit});
 }
 
-/// Tries [_leadingQuantity] then [_trailingQuantity]. A unit token that
-/// doesn't match a recognized symbol (see [_normalizeUnitSymbol]) is
-/// treated as part of the food name instead of a unit, since a run of
-/// letters glued to a number is more often a product code than a unit
-/// this parser doesn't know — leaving it in the query keeps the segment
-/// searchable rather than silently discarding it.
+/// Tries [_leadingQuantity] then [_trailingQuantity]. Because the unit
+/// group only ever matches a known symbol, a letter run that is not a unit
+/// stays in the food name instead of being mistaken for one — `2 chicken
+/// breasts` keeps its quantity, and `100xyz toast` (letters glued to the
+/// number, more often a product code than anything else) is left whole for
+/// the search rather than silently losing the `100xyz`.
 _Extracted _extractQuantityAndUnit(String segment) {
   final leading = _leadingQuantity.firstMatch(segment);
   if (leading != null) {
-    final rawUnit = leading.group(2)!;
-    final unit = rawUnit.isEmpty ? null : _normalizeUnitSymbol(rawUnit);
-    if (rawUnit.isEmpty || unit != null) {
-      return _Extracted(
-        query: leading.group(3)!,
-        quantity: double.parse(leading.group(1)!),
-        unit: unit,
-      );
-    }
+    return _Extracted(
+      query: leading.group(3)!,
+      quantity: _parseQuantity(leading.group(1)!),
+      unit: leading.group(2)?.toLowerCase(),
+    );
   }
 
   final trailing = _trailingQuantity.firstMatch(segment);
   if (trailing != null) {
-    final rawUnit = trailing.group(3)!;
-    final unit = rawUnit.isEmpty ? null : _normalizeUnitSymbol(rawUnit);
-    if (rawUnit.isEmpty || unit != null) {
-      return _Extracted(
-        query: trailing.group(1)!,
-        quantity: double.parse(trailing.group(2)!),
-        unit: unit,
-      );
-    }
+    return _Extracted(
+      query: trailing.group(1)!,
+      quantity: _parseQuantity(trailing.group(2)!),
+      unit: trailing.group(3)?.toLowerCase(),
+    );
   }
 
   return _Extracted(query: segment);
-}
-
-/// `null` when [raw] (case-insensitive) isn't one of the five symbols this
-/// parser recognizes as input. Deliberately just `g`/`kg`/`ml`/`l`/`oz` —
-/// see the file doc comment for why word-based units are out of scope.
-String? _normalizeUnitSymbol(String raw) {
-  switch (raw.toLowerCase()) {
-    case 'g':
-    case 'kg':
-    case 'ml':
-    case 'l':
-    case 'oz':
-      return raw.toLowerCase();
-    default:
-      return null;
-  }
 }
 
 /// The app's [UnitDropdownItem] (`meal_detail_bloc.dart`) has no `kg` or

--- a/lib/features/add_meal/util/meal_text_parser.dart
+++ b/lib/features/add_meal/util/meal_text_parser.dart
@@ -108,11 +108,12 @@ _Extracted _extractQuantityAndUnit(String segment) {
   final leading = _leadingQuantity.firstMatch(segment);
   if (leading != null) {
     final rawUnit = leading.group(2)!;
-    if (rawUnit.isEmpty || _normalizeUnitSymbol(rawUnit) != null) {
+    final unit = rawUnit.isEmpty ? null : _normalizeUnitSymbol(rawUnit);
+    if (rawUnit.isEmpty || unit != null) {
       return _Extracted(
         query: leading.group(3)!,
         quantity: double.parse(leading.group(1)!),
-        unit: rawUnit.isEmpty ? null : rawUnit.toLowerCase(),
+        unit: unit,
       );
     }
   }
@@ -120,11 +121,12 @@ _Extracted _extractQuantityAndUnit(String segment) {
   final trailing = _trailingQuantity.firstMatch(segment);
   if (trailing != null) {
     final rawUnit = trailing.group(3)!;
-    if (rawUnit.isEmpty || _normalizeUnitSymbol(rawUnit) != null) {
+    final unit = rawUnit.isEmpty ? null : _normalizeUnitSymbol(rawUnit);
+    if (rawUnit.isEmpty || unit != null) {
       return _Extracted(
         query: trailing.group(1)!,
         quantity: double.parse(trailing.group(2)!),
-        unit: rawUnit.isEmpty ? null : rawUnit.toLowerCase(),
+        unit: unit,
       );
     }
   }

--- a/test/unit_test/meal_text_parser_test.dart
+++ b/test/unit_test/meal_text_parser_test.dart
@@ -1,0 +1,76 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:opennutritracker/features/add_meal/util/meal_text_parser.dart';
+
+void main() {
+  group('parseMealText segmentation', () {
+    test('a single item with no separator at all is one segment', () {
+      final result = parseMealText('black coffee');
+
+      expect(result.errors, isEmpty);
+      expect(result.items, hasLength(1));
+      expect(result.items.single.query, 'black coffee');
+    });
+
+    test('splits on comma when the comma is not a decimal point', () {
+      final result = parseMealText('toast, eggs');
+
+      expect(result.items.map((i) => i.query), ['toast', 'eggs']);
+    });
+
+    test('splits on semicolon, newline, and plus', () {
+      final result = parseMealText('toast; eggs\nbacon+coffee');
+
+      expect(result.items.map((i) => i.query), [
+        'toast',
+        'eggs',
+        'bacon',
+        'coffee',
+      ]);
+    });
+
+    test(
+      'a comma with digits on both sides is a decimal point, not a separator',
+      () {
+        final result = parseMealText('1,5 l milk');
+
+        expect(result.items, hasLength(1));
+      },
+    );
+
+    test('a comma with no digit before it is a separator', () {
+      final result = parseMealText('toast,2 eggs');
+
+      expect(result.items.map((i) => i.query), ['toast', '2 eggs']);
+    });
+
+    test(
+      'a comma followed by a space is a separator even between digits and letters',
+      () {
+        final result = parseMealText('100g toast, 2 eggs');
+
+        expect(result.items.map((i) => i.query), ['100g toast', '2 eggs']);
+      },
+    );
+
+    test('empty segments are skipped, not errors', () {
+      final result = parseMealText('toast,, eggs,');
+
+      expect(result.errors, isEmpty);
+      expect(result.items.map((i) => i.query), ['toast', 'eggs']);
+    });
+
+    test('empty string input produces no items and no errors', () {
+      final result = parseMealText('');
+
+      expect(result.items, isEmpty);
+      expect(result.errors, isEmpty);
+    });
+
+    test('whitespace-only input produces no items and no errors', () {
+      final result = parseMealText('   ');
+
+      expect(result.items, isEmpty);
+      expect(result.errors, isEmpty);
+    });
+  });
+}

--- a/test/unit_test/meal_text_parser_test.dart
+++ b/test/unit_test/meal_text_parser_test.dart
@@ -191,4 +191,36 @@ void main() {
       expect(result.errors, ['Item 1: not a valid food name']);
     });
   });
+
+  group('parseMealText quantity bounds', () {
+    test('a quantity of 0 is rejected', () {
+      final result = parseMealText('0g water');
+
+      expect(result.items, isEmpty);
+      expect(result.errors, ['Item 1: quantity must be greater than 0']);
+    });
+
+    test('a quantity over 10000 is rejected', () {
+      final result = parseMealText('10001g flour');
+
+      expect(result.items, isEmpty);
+      expect(result.errors, ['Item 1: quantity must be 10000 or less']);
+    });
+
+    test('exactly 10000 is accepted', () {
+      final result = parseMealText('10000g flour');
+
+      expect(result.errors, isEmpty);
+      expect(result.items.single.quantity, 10000);
+    });
+
+    test('the 10000 bound applies after kg -> g conversion, not before', () {
+      // 15 kg converts to 15000 g, which exceeds the bound — it must not
+      // be evaluated as 15 (under the bound) before the x1000 conversion.
+      final result = parseMealText('15kg flour');
+
+      expect(result.items, isEmpty);
+      expect(result.errors, ['Item 1: quantity must be 10000 or less']);
+    });
+  });
 }

--- a/test/unit_test/meal_text_parser_test.dart
+++ b/test/unit_test/meal_text_parser_test.dart
@@ -99,11 +99,14 @@ void main() {
     test(
       'a space between the number and the unit is also accepted (1.5 l milk)',
       () {
+        // Unit normalization (l -> ml x1000) is covered in detail in the
+        // group below; this just confirms the space-before-unit case is
+        // recognized as quantity+unit at all.
         final item = parseMealText('1.5 l milk').items.single;
 
         expect(item.query, 'milk');
-        expect(item.quantity, 1.5);
-        expect(item.unit, 'l');
+        expect(item.quantity, isNotNull);
+        expect(item.unit, isNotNull);
       },
     );
 
@@ -135,6 +138,33 @@ void main() {
       expect(item.query, '100xyz toast');
       expect(item.quantity, isNull);
       expect(item.unit, isNull);
+    });
+  });
+
+  group('parseMealText unit normalization', () {
+    test('kg is converted to g, quantity times 1000', () {
+      final item = parseMealText('1kg flour').items.single;
+
+      expect(item.quantity, 1000);
+      expect(item.unit, 'g');
+    });
+
+    test('l is converted to ml, quantity times 1000', () {
+      final item = parseMealText('1.5 l milk').items.single;
+
+      expect(item.quantity, 1500);
+      expect(item.unit, 'ml');
+    });
+
+    test('g, ml, and oz pass through unchanged', () {
+      final results = [
+        parseMealText('100g toast').items.single,
+        parseMealText('100ml juice').items.single,
+        parseMealText('4oz steak').items.single,
+      ];
+
+      expect(results.map((i) => i.unit), ['g', 'ml', 'oz']);
+      expect(results.map((i) => i.quantity), [100, 100, 4]);
     });
   });
 }

--- a/test/unit_test/meal_text_parser_test.dart
+++ b/test/unit_test/meal_text_parser_test.dart
@@ -166,6 +166,83 @@ void main() {
     });
   });
 
+  group('parseMealText multi-word foods with a bare quantity', () {
+    // Regression: the unit group used to be a bare ([a-zA-Z]*), which
+    // greedily took the first word of the food name as a candidate unit
+    // and then discarded the whole match when it turned out not to be
+    // one. '2 eggs' survived only because a single trailing word forced
+    // the engine to backtrack into the no-unit reading; anything longer
+    // silently lost its quantity.
+    test('a two-word food keeps its quantity', () {
+      final item = parseMealText('2 chicken breasts').items.single;
+
+      expect(item.query, 'chicken breasts');
+      expect(item.quantity, 2);
+      expect(item.unit, isNull);
+    });
+
+    test('a three-word food keeps its quantity', () {
+      final item = parseMealText('4 chocolate chip cookies').items.single;
+
+      expect(item.query, 'chocolate chip cookies');
+      expect(item.quantity, 4);
+      expect(item.unit, isNull);
+    });
+
+    test('a food whose first word starts with a unit letter', () {
+      // 'lemons' begins with 'l'; the unit group must not claim it.
+      final item = parseMealText('2 lemons').items.single;
+
+      expect(item.query, 'lemons');
+      expect(item.quantity, 2);
+      expect(item.unit, isNull);
+    });
+
+    test('an explicit unit before a multi-word food still parses', () {
+      final item = parseMealText('200g chicken breasts').items.single;
+
+      expect(item.query, 'chicken breasts');
+      expect(item.quantity, 200);
+      expect(item.unit, 'g');
+    });
+
+    test('several multi-word items in one line', () {
+      final result = parseMealText('2 boiled eggs, 3 slices bread');
+
+      expect(result.errors, isEmpty);
+      expect(result.items.map((i) => i.query), ['boiled eggs', 'slices bread']);
+      expect(result.items.map((i) => i.quantity), [2, 3]);
+    });
+  });
+
+  group('parseMealText leaves the food name as the user typed it', () {
+    // Regression: decimal commas used to be rewritten to '.' across the
+    // whole input before segmentation, which also rewrote commas inside
+    // food names — so the string handed to the food search contained
+    // characters the user never typed.
+    test('a comma inside a food name is not rewritten', () {
+      final item = parseMealText('yoghurt 3,5% fat').items.single;
+
+      expect(item.query, 'yoghurt 3,5% fat');
+    });
+
+    test('repeated digit-commas inside a food name are not rewritten', () {
+      final item = parseMealText('Omega 3,6,9 capsules').items.single;
+
+      expect(item.query, 'Omega 3,6,9 capsules');
+    });
+
+    test('a decimal comma in the quantity is still parsed as a number', () {
+      // The conversion happens only on the number actually matched, so
+      // this keeps working while the two cases above are left alone.
+      final item = parseMealText('0,5kg rice').items.single;
+
+      expect(item.query, 'rice');
+      expect(item.quantity, 500);
+      expect(item.unit, 'g');
+    });
+  });
+
   group('parseMealText unit normalization', () {
     test('kg is converted to g, quantity times 1000', () {
       final item = parseMealText('1kg flour').items.single;

--- a/test/unit_test/meal_text_parser_test.dart
+++ b/test/unit_test/meal_text_parser_test.dart
@@ -151,6 +151,19 @@ void main() {
       expect(item.quantity, isNull);
       expect(item.unit, isNull);
     });
+
+    test('a negative number is not recognized as a quantity', () {
+      // Neither quantity regex matches a leading '-' (the spec only
+      // describes unsigned digits), so the whole segment falls through to
+      // the query as-is rather than being parsed as quantity -5. It still
+      // passes FoodNameValidator (it contains letters), so this is
+      // accepted as an odd-looking but valid item, not an error.
+      final item = parseMealText('-5g sugar').items.single;
+
+      expect(item.query, '-5g sugar');
+      expect(item.quantity, isNull);
+      expect(item.unit, isNull);
+    });
   });
 
   group('parseMealText unit normalization', () {

--- a/test/unit_test/meal_text_parser_test.dart
+++ b/test/unit_test/meal_text_parser_test.dart
@@ -28,6 +28,18 @@ void main() {
       ]);
     });
 
+    test('all four separators together in one input', () {
+      final result = parseMealText('toast, eggs; bacon\ncoffee+juice');
+
+      expect(result.items.map((i) => i.query), [
+        'toast',
+        'eggs',
+        'bacon',
+        'coffee',
+        'juice',
+      ]);
+    });
+
     test(
       'a comma with digits on both sides is a decimal point, not a separator',
       () {
@@ -149,9 +161,20 @@ void main() {
       expect(item.unit, 'g');
     });
 
-    test('l is converted to ml, quantity times 1000', () {
+    test('l is converted to ml, quantity times 1000 (period decimal)', () {
       final item = parseMealText('1.5 l milk').items.single;
 
+      expect(item.quantity, 1500);
+      expect(item.unit, 'ml');
+    });
+
+    test('l is converted to ml, quantity times 1000 (comma decimal)', () {
+      // '1,5' is normalized to the decimal 1.5 before segmentation (the
+      // digit-digit comma rule), so this is one item, not two.
+      final result = parseMealText('1,5 l milk');
+      final item = result.items.single;
+
+      expect(item.query, 'milk');
       expect(item.quantity, 1500);
       expect(item.unit, 'ml');
     });

--- a/test/unit_test/meal_text_parser_test.dart
+++ b/test/unit_test/meal_text_parser_test.dart
@@ -40,7 +40,11 @@ void main() {
     test('a comma with no digit before it is a separator', () {
       final result = parseMealText('toast,2 eggs');
 
-      expect(result.items.map((i) => i.query), ['toast', '2 eggs']);
+      // Two segments: 'toast' and '2 eggs'. Quantity/unit extraction turns
+      // the second into query 'eggs' + quantity 2 — see the extraction
+      // group below for that behavior in isolation.
+      expect(result.items, hasLength(2));
+      expect(result.items.map((i) => i.query), ['toast', 'eggs']);
     });
 
     test(
@@ -48,7 +52,8 @@ void main() {
       () {
         final result = parseMealText('100g toast, 2 eggs');
 
-        expect(result.items.map((i) => i.query), ['100g toast', '2 eggs']);
+        expect(result.items, hasLength(2));
+        expect(result.items.map((i) => i.query), ['toast', 'eggs']);
       },
     );
 
@@ -71,6 +76,65 @@ void main() {
 
       expect(result.items, isEmpty);
       expect(result.errors, isEmpty);
+    });
+  });
+
+  group('parseMealText quantity/unit extraction', () {
+    test('leading quantity with no space before the unit (100g toast)', () {
+      final item = parseMealText('100g toast').items.single;
+
+      expect(item.query, 'toast');
+      expect(item.quantity, 100);
+      expect(item.unit, 'g');
+    });
+
+    test('trailing quantity with no space before the unit (toast 100g)', () {
+      final item = parseMealText('toast 100g').items.single;
+
+      expect(item.query, 'toast');
+      expect(item.quantity, 100);
+      expect(item.unit, 'g');
+    });
+
+    test(
+      'a space between the number and the unit is also accepted (1.5 l milk)',
+      () {
+        final item = parseMealText('1.5 l milk').items.single;
+
+        expect(item.query, 'milk');
+        expect(item.quantity, 1.5);
+        expect(item.unit, 'l');
+      },
+    );
+
+    test('quantity with no unit (2 eggs)', () {
+      final item = parseMealText('2 eggs').items.single;
+
+      expect(item.query, 'eggs');
+      expect(item.quantity, 2);
+      expect(item.unit, isNull);
+    });
+
+    test('no quantity at all (black coffee) leaves both fields null', () {
+      final item = parseMealText('black coffee').items.single;
+
+      expect(item.query, 'black coffee');
+      expect(item.quantity, isNull);
+      expect(item.unit, isNull);
+    });
+
+    test('unit matching is case-insensitive and normalized to lowercase', () {
+      final item = parseMealText('100G toast').items.single;
+
+      expect(item.unit, 'g');
+    });
+
+    test('an unrecognized unit-like token is left as part of the query', () {
+      final item = parseMealText('100xyz toast').items.single;
+
+      expect(item.query, '100xyz toast');
+      expect(item.quantity, isNull);
+      expect(item.unit, isNull);
     });
   });
 }

--- a/test/unit_test/meal_text_parser_test.dart
+++ b/test/unit_test/meal_text_parser_test.dart
@@ -167,4 +167,28 @@ void main() {
       expect(results.map((i) => i.quantity), [100, 100, 4]);
     });
   });
+
+  group('parseMealText food-name validation', () {
+    test('a segment with no letters (123) is rejected', () {
+      final result = parseMealText('123');
+
+      expect(result.items, isEmpty);
+      expect(result.errors, ['Item 1: not a valid food name']);
+    });
+
+    test('a valid segment after a rejected one keeps its own item number', () {
+      final result = parseMealText('123, toast');
+
+      expect(result.errors, ['Item 1: not a valid food name']);
+      expect(result.items.single.query, 'toast');
+    });
+
+    test('empty segments do not consume an item number', () {
+      // The leading empty segment (before the comma) is skipped silently,
+      // so the invalid '123' is still 'Item 1', not 'Item 2'.
+      final result = parseMealText(',123');
+
+      expect(result.errors, ['Item 1: not a valid food name']);
+    });
+  });
 }

--- a/test/unit_test/meal_text_parser_test.dart
+++ b/test/unit_test/meal_text_parser_test.dart
@@ -152,17 +152,49 @@ void main() {
       expect(item.unit, isNull);
     });
 
-    test('a negative number is not recognized as a quantity', () {
-      // Neither quantity regex matches a leading '-' (the spec only
-      // describes unsigned digits), so the whole segment falls through to
-      // the query as-is rather than being parsed as quantity -5. It still
-      // passes FoodNameValidator (it contains letters), so this is
-      // accepted as an odd-looking but valid item, not an error.
-      final item = parseMealText('-5g sugar').items.single;
+    test('a negative quantity is rejected, not swallowed into the query', () {
+      // The number pattern matches the leading '-' on purpose. If it did
+      // not, the segment would fall through to the food search as the
+      // literal query '-5g sugar' and the review row would quietly apply
+      // the default amount — the user typed -5 and would get 100. Matching
+      // it routes the input into the same bound that rejects '0g water'.
+      final result = parseMealText('-5g sugar');
 
-      expect(item.query, '-5g sugar');
-      expect(item.quantity, isNull);
-      expect(item.unit, isNull);
+      expect(result.items, isEmpty);
+      expect(result.errors, ['Item 1: quantity must be greater than 0']);
+    });
+
+    test('a negative trailing quantity is rejected too', () {
+      final result = parseMealText('sugar -5g');
+
+      expect(result.items, isEmpty);
+      expect(result.errors, ['Item 1: quantity must be greater than 0']);
+    });
+
+    test('a negative kg quantity is rejected after conversion', () {
+      final result = parseMealText('-5kg flour');
+
+      expect(result.items, isEmpty);
+      expect(result.errors, ['Item 1: quantity must be greater than 0']);
+    });
+
+    test('a lone negative number is still an invalid food name', () {
+      // No whitespace, so neither quantity regex matches and the segment
+      // reaches FoodNameValidator whole — which rejects it for having no
+      // letters, not for its sign.
+      final result = parseMealText('-123');
+
+      expect(result.items, isEmpty);
+      expect(result.errors, ['Item 1: not a valid food name']);
+    });
+
+    test('a hyphen inside a food name is left alone', () {
+      // The '-' only reads as a sign when it is glued to the digits of a
+      // quantity; hyphenated names must not be disturbed.
+      final result = parseMealText('low-fat milk, 100g Coca-Cola');
+
+      expect(result.errors, isEmpty);
+      expect(result.items.map((i) => i.query), ['low-fat milk', 'Coca-Cola']);
     });
   });
 

--- a/test/unit_test/meal_text_parser_test.dart
+++ b/test/unit_test/meal_text_parser_test.dart
@@ -223,4 +223,48 @@ void main() {
       expect(result.errors, ['Item 1: quantity must be 10000 or less']);
     });
   });
+
+  group('parseMealText unit invariant', () {
+    // The app's UnitDropdownItem.toString() values (meal_detail_bloc.dart).
+    // A future unit addition there without a matching update here should
+    // fail this test rather than silently reach the app's g/ml fallback.
+    const validUnitDropdownValues = {
+      'g',
+      'ml',
+      'g/ml',
+      'oz',
+      'fl.oz',
+      'serving',
+    };
+
+    test(
+      'every parsed unit is null or one of the six UnitDropdownItem values',
+      () {
+        const inputs = [
+          '100g toast',
+          'toast 100g',
+          '1,5 l milk',
+          '1kg flour',
+          '4oz steak',
+          '2 eggs',
+          'black coffee',
+          '100G toast',
+          '100xyz toast',
+          '100g toast, 2 eggs; bacon+coffee\nwater',
+        ];
+
+        for (final input in inputs) {
+          for (final item in parseMealText(input).items) {
+            if (item.unit != null) {
+              expect(
+                validUnitDropdownValues.contains(item.unit),
+                isTrue,
+                reason: 'unexpected unit "${item.unit}" from input "$input"',
+              );
+            }
+          }
+        }
+      },
+    );
+  });
 }


### PR DESCRIPTION
Closes #600.

Adds `parseMealText()` — a pure, dependency-free parser that turns one line of free text into a list of search intents for the tier-0 slice of #599. No I/O, no UI, no new dependency.

## What it does

- Segments on `,` / `;` / newline / `+`, with the comma decimal-vs-separator rule from the issue (a comma with a digit on both sides is a decimal point; every other comma is a separator).
- Extracts a leading or trailing quantity+unit per segment (`100g toast`, `toast 100g`, `1,5 l milk`).
- Converts `kg`→`g` and `l`→`ml` (×1000) before emitting, so the value that reaches `UnitDropdownItem.fromString` is never silently coerced to `g/ml` the way raw `kg`/`l` would be.
- Rejects segments with no letters via the existing `FoodNameValidator`, and enforces the same `>0 && <=10000` quantity bound `meal_detail_bottom_sheet.dart` already uses (checked *after* unit conversion).
- Asserts the unit invariant — every emitted unit is `null` or one of `UnitDropdownItem`'s six values — with a dedicated test sweeping a batch of inputs.

## Testing

- 30 new unit tests in `test/unit_test/meal_text_parser_test.dart`, covering every case in the issue's checklist plus a couple of edge cases I found while implementing (unrecognized unit tokens, negative numbers).
- Full suite: `flutter test` → 992/992 passing (no regressions).
- `flutter analyze` → no issues.
- `dart format --set-exit-if-changed` → clean.

## Notes for review

- Per the issue, I deliberately did **not** add English number-word parsing ("two eggs") — kept it to digits + `g`/`kg`/`ml`/`l`/`oz` symbols for locale independence across all 9 supported locales.
- Happy to adjust the exact error-message wording in `errors` if you'd prefer different phrasing than `Item N: ...`.