### PR TITLE
docs: add the AI-feature and F-Droid research notes

### DIFF
--- a/docs/ai-cohort-restrictions.md
+++ b/docs/ai-cohort-restrictions.md
@@ -1,0 +1,829 @@
+# Restrictions the cohort's experience places on our AI plan
+
+Research notes gathered 2026-08-02 against primary sources — the cohort
+projects' own `LICENSE` files and source, pub.dev's own licence pages, F-Droid's
+own docs and the `fdroiddata` metadata repository, providers' own legal pages,
+and the GPLv3 text in this repo's `LICENSE`. Written as the follow-up to
+[`ai-in-open-source-nutrition-trackers.md`](ai-in-open-source-nutrition-trackers.md)
+and [`ai-legal-constraints.md`](ai-legal-constraints.md), against the design
+recorded in [#599](https://github.com/simonoppowa/OpenNutriTracker/issues/599)
+as revised on 2026-08-02 and the tier-0 sub-issues
+[#600](https://github.com/simonoppowa/OpenNutriTracker/issues/600) /
+[#601](https://github.com/simonoppowa/OpenNutriTracker/issues/601) /
+[#602](https://github.com/simonoppowa/OpenNutriTracker/issues/602).
+
+The two earlier documents answer *what other projects did* and *what the law
+says*. This one answers a narrower question: **what is this project not allowed
+to do, or blocked from doing, that our current documents assume it can?**
+
+Every finding is labelled:
+
+- **Restriction** — a rule that forbids something. Compliance is not optional.
+- **Risk** — something that might go wrong or might be ruled against us.
+- **Cost** — permitted, but it costs time, money or capability.
+
+Design decisions already settled in #599's comments are taken as given and are
+not re-litigated. Where a document of ours is simply correct, that is recorded
+too — a clean bill of health on a specific point saves the next person the
+lookup. Things I could not verify are in [Not verified](#not-verified) rather
+than stated.
+
+## Bottom line up front
+
+Three restrictions actually change what gets built.
+
+1. **Google ML Kit is already in the APK, and it blocks F-Droid inclusion
+   outright** — not as an anti-feature label but under the Free Software
+   Requirement. `ai-legal-constraints.md` treats F-Droid as a labelling question
+   that a build flavour could tidy up later; it is a *blocking* question that
+   exists today, before any AI work.
+2. **Anthropic's Usage Policy prohibits disordered-eating and body-image
+   content in its Universal Usage Standards**, not only in the High-Risk
+   section. #599's decision table cites that prohibition as an OpenAI-specific
+   reason to prefer Anthropic. Both providers have it; Anthropic's is broader.
+3. **A local endpoint needs a request timeout in the minutes, and our documents
+   specify none.** Revision 2's whole reach argument rests on Ollama and
+   LM Studio, and the one cohort project that shipped that path measured 54–100
+   second responses and had to raise its client timeout to a 180-second default.
+
+Everything else is either a smaller restriction, an attribution obligation, or —
+in several places worth knowing — confirmation that what we wrote is right.
+
+## Restrictions that bind
+
+| # | Restriction | Type | Source | Affects | Consequence |
+| :-- | :-- | :-- | :-- | :-- | :-- |
+| C1 | Bundled Google ML Kit (via `mobile_scanner`) is proprietary; F-Droid requires every binary dependency to be freely licensed | Restriction | [F-Droid Inclusion Policy](https://f-droid.org/en/docs/Inclusion_Policy/); [ML Kit Terms](https://developers.google.com/ml-kit/terms) | RFP [#2540](https://gitlab.com/fdroid/rfp/-/issues/2540), not an AI issue | An `fdroid` flavour is needed regardless of the AI feature — swap the scanner, as Open Food Facts did |
+| D2 | Anthropic AUP forbids facilitating "disordered eating" and promoting "unhealthy or unattainable body image", in Universal Usage Standards | Restriction | [Anthropic Usage Policy](https://www.anthropic.com/legal/aup) | #599 decision #7 rationale; tier-1 prompt design | Never put weight, goal or body metrics in the prompt; never ask the model to comment on an intake pattern |
+| E1 | A user-supplied local endpoint needs a client timeout measured in minutes | Restriction | [fud-ai#147](https://github.com/apoorvdarshan/fud-ai/issues/147) | #599 revision 2 (endpoint field) | Configurable timeout, ~180 s default. Without it the Ollama/LM Studio story does not work at all |
+| C3 | A build flavour does **not** by itself avoid `NonFreeNet` | Restriction | [fdroiddata `com.inspiredandroid.kai.yml`](https://gitlab.com/fdroid/fdroiddata/-/raw/master/metadata/com.inspiredandroid.kai.yml) | `ai-legal-constraints.md` F-Droid section | The flavour must remove the prefilled commercial endpoint, not just proprietary libraries |
+| A3–A6 | NutriTrace (AGPL-3.0), Tandoor (AGPL + Commons Clause), MacroShot (FSL-1.1), SparkyFitness (non-commercial) cannot be copied into this repo | Restriction | Their `LICENSE` files; GPLv3 §5(c), §7, §10, §13 in this repo's `LICENSE` | #599 tier-1 checklist items lifted from those projects | Re-implement the ideas; do not lift the code |
+| A2 | MIT cohort code (Fud AI, Scranbook, EatWise) may be copied in, but the copyright and permission notice must ship with it | Restriction | Their `LICENSE` files | #599 checklist "Keystore corruption on reinstall" | Carry the notice, or write it fresh (and see E5 — you probably need neither) |
+| E2 | Image `media_type` must be sniffed from the bytes, not derived from the `.webp` filename | Restriction | [`user_image_storage.dart:91-108`](../lib/core/utils/user_image_storage.dart); [Anthropic vision docs](https://platform.claude.com/docs/en/build-with-claude/vision) | Tier 2; the plan's "no transcode" claim | Our own fallback path copies source bytes under a `.webp` name — HEIC would be rejected |
+| C5 | Bundled Unsplash demo photos are under a licence that restricts selling; F-Droid's `NonFreeAssets` names exactly that | Restriction | [Unsplash License](https://unsplash.com/license); [F-Droid Anti-Features](https://f-droid.org/en/docs/Anti-Features/) | `assets/demo/`, not an AI issue | Expect `NonFreeAssets` on any future F-Droid listing, or replace the 12 images |
+| D9 | LM Studio is proprietary software; naming it in the UI is promotion of a non-free app | Restriction | [LM Studio Terms](https://lmstudio.ai/terms); F-Droid `NonFreeAdd` | Tier-1 settings copy | If one local option is named, name Ollama (MIT) |
+| D7 | OpenAI prohibits "automation of high-stakes decisions in sensitive areas without human review", medical included | Restriction | OpenAI Usage Policies (stale mirror — see [Not verified](#not-verified)) | #602 | The confirm-before-log screen is a compliance artefact; removing it is not a UX-only change |
+| F2 | #600 segments on `,` and also accepts `,` as a decimal separator, with no stated precedence | Restriction (spec) | [#600](https://github.com/simonoppowa/OpenNutriTracker/issues/600) body vs its own test list | #600 | `1,5 l milk` cannot both segment and parse. Decide the order before writing the parser |
+
+---
+
+## A. Licence restrictions on reuse
+
+Our repo is GPL-3.0 (`LICENSE` is the unmodified GPLv3 text). The rules that
+govern reuse are in that file, and they are the primary source that actually
+binds us:
+
+- **§5(b)–(c)**: "The work must carry prominent notices stating that it is
+  released under this License and any conditions added under section 7" and
+  "You must license the entire work, as a whole, under this License … This
+  License gives no permission to license the work in any other way."
+- **§7**: "All other non-permissive additional terms are considered 'further
+  restrictions' within the meaning of section 10."
+- **§10**: "You may not impose any further restrictions on the exercise of the
+  rights granted or affirmed under this License."
+- **§13**: "you have permission to link or combine any covered work with a work
+  licensed under version 3 of the GNU Affero General Public License into a
+  single combined work … but the special requirements of the GNU Affero General
+  Public License, section 13, concerning interaction through a network will
+  apply to the combination as such."
+
+Read against the cohort:
+
+| Project | Actual licence (read from the repo) | May we copy code in? |
+| :-- | :-- | :-- |
+| [Train Libre](https://github.com/rfivesix/train-libre/blob/main/LICENSE) | GPL-3.0 (full GPLv3 text) | **Yes**, with §5(a)/(b) notices |
+| [Fud AI](https://github.com/apoorvdarshan/fud-ai/blob/main/LICENSE) | MIT — "Copyright (c) 2026 Apoorv Darshan" | **Yes**, notice must ship |
+| [Scranbook](https://github.com/taugr/scranbook/blob/main/LICENSE) | MIT — "Copyright (c) 2026-present Tom Auger" | **Yes**, notice must ship |
+| [EatWise](https://github.com/zkwi/EatWise/blob/main/LICENSE) | MIT — "Copyright (c) 2026 zkwi" | **Yes**, notice must ship |
+| [NutriTrace](https://github.com/TraceApps/nutritrace/blob/main/LICENSE) | AGPL-3.0 | **No** — see A3 |
+| [Tandoor](https://github.com/TandoorRecipes/recipes/blob/develop/LICENSE.md) | AGPL-3.0 **plus Commons Clause v1.0** | **No** |
+| [MacroShot](https://github.com/anirudhtopiwala/macroshot/blob/main/LICENSE.md) | FSL-1.1-Apache-2.0 | **No** (until each version's Change Date) |
+| [SparkyFitness](https://github.com/CodeWithCJ/SparkyFitness/blob/main/LICENSE) | Custom non-commercial | **No** |
+| [smooth-app](https://github.com/openfoodfacts/smooth-app/blob/develop/LICENSE) | Apache-2.0 | **Yes**, one-way, with NOTICE preserved |
+| [Robotoff](https://github.com/openfoodfacts/robotoff) | AGPL-3.0 (`LICENCE`, British spelling) | **No** — see A3 |
+| [NutriTracker (cdz-hy)](https://github.com/cdz-hy/NutriTracker/blob/main/LICENSE) | GPL-3.0 | **Yes** |
+| [Waistline](https://github.com/davidhealey/waistline) | GPLv3, at `www/LICENSE.txt` — see A8 | **Yes** |
+| [Food You](https://github.com/maksimowiczm/FoodYou/blob/main/LICENSE) | GPL-3.0; fdroiddata records `GPL-3.0-or-later` | **Yes** |
+
+**A1 — "Model on" Train Libre is fine; "mirror" its prompt is copying.
+Restriction (mild).** #599's second comment offers "adopting the Train Libre
+posture (model names foods, database supplies numbers)" as a way to re-settle
+decision #5. Adopting a design posture is not copying — ideas and architectural
+approaches are not the subject of the licence. But
+[`documentation/features/byok_ai_validation.md`](https://github.com/rfivesix/train-libre/blob/main/documentation/features/byok_ai_validation.md)
+is a file in a GPL-3.0 repository, so its system-prompt text, its Jaro-Winkler
+thresholds table (0.95 / 0.78 / 0.55) and its plausibility rules are covered
+expression. Lifting them verbatim is a copy, and GPLv3 §5(a) then requires
+"prominent notices stating that you modified it, and giving a relevant date".
+Since we are GPL-3.0 too this is cheap — but it is not nothing, and it should be
+done deliberately rather than by paste.
+
+**A2 — MIT does not mean "no strings". Restriction.** All three MIT cohort
+projects carry the standard clause: "The above copyright notice and this
+permission notice shall be included in all copies or substantial portions of the
+Software." #599's tier-1 checklist says the Keystore recovery path "Needs a
+catch-wipe-rebuild path", and the survey points at Fud AI's `KeyStore.kt` as the
+reference. If that code is transcribed, `Copyright (c) 2026 Apoorv Darshan` plus
+the MIT text has to ship in the repo and in any about/licences screen. See **E5**
+— the pinned `flutter_secure_storage` version already does this, so the cheapest
+answer is to copy nothing.
+
+**A3 — AGPL-3.0 code cannot be absorbed without changing what this app is.
+Restriction.** GPLv3 §13 permits *combining*, but the combination then carries
+AGPL §13's network-interaction requirement, and §5(c) forbids licensing the whole
+work any other way. Practically: for an app that runs no server, AGPL §13 is
+close to inert (as `ai-legal-constraints.md` already establishes), but the
+combination is no longer a plain GPL-3.0 work, downstream redistributors inherit
+the condition, and F-Droid's `License:` field would have to change. This bites on
+exactly one #599 checklist item — "Put wire-shape adaptation at the boundary",
+whose reference implementation is NutriTrace's
+[`server/routes/ai.js`](https://github.com/TraceApps/nutritrace/blob/main/server/routes/ai.js).
+Write the OpenAI-shape image normalisation from the wire format, not from their
+source.
+
+**A4 — Tandoor is not open source and cannot be copied at all. Restriction.**
+`LICENSE.md` opens with the Commons Clause: "the grant of rights under the
+License will not include, and the License does not grant to you, the right to
+Sell the Software", where "Sell" reaches "a product or service whose value
+derives, entirely or substantially, from the functionality of the Software". That
+is a non-permissive additional term — a "further restriction" under GPLv3 §7,
+which §10 forbids us from imposing on our recipients. The #599 checklist item
+"Cap request size and retry count even though the user pays" is modelled on
+Tandoor's `AiLog` credit ceiling and NutriTrace's caps; both must be
+re-implemented rather than adapted.
+
+**A5 — MacroShot is time-delayed, not open. Restriction.** FSL-1.1-Apache-2.0
+grants use "provided that you do not use the Licensed Work for a Competing Use",
+with a "Change Date: Two years from the date the Licensed Work is published" and
+a Change License of Apache-2.0. A use restriction is a further restriction. The
+first versions convert in 2028.
+
+**A6 — SparkyFitness is non-commercial and assigns contributions. Restriction.**
+"the Software may not be used, directly or indirectly, in any product, service,
+or project primarily intended for or resulting in commercial advantage" and
+"By submitting any code … you hereby assign **all** right, title" — both are
+incompatible with GPL-3.0 and with F-Droid's Free Software Requirement.
+
+**A7 — Apache-2.0 is safe and one-way. Clean.** smooth-app's
+[`main_fdroid.dart`](https://github.com/openfoodfacts/smooth-app/blob/develop/packages/smooth_app/lib/entrypoints/android/main_fdroid.dart)
+entry-point pattern — the single most directly useful piece of cohort code for
+us, given **C1** — is Apache-2.0 and may be adapted into a GPL-3.0 work provided
+Apache §4's notice and NOTICE-file obligations are honoured. The reverse
+direction is not available; nothing we write can go back to them under GPL.
+
+**A8 — Do not trust GitHub's licence badge. Risk (process).** `GET
+/repos/davidhealey/waistline/license` returns HTTP 404 — GitHub's detector finds
+nothing, because the licence lives at `www/LICENSE.txt` (35,149 bytes, the full
+GPLv3 text) and the README explains "The full license file is in the www
+sub-folder and the license notice is placed at the top of every source file". A
+"no licence file means all rights reserved" check run against the API alone would
+have got this exactly backwards. Read the tree. Of the fourteen cohort repos
+checked, **every one has a licence file**; the four that GitHub reports as
+`NOASSERTION` (SparkyFitness, Tandoor, MacroShot, Daily Dozen) are the four where
+reading the file actually matters.
+
+**A9 — Our own licence has no version qualifier. Restriction (procedural).**
+`LICENSE` is the bare GPLv3 text; there are no per-file headers, and the README
+badge says only "GPLv3". GPLv3 §14 governs what that means, and F-Droid metadata
+for peers is explicit either way — Food You is `GPL-3.0-or-later`, Daily Dozen
+and Translate You are `GPL-3.0-only`. If OpenNutriTracker is ever accepted into
+`fdroiddata`, a value has to be chosen. Worth deciding before someone else
+decides it for us, and worth deciding before absorbing GPL-3.0-only code from a
+peer, which would force the combination to `-only`.
+
+---
+
+## B. Dependency licence restrictions
+
+Checked against pub.dev's own licence page for each package.
+
+| Package | In pubspec today | Licence | GPL-3.0 compatible | F-Droid |
+| :-- | :-- | :-- | :-- | :-- |
+| [`flutter_secure_storage`](https://pub.dev/packages/flutter_secure_storage/license) | ✅ `^10.0.0` | BSD 3-Clause ("Copyright 2017 German Saprykin") | Yes | Fine |
+| [`http`](https://pub.dev/packages/http) | ✅ `^1.6.0` | BSD-3-Clause (Dart team) | Yes | Fine |
+| [`flutter_image_compress`](https://pub.dev/packages/flutter_image_compress) | ✅ `^2.4.0` | MIT | Yes | Fine |
+| [`image_picker`](https://pub.dev/packages/image_picker) | ✅ `^1.1.2` | BSD-3-Clause (Flutter team) | Yes | Fine |
+| [`sentry_flutter`](https://pub.dev/packages/sentry_flutter/license) | ✅ `^9.19.0` | MIT ("Copyright (c) 2019 Sentry") | Yes | Licence fine; **service** is the problem — see C6 |
+| [`mobile_scanner`](https://pub.dev/packages/mobile_scanner) | ✅ `^7.2.0` | BSD-3-Clause **package**, proprietary **ML Kit** binary | Package yes | **Blocks inclusion** — see C1 |
+| [`openai_dart`](https://pub.dev/packages/openai_dart) | ❌ (candidate) | MIT, v8.0.0, supports a custom `baseUrl` | Yes | Fine |
+| [`anthropic_sdk_dart`](https://pub.dev/packages/anthropic_sdk_dart) | ❌ (candidate) | MIT, v7.0.0, publisher `davidmiguel.com` | Yes | Fine |
+
+**B1 — No licence blocker exists in the dependency path tier 1 would need.
+Clean.** Every package the design implies is BSD-3, MIT or Apache-2.0, all of
+which are one-way compatible with GPL-3.0. There is no equivalent here of the
+licence skew the survey found at the project level.
+
+**B2 — And no new dependency is actually required. Clean.** `http ^1.6.0` is
+already in `pubspec.yaml`. #599's revision 2 settles on "three fields — endpoint,
+API key, model — speaking the OpenAI chat-completions shape", and revision 3
+settles on treating every response as untrusted text to be parsed by hand. Both
+of those decisions remove the reason to add `openai_dart`: a typed client whose
+guarantees you then discard is a dependency for nothing, and a typed client
+cannot help with an arbitrary user endpoint. This is worth stating positively
+because the plan's Scope-boundary promise of "no new dependency" can hold for
+tier 1 as well as tier 0.
+
+**B3 — WebP encoding is slower on iOS. Cost.** pub.dev's platform matrix for
+`flutter_image_compress`: WebP on Android "uses the system encoder, which is
+fast"; on iOS it is "encoded via SDWebImageWebPCoder. Functional, but noticeably
+slower than the other formats"; on macOS "not supported". HEIC is "iOS 11+ only"
+and on Android "API 28+ only, and requires a working hardware encoder". This is
+already the app's shipped pipeline so it is not new — but it is the mechanism
+behind **E2**.
+
+---
+
+## C. F-Droid restrictions
+
+Primary sources: the [Inclusion Policy](https://f-droid.org/en/docs/Inclusion_Policy/),
+the [Anti-Features page](https://f-droid.org/en/docs/Anti-Features/), the
+canonical definitions in
+[`fdroiddata/config/antiFeatures.yml`](https://gitlab.com/fdroid/fdroiddata/-/raw/master/config/antiFeatures.yml),
+and the per-app metadata YAML in `fdroiddata`.
+
+The canonical anti-feature strings, verbatim from `antiFeatures.yml`:
+
+| Key | Definition |
+| :-- | :-- |
+| `NonFreeNet` | "This app promotes or depends entirely on a non-free network service" |
+| `NonFreeDep` | "This app depends on other non-free apps" |
+| `NonFreeAdd` | "This app promotes non-free add-ons" |
+| `NonFreeAssets` | "This app contains non-free assets" |
+| `TetheredNet` | "This app depends entirely on a certain instance of a network service" |
+| `Tracking` | "This app tracks and reports your activity" |
+
+**C1 — ML Kit blocks inclusion today, and this has nothing to do with AI.
+Restriction.** This is the biggest finding in the document and it is
+present-tense.
+
+`pubspec.yaml` pins `mobile_scanner: ^7.2.0`, used in five screens. Its own
+documentation: "This package uses by default the **bundled version** of MLKit
+Barcode-scanning for Android." Google's
+[ML Kit Terms](https://developers.google.com/ml-kit/terms) state "you may not
+reverse engineer or attempt to extract the source code or any related software"
+— i.e. proprietary — and that the APIs "send metrics about the performance and
+utilization of the APIs in your app to Google". `android/gradle.properties`
+contains no `dev.steenbakker.mobile_scanner.useUnbundled=true`, and switching to
+the unbundled variant would only trade a bundled proprietary blob for a runtime
+Play Services dependency.
+
+The Inclusion Policy's Free Software Requirement is unambiguous:
+
+> All binary dependencies including JAR files must originate either from source
+> compilation or Debian repository downloads. … Applications can download
+> prebuilt FLOSS binaries with specific conditions from trusted Maven
+> repositories. … **Those binaries must still be freely licensed, simply being
+> included in one of those repositories is not enough.**
+
+and
+
+> Upstream developers must implement either a FLOSS alternative or **a build
+> flavour that does not require these dependencies** when such features become
+> necessary.
+
+`ai-legal-constraints.md` concludes that F-Droid is a labelling question —
+"`NonFreeNet` is a label, not a bar" — and offers the build flavour as an
+optional nicety "if the project cared to". That is right about the network
+service and wrong about the whole picture. The build flavour is required for
+[RFP #2540](https://gitlab.com/fdroid/rfp/-/issues/2540) to succeed at all, and
+the exemplar is Open Food Facts' `main_fdroid.dart` swapping ML Kit for ZXing.
+The good news is that `android/app/build.gradle` already declares
+`flavorDimensions "version"` with `develop` and `full`, so a third flavour is
+cheap.
+
+**C2 — "Optional and off by default" does not clear `NonFreeNet`. Restriction.**
+The definition is disjunctive: "promotes **or** depends entirely on". Our design
+comfortably fails the "depends entirely" limb — the app is fully usable with the
+feature off — but #599 revision 2 prefills "Anthropic's URL and a sensible model
+… as the default", and a prefilled commercial endpoint is promotion.
+
+**C3 — A build flavour does not by itself avoid the flag. Restriction, and this
+corrects `ai-legal-constraints.md`.** Kai 9000 is the decisive case:
+[`com.inspiredandroid.kai.yml`](https://gitlab.com/fdroid/fdroiddata/-/raw/master/metadata/com.inspiredandroid.kai.yml)
+selects `gradle: [foss]` in 49 of its 55 build entries **and still carries**
+`NonFreeNet: "Rely on Gemini and Groq"`. Compare
+[`org.breezyweather.yml`](https://gitlab.com/fdroid/fdroiddata/-/raw/master/metadata/org.breezyweather.yml),
+which selects `gradle: [freenet]` in 20 of 21 entries and carries no
+anti-features at all. The difference is not the existence of a flavour; it is
+what the flavour removes. A `foss` flavour that strips Google libraries but
+leaves the provider list intact earns the label anyway. The flavour has to remove
+the prefilled commercial endpoint.
+
+**C4 — the Translate You precedent in `ai-legal-constraints.md` is stale.
+Correction.** That document states Translate You "builds `gradle: [libre]`".
+[`com.bnyro.translate.yml`](https://gitlab.com/fdroid/fdroiddata/-/raw/master/metadata/com.bnyro.translate.yml)
+uses `libre` in only 3 build entries and `yes` in the 15 most recent, and the app
+carries **no `AntiFeatures:` block at all** while still supporting DeepL. So
+Translate You is not currently an example of the flavour pattern; Breezy Weather
+is. This weakens rather than strengthens the "you must have a flavour" reading,
+and suggests F-Droid's application of the "promotes" limb is not perfectly
+consistent — which is a reason to ask rather than to assume.
+
+**C5 — Bundled Unsplash photos are non-free assets. Restriction.**
+`pubspec.yaml` ships `assets/demo/alex_demo_avatar.jpg` and eleven JPEGs in
+`assets/demo/meals/`. The [Unsplash License](https://unsplash.com/license)
+states images "cannot be **sold** without significant modification" and does not
+grant "the right to compile images from Unsplash to replicate a similar or
+competing service". F-Droid's `NonFreeAssets` definition names precisely this
+shape: "apps using artwork … under a license that restricts commercial usage or
+making derivative works". The Inclusion Policy adds that non-functional assets
+"must allow redistribution when using non-commercial licenses". The comment in
+`unsplash_attribution.dart` correctly reasons about *attribution* — the general
+Licence does not require it — but attribution and freeness are different
+questions. Unrelated to AI; worth an issue of its own.
+
+**C6 — Sentry is the closest precedent we have, and it went against a peer.
+Risk.** The legacy Open Food Facts app's metadata carries `Tracking: "Analytics
+are opt-in but the app connects to sentry.io from the start, and connects even if
+rejected"` alongside `NonFreeNet` naming sentry.io among its servers. `Tracking`
+is the one anti-feature the F-Droid client hides by default. Our Sentry is opt-in
+and initialises only in release builds (`main.dart`), which is a materially
+better posture than the one that earned the label — but the label was earned on
+connection behaviour, not on the toggle, so the posture needs to be demonstrable
+rather than asserted.
+
+**C7 — F-Droid can build a Flutter app, in one specific shape. Restriction
+(build).** [`com.danemadsen.maid.yml`](https://gitlab.com/fdroid/fdroiddata/-/raw/master/metadata/com.danemadsen.maid.yml)
+is the working precedent: `submodules: true` with the Flutter SDK vendored into
+the repo and invoked as `packages/flutter/bin/flutter`, `flutter config
+--no-analytics` in `prebuild`, `scanignore: [packages/flutter/bin/cache]`,
+`scandelete: [.pub-cache, packages/flutter]`, `flutter build apk --release
+--split-per-abi`, and **one metadata entry per ABI** with a distinct
+`versionCode`. The Inclusion Policy separately permits this: "The Android SDK,
+Flutter SDK and Hermes have permission to use official prebuilt binaries until
+Debian provides alternative solutions." Our current release flow builds an AAB
+for Play; F-Droid needs per-ABI APKs from a vendored SDK.
+
+**C8 — F-Droid does permit shipping a client for a proprietary network service.
+Clean.** Inclusion Policy: anti-features "serve as warning indicators about user
+freedom, privacy or etc. **without necessarily disqualifying applications from
+inclusion**", and only `Tracking` is hidden by default. maid, oxproxion and Kai
+9000 are all in the main repository. There is no rule against the AI feature as
+such.
+
+**C9 — Never ship a project key. Clean, satisfied by construction.** "F-Droid
+does not sign up for any API keys. Even if provided by a third party, we include
+them in both binary and source code releases." BYO-key satisfies this by design.
+
+**C10 — If a local model is ever bundled or downloaded, it needs an explicit
+opt-in. Restriction (future).** "Applications must not download additional
+executable binary files (e.g. add-ons, auto-updates, etc.) without explicit user
+consent. Consent means it needs to be opt-in … and structured in a way that
+clearly explains to users that they're choosing to bypass F-Droid's checks."
+Nothing in the current design does this. It would bite immediately if #250's
+reopening conditions are ever met and an on-device model lands.
+
+---
+
+## D. Provider terms that bind the developer, not the user
+
+Our design is BYO-key and device-to-endpoint. The question is whether any of
+these terms reach *us* anyway.
+
+**D1 — Anthropic's Usage Policy scope clause reaches passthrough clients.
+Risk.** The AUP opens: "Our Usage Policy applies to anyone who can submit inputs
+to Anthropic's products and/or services, **including via any authorized resellers
+or passthrough access**, all of whom we refer to as 'users.'" That is a broader
+scope clause than "our customers". It does not obviously make a client-app
+developer a "user" — the developer never submits an input; the end user does, on
+their own device, with their own key. But the drafting anticipates the
+intermediary pattern, so the comfortable position that the AUP is purely the
+user's contract is not free. Treat AUP compliance as a design constraint on the
+prompt we ship, not as someone else's problem.
+
+**D2 — Anthropic prohibits disordered-eating and body-image content in its
+*universal* standards, and #599's provider rationale reads as though it does not.
+Restriction.** Under **Universal Usage Standards → "Do Not Create
+Psychologically or Emotionally Harmful Content"**:
+
+> Facilitate, promote, or glamorize any form of suicide or self-harm, including
+> disordered eating and unhealthy or compulsive exercise
+
+> Engage in behaviors that promote unhealthy or unattainable body image or
+> beauty standards, such as using the model to critique anyone's body shape or
+> size
+
+#599's decision table rejects OpenAI in part because "the usage policy prohibits
+*'disordered eating promotion or facilitation'*", implying a contrast. There is
+none: Anthropic has the same prohibition and adds a body-image limb that OpenAI's
+universal section does not. This does not unsettle decision #7 — the other three
+reasons for Anthropic (the nutrition carve-out from High-Risk, ephemeral image
+handling, structured outputs) stand — but it does impose a concrete constraint on
+the prompt:
+
+- do not include the user's weight, weight goal, BMI, TDEE or calorie deficit in
+  the request; the model does not need them to name a food;
+- do not add any feature that asks the model to comment on, summarise or judge
+  the user's intake pattern, body or progress. That is the "critique anyone's
+  body shape or size" limb, and it is where a "coach" feature would land.
+
+The app already ships a low-kcal warning and an intermittent-fasting content
+gate. Those instincts are correct and should extend to the prompt.
+
+**D3 — The High-Risk disclosure and human-review duties do *not* attach to this
+feature. Clean.** The AUP's structure is three sections: Universal Usage
+Standards, High-Risk Use Case Requirements, Additional Use Case Guidelines. The
+per-session disclosure — "If model outputs are presented directly to individuals
+or consumers, you must disclose to them that you are using AI to help produce
+your advice, decisions, or recommendations. This disclosure must be provided at a
+minimum at the beginning of each session" — sits in **High-Risk Use Case
+Requirements**, alongside "A qualified professional in that field must review the
+content or decision prior to dissemination or finalization." The High-Risk
+categories are Legal, Healthcare, Insurance, Finance, Employment and housing,
+Academic testing/accreditation/admissions, and Media or professional journalistic
+content — and Healthcare expressly excludes us: "Wellness advice (e.g., advice on
+sleep, stress, nutrition, exercise, etc.) does not fall under this category."
+
+So Anthropic imposes **no** attribution or per-session AI-disclosure duty on
+meal logging. The in-app disclosure `ai-legal-constraints.md` calls for is driven
+by Apple 5.1.2(i) and Google Play, not by Anthropic. The caution is the mirror
+image of D2: any drift toward advice flips the classification and switches on a
+*qualified-professional review* requirement that a solo project cannot satisfy.
+
+**D4 — The Commercial Terms bind the account holder, who is the user. Clean.**
+"Subject to these Terms, Anthropic gives Customer permission to use the Services,
+including to power products and services Customer makes available to its own
+customers and end users"; "Customer is responsible for all activity under its
+account"; "Customer and its Users may only use the Services in compliance with
+these Terms". Under BYO-key the user is Customer. Two clauses were checked
+specifically and do not bite:
+
+- **Resale.** "Customer may not and must not attempt to … resell the Services
+  except as expressly approved by Anthropic." The project charges nothing and
+  intermediates nothing.
+- **Credentials.** No clause was found forbidding a Customer from entering their
+  own key into third-party software running on their own device. The
+  confidentiality provisions run between the parties, not to the user's own
+  tooling.
+- **Age.** No minimum-age requirement appears in the Commercial Terms or the
+  AUP.
+
+**D5 — Anthropic will not name people in images, and says so in the docs.
+Clean.** The vision documentation lists under Limitations: "**People
+identification:** Claude [cannot be used](https://www.anthropic.com/legal/aup) to
+name people in images and refuses to do so." That matches
+`ai-legal-constraints.md`'s advice to never ask the model about people in the
+frame, and means the tier-2 photo path cannot accidentally acquire a biometric
+character through the model's own behaviour.
+
+**D6 — And it disclaims healthcare use. Clean, reinforcing.** Same page:
+"Although Claude can analyze general medical images, it is not designed to
+interpret complex diagnostic scans … Claude's outputs should not be considered a
+substitute for professional medical advice or diagnosis."
+
+**D7 — OpenAI's human-review clause makes #602 load-bearing. Restriction (source
+quality weak — see [Not verified](#not-verified)).** From the Usage Policies:
+
+> automation of high-stakes decisions in sensitive areas without human review …
+> medical
+
+> provision of tailored advice that requires a license, such as legal or medical
+> advice, without appropriate involvement by a licensed professional
+
+> suicide, self-harm, or disordered eating promotion or facilitation
+
+> promoting unhealthy dieting or exercise behavior to minors
+
+The confirm-before-log review screen in #602 is what keeps an OpenAI endpoint on
+the right side of the first clause, exactly as #599's third comment already
+argues it may be under AI Act Article 50(4). That is now two independent regimes
+resting on the same screen. It should be recorded in #602 that the screen is not
+purely a UX affordance.
+
+The "promoting unhealthy dieting … to minors" clause is worth a note because the
+app is not age-gated. Nothing in the current design targets minors or generates
+diet advice, so it does not attach — but a "coach" feature in an
+all-ages-rated app would.
+
+**D8 — Ollama is the only endpoint with no terms at all in the loop. Clean, and
+useful.** The Ollama binary is [MIT](https://github.com/ollama/ollama/blob/main/LICENSE)
+("Copyright (c) Ollama"). [ollama.com's Terms of Service](https://ollama.com/terms)
+govern the hosted service — they require account holders to be at least 18, cover
+registration and prohibited activities — and contain no clause about the local
+server API or third-party clients, because the local binary needs no account.
+Pointing the app at `http://localhost:11434` therefore engages no third-party
+terms, no age gate, and no data-handling question. That is a genuine argument for
+naming Ollama specifically in the settings copy.
+
+**D9 — LM Studio is proprietary, and that has an F-Droid consequence.
+Restriction.** [LM Studio's Terms](https://lmstudio.ai/terms) grant "a
+non-exclusive, non-transferable license to use the Software solely for Your
+personal and / or internal business purposes" and forbid, among other things:
+
+> (a) modify, adapt, alter, translate, or create derivative works from the
+> Software … (b) integrate the Software with other software other than through
+> Element Labs published interfaces made available with the Software … (c) use
+> any open source products with the Software in a manner that imposes … a
+> requirement … that the Software or any part thereof: (i) be disclosed or
+> distributed in source code for[m] … (e) reverse engineer, decompile,
+> disassemble
+
+Two consequences. First, a client speaking LM Studio's documented
+OpenAI-compatible local server *is* going "through Element Labs published
+interfaces", so the integration itself is permitted, and clause (c) is not
+triggered by an HTTP request — the FSF's socket analysis in
+`ai-legal-constraints.md` covers this. Second, and more practically: LM Studio is
+**non-free software**, so a settings screen that names it or prefills its port is
+promoting a non-free app, which is what F-Droid's `NonFreeAdd` covers ("This app
+promotes non-free add-ons") and adjacent to `NonFreeDep` ("This app depends on
+other non-free apps"). If the UI names exactly one local option — and it should,
+because "run a local server" is meaningless to most users — name Ollama.
+
+---
+
+## E. Technical restrictions the cohort hit that our documents do not account for
+
+The four already recorded in #599 (Keystore `AEADBadTagException`, key-regex
+validation, truncation vs malformed output, and the Anthropic image content-part
+shape) are not repeated. These are the ones that are not in our documents.
+
+**E1 — There is no timeout in our design, and a local endpoint needs a big one.
+Restriction — this is a hard blocker, not a bug.**
+[fud-ai#147](https://github.com/apoorvdarshan/fud-ai/issues/147) is the only
+cohort report from someone actually running the architecture #599 revision 2
+describes: a self-hosted Ollama with `qwen3-vl:4b` on a GTX 1660 Super, reached
+through the app's OpenAI-compatible custom-provider field.
+
+> Photo-based food logging consistently fails with a "network error: timeout" in
+> the app, even though the server-side request *does* complete successfully —
+> confirmed via server logs showing `HTTP 200` after ~54-100 seconds
+
+The maintainer's fix, in the same thread: "Ollama and Custom OpenAI-compatible
+request timeouts are now configurable from **30–600 seconds**, with a
+**180-second default**", plus downscaling analysis images to 1600 px before
+upload.
+
+Revision 2's central argument is that the endpoint field "removes the constraint
+that most weakened this feature" by making local inference viable. That argument
+does not survive a default HTTP timeout. Neither the plan nor #599 nor #601 nor
+#602 mentions a timeout at all. Concretely: whichever issue scopes the tier-1
+client must specify a configurable timeout with a default in the low hundreds of
+seconds, and the review screen must show progress rather than appearing hung —
+a 90-second wait with no feedback reads as a crash.
+
+**E2 — Our `.webp` filenames are not a guarantee, and Anthropic validates
+`media_type`. Restriction.** The plan and #599 both assert that "the existing
+1024 px q80 pipeline in `user_image_storage.dart` feeds the API with no
+transcode". Our own code says otherwise on the fallback path
+([`user_image_storage.dart:91-108`](../lib/core/utils/user_image_storage.dart)):
+
+> If the on-device WebP encoder is unavailable for some reason (very old
+> hardware, simulator quirks), `FlutterImageCompress` returns `null` and we fall
+> back to copying the source bytes verbatim — **the file extension stays
+> `.webp` either way** so callers don't have to branch on it.
+
+Anthropic's vision documentation: "Claude supports JPEG, PNG, GIF, and WebP
+images (`image/jpeg`, `image/png`, `image/gif`, `image/webp`)." HEIC is not on
+that list, and iOS `image_picker` can hand back HEIC. So a stored
+`meal_images/<code>.webp` that is actually HEIC bytes, sent with a `media_type`
+derived from its extension, is a request Anthropic rejects — and the failure
+would be a rare, device-specific, unreproducible bug report. The tier-2 client
+must sniff the format from the leading bytes and re-encode or refuse, not read
+the extension. This is a small change made much cheaper by knowing about it
+first.
+
+**E3 — Anthropic's hard image limits, sourced. Clean, with the numbers now
+written down.** From the vision docs, none of which our documents record:
+
+- maximum dimensions **8000×8000 px**;
+- maximum size per image **10 MB base64** on the Claude API (5 MB on Bedrock and
+  Google Cloud);
+- **32 MB request-size limit** for standard endpoints;
+- **≤20 image/document blocks per request**, above which "a stricter per-image
+  dimension limit applies" and oversize images are rejected with an
+  `invalid_request_error` referencing "many-image requests";
+- standard-tier models downscale anything with a long edge above **1568 px**
+  (high-resolution tier, Claude 4.7+, is 2576 px);
+- images cost `⌈width / 28⌉ × ⌈height / 28⌉` visual tokens.
+
+Our 1024 px q80 WebP is comfortably inside every one of these, single-image
+requests are far under the block limit, and the plan's arithmetic checks out:
+⌈1024/28⌉² = 37² = **1369 visual tokens**, exactly as stated. The lossy-compression
+warning the plan flags is verbatim from the same page. This is a clean bill of
+health for the tier-2 sizing decisions.
+
+**E4 — The cohort's only measured accuracy datum supports #601's database-first
+rule. Confirming.** [fud-ai#157](https://github.com/apoorvdarshan/fud-ai/issues/157),
+a feature request asking Fud AI to consult Open Food Facts before trusting the
+model:
+
+> I tested the exact same meal 10 times via text input with identical quantities
+> and brand names, and the reported calories varied by about 900 ± 300 kcal.
+> That's too inconsistent for reliable calorie tracking.
+
+The reporter also asks for "A small icon showing the source (🗄️ Database / 🤖 AI)".
+That is #601's database-first policy and #599 revision 1's `estimated` marker,
+independently arrived at by a user of the app that did not do it. The survey
+notes that no cohort project publishes measured accuracy; this is the closest
+thing, and it is a run-to-run *variance* figure rather than an error figure,
+which is arguably worse. It is a good argument to keep in #601.
+
+**E5 — The Keystore recovery path is already handled by the version we pin.
+Clean; a checklist item can be closed.** #599's tier-1 checklist opens with
+"Keystore corruption on reinstall … Needs a catch-wipe-rebuild path". The
+[`flutter_secure_storage` 10.0.0 changelog](https://pub.dev/packages/flutter_secure_storage/changelog)
+states:
+
+> ResetOnError will now automatically be true, because most errors are
+> unrecoverable due to key storage problems
+
+along with `encryptedSharedPreferences` being deprecated "due to Jetpack Crypto
+package deprecation", default ciphers moving to
+`RSA_ECB_OAEPwithSHA_256andMGF1Padding` and `AES_GCM_NoPadding`, and minimum
+Android SDK rising from 19 to 23. `pubspec.yaml` pins `^10.0.0`, so the
+catch-wipe-rebuild behaviour Fud AI had to write by hand in Kotlin is now the
+library default for us. Two follow-ons: the checklist item should be rewritten as
+"verify `resetOnError` is on and that losing the key on reinstall is surfaced to
+the user, not silently swallowed", and there is now no reason to transcribe
+`KeyStore.kt` (removing the **A2** attribution obligation entirely). minSdk 23 is
+below #599's stated floor of 24, so nothing is lost there.
+
+**E6 — One real store-review restriction in the cohort, and it is not about AI.
+Cost.** [train-libre#480](https://github.com/rfivesix/train-libre/issues/480) —
+"fix(ios): Restrict app deployment to iPhone only to bypass iPad screenshot
+requirements". The nearest neighbour project by construction hit an App Store
+submission requirement and solved it by narrowing device support. No cohort
+project shows an App Store or Play rejection caused by an AI feature; the survey's
+finding that "nobody was removed from F-Droid over AI" has a store-side
+equivalent. Absence of evidence, but the search was reasonably thorough.
+
+---
+
+## F. What our documents assume away
+
+**F1 — The plan's Scope boundary holds. Clean.** "Deterministic text parser" /
+"Any model, local or remote"; "Resolution against existing search" / "Network
+calls to any new destination"; "no new dependency". Verified against the repo:
+`resolve_parsed_meals_usecase.dart` reuses `SearchProductsUseCase`, which reaches
+only Open Food Facts and the Supabase backend — both already in the README's
+destination table — and the parser needs nothing that is not already in
+`pubspec.yaml`. Tier 0 changes nothing about the privacy table, and no restriction
+found in this document attaches to it. #600, #601 and #602 can proceed on the
+licence, F-Droid and provider-terms axes without further work.
+
+**F2 — #600 contradicts itself on the comma, and the cohort's own worked example
+is the failing case. Restriction (spec).** The issue body says "**Segment** the
+input on `,`, `;`, newline, and `+`" and then "Accept `.` or `,` as the decimal
+separator". Its own test checklist asks for both "Comma decimal (`1,5 l milk`)"
+and "Each separator: `,` `;` newline `+`". These cannot both hold under a
+naive left-to-right segmentation: `1,5 l milk` becomes `1` and `5 l milk`.
+
+This is not a nitpick, because it is exactly the case the cohort raised.
+[fud-ai#130](https://github.com/apoorvdarshan/fud-ai/issues/130) — the issue #599
+cites approvingly as validating #600's locale-independence — proposed a German
+quick-parser whose worked example was `1 EL Öl`, and German writes `1,5 l Milch`.
+Seven of the nine shipped locales use the comma as the decimal separator
+(`cs`, `de`, `it`, `pl`, `sk`, `tr`, `uk`); only `en` and `zh` do not. The
+parser needs a stated
+precedence rule (the obvious one: a comma flanked by digits on both sides is a
+decimal point, everything else is a separator), and #600's acceptance tests need
+a case that exercises both in one input, e.g. `1,5 l milk, 2 eggs`.
+
+**F3 — The Anthropic-versus-OpenAI rationale in #599 overstates the difference.
+Correction.** Covered at **D2**. The decision stands; the reasoning has one leg
+fewer than it appears to.
+
+**F4 — Revision 2's local-endpoint story carries two restrictions the comment
+does not.** The timeout (**E1**) and LM Studio's non-free status versus Ollama's
+MIT (**D9**). Both belong in whichever issue scopes tier 1.
+
+**F5 — `ai-legal-constraints.md`'s F-Droid section needs two corrections and one
+enlargement.** The build-flavour conclusion is too optimistic (**C3**), the
+Translate You citation is stale (**C4**), and the framing of F-Droid as a
+label-only question is wrong in two places that have nothing to do with AI —
+ML Kit (**C1**) and the Unsplash assets (**C5**). The net effect is that
+"F-Droid work" is a larger, earlier and more separable piece of work than that
+document implies, and it should not be bundled into the AI feature.
+
+**F6 — #602's review screen is now load-bearing under three regimes. Confirming,
+and worth recording in the issue.** AI Act Article 50(4)'s human-editorial-review
+exception (already noted in #599's third comment, flagged there as a reading
+rather than a verified position); OpenAI's prohibition on "automation of
+high-stakes decisions in sensitive areas without human review" (**D7**); and
+Anthropic's High-Risk human-in-the-loop requirement should the feature ever drift
+into advice (**D3**). #602 currently describes the screen purely as UX. A one-line
+note that removing or auto-confirming it has consequences beyond usability would
+be cheap insurance against a future "just log it automatically" optimisation.
+
+**F7 — A small drift worth fixing while nearby.** The plan and #599 both quote
+the README as promising *"these four destinations, nothing else"*. `README.md`
+line 131 says "**Three** destinations, nothing else" and lists Open Food Facts,
+the Supabase backend and Sentry. Not a restriction, but the sentence is the one
+the plan says "is the product", so it is worth quoting accurately.
+
+---
+
+## Not verified
+
+- **OpenAI's Services Agreement / Business Terms §2.2 and §3.3(g)** — the
+  clauses #599 cites as explicitly blessing BYO-key. `openai.com` returned
+  HTTP 403 to every attempt (WebFetch and `curl` with a browser user-agent, on
+  `/policies/services-agreement/`, `/policies/business-terms/` and the `en-GB`
+  variants). The BYO-key blessing remains unverified.
+- **OpenAI's current Usage Policies.** The text quoted at **D7** comes from a
+  Microsoft-hosted PDF copy
+  (`learn.microsoft.com/.../usage-policies-openai.pdf`) printed 2025-11-07 and
+  marked "Effective: October 29, 2025" — a mirror, and roughly nine months stale
+  as of today. The quotes are verbatim from that copy; they should be re-checked
+  against openai.com before being relied on.
+- **gnu.org's licence list and GPL FAQ.** Repeated HTTP 429 and a connection
+  reset; `curl` was served a 199-byte stub. Every GPL-compatibility conclusion in
+  section A is therefore drawn from the GPLv3 text in this repo's own `LICENSE`
+  (§5, §7, §10, §13, §14) rather than from the FSF's commentary. That is arguably
+  the better source for our purposes, but it means the FSF's own characterisation
+  of AGPLv3-versus-GPLv3 compatibility is not quoted here.
+- **What Kai 9000's `foss` flavour actually removes.** `fdroiddata` selects
+  `gradle: [foss]`, which is a fact from the metadata. I could not find a
+  `productFlavors` block in `composeApp/build.gradle.kts` on `main`, so the
+  inference at **C3** — that the flavour strips Google libraries but not the
+  provider list — is reasoning from the outcome, not from the build file.
+- **Whether F-Droid would in fact apply `NonFreeAssets` to the Unsplash demo
+  photos.** The definition fits the Unsplash Licence's no-sale clause, but no
+  ruling on Unsplash-licensed assets specifically was found in `fdroiddata` or
+  the F-Droid docs.
+- **Whether `ollama.com`'s Terms reach a locally-run `ollama serve`.** The Terms
+  describe an account-based hosted service and are silent on the local binary,
+  which is MIT and needs no account. Silence is not the same as an exclusion.
+- **Whether the ML Kit dependency can be swapped without losing barcode
+  formats.** `mobile_scanner` offers bundled and unbundled ML Kit; it does not
+  offer a free-software backend on Android. Open Food Facts used ZXing. Whether
+  ZXing covers every symbology the app relies on was not checked.
+- **Our current Play content rating and App Store age rating.** Neither is in the
+  repo — both live in the consoles — so the interaction between an all-ages
+  rating and OpenAI's "promoting unhealthy dieting … to minors" clause could not
+  be assessed.
+- **Whether `flutter.minSdkVersion` currently resolves to 24.**
+  `android/app/build.gradle` defers to the Flutter default rather than pinning a
+  number, so #599's "runs down to minSdk 24" claim was taken at face value.
+  `flutter_secure_storage` 10 requires 23, so the conclusion at **E5** holds
+  either way.
+- **Any App Store or Play rejection caused by an AI feature.** None found across
+  the cohort's issue trackers. That is an absence of evidence from a
+  keyword-driven search, not evidence of absence.
+
+## Sources
+
+Cohort licences, read from the repositories:
+[Train Libre](https://github.com/rfivesix/train-libre/blob/main/LICENSE) ·
+[Fud AI](https://github.com/apoorvdarshan/fud-ai/blob/main/LICENSE) ·
+[Scranbook](https://github.com/taugr/scranbook/blob/main/LICENSE) ·
+[EatWise](https://github.com/zkwi/EatWise/blob/main/LICENSE) ·
+[NutriTrace](https://github.com/TraceApps/nutritrace/blob/main/LICENSE) ·
+[Tandoor](https://github.com/TandoorRecipes/recipes/blob/develop/LICENSE.md) ·
+[MacroShot](https://github.com/anirudhtopiwala/macroshot/blob/main/LICENSE.md) ·
+[SparkyFitness](https://github.com/CodeWithCJ/SparkyFitness/blob/main/LICENSE) ·
+[smooth-app](https://github.com/openfoodfacts/smooth-app/blob/develop/LICENSE) ·
+[Waistline `www/LICENSE.txt`](https://github.com/davidhealey/waistline/tree/master/www) ·
+[Food You](https://github.com/maksimowiczm/FoodYou/blob/main/LICENSE) ·
+[NutriTracker (cdz-hy)](https://github.com/cdz-hy/NutriTracker/blob/main/LICENSE)
+
+Our own licence text: [`LICENSE`](../LICENSE) (GPLv3 §5, §7, §10, §13, §14).
+
+Package licences, from pub.dev's own licence pages:
+[flutter_secure_storage](https://pub.dev/packages/flutter_secure_storage/license) ·
+[sentry_flutter](https://pub.dev/packages/sentry_flutter/license) ·
+[flutter_image_compress](https://pub.dev/packages/flutter_image_compress) ·
+[mobile_scanner](https://pub.dev/packages/mobile_scanner) ·
+[openai_dart](https://pub.dev/packages/openai_dart) ·
+[anthropic_sdk_dart](https://pub.dev/packages/anthropic_sdk_dart) ·
+[flutter_secure_storage changelog](https://pub.dev/packages/flutter_secure_storage/changelog)
+
+F-Droid:
+[Inclusion Policy](https://f-droid.org/en/docs/Inclusion_Policy/) ·
+[Anti-Features](https://f-droid.org/en/docs/Anti-Features/) ·
+[`config/antiFeatures.yml`](https://gitlab.com/fdroid/fdroiddata/-/raw/master/config/antiFeatures.yml) ·
+[`com.inspiredandroid.kai.yml`](https://gitlab.com/fdroid/fdroiddata/-/raw/master/metadata/com.inspiredandroid.kai.yml) ·
+[`io.github.stardomains3.oxproxion.yml`](https://gitlab.com/fdroid/fdroiddata/-/raw/master/metadata/io.github.stardomains3.oxproxion.yml) ·
+[`com.danemadsen.maid.yml`](https://gitlab.com/fdroid/fdroiddata/-/raw/master/metadata/com.danemadsen.maid.yml) ·
+[`org.breezyweather.yml`](https://gitlab.com/fdroid/fdroiddata/-/raw/master/metadata/org.breezyweather.yml) ·
+[`com.bnyro.translate.yml`](https://gitlab.com/fdroid/fdroiddata/-/raw/master/metadata/com.bnyro.translate.yml) ·
+[`com.maksimowiczm.foodyou.yml`](https://gitlab.com/fdroid/fdroiddata/-/raw/master/metadata/com.maksimowiczm.foodyou.yml) ·
+[`openfoodfacts.github.scrachx.openfood.yml`](https://gitlab.com/fdroid/fdroiddata/-/raw/master/metadata/openfoodfacts.github.scrachx.openfood.yml) ·
+[RFP #2540](https://gitlab.com/fdroid/rfp/-/issues/2540)
+
+Provider terms:
+[Anthropic Usage Policy](https://www.anthropic.com/legal/aup) ·
+[Anthropic Commercial Terms of Service](https://www.anthropic.com/legal/commercial-terms) ·
+[Anthropic Service Specific Terms](https://www.anthropic.com/legal/service-specific-terms) ·
+[Anthropic vision documentation](https://platform.claude.com/docs/en/build-with-claude/vision) ·
+OpenAI Usage Policies (mirror, see [Not verified](#not-verified)) ·
+[Ollama Terms of Service](https://ollama.com/terms) ·
+[Ollama LICENSE](https://github.com/ollama/ollama/blob/main/LICENSE) ·
+[LM Studio Terms](https://lmstudio.ai/terms) ·
+[Google ML Kit Terms](https://developers.google.com/ml-kit/terms) ·
+[Unsplash License](https://unsplash.com/license)
+
+Cohort issue threads:
+[fud-ai#147](https://github.com/apoorvdarshan/fud-ai/issues/147) ·
+[fud-ai#157](https://github.com/apoorvdarshan/fud-ai/issues/157) ·
+[fud-ai#130](https://github.com/apoorvdarshan/fud-ai/issues/130) ·
+[train-libre#480](https://github.com/rfivesix/train-libre/issues/480)
+
+In-repo files cited:
+[`LICENSE`](../LICENSE) ·
+[`pubspec.yaml`](../pubspec.yaml) ·
+[`android/app/build.gradle`](../android/app/build.gradle) ·
+[`android/gradle.properties`](../android/gradle.properties) ·
+[`lib/core/utils/user_image_storage.dart`](../lib/core/utils/user_image_storage.dart) ·
+[`lib/core/utils/demo/unsplash_attribution.dart`](../lib/core/utils/demo/unsplash_attribution.dart) ·
+[`README.md`](../README.md)

--- a/docs/ai-in-open-source-nutrition-trackers.md
+++ b/docs/ai-in-open-source-nutrition-trackers.md
@@ -1,0 +1,599 @@
+# AI features in other open-source nutrition trackers
+
+Research notes gathered 2026-08-02 against primary sources — repositories,
+source files, dependency manifests, project docs, and issue threads. Written to
+inform issue [#599](https://github.com/simonoppowa/OpenNutriTracker/issues/599),
+which scoped AI-assisted meal logging for this app as a deterministic local
+parser for everyone plus an opt-in bring-your-own-key tier using Anthropic.
+
+Every factual claim below links to the file or issue it came from. Star counts
+and "last pushed" dates are as of 2026-08-02. Things I could not confirm are
+listed at the end rather than guessed at.
+
+> **Read alongside [`ai-cohort-restrictions.md`](ai-cohort-restrictions.md).**
+> This document answers *what other projects did*. That one answers *what we
+> are allowed to copy* — several of the projects surveyed here are under
+> licences (AGPL-3.0, FSL-1.1, Commons Clause, non-commercial) that this
+> repo's GPL-3.0 cannot take code from. Treat everything below as
+> read-for-ideas unless that document says otherwise.
+
+## Summary
+
+The landscape splits cleanly along a line that is not the one you would expect.
+The strictly-free, F-Droid-distributed calorie trackers with real user
+bases — [Waistline](https://github.com/davidhealey/waistline),
+[Food You](https://github.com/maksimowiczm/FoodYou),
+[FitBook](https://github.com/brandonp2412/FitBook) — have **no AI code at all**,
+not behind a flag and not in a branch; their dependency manifests contain no
+model runtime and no provider SDK. Everything that does ship AI is either
+self-hosted server software under a source-available or non-commercial licence
+([Tandoor](https://github.com/TandoorRecipes/recipes),
+[SparkyFitness](https://github.com/CodeWithCJ/SparkyFitness),
+[MacroShot](https://github.com/anirudhtopiwala/macroshot)), or a small
+mobile app that ships **bring-your-own-key and nothing else** — no bundled
+credential, no project-operated proxy
+([Fud AI](https://github.com/apoorvdarshan/fud-ai),
+[Train Libre](https://github.com/rfivesix/train-libre),
+[EatWise](https://github.com/zkwi/EatWise),
+[Scranbook](https://github.com/taugr/scranbook)). BYO-key is therefore the
+conventional choice, not a novel one; the two design decisions where
+OpenNutriTracker's plan is genuinely unusual are hardcoding a *single* provider
+(everyone else is multi-provider or OpenAI-compatible from day one) and letting
+the model emit macros at all (the closest comparator forbids it outright).
+Open Food Facts is the outlier in the other direction: it runs its ML
+server-side on self-hosted fine-tuned open weights and deliberately disables the
+one on-device ML dependency it has in its F-Droid build.
+
+## Comparison table
+
+| Project | Licence | AI feature | Where inference runs | Provider(s) | BYO key? | Shipped? |
+| :-- | :-- | :-- | :-- | :-- | :-- | :-- |
+| [Fud AI](https://github.com/apoorvdarshan/fud-ai) | MIT | Photo→meal (up to 10 images), text, voice, coach chat, nutrient-goal estimation | Device → provider, direct. Apple Intelligence on-device as last fallback | 13, incl. Anthropic, OpenAI, Gemini, Ollama, custom OpenAI-compatible | Yes, only | Yes — App Store + Play |
+| [Train Libre](https://github.com/rfivesix/train-libre) | GPL-3.0 | Photo + text meal capture; LLM forbidden from emitting numbers | Device → provider, direct; no intermediate server | OpenAI, Gemini, Anthropic, Mistral, xAI | Yes, only | Yes (beta) — App Store, Obtainium, own F-Droid repo |
+| [NutriTrace](https://github.com/TraceApps/nutritrace) | AGPL-3.0 | Conversational assistant with 16 tools, Smart Log text/voice, photo `propose_food`, Scan Label OCR | Self-hosted server (proxy mode) or browser → provider | Claude, OpenAI, Gemini, any OpenAI-compatible incl. Ollama | Yes (per-instance or admin env) | Yes |
+| [SparkyFitness](https://github.com/CodeWithCJ/SparkyFitness) | Non-commercial (custom) | "SparkyAI" chat logging, food-image logging | Self-hosted server | Anthropic, OpenAI, Gemini, Ollama, OpenAI-compatible | Yes (admin-configured) | Yes (beta) |
+| [Tandoor Recipes](https://github.com/TandoorRecipes/recipes) | AGPL + Commons Clause | Recipe import from image/PDF/text, step sorting, food + recipe property (nutrition) extraction | Self-hosted server, via LiteLLM | Anything LiteLLM routes | Yes, per space | Yes, since Tandoor 2 |
+| [Open Food Facts](https://github.com/openfoodfacts/robotoff) (Robotoff) | AGPL-3.0 | Category/brand/label prediction, nutrition-table extraction, ingredient spellcheck, logo ANN | Project's own servers (Triton) | Self-hosted fine-tuned Mistral-7B + custom models | No | Yes |
+| [Open Food Facts](https://github.com/openfoodfacts/smooth-app) (Smoothie app) | Apache-2.0 | On-device OCR/classification via ML Kit; on-device LLM exploratory only | On-device (non-F-Droid builds only) | Google ML Kit | No | Partly — **disabled in the F-Droid build** |
+| [MacroShot](https://github.com/anirudhtopiwala/macroshot) | FSL-1.1-Apache-2.0 (source-available) | Photo/text/barcode logging, MCP coach with 23 tools | Self-hosted server or author's hosted instance | Gemini (single, required env var) | No — operator supplies | Yes (open beta) |
+| [Scranbook](https://github.com/taugr/scranbook) | MIT | Photo→dish + label transcription; **macros computed locally** from bundled composition data | Browser → user's OpenAI-compatible endpoint | LM Studio default, any OpenAI-compatible | Yes, only | Yes (small) |
+| [EatWise](https://github.com/zkwi/EatWise) | MIT | Photo meal analysis, ranges only | Device → user's endpoint | OpenRouter default, any OpenAI-compatible | Yes, only | Yes (GitHub releases) |
+| [NutriTracker (cdz-hy)](https://github.com/cdz-hy/NutriTracker) | GPL-3.0 | Photo food recognition, weight + nutrient estimation | Device → user's endpoint | Any OpenAI-compatible multimodal | Yes, only | Yes (GitHub releases) |
+
+Projects with a comparable user base and **no AI**: Waistline (728★),
+Food You (515★), FitBook (157★), kcal (350★),
+[PANTS](https://github.com/dylanleigh/PriceAndNutritionTrackingSystem) (131★),
+[Daily Dozen](https://github.com/nutritionfactsorg/daily-dozen-android) (294★).
+
+## Fud AI — the closest shipped comparator
+
+[`apoorvdarshan/fud-ai`](https://github.com/apoorvdarshan/fud-ai), MIT, Kotlin
+(Compose) + Swift (SwiftUI), 299★, last pushed 2026-07-25. Ships on the
+[App Store](https://apps.apple.com/us/app/fud-ai-calorie-tracker/id6758935726)
+and [Google Play](https://play.google.com/store/apps/details?id=com.apoorvdarshan.calorietracker).
+The README contains no F-Droid reference.
+
+This is the app OpenNutriTracker's tier 1 + tier 2 would resemble if both
+shipped, and it is worth reading in full because it has already absorbed a
+year of BYO-key support load.
+
+**Provider surface.** Thirteen providers, enumerated in
+[`android/app/src/main/java/com/apoorvdarshan/calorietracker/models/AIProvider.kt`](https://github.com/apoorvdarshan/fud-ai/blob/main/android/app/src/main/java/com/apoorvdarshan/calorietracker/models/AIProvider.kt)
+as a Kotlin enum carrying a `baseUrl` and a curated `models` list per provider,
+mirrored by `ios/calorietracker/Models/AIProvider.swift`. Nine of the thirteen
+are just "OpenAI-compatible with a different base URL"; only Gemini and
+Anthropic need bespoke wire formats. Ollama and a free-form "Custom
+(OpenAI-compatible)" entry give local inference for free. There is a fallback
+provider setting: if the primary returns 429/503, the app silently retries
+against a second configured provider.
+
+**Key storage.**
+[`data/KeyStore.kt`](https://github.com/apoorvdarshan/fud-ai/blob/main/android/app/src/main/java/com/apoorvdarshan/calorietracker/data/KeyStore.kt)
+uses `EncryptedSharedPreferences` (AES-256, AndroidKeystore-backed), one entry
+per provider under an `apikey_` prefix; iOS uses `KeychainHelper`. This is the
+same substrate `flutter_secure_storage` sits on. That file also carries a
+comment worth reading before we write ours:
+
+> On Android 14/15 (and occasionally older), the AndroidKeystore master-key
+> alias survives `pm uninstall` but the encrypted prefs file does not — so a
+> reinstall […] hits an `AEADBadTagException` on the first read […] Without
+> this, the app crashes on `Application.onCreate` before showing any UI.
+
+Their recovery path catches the failure, deletes both the prefs file and the
+Keystore alias, and rebuilds.
+
+**No bundled key, and a hosted proxy they killed.** The README states plainly
+that requests "go directly from your device to the provider you configure", and
+that "The optional Fud AI Premium proxy from earlier iOS versions has been
+discontinued." A project of this size tried operating a paid proxy and stopped.
+[`SECURITY.md`](https://github.com/apoorvdarshan/fud-ai/blob/main/SECURITY.md)
+puts "Denial-of-service against the user's own AI provider via API quota
+exhaustion" explicitly out of scope as "a user-controlled cost, not a security
+boundary".
+
+**What BYO-key actually costs in support.** The issue tracker is the most
+valuable artefact here:
+
+- [#139](https://github.com/apoorvdarshan/fud-ai/issues/139) — Claude Sonnet
+  returns responses the app cannot parse ("Could not understand the AI
+  response"), while the Anthropic dashboard confirms the requests landed. The
+  community workaround was to tell users to add `Response Format: **1024
+  tokens**` to their custom instructions.
+- [#145](https://github.com/apoorvdarshan/fud-ai/issues/145) — the user raises
+  "Max response tokens" to 2048 to work around #139 and the app becomes
+  unstable and crashes. Fixed by handling "truncated and reasoning-only
+  responses safely".
+- [#105](https://github.com/apoorvdarshan/fud-ai/issues/105) — `unexpected char
+  0x0a at 15 in Authorization value`: the pasted key carried a trailing
+  newline.
+- [#140](https://github.com/apoorvdarshan/fud-ai/issues/140) — Google's new
+  `AQ.`-prefixed Gemini keys were rejected by the app's own key validation even
+  though they worked against Google's curl example.
+- [#106](https://github.com/apoorvdarshan/fud-ai/issues/106) — "What does it
+  mean api limit it reached?" drew a several-hundred-word maintainer reply
+  walking the user through three different free tiers.
+- [#63](https://github.com/apoorvdarshan/fud-ai/issues/63),
+  [#170](https://github.com/apoorvdarshan/fud-ai/issues/170) — keys that "don't
+  work", and a key entered during onboarding not showing up in settings.
+
+**Two declines worth noting.**
+[#36](https://github.com/apoorvdarshan/fud-ai/issues/36) asked for on-device
+Gemma via Google AI Edge Gallery; the maintainer kept it open as research but
+said current phone models are "weaker and slower" for "accurate structured
+nutrition JSON, image/label understanding, and serving estimates".
+[#130](https://github.com/apoorvdarshan/fud-ai/issues/130) proposed exactly the
+kind of deterministic local work OpenNutriTracker's tier 0 describes — a local
+correction-memory table and a German quick-parser for `1 EL Öl` — and was
+**closed as not planned**, on the grounds that a language-specific parser "would
+add language-specific behavior that would need to be maintained across all
+supported languages".
+
+## Train Libre — the same stack, the opposite call on estimates
+
+[`rfivesix/train-libre`](https://github.com/rfivesix/train-libre), GPL-3.0,
+Flutter/Dart, 5★, in beta since 2026-07-22 (currently `v1.0.0-beta.7`).
+Distributed via the Apple App Store, Obtainium, and **its own F-Droid
+repository**, not the main F-Droid catalogue.
+
+Technically this is the nearest neighbour we have: same language, same licence,
+same offline-first pitch, same `flutter_secure_storage`. Its design document
+[`documentation/features/byok_ai_validation.md`](https://github.com/rfivesix/train-libre/blob/main/documentation/features/byok_ai_validation.md)
+is the single most useful file found in this survey.
+
+**Key storage** is per-provider under `ai_api_key_openai`, `ai_api_key_gemini`,
+`ai_api_key_anthropic`, `ai_api_key_mistral`, `ai_api_key_xai`, via
+`FlutterSecureStorage`. "Train Libre does not deploy intermediate servers to
+handle AI requests."
+
+**The model is banned from producing numbers.** From the system-prompt rules:
+
+> **Macro/Calorie Ban**: The AI is strictly prohibited from estimating,
+> guessing, or returning any nutritional numbers (calories, protein, carbs,
+> fat). Nutritional calculations are resolved deterministically by Train Libre
+> using its local database.
+
+Instead the model is required to decompose a meal into atomic, generically-named
+ingredients ("Spaghetti Bolognese" → spaghetti, beef mince, tomatoes, onions,
+garlic, olive oil, parmesan), consolidate duplicates, and return grams plus a
+`mealContext` block containing an `expectedKcalRange`, a `cookingState`, and an
+`expectedMacroProfile`. Those anchors exist purely so a local engine can
+cross-check the database matches it produced.
+
+**The local validation engine** then fuzzy-matches each ingredient against the
+app's SQLite food database (Jaro-Winkler, thresholds at 0.95 / 0.78 / 0.55),
+applies plausibility rules (`grams > 3000` is a hard error, `< 5g` a warning),
+and runs four cross-checks against the anchors: total kcal deviation >25% warns
+and >50% errors; macro-profile deviation >15% warns; raw-vs-cooked state
+mismatch errors if caloric density differs by >30%; portion density outside
+0.5–2× the database default warns.
+
+**When validation fails, the model is demoted to a selector.** The engine pulls
+the top 5–10 fuzzy candidates from the local database, re-ranks them by cooking
+state, injects them into the repair prompt as a `CANDIDATES` block, and asks the
+LLM to pick — "The LLM acts as a semantic selector rather than an estimator."
+The loop runs at most three passes; a candidate passes only at score ≥70 with
+zero critical errors.
+
+This is the same problem OpenNutriTracker faces, solved by never letting the
+provenance chain break in the first place.
+
+## NutriTrace — self-hosted, and the only one with a documented proxy mode
+
+[`TraceApps/nutritrace`](https://github.com/TraceApps/nutritrace), AGPL-3.0,
+Svelte + Node, 162★, actively developed. Single Docker container, PWA plus a
+Capacitor Android build.
+
+"Trace AI" is a tool-using assistant (16 tools) that can read the diary,
+wellness data and fasting state, and propose foods and diary entries for
+confirmation. Providers are `claude | openai | gemini | oai-compat`, set via
+[`.env.example`](https://github.com/TraceApps/nutritrace/blob/main/.env.example)
+or the Settings UI.
+
+Two implementation details are relevant to us:
+
+- **Env vars lock the UI.** [`server/ai.js`](https://github.com/TraceApps/nutritrace/blob/main/server/ai.js)
+  seeds `ai_provider`, `ai_api_key`, `ai_model`, `ai_base_url` into an
+  `app_config` table and sets `ai_env_locked`; when locked, calls are proxied
+  server-side so "The API key never leaves the server". The key is stored as a
+  plain row in SQLite.
+- **The proxy is hardened against its own users.**
+  [`server/routes/ai.js`](https://github.com/TraceApps/nutritrace/blob/main/server/routes/ai.js)
+  caps requests at `AI_MAX_MESSAGES = 60` and `AI_MAX_BYTES = 8_000_000`, and
+  rate-limits to 30/minute, with the stated reason of bounding "a misbehaving
+  client (or compromised account) from burning through the admin's AI API
+  budget with one giant request".
+
+It also documents a wire-format bug worth knowing: the proxy normalises every
+image part to the OpenAI `{type:'image_url', image_url:{url:'data:...'}}` shape
+because an OpenAI-compatible gateway "would reject Anthropic-shaped image parts
+with `invalid content type=image`" (fixes their #114). Anthropic's native
+`{type:'image', source:{type:'base64', ...}}` shape is not portable.
+
+On privacy, the docs state that for voice logging "only the transcript reaches
+your configured LLM; the audio stays on-device", and the README carries a long
+medical disclaimer naming eating disorders, diabetes and pregnancy explicitly,
+ending "Trace AI answers can be incorrect or incomplete".
+
+## Tandoor Recipes — the largest shipped AI feature, and the Anthropic bug
+
+[`TandoorRecipes/recipes`](https://github.com/TandoorRecipes/recipes), 8501★,
+AGPL plus a Commons Clause rider (so not OSI-free). Recipe parsing is the close
+cousin of our text parsing, and Tandoor 2 shipped it.
+
+[`docs/features/ai.md`](https://github.com/TandoorRecipes/recipes/blob/develop/docs/features/ai.md)
+documents the design: everything routes through **LiteLLM**, so any provider it
+supports works; AI providers are configured per space (or globally by a
+superuser) with name, model, API key and optional base URL; and there is a
+**default spending limit of roughly 1 USD per month per space**, enforced by
+[`cookbook/helper/ai_helper.py`](https://github.com/TandoorRecipes/recipes/blob/develop/cookbook/helper/ai_helper.py)
+via an `AiLog` table that records input/output tokens and credit cost on both
+success and failure. `AI_RATELIMIT` defaults to `60/hour`.
+
+The API key is stored unencrypted: `api_key = models.CharField(max_length=2048)`
+on the `AiProvider` model in `cookbook/models.py`.
+
+Their documented troubleshooting list reads like a checklist of BYO-key failure
+modes: JSON mode is required and models that ignore `response_format` will
+error; vision support is required for image/PDF import; AI calls are synchronous
+so slow models hit reverse-proxy timeouts; cost tracking silently degrades if
+the provider does not return usage data. There is also an explicit warning that
+"AI import sends the entire file as base64 inside the request. Large files can
+exceed provider limits or reverse proxy limits."
+
+**The Anthropic-specific bug** is
+[#4659](https://github.com/TandoorRecipes/recipes/issues/4659), still open. The
+`aiproperties` endpoint 500s with `JSONDecodeError: Expecting value: line 1
+column 1 (char 0)` for any Claude model, because:
+
+> Although `response_format={"type": "json_object"}` is passed to LiteLLM, the
+> Anthropic backend in LiteLLM does *not* enforce JSON mode the way OpenAI does
+> — Claude is free to return JSON wrapped in a Markdown code fence.
+
+The reporter's own recommendation is to stop relying on the OpenAI-shaped
+`response_format` and "switch to Anthropic's structured outputs / tool-use
+schema enforcement". This is worth reading as a validation of #599's choice of
+constrained decoding rather than as a warning against Anthropic — but it also
+shows how easy it is to end up on the fence-stripping path by accident when you
+go through an abstraction layer.
+
+## Open Food Facts — server-side by design, and F-Droid-aware
+
+We already consume their API, so their posture matters.
+
+**Robotoff** ([`openfoodfacts/robotoff`](https://github.com/openfoodfacts/robotoff),
+AGPL-3.0, 113★) is a batch and real-time prediction service that turns product
+data into "insights" — category, brand and label prediction, nutrition-table
+extraction, logo ANN, image quality. Inference runs on their infrastructure
+behind a Triton inference server; high-confidence insights are auto-applied,
+lower-confidence ones go to human validation.
+
+Their [ingredients spellcheck](https://openfoodfacts.github.io/robotoff/references/ingredients-spellcheck/)
+is the clearest statement of philosophy: the production model is a **self-hosted
+fine-tune of Mistral-7B-Base**, benchmarked against GPT-4o, Gemini-1.5-flash and
+Claude 3 Sonnet and beating them on correction precision. A closed model
+(GPT-3.5-Turbo) was used only to *generate synthetic training data*, which was
+then reviewed in Argilla. Third-party APIs are a tool for building the model,
+not a runtime dependency.
+
+**On-device is treated as speculative and F-Droid-hostile.** The app-side
+tracker [smooth-app#4027](https://github.com/openfoodfacts/smooth-app/issues/4027)
+contains the line that matters most for us:
+
+> Add optional offline ingredient extraction using MLKIT (**disabled on the
+> F-Droid build**)
+
+and the same for packaging extraction. The mechanism is visible in the source:
+[`packages/smooth_app/lib/entrypoints/android/main_fdroid.dart`](https://github.com/openfoodfacts/smooth-app/blob/develop/packages/smooth_app/lib/entrypoints/android/main_fdroid.dart)
+is a separate entry point that swaps Google ML Kit for ZXing, tagged
+`ScannerLabel.ZXing` and `StoreLabel.FDroid`.
+[smooth-app#5009](https://github.com/openfoodfacts/smooth-app/issues/5009),
+"Explore using the on-device LLM for various tasks", has been open since January
+2024 and opens with "this is highly speculative"; food-intake journaling is
+listed under *speculative* use cases, and the caveats are battery drain and
+device availability.
+
+Their one concrete multimodal-LLM proposal,
+[openfoodfacts-ai#341](https://github.com/openfoodfacts/openfoodfacts-ai/issues/341),
+extracts a product name and brand from a photo — and gates it on
+"the user requests it (with a button?)".
+
+## Smaller projects, and one structural variant
+
+**Scranbook** ([`taugr/scranbook`](https://github.com/taugr/scranbook), MIT) is
+a local-first PWA whose README describes a split we should consider: the vision
+model identifies the dish and ingredients, but "Editable calorie and macro
+estimates calculated locally from bundled official food-composition data" —
+the model never produces the numbers. It also states "No external nutrition API
+and no medical, allergy, or food-safety claims", defaults to LM Studio with
+`google/gemma-4-e4b`, and requires "Response mode: Strict JSON schema".
+
+**EatWise** ([`zkwi/EatWise`](https://github.com/zkwi/EatWise), MIT, Kotlin)
+takes the presentation route instead: it ships model estimates, but the README
+says calories, macros and fibre are shown **only as wide ranges**, vegetable
+quantity is qualitative, and the result explicitly "does not count as a weighed
+record". Base URL defaults to OpenRouter; key, base URL, model and dietary goal
+are all user-supplied.
+
+**NutriTracker** ([`cdz-hy/NutriTracker`](https://github.com/cdz-hy/NutriTracker),
+GPL-3.0, Kotlin) is directly downstream of us — its README credits
+OpenNutriTracker as the origin of "灵感和部分程序思路" (inspiration and part of the
+program design), and it reproduces our IOM 2005 TDEE, WHO BMI and MET
+calculations. It adds photo recognition and states "应用不内置 AI 服务" — the app
+bundles no AI service; the user configures API key, base URL and model, and the
+settings screen offers a connection test that verifies multimodal capability.
+
+**A structural variant: expose the tracker, don't embed the model.** A visible
+cluster of projects skips in-app AI entirely and ships an MCP server so the
+user's own agent does the logging —
+[`akutishevsky/nutrition-mcp`](https://github.com/akutishevsky/nutrition-mcp)
+(30★), [`rockitdev/macro-engine`](https://github.com/rockitdev/macro-engine),
+[`neonwatty/food-tracker-mcp`](https://github.com/neonwatty/food-tracker-mcp),
+[`RenierM26/calorie-tracker`](https://github.com/RenierM26/calorie-tracker).
+Fud AI was asked for exactly this in
+[#110](https://github.com/apoorvdarshan/fud-ai/issues/110) and declined it —
+"there's no backend, no account, and no cloud sync, so there's no server for an
+external tool like Claude to connect to" — offering JSON/CSV/Markdown export
+instead. That answer applies verbatim to us.
+
+## Projects that considered AI and declined
+
+**Grocy** ([`grocy/grocy`](https://github.com/grocy/grocy), 9337★) has declined
+every AI request it has received. On
+[#917 "AI vision"](https://github.com/grocy/grocy/issues/917), asking for ML Kit
+object detection, the maintainer closed with: "This is more something for native
+companion apps or other external add-ons."
+[#2486](https://github.com/grocy/grocy/issues/2486) (fridge camera with object
+recognition) and [#2927](https://github.com/grocy/grocy/issues/2927) (AI
+recipes) were both closed as duplicates without engagement. The consistent
+position is that AI belongs outside the core.
+
+**Food You** ([`maksimowiczm/FoodYou`](https://github.com/maksimowiczm/FoodYou),
+515★, GPL-3.0, on F-Droid with no anti-features) has an open request that is
+almost exactly #599's tier 1:
+[#419 "Natural Language AI Food Logging"](https://github.com/maksimowiczm/FoodYou/issues/419),
+opened 2026-05-25. The reporter even anticipates the architecture — "to maintain
+the app's open-source nature and avoid server costs for the developer, this
+could be implemented by allowing users to simply input their own API key (e.g.
+OpenAI, Gemini, Anthropic, or even a local AI endpoint)". Nine months on there
+is **no maintainer response**, and one community comment suggesting LiteRT /
+Google AI Edge for on-device Gemma. `gradle/libs.versions.toml` contains no AI,
+ML Kit, TFLite or LiteRT dependency. This is a decline by silence rather than by
+argument, but the outcome is the same.
+
+**Waistline** ([`davidhealey/waistline`](https://github.com/davidhealey/waistline),
+728★, GPL-3.0-only, on F-Droid with no anti-features) has no AI code and no AI
+discussion beyond [#923 "Pantry Wizard"](https://github.com/davidhealey/waistline/issues/923),
+an unanswered request for LLM-generated recipes. Its `package.json` lists only
+Cordova plugins — camera, barcode, TTS — no model runtime.
+
+**FitBook** ([`brandonp2412/FitBook`](https://github.com/brandonp2412/FitBook),
+157★, MIT, Flutter, on F-Droid) is the other Dart tracker; its `pubspec.yaml`
+contains `openfoodfacts`, `barcode_scan2` and nothing model-related. Its
+description is "Track your calories - Completely offline!".
+
+**kcal** ([`kcal-app/kcal`](https://github.com/kcal-app/kcal), 350★, MPL-2.0)
+declines even *food database APIs*, on the grounds that large community datasets
+are "daunting" to search and "can be inaccurate and counter-productive for users
+with calorie and/or macro goals".
+
+**OpenNutriTracker itself.** Issue
+[#250](https://github.com/simonoppowa/OpenNutriTracker/issues/250), "Ask AI to
+fill out custom dish information", was closed on 2026-05-15 as
+"researched, not shipping for now" after a documented spike: twelve small
+models, eight reference foods plus three multi-food prompts, run on a Pixel 8.
+The write-up rejects the on-device path on accuracy (the best phone-viable
+model, Qwen 2.5 1.5B, landed 25–45% high on an unseen freeform prompt) — and
+then **rejects the BYO-key path separately**, on four grounds: maintenance
+surface (key entry, secure storage, billing communication, model-deprecation
+drift), single-digit adoption, the privacy regression of dish descriptions
+leaving the device, and store-review provenance expectations for health apps.
+Its central claim is that "wrapping it in confidence flags doesn't add
+provenance, it adds a warning". Issue #599 reaches the opposite conclusion on
+the BYO-key question and does not reference #250.
+
+## Licensing and F-Droid consequences
+
+**Adding AI has skewed projects away from free licences.** Of the shipped
+server-side AI trackers, SparkyFitness is non-commercial-only, Tandoor carries a
+Commons Clause, and MacroShot uses FSL-1.1-Apache-2.0. None of the three would
+be accepted by F-Droid or be GPL-compatible. The AI-shipping projects that *are*
+OSI-free are all small mobile BYO-key apps (Fud AI MIT, Train Libre GPL-3.0,
+NutriTrace AGPL-3.0, EatWise/Scranbook MIT, cdz-hy GPL-3.0).
+
+**F-Droid's anti-features.** The catalogue currently defines ten
+([docs](https://f-droid.org/docs/Anti-Features/)); the relevant ones are
+*Non-Free Network Services* ("promotes or depends entirely on a proprietary
+network service"), *Non-Free Dependencies* ("requires things that are not Free
+Software in order to run"), and *Tethered Network Services*. NonFreeNet was
+narrowed in July 2024 when Tethered was split out of it
+([TWIF, 2024-07-25](https://f-droid.org/2024/07/25/twif.html)); 819 apps
+currently carry NonFreeNet.
+
+**Precedent for a BYO-key LLM app.** Two are directly on point:
+
+- [Kai 9000](https://f-droid.org/packages/com.inspiredandroid.kai/) (Apache-2.0),
+  a multi-provider LLM chat app, carries **Non-Free Network Services** —
+  "This app promotes or depends entirely on a non-free network service.
+  Specifically, the app relies on Gemini and Groq services."
+- [oxproxion](https://f-droid.org/packages/io.github.stardomains3.oxproxion/)
+  (Apache-2.0) supports Ollama, LM Studio, llama.cpp and MLX LM alongside
+  OpenRouter, and still carries **Non-Free Network Services** — "Depends on
+  OpenRouter API servers."
+
+So the presence of a local-inference option did not spare oxproxion. Both apps
+are *primarily* LLM clients, which is not our case; I could not find an app
+where AI is an optional secondary feature and F-Droid ruled on it either way.
+
+**What the food apps carry today.** Food You and Waistline have no anti-features
+listed. The legacy Open Food Facts Android app carries **Non-Free Network
+Services** ("depends on openfoodfacts.net/.org, openproductfacts.org,
+openstreetmap.org and sentry.io servers") and **Tracking** ("Analytics are
+opt-in but the app connects to sentry.io from the start, and connects even if
+rejected"). That second one is worth staring at: OpenNutriTracker also ships
+opt-in Sentry.
+
+**Nobody was removed from F-Droid over AI.** I found no case of an app being
+delisted for adding an AI feature. The observed responses are (a) build a
+separate F-Droid flavour with the proprietary bit removed — Open Food Facts
+swapping ML Kit for ZXing in `main_fdroid.dart`; or (b) skip the main catalogue
+and self-host a repo — Train Libre publishes its own
+[F-Droid repo](https://rfivesix.github.io/train-libre/fdroid/repo).
+
+**Our own status.** OpenNutriTracker is not in the main F-Droid catalogue;
+[RFP #2540](https://gitlab.com/fdroid/rfp/-/issues/2540) is outstanding and the
+README says "from F-Droid once the app is published there". Any AI work lands
+before that listing is decided, not after.
+
+## Privacy posture — what these projects tell users
+
+- **Fud AI**: "Requests go directly from your device to the provider you
+  configure." Marketing site carries a privacy page; the security policy scopes
+  API-key handling and names the exact storage mechanism per platform.
+- **Train Libre**: "User-Controlled AI: Optional AI features require your own
+  API key; no data is sent to providers without opt-in", plus "Train Libre does
+  not deploy intermediate servers to handle AI requests." It ships a clinical
+  disclaimer naming diabetes.
+- **NutriTrace**: per-feature statements ("only the transcript reaches your
+  configured LLM; the audio stays on-device"; label photos go to the provider as
+  base64 under a 12 MB body limit) and a long medical disclaimer.
+- **Scranbook**: "There are no Scranbook accounts, analytics, Worker code, or
+  server-side diary APIs", and the photo goes to the user's endpoint only "when
+  the user explicitly chooses to analyse a photo".
+- **EatWise**: privacy-first framing, and screenshots deliberately generated
+  from synthetic records so no real photo, key or dietary goal appears.
+- **Open Food Facts**: nothing runs on-device that isn't disabled in the F-Droid
+  build; server-side inference is documented publicly per model.
+
+The pattern: the credible ones make a *mechanical* claim ("no intermediate
+server", "audio stays on-device") rather than a values claim. That is the same
+move as our README's destination table.
+
+## What this means for OpenNutriTracker
+
+**Where our design is conventional.**
+
+- BYO-key with no bundled credential is the norm, not a novelty. Every shipped
+  free-licence mobile tracker with AI does this, and the one project that tried
+  operating its own proxy (Fud AI Premium) discontinued it.
+- Secure-storage choice matches exactly. Train Libre uses
+  `flutter_secure_storage` with one key per provider; Fud AI uses the native
+  equivalents directly.
+- Resolving model output against the existing food database rather than trusting
+  it is what the two most careful projects do (Train Libre, Scranbook).
+- Refusing to call the local tier "AI" is unusual but defensible; nobody else
+  ships a deterministic parser to compare against.
+
+**Where our design is unusual, and worth re-examining.**
+
+1. **One hardcoded provider.** Every shipped comparator is multi-provider from
+   v1, and most get there cheaply because nine of Fud AI's thirteen providers
+   are just a base-URL swap. Anthropic-only means no Ollama/LM Studio story at
+   all — which is the first thing the privacy-focused audience asks for
+   (Food You #419 asks for "even a local AI endpoint"; Fud AI #36 asks for
+   on-device Gemma). A single `baseUrl` text field behind the provider
+   interface would buy local inference and OpenRouter for near-zero cost.
+2. **Letting the model emit macros at all.** Decision #5 in #599 is the loosest
+   posture in the entire cohort. Train Libre bans it outright; Scranbook
+   computes macros locally from bundled composition data; EatWise ships only
+   wide ranges and qualitative portions. Our "every number is cited" claim is
+   stronger than any of theirs, and #599's answer — a new `MealSourceEntity`
+   value plus an "estimated" marker — is the *warning* approach that our own
+   #250 spike argued does not substitute for provenance.
+3. **Text first, photo deferred.** The cohort is the other way round: photo is
+   the headline feature and text is secondary. That is not obviously wrong (it
+   is the cheaper, more testable path) but it means tier 1 alone will not read
+   as competitive with Fud AI or Train Libre.
+4. **No free tier to fall back on.** #599 already notes this. Fud AI's #106 is
+   what it looks like in practice, and Fud AI could at least redirect users to
+   free Gemini, Groq and OpenRouter tiers. Anthropic-only removes that valve
+   and makes every support thread about billing end in "add a card".
+
+**Concrete pitfalls other projects hit that #599 does not cover.**
+
+- **Keystore corruption on reinstall.** Fud AI's `KeyStore.kt` documents an
+  `AEADBadTagException` on Android 14/15 where the Keystore master-key alias
+  outlives the encrypted prefs file, crashing in `Application.onCreate` before
+  any UI. `flutter_secure_storage` sits on the same substrate. We need the
+  equivalent catch-wipe-rebuild path, and losing the key on reinstall is the
+  correct behaviour.
+- **Never validate the shape of a pasted key.** Fud AI #140 rejected valid
+  Gemini keys because Google changed the prefix from `AIza` to `AQ.`, and #105
+  was a trailing newline in a paste. Trim aggressively, validate with a live
+  ping, never with a regex.
+- **Truncation is a distinct failure from malformed output.** Constrained
+  decoding solves the Tandoor #4659 problem (Claude fencing its JSON), but not
+  Fud AI #139/#145, where the response was cut off by the token budget and
+  raising the budget destabilised the app. Handle `stop_reason: "max_tokens"`
+  explicitly and cap the retry loop.
+- **Anthropic's image content-part shape is not portable.** NutriTrace had to
+  normalise `{type:'image', source:{...}}` to the OpenAI `image_url` shape
+  because gateways reject the Anthropic form. If the provider interface is meant
+  to admit more providers later, put the wire-shape adaptation at the boundary
+  now rather than leaking Anthropic's shape through it.
+- **Cap request size and retries even when the user pays.** Tandoor enforces a
+  ~$1/month per-space credit ceiling and logs every call; NutriTrace caps at 60
+  messages / 8 MB and rate-limits to 30/min. BYO-key moves the cost to the user
+  but does not make a runaway loop harmless.
+- **Base64 payload limits are a real failure mode.** Tandoor's docs warn that
+  base64-in-request "can exceed provider limits or reverse proxy limits".
+  Relevant to tier 2's WebP path.
+- **A per-locale parser is a maintenance argument, not just a code one.**
+  Fud AI closed #130 — which proposed exactly a local quick-parser — because
+  language-specific parsing "would need to be maintained across all supported
+  languages". We ship 9 locales. Tier 0 needs an explicit answer: either
+  language-neutral heuristics, or a stated English-first scope.
+- **#250 and #599 disagree and both are live.** Our own tracker now contains a
+  closed issue arguing the BYO-key path is not worth maintaining, and an open
+  umbrella issue adopting it. Whoever picks up tier 1 will find #250 first.
+  Reconciling them — particularly the store-review provenance argument, which
+  is independent of who runs the model — should happen before tier 1 is scoped.
+
+## What I could not verify
+
+- Whether Fud AI is distributed on F-Droid. Its README links only App Store,
+  Play and its own site, and contains no F-Droid reference; I did not search the
+  `fdroiddata` metadata repository directly.
+- The date, terms, or reason for the discontinuation of the "Fud AI Premium
+  proxy". The only source is one sentence in the current README.
+- Whether Kai 9000 ships a bundled free tier (which would explain its NonFreeNet
+  label more simply than BYO-key access does). That claim came from a search
+  result summary, not the repository.
+- Whether F-Droid has ever ruled on an app where AI is an *optional secondary*
+  feature. Both precedents found are apps whose primary purpose is LLM chat.
+- Whether Tandoor encrypts the provider API key anywhere outside the
+  `AiProvider.api_key` `CharField`; I read the model definition only.
+- Whether NutriTrace's AI configuration is genuinely per-user. The docs say
+  "per-user in Settings → AI Assistant", but `server/ai.js` stores it in an
+  instance-wide `app_config` table.
+- SparkyFitness's AI key scoping and whether its licence has changed; GitHub
+  reports no recognised licence and `LICENSE` reads as a custom
+  non-commercial grant.
+- Detail beyond metadata and one config file for MacroShot,
+  [Luma](https://github.com/d3mocide/Luma) and
+  [OpenFoodJournal](https://github.com/kvn8888/OpenFoodJournal); all three claim
+  AI features but were not read in depth.
+- Whether any project has published measured accuracy for cloud-model nutrition
+  estimation. None of the shipped projects publish evaluation numbers; the only
+  measured data found is our own #250 spike, and that covers on-device models.
+- Download or install counts for any of these apps. GitHub stars are a proxy
+  only.

--- a/docs/ai-legal-constraints.md
+++ b/docs/ai-legal-constraints.md
@@ -1,0 +1,1190 @@
+# Legal and platform-policy constraints on AI-assisted meal logging
+
+Research notes gathered 2026-08-02 against primary sources — EUR-Lex for EU
+legislation, the European Commission's own MDCG guidance, Apple's and Google's
+own policy pages, F-Droid's own documentation, gnu.org, and
+gesetze-im-internet.de. Where a secondary source pointed at a provision, the
+provision itself was fetched and quoted. Written to inform issue
+[#599](https://github.com/simonoppowa/OpenNutriTracker/issues/599) and the tier-1
+scoping decision it defers.
+
+**This is not legal advice.** It reports what the texts say, distinguishes what
+plainly attaches from what plainly does not, and names the judgements a lawyer
+should make rather than guessing at them. Anything I could not verify is listed
+at the end rather than smoothed over.
+
+> **Partly superseded — read this first.** Two later documents correct
+> conclusions below. Where they conflict, they win.
+>
+> - [`ai-cohort-restrictions.md`](ai-cohort-restrictions.md) corrects the
+>   F-Droid section twice: the Translate You `gradle: [libre]` citation is
+>   stale, and "a build flavour would avoid `NonFreeNet`" is too optimistic —
+>   the flavour has to remove the prefilled commercial endpoint, not just
+>   proprietary libraries. It also finds a blocker this document missed
+>   entirely: bundled Google ML Kit, which is present-tense and unrelated to
+>   AI. (Independently reached by
+>   [`fdroid-submission-feasibility.md`](fdroid-submission-feasibility.md),
+>   written earlier for #575.)
+> - [`ai-open-research-questions.md`](ai-open-research-questions.md) closes
+>   several items from the "not verified" list here — including the Digital
+>   Omnibus deferral, now confirmed from EUR-Lex as Regulation (EU) 2026/1744.
+>   **Article 50 was not deferred**, which is the point the timeline here
+>   turns on.
+
+The thing assessed is the design recorded in #599 as revised on 2026-08-02:
+tier 0 is a deterministic parser with no model and no new network call; tiers 1–2
+are opt-in, off by default, with the user supplying their own endpoint URL, API
+key and model name, requests going from the device straight to that endpoint, the
+project operating no server and paying nothing, database values winning on every
+match, and model-supplied macros used only on a database miss and flagged
+`estimated`.
+
+## Bottom line up front
+
+Tier 0 attaches nothing: no AI Act obligation, no medical-device question, no new
+GDPR processing, no store declaration, no F-Droid label. For tiers 1–2 the only
+EU obligation that plausibly bites is **Article 50(2) of the AI Act** — a
+machine-readable marking duty on generated content, in force since today,
+2 August 2026, and most likely engaged by the tier-2 photo path rather than the
+text path; everything else in the AI Act either exempts free-software projects,
+exempts the user, or lands in a risk tier this app is nowhere near. Medical-device
+law turns entirely on the *intended purpose you state in your own marketing*, not
+on accuracy or on the `estimated` flag, so it stays out of scope for as long as
+the store listing and in-app copy avoid claiming to detect, monitor or treat
+anything. Under GDPR the project processes nothing — the user directs each
+transmission to a counterparty the user chose — but "does shipping the code make
+you a controller" is a genuine judgement call, not a settled question, and it is
+the one place where the honest answer is "ask a lawyer". The concrete work is
+small and mostly writing: an in-app disclosure and consent gate, an in-app report
+control (Google Play requires one for any app that generates content with AI), a
+privacy-policy section, revised Data safety answers, and — separately and
+independently of AI — the Google Play health disclaimer wording that the current
+store listing appears to be missing already.
+
+## Tier 0 — nothing attaches
+
+Tier 0 is a deterministic text parser resolving food names against the existing
+Open Food Facts / USDA / BLS databases. No model, no inference, no new
+destination. Taking each instrument in turn:
+
+- **AI Act.** Article 3(1) defines an AI system as "a machine-based system that
+  is designed to operate with varying levels of autonomy and that may exhibit
+  adaptiveness after deployment, and that, for explicit or implicit objectives,
+  **infers**, from the input it receives, how to generate outputs" ([Reg. (EU)
+  2024/1689 Art. 3(1)](https://eur-lex.europa.eu/legal-content/EN/TXT/HTML/?uri=OJ:L_202401689)).
+  A parser that applies fixed rules to digits and unit symbols does not infer; it
+  computes. Even if the definition were stretched, Article 50 attaches only to
+  systems that interact with natural persons as AI or that *generate* synthetic
+  content — tier 0 generates nothing, it retrieves. The system is also released
+  under a free and open-source licence, and Article 2(12) disapplies the whole
+  Regulation to such systems "unless they are placed on the market or put into
+  service as high-risk AI systems or as an AI system that falls under Article 5
+  or 50". None of those carve-backs is met.
+- **MDR.** No change in intended purpose; the numbers still come from the same
+  databases they came from before, and MDCG 2019-11 rev.1 expressly excludes
+  "wellness or fitness apps" from medical device software (p. 8).
+- **GDPR.** No new personal data leaves the device. The README's destination
+  table is unchanged.
+- **Apple 5.1.2, Google Play User Data / Data safety.** No new data collected,
+  no new third party, nothing to declare. Google Play's AI-Generated Content
+  policy is scoped to "content that is created by generative AI models based on
+  user prompts" — a parser is neither.
+- **F-Droid.** No new network service, proprietary or otherwise; `NonFreeNet`
+  requires an app that "promote[s] or depend[s] entirely on a proprietary network
+  service".
+- **GPL-3.0.** No third-party code, no service call, no licence interaction.
+- **German law.** No new duty. The existing Impressum and misleading-advertising
+  positions are unchanged.
+
+The single thing worth saying out loud: #599 already records that tier 0 must not
+be marketed as "AI". That is the right call for product reasons, and it is also
+what keeps this paragraph true. If the release notes or store listing call the
+parser "AI", the Article 50(1) question stops being obviously answerable in the
+negative — not because the parser changed, but because Article 3(12) defines
+"intended purpose" partly by reference to "promotional or sales materials and
+statements".
+
+## EU AI Act — Regulation (EU) 2024/1689
+
+Primary text: [OJ L, 2024/1689](https://eur-lex.europa.eu/legal-content/EN/TXT/HTML/?uri=OJ:L_202401689)
+([ELI](https://eur-lex.europa.eu/eli/reg/2024/1689/oj/eng)), as amended by
+[Regulation (EU) 2026/1744](https://eur-lex.europa.eu/legal-content/EN/TXT/HTML/?uri=OJ%3AL_202601744)
+of 8 July 2026 (the "Digital Omnibus on AI",
+[ELI](https://eur-lex.europa.eu/eli/reg/2026/1744/oj/eng)).
+
+### Application timeline
+
+Article 113 as amended by Regulation (EU) 2026/1744 Art. 1(40):
+
+| Provision | Applies from | Status today (2026-08-02) |
+| :-- | :-- | :-- |
+| Chapters I and II — scope, definitions, Art. 4 AI literacy, Art. 5 prohibitions | 2 February 2025 | **in force** |
+| Art. 5(1) points (ba), (bb) and Art. 5(1a), (1b) (inserted by the Omnibus) | 2 December 2026 | not yet |
+| Chapter III Section 4, Chapter V, Chapter VII, Chapter XII, Art. 78 | 2 August 2025 | **in force** |
+| Articles 102 to 110 | 27 July 2026 | **in force** |
+| General date of application — including **Chapter IV, Article 50** | **2 August 2026** | **in force as of today** |
+| Chapter III Sections 1–3 for Art. 6(2) / Annex III high-risk systems | **2 December 2027** | not yet |
+| Chapter III Sections 1–3 for Art. 6(1) / Annex I high-risk systems | **2 August 2028** | not yet |
+
+The Omnibus did **not** move Article 50. It changed only Article 50(7) (removing
+the Commission's implementing-act empowerment over codes of practice) and added a
+transitional in Article 111(4): "Providers of AI systems, including
+general-purpose AI systems, generating synthetic audio, image, video or text
+content, that have been placed on the market before 2 August 2026 shall take the
+necessary steps in order to comply with Article 50(2) by 2 December 2026."
+
+That transitional is worth noting for sequencing. It is drafted for systems
+*already on the market* on 2 August 2026. Tiers 1–2 would be placed on the market
+after that date, so on the face of it the four-month grace does not apply to
+them — an argument that the marking duty is immediate on first release rather
+than deferred. This is exactly the kind of point a lawyer should confirm.
+
+### Who is provider, who is deployer
+
+Article 3(3): "'provider' means a natural or legal person … that develops an AI
+system … and places it on the market or puts the AI system into service under its
+own name or trademark, **whether for payment or free of charge**".
+
+Article 3(4): "'deployer' means a natural or legal person … using an AI system
+under its authority **except where the AI system is used in the course of a
+personal non-professional activity**".
+
+Article 2(10) says the same thing from the other end: "This Regulation does not
+apply to obligations of deployers who are natural persons using AI systems in the
+course of a purely personal non-professional activity."
+
+So:
+
+- **The user is out of scope, completely.** Someone logging their own dinner is
+  not a deployer, whether they point the app at Anthropic or at Ollama on their
+  laptop. This is not a close question.
+- **The endpoint operator** (Anthropic, OpenAI, whoever) is the provider of the
+  general-purpose AI model, with Chapter V obligations that are none of this
+  project's business. If the endpoint is the user's own Ollama, the user is
+  putting a model into service for own use — and Article 2(10) exempts them
+  anyway.
+- **The project** develops the software that turns a user prompt plus a
+  user-supplied model into structured meal data, and distributes it under its own
+  name. If that composite is an "AI system" within Article 3(1), the project is
+  its provider. The awkwardness is that the inference component is not shipped:
+  it arrives at runtime from an address the user typed. I could find nothing in
+  the Regulation that resolves this cleanly. The safest working assumption is
+  **provider, not deployer** — the project never uses the system under its own
+  authority.
+
+Two provisions that people reach for here and that do **not** apply:
+
+- **Article 25** ("Responsibilities along the AI value chain") reclassifies
+  distributors, importers, deployers and third parties as providers when they
+  put their name on, substantially modify, or change the intended purpose of a
+  **high-risk** AI system. Every limb of Article 25(1) is expressly about
+  high-risk systems. Nothing here is high-risk, so Article 25 is inert.
+- **Article 2(12)**, the free-and-open-source exemption: "This Regulation does
+  not apply to AI systems released under free and open-source licences, unless
+  they are placed on the market or put into service as high-risk AI systems or as
+  an AI system that falls under Article 5 or 50." OpenNutriTracker is GPL-3.0.
+  The exemption therefore covers everything **except** Article 50 — which is
+  precisely the article in play. Article 2(12) is not the escape hatch it looks
+  like at first glance; it disposes of every other chapter and leaves Article 50
+  standing.
+
+  Recital 103 adds a monetisation caveat: components "provided against a price or
+  otherwise monetised, including through the provision of technical support or
+  other services … should not benefit from the exceptions". The repo has a
+  Patreon link (`.github/FUNDING.yml`). Voluntary donations are not obviously
+  "against a price", and recital 103 also says "making AI components available
+  through open repositories should not, in itself, constitute a monetisation" —
+  but this is a judgement, not a certainty.
+
+### Article 50 in detail
+
+**Article 50(1) — interaction disclosure.**
+
+> Providers shall ensure that AI systems intended to interact directly with
+> natural persons are designed and developed in such a way that the natural
+> persons concerned are informed that they are interacting with an AI system,
+> unless this is obvious from the point of view of a natural person who is
+> reasonably well-informed, observant and circumspect, taking into account the
+> circumstances and the context of use.
+
+Recital 132 frames this as a rule against impersonation and deception, aimed at
+systems a person might mistake for a human. A meal-logging feature that returns a
+review list of foods is not that. And even on the broadest reading, the "obvious"
+exception is comfortably met: the user opened Settings, pasted an endpoint URL, an
+API key and a model name, and enabled a feature that is off by default. Nobody
+reaching that screen is unaware they are talking to a model.
+
+Practically: comply anyway. A one-line label on the entry point costs nothing and
+removes the argument.
+
+**Article 50(2) — machine-readable marking. This is the one that matters.**
+
+> Providers of AI systems, including general-purpose AI systems, generating
+> synthetic audio, image, video or text content, shall ensure that the outputs of
+> the AI system are marked in a machine-readable format and detectable as
+> artificially generated or manipulated. Providers shall ensure their technical
+> solutions are effective, interoperable, robust and reliable as far as this is
+> technically feasible, taking into account the specificities and limitations of
+> various types of content, the costs of implementation and the generally
+> acknowledged state of the art … **This obligation shall not apply to the extent
+> the AI systems perform an assistive function for standard editing or do not
+> substantially alter the input data provided by the deployer or the semantics
+> thereof** …
+
+Three things follow.
+
+*First, "does a nutrition estimate count as content requiring disclosure?"* The
+model emits **text** — food names, quantities, units, and on a database miss a set
+of kcal/macro numbers. Text is squarely inside "synthetic audio, image, video or
+text content". Recital 133 explains the mischief as synthetic content that "becomes
+increasingly hard for humans to distinguish from human-generated and authentic
+content", with impacts on "the integrity and trust in the information ecosystem".
+A private food diary is a long way from that mischief. But the operative text of
+Article 50(2) contains no "public dissemination" qualifier — the recital narrows
+the *reason*, not the *scope*. On the text, a model-generated kcal figure is
+generated text content.
+
+*Second, the exception does real work, and it splits the two tiers.* The carve-out
+covers systems that "do not substantially alter the input data provided by the
+deployer or the semantics thereof".
+
+- **Tier 1 (text).** The user types "two eggs and a slice of toast"; the model
+  returns `{egg, 2, piece}, {bread, 1, slice}`. That is structuring the user's own
+  input without altering its semantics — a good fit for the exception. Where the
+  model additionally supplies macros for a database miss, it is creating new
+  information, and the fit weakens.
+- **Tier 2 (photo).** The model looks at a picture and produces names, portions
+  and possibly numbers that were nowhere in the input as data. That is not
+  "assistive editing" and it does alter the semantics of the input. The exception
+  most likely does not cover it.
+
+*Third, note what the obligation actually is.* Article 50(2) requires
+**machine-readable marking** — watermarks, metadata, provenance signals; recital
+133 lists "watermarks, metadata identifications, cryptographic methods for proving
+provenance and authenticity of content, logging methods, fingerprints". It does
+**not** require an on-screen badge. The visible-labelling duty in Article 50(4) is
+confined to deep fakes and to text "published with the purpose of informing the
+public on matters of public interest" — neither applies here.
+
+This is a useful result: the `estimated` value on `MealSourceEntity`, persisted in
+the Hive record and carried into `docs/export-format.md`, is a machine-readable
+provenance marker, and is a much better fit for Article 50(2) than the on-screen
+badge is. The on-screen badge is worth building for the misleading-advertising
+reasons below, not for Article 50.
+
+The proportionality language — "as far as this is technically feasible, taking
+into account … the costs of implementation and the generally acknowledged state of
+the art" — is the lever for a project that cannot watermark at generation time
+because it does not run the model. There is no state of the art for watermarking a
+JSON payload returned by an arbitrary third-party endpoint.
+
+**Article 50(3) and (4)** do not apply: no emotion recognition, no biometric
+categorisation, no deep fakes, no publication to inform the public.
+
+**Article 50(5) — how the information must be given.** The user's question used
+the phrase "clearly perceptible"; that phrase is not in Article 50. The operative
+wording is:
+
+> The information referred to in paragraphs 1 to 4 shall be provided to the
+> natural persons concerned in a **clear and distinguishable manner at the latest
+> at the time of the first interaction or exposure**. The information shall
+> conform to the applicable accessibility requirements.
+
+Two consequences. It governs only the information required by paragraphs 1–4, so
+it does not turn the 50(2) machine-readable marking into a visible label. And the
+accessibility sentence means whatever disclosure you do write has to be reachable
+by a screen reader — which for this repo means a `Semantics` label, not just a
+styled `Text`.
+
+**Penalty.** Article 99(4)(g): breach of "transparency obligations for providers
+and deployers pursuant to Article 50" attracts administrative fines "up to EUR
+15 000 000 or, if the offender is an undertaking, up to 3 % of its total worldwide
+annual turnover", with Article 99(6) capping SMEs at whichever of the percentage
+or the absolute figure is **lower**. For a solo project with no turnover the
+percentage limb is zero, but the EUR figure is not, and Article 99(1) requires
+penalties to be "effective, proportionate and dissuasive" while "tak[ing] into
+account the interests of SMEs, including start-ups, and their economic viability".
+
+### Could it be high-risk via Annex III?
+
+No. Annex III has eight headings: biometrics; critical infrastructure; education
+and vocational training; employment and worker management; access to essential
+private and public services and benefits; law enforcement; migration, asylum and
+border control; administration of justice and democratic processes. Reading each
+entry against a consumer food diary:
+
+- The nearest miss is point 5(a), eligibility for "essential public assistance
+  benefits and services, including healthcare services" — but that entry is
+  confined to systems "intended to be used by public authorities or on behalf of
+  public authorities".
+- Point 5(c) covers "risk assessment and pricing in relation to natural persons
+  in the case of life and health insurance". Not this.
+- Point 1 covers biometrics. A meal photo containing a face is not biometric
+  processing: Annex III(1)(a) is remote biometric identification, (b) is biometric
+  categorisation "according to sensitive or protected attributes … based on the
+  inference of those attributes", (c) is emotion recognition. Naming the food on
+  the plate is none of these, and the design should keep it that way — do not
+  ask the model anything about the people in the photo.
+
+Even if an entry were somehow engaged, Article 6(3) derogates where the system
+"does not pose a significant risk of harm to the health, safety or fundamental
+rights of natural persons", including where it "is intended to perform a narrow
+procedural task" — with the caveat that a system "shall always be considered to be
+high-risk where the AI system performs profiling of natural persons". And the
+Annex III obligations do not apply until **2 December 2027** in any event.
+
+**Article 4 (AI literacy)** has applied since 2 February 2025 and, as amended by
+the Omnibus, requires providers and deployers to "take measures to support the
+development of AI literacy of their staff and other persons dealing with the
+operation and use of AI systems on their behalf" — expressly adding that it "does
+not require providers or deployers to guarantee any specific level of AI literacy
+of any individual". For a project with no staff this is close to nominal;
+documenting the feature's limitations in the repo discharges the spirit of it.
+
+## EU medical device law — MDR 2017/745
+
+Primary text: [consolidated Regulation (EU) 2017/745](https://eur-lex.europa.eu/legal-content/EN/TXT/HTML/?uri=CELEX:02017R0745-20240709).
+Guidance: [MDCG 2019-11 rev.1, June 2025](https://health.ec.europa.eu/document/download/b45335c5-1679-4c71-a91c-fc7a4d37f12b_en?filename=mdcg_2019_11_en.pdf)
+([announcement](https://health.ec.europa.eu/latest-updates/update-mdcg-2019-11-rev1-qualification-and-classification-software-regulation-eu-2017745-and-2025-06-17_en)).
+
+### The qualification test
+
+Article 2(1) MDR:
+
+> 'medical device' means any instrument, apparatus, appliance, **software**,
+> implant, reagent, material or other article **intended by the manufacturer** to
+> be used, alone or in combination, for human beings for one or more of the
+> following specific medical purposes:
+> — diagnosis, prevention, monitoring, prediction, prognosis, treatment or
+> alleviation of disease,
+> — diagnosis, monitoring, treatment, alleviation of, or compensation for, an
+> injury or disability,
+> — investigation, replacement or modification of the anatomy or of a
+> physiological or pathological process or state, …
+
+Article 2(12) MDR defines intended purpose as "the use for which a device is
+intended **according to the data supplied by the manufacturer on the label, in the
+instructions for use or in promotional or sales materials or statements** and as
+specified by the manufacturer in the clinical evaluation".
+
+MDCG 2019-11 rev.1 states the qualification rule directly (§3.1, p. 8):
+
+> Software must have a medical purpose on its own to be qualified as a MDSW … the
+> intended purpose, as described by the manufacturer of the software is relevant
+> for the qualification and classification of any device.
+
+and, in the same section, excludes this category of app by name:
+
+> In addition, software only intended for non-medical purposes … such as
+> invoicing, staff planning, e-mailing, web or voice messaging, data parsing, word
+> processing, and back-up, **wellness or fitness apps, do not qualify as MDSW**.
+
+### Does "estimates calories from a photo, user logs it against a weight goal" cross the line?
+
+On the current design, no. The intended purpose stated in the store listing, the
+in-app copy and the README is nutritional tracking and weight management for
+general wellness. That is the "wellness or fitness apps" category MDCG expressly
+excludes. Adding a model that names foods from a photo does not change the
+purpose; it changes the input method. MDCG's decision steps make the same point
+from the other direction — step 3 asks whether the software performs an action on
+data beyond storage, archival, communication, simple search or lossless
+compression, and step 4 asks "is the action for the benefit of individual
+patients?", with step 5 asking whether the software meets the MDSW definition at
+all. A calorie estimate benefits an individual *user*; it is not directed at a
+*patient* in a diagnostic or therapeutic sense.
+
+### What specifically would push it over
+
+Any statement — in the app, on the store listing, in release notes, in the
+README — that attaches the output to a disease, injury or physiological state.
+Concretely, the things to never write:
+
+- "helps you manage diabetes" / "for coeliac disease" / "detects nutrient
+  deficiencies" — monitoring or diagnosis of disease;
+- "supports recovery from an eating disorder" — MDCG's own worked example of MDSW
+  is software "intended to alleviate certain eating disorder behaviours such as
+  bulimia and anorexia" reacting to "different patient inputs related of the
+  disease (diet, physical activity, body image, etc.)" (p. 9). This is the single
+  closest example in the guidance to what a nutrition app could accidentally
+  become;
+- "medically supervised weight loss" or anything implying a clinical protocol;
+- linking the output to a clinician or to a treatment decision.
+
+Note the app already ships an intermittent-fasting timer behind a "content-warning
+gate" and a low-kcal warning that advises consulting a healthcare professional.
+Those are the right instincts — they push away from a medical purpose, not toward
+one.
+
+### Does the `estimated` flag or a disclaimer change the analysis?
+
+**No, and it is important to be clear about why.** Qualification depends on stated
+intended purpose, not on accuracy, and MDCG says so explicitly (p. 8):
+
+> It must be highlighted that the risk of harm to patients, users of the software,
+> or any other person, related to the use of the software within healthcare,
+> including a possible malfunction **is not a criterion on whether the software
+> qualifies as a medical device**.
+
+So a disclaimer cannot cure a stated medical purpose — you cannot claim to detect
+disease and then disclaim your way out. Conversely, an `estimated` marker does not
+make an otherwise-medical device non-medical, and its absence would not make a
+wellness app medical. What the disclaimer *does* do is form part of the
+"promotional or sales materials or statements" that constitute the intended
+purpose under Article 2(12) MDR — so keeping the marketing free of medical claims
+is the whole game, and the disclaimer is evidence of that, not a shield.
+
+For completeness, if it ever did qualify, Annex VIII Rule 11 would put it at class
+IIa at minimum: "Software intended to provide information which is used to take
+decisions with diagnosis or therapeutic purposes is classified as class IIa". That
+means a notified body, a QMS, a clinical evaluation and a CE mark — an order of
+magnitude beyond anything this project can absorb. The correct posture is to stay
+firmly outside the definition rather than to manage the classification.
+
+## GDPR — Regulation (EU) 2016/679
+
+Primary text: [Regulation (EU) 2016/679](https://eur-lex.europa.eu/legal-content/EN/TXT/HTML/?uri=CELEX:32016R0679).
+Guidance: [EDPB Guidelines 07/2020 on the concepts of controller and processor](https://www.edpb.europa.eu/system/files/2023-10/EDPB_guidelines_202007_controllerprocessor_final_en.pdf).
+
+### Who is controller for the meal text and photos?
+
+Article 4(7): "'controller' means the natural or legal person … which, alone or
+jointly with others, **determines the purposes and means of the processing** of
+personal data". Article 4(8): "'processor' means a natural or legal person … which
+processes personal data **on behalf of** the controller".
+
+Article 2(2)(c) excludes processing "by a natural person in the course of a purely
+personal or household activity". Someone logging their own meals is inside that
+exclusion.
+
+Recital 18 supplies the carve-back everyone cites at this point:
+
+> This Regulation does not apply to the processing of personal data by a natural
+> person in the course of a purely personal or household activity and thus with no
+> connection to a professional or commercial activity … **However, this Regulation
+> applies to controllers or processors which provide the means for processing
+> personal data for such personal or household activities.**
+
+Read carefully, recital 18 says the Regulation *applies to* such controllers and
+processors. It does not say that providing the means *makes* you one. Whether the
+project is a controller still has to be answered under Article 4(7).
+
+Against controllership, on the BYO-endpoint design:
+
+- The project does not determine the **purpose** of any transmission. The user
+  does, per request, by choosing to send a particular photo or sentence.
+- The project does not determine the **recipient**. The user pastes the endpoint
+  URL. EDPB 07/2020 §40 lists "the categories of recipients ('who shall have
+  access to them?')" among the "essential means" that "are traditionally and
+  inherently reserved to the controller" — and here the user determines it.
+- The project does not determine **retention**. That is between the user and the
+  endpoint's terms.
+- The project never **receives** the data. There is no server, no log, no key.
+
+For controllership, honestly stated: the project does determine part of what EDPB
+calls essential means — "the type of personal data which are processed ('which
+data shall be processed?')" — because the request body is built by code the
+project wrote. It decides that the photo goes in, that the prompt includes the
+user's free text, and (a design choice worth making explicitly) whether anything
+else does.
+
+The better reading is that the project is **neither controller nor processor**:
+it processes no personal data at all, it merely ships a tool. But this is the
+genuinely contestable question in the whole document, and the answer would be
+different if the project ever operated a proxy, bundled a key, or received
+telemetry about requests. Two guardrails follow from that: never add a
+project-operated relay, and never log request contents to Sentry.
+
+### The photo containing an identifiable third party
+
+Meal photos may contain faces, hands or other diners. When the user sends such a
+photo to a commercial endpoint, that is processing of a third party's personal
+data by the user, and the third party did not consent.
+
+This is the **user's** exposure, not the project's, and in practice a small one:
+Article 2(2)(c) covers purely personal or household activity, and a single
+API call to a service the user chose in order to log their own dinner sits much
+closer to the household end than to publication. It is not a problem the project
+can solve on the user's behalf, and it is not one the project creates.
+
+What the project can do — as design choices, not obligations:
+
+- Make the photo path opt-in per use, not a background behaviour.
+- Say plainly, at the point of sending, that the photo leaves the device and
+  where it goes.
+- Consider offering an on-device crop or face-blur before send. This is a
+  courtesy, not a duty, and it should not be presented as making the send lawful.
+
+Note that faces in a photo are **not** Article 9 biometric data merely by being
+faces. Article 4(14) and Article 9(1) cover "biometric data **for the purpose of
+uniquely identifying a natural person**". Naming the food on the plate is not that
+purpose. Do not add any feature that asks the model about the people in the frame.
+
+### Article 9 — the special-category angle
+
+Article 9(1) prohibits, subject to exceptions, "processing of personal data
+revealing racial or ethnic origin, political opinions, **religious or philosophical
+beliefs** … or **data concerning health** or data concerning a natural person's sex
+life or sexual orientation".
+
+Article 4(15) defines data concerning health as "personal data related to the
+physical or mental health of a natural person … which reveal information about his
+or her health status", and recital 35 reads it broadly: "all data pertaining to the
+health status of a data subject which reveal information relating to the past,
+current or future physical or mental health status … any information on, for
+example, a disease, disability, disease risk, medical history, clinical treatment
+or the physiological or biomedical state of the data subject **independent of its
+source**".
+
+A food log can plainly reveal all three of the categories in the question — a
+consistently gluten-free diary suggests coeliac disease; a halal or kosher or
+Lenten pattern reveals religious belief; a sudden shift in intake plus a weight
+curve can suggest pregnancy. Whether a bare list of foods is itself "data
+concerning health" is contested and depends on inference, but the safe assumption
+is that a longitudinal diary is.
+
+Where that matters:
+
+- **Not for the project**, which holds none of it and never has. The data sits in
+  AES-encrypted Hive boxes on the device.
+- **Not for the user's own data** while they stay inside Article 2(2)(c).
+- **For the endpoint operator**, whose lawful basis for handling Article 9 data is
+  a matter between them and the user, governed by their terms. It is a reason to
+  surface which endpoint the user is about to send to, and to make the default
+  endpoint's data-handling terms discoverable from the settings screen.
+
+Article 26 (joint controllers) would only come into play if the project turned out
+to be a controller alongside the user — an outcome that would require a written
+arrangement whose "essence … shall be made available to the data subject". That
+would be an odd result, and if a lawyer thought it likely, the design should
+change rather than the paperwork.
+
+## Apple App Review Guidelines
+
+Primary text: [App Review Guidelines](https://developer.apple.com/app-store/review/guidelines/),
+last updated 8 June 2026. Guidelines 1.4.1 and 1.4.2 were already verified in
+[#599](https://github.com/simonoppowa/OpenNutriTracker/issues/599) and nothing
+found here changes that analysis.
+
+### The AI-specific provision does exist. It is in 5.1.2(i)
+
+The phrase "third-party AI" appears **exactly once** in the entire guidelines
+document, in 5.1.2(i) "Data Use and Sharing":
+
+> Unless otherwise permitted by law, you may not use, transmit, or share someone's
+> personal data without first obtaining their permission. You must provide access
+> to information about how and where the data will be used. **You must clearly
+> disclose where personal data will be shared with third parties, including with
+> third-party AI, and obtain explicit permission before doing so.**
+
+There is no separate AI section, no AI-specific guideline number, and nothing in
+the guidelines about labelling AI-generated output. The whole of Apple's
+AI-specific requirement, for this feature, is that sentence: **disclose, and get
+explicit permission, before sharing personal data with third-party AI.**
+
+### 5.1.1 — Data Collection and Storage
+
+5.1.1(i) requires the privacy policy to "Identify what data, if any, the
+app/service collects, how it collects that data, and all uses of that data", and
+to:
+
+> Confirm that any third party with whom an app shares user data … will provide
+> the same or equal protection of user data as stated in the app's privacy policy
+> and required by these Guidelines.
+
+This is the one place where BYO-key creates a genuine tension rather than an
+easier answer. You cannot confirm the data-protection posture of an endpoint you
+have never seen, because the user typed the URL. The honest position is that the
+recipient is the user's counterparty, chosen by the user, and that the policy
+names the *default* endpoint and describes the category for the rest. Whether App
+Review accepts that framing is unknowable in advance; it is a review-risk item,
+not a resolvable question.
+
+5.1.1(ii) requires consent for collection "even if such data is considered to be
+anonymous", and "an easily accessible and understandable way to withdraw consent"
+— satisfied by the settings toggle, provided disabling it is as easy as enabling
+it.
+
+5.1.1(iii) data minimisation: "Where possible, use the out-of-process picker or a
+share sheet rather than requesting full access to protected resources like Photos
+or Contacts." Relevant to the tier-2 camera/photo entry point.
+
+5.1.1(ix) is worth flagging even though it is not AI-specific:
+
+> Apps that provide services in highly regulated fields (such as banking and
+> financial services, healthcare, gambling, legal cannabis use, air travel and
+> crypto exchanges) or that require sensitive user information should be submitted
+> by a legal entity that provides the services, and not by an individual
+> developer.
+
+A nutrition tracker is not "healthcare" on any ordinary reading, and the
+guideline is aimed at apps that *provide* regulated services. But the app is
+published by an individual, and anything that pushes the app toward looking like
+healthcare — see the MDR section — makes this clause more visible than it needs
+to be.
+
+### 5.1.3 — Health and Health Research
+
+5.1.3(i) prohibits using or disclosing data gathered "in the health, fitness, and
+medical research context—including from the Clinical Health Records API, HealthKit
+API, Motion and Fitness, MovementDisorder APIs, or health-related human subject
+research—for advertising, marketing, or other use-based data mining purposes", and
+ends: "You must disclose the specific health data that you are collecting from the
+device."
+
+The app does not use HealthKit (README: "No location, contacts, microphone, or
+health-data access"), so the API-scoped part of 5.1.3(i) does not engage. The
+prohibition on advertising and use-based data mining is satisfied trivially — there
+is no advertising and no data mining. 5.1.3(ii)–(iv) concern writing to HealthKit
+and human-subject research; neither applies.
+
+### Does a user-supplied API key change the analysis versus a developer-supplied one?
+
+For **5.1.2(i)**, no. The rule is about *where personal data will be shared*, not
+about who pays for the sharing. Personal data leaves the device to a third party
+either way, so the disclose-and-obtain-permission duty is identical.
+
+What BYO-key does change is the *content* of the disclosure. With a
+developer-supplied key you name one recipient and can point at its terms. With a
+user-supplied endpoint you must instead say: (a) that the destination is whatever
+address the user configured; (b) which address is prefilled by default and what
+its terms say; and (c) that the project has no visibility into and no control over
+what the chosen endpoint does with the data. That last sentence is both the honest
+position and the strongest one.
+
+What BYO-key genuinely improves is the *first-party* story: the project receives
+nothing, so there is no first-party collection to disclose, no retention policy to
+write, and no deletion mechanism to build for data the project never holds.
+
+## Google Play
+
+### Generative AI — the in-app reporting requirement is the concrete new build item
+
+[AI-Generated Content policy](https://support.google.com/googleplay/android-developer/answer/13985936):
+
+> AI-generated content is content that is created by generative AI models based on
+> user prompts. Examples of AI-generated content include:
+> - Text–to-text conversational generative AI chatbots, in which interacting with
+>   the chatbot is a central feature of the app
+> - Image or video generated by AI based on text, image, or voice prompts
+
+and the operative requirement:
+
+> **Apps that generate content using AI must contain in-app user reporting or
+> flagging features that allow users to report or flag offensive content to
+> developers without needing to exit the app.** Developers should utilize user
+> reports to inform content filtering and moderation in their apps.
+
+The two listed examples are chatbots and image/video generation, and a structured
+meal list is neither. But the operative sentence is not scoped to those examples —
+it says "apps that generate content using AI". Tiers 1–2 do generate text content
+from user prompts. Arguing the scope is not worth it: a "Report this result"
+affordance on the review screen is a few hours of work and settles it. Build it.
+
+There is a live-policy caveat here: the equivalent requirement under Apple's 1.2
+(user-generated content) is not engaged, because model output on the user's own
+device is not content posted by a community of users. Google's rule is
+developer-facing reporting, not community moderation, which is a lower bar.
+
+### User Data policy
+
+[User Data policy](https://support.google.com/googleplay/android-developer/answer/9888076)
+extends the third-party rules to AI explicitly:
+
+> If you include third party code (for example, an SDK) in your app, you must
+> ensure that the third party code used in your app, and that third party's
+> practices with respect to user data from your app, are compliant with Google
+> Play Developer Program policies … **These requirements also apply to third-party
+> AI integrations (such as products, services, code) and you remain responsible
+> for ensuring compliance with this policy, including limited use, disclosure and
+> consent.**
+
+Note "you remain responsible" — Google places the burden on the developer even
+where the integration is one the user configured. This is the same tension as
+Apple 5.1.1(i), and it has the same honest answer and the same residual risk.
+
+Two helpful provisions. On sale:
+
+> "Sale" means the exchange or transfer of personal and sensitive user data to a
+> third party for monetary consideration. **User-initiated transfer of personal and
+> sensitive user data (for example, when the user is using a feature of the app to
+> transfer a file to a third party …), is not regarded as sale.**
+
+And the Prominent Disclosure & Consent requirement is triggered where the handling
+"may not be within the reasonable expectation of the user of the product or feature
+in question". An opt-in settings screen where the user pastes their own endpoint is
+arguably within expectation. Send an in-app disclosure anyway before the first
+request, and again the first time a photo is sent — it is cheap and it is what the
+Apple rule requires regardless.
+
+Health data is listed in the policy's own enumeration of "personal and sensitive
+user data", alongside "camera".
+
+### Health Content and Services — an existing gap, independent of AI
+
+[Health Content and Services](https://support.google.com/googleplay/android-developer/answer/12261419).
+Scope:
+
+> If your app offers health-related features or information as part of its
+> functionality, or accesses health data to support non-health features, it must
+> comply with the existing Google Play Developer Policies …
+
+Google's own [health app categories](https://support.google.com/googleplay/android-developer/answer/13996367)
+places nutrition trackers in "health and fitness apps" — "These apps usually inform
+or let users track or sync information about their personal health and fitness …
+in areas such as fitness, nutrition, wellness, and sleep. Examples include fitness
+trackers, **nutrition trackers**, sleep trackers, and stress management apps" — and
+not in "medical apps", which is the SaMD-adjacent category. That is the right
+outcome and consistent with the MDR analysis.
+
+But the policy then says:
+
+> Apps that are regulated because they are a medical device must be declared as
+> such … **Other health and medical apps must include a clear disclaimer in their
+> app description indicating that the app is "not a medical device and does not
+> diagnose, treat, cure, or prevent any medical condition."**
+>
+> Apps must also remind users to consult a healthcare professional for medical
+> advice, diagnosis, or treatment.
+
+Two observations about the repo as it stands today:
+
+1. `fastlane/metadata/android/en-US/full_description.txt` does not contain that
+   disclaimer, or anything close to it.
+2. The in-app disclaimer string (`disclaimerText` in `lib/l10n/intl_en.arb`) reads
+   "OpenNutriTracker is not a medical **application**. All data provided is not
+   validated and should be used with caution. Please maintain a healthy lifestyle
+   and consult a professional if you have any problems." That covers the
+   consult-a-professional limb well, but it is not the phrase Google specifies, and
+   the policy requires the disclaimer "in their app description", not only in-app.
+
+This is a **present-tense finding that has nothing to do with AI** and is the most
+actionable item in this document. It costs one paragraph in the store listing.
+
+The policy also requires the Health apps declaration form in Play Console for all
+developers, with nutrition tracking as a declarable feature.
+
+### Data safety — what BYO-key does and does not change
+
+[Data safety guidance](https://support.google.com/googleplay/android-developer/answer/10787469).
+
+Collection:
+
+> "Collect" means transmitting data from your app off a user's device.
+
+with the on-device exclusion:
+
+> On-device access/processing: User data accessed by your app that is only
+> processed locally on the user's device and not sent off device does not need to
+> be disclosed.
+
+Sharing:
+
+> "Sharing" refers to transferring user data collected from your app to a third
+> party.
+
+with an exception that fits this design almost exactly:
+
+> The following types of data transfers do not need to be disclosed as "sharing":
+> … **User-initiated action or prominent disclosure and user consent.** Transferring
+> user data to a third party based on a specific user-initiated action, where the
+> user reasonably expects the data to be shared, or based on a prominent in-app
+> disclosure and consent that meets the requirements described in our User Data
+> policy.
+
+So the answer to "does BYO-key change the Data safety form answers, given the app
+itself transmits nothing to the developer?" is: **it changes the *sharing* answers,
+not the *collection* answers.**
+
+- **Collection.** Yes, tiers 1–2 collect in Play's sense, because "collect" means
+  transmitting off device — irrespective of destination. Photos and the meal
+  description (which Play would treat under "Health and fitness" and "Photos and
+  videos") must be declared as collected, marked **optional** (the user can use the
+  entire app without ever enabling the feature), with purpose "App functionality".
+  Tier 0 collects nothing new.
+- **Sharing.** The user-initiated-action exception is a strong fit — the user
+  pastes an endpoint, then taps a button to send a specific photo or sentence. On
+  the strict reading you need not declare sharing. Declare it anyway: it costs
+  nothing, it is unambiguously true, and it aligns the Play answers with the
+  Apple 5.1.2(i) disclosure you have to write regardless.
+- **Ephemeral processing** is defined as data "only stored in memory and retained
+  for no longer than necessary to service the specific request in real-time", and
+  such data "needs to be included in your form response, but … will not be
+  disclosed in your app's Data safety section". **Do not rely on this.** You cannot
+  warrant the retention behaviour of an endpoint the user chose. Anthropic's own
+  vision documentation describing images as ephemeral would support the claim for
+  that one default, but not for an arbitrary URL.
+
+The "Encryption in transit" declaration remains true — HTTPS to whatever endpoint.
+
+## F-Droid
+
+Primary text: [Anti-Features](https://f-droid.org/en/docs/Anti-Features/),
+[Inclusion Policy](https://f-droid.org/en/docs/Inclusion_Policy/).
+
+### The label, and whether it blocks inclusion
+
+> **Non-Free Network Services** — This Anti-Feature is applied to apps that
+> **promote or depend entirely on** a proprietary network service.
+
+The Inclusion Policy answers the blocking question directly:
+
+> F-Droid uses pre-defined labels known as Anti-Features which serve as warning
+> indicators about user freedom, privacy or etc. **without necessarily disqualifying
+> applications from inclusion.**
+
+So `NonFreeNet` is a label, not a bar. It is also not one of the flags the client
+hides by default — the Anti-Features page notes that only apps marked `Tracking`
+"are not displayed by default".
+
+The Inclusion Policy also contains a line that BYO-key satisfies by construction:
+
+> F-Droid does not sign up for any API keys. Even if provided by a third party, we
+> include them in both binary and source code releases.
+
+### Does supporting Ollama avoid the flag? On the observed record, no
+
+Three LLM clients currently in the F-Droid main repository, all of which support
+a locally-hosted endpoint, and all of which carry `NonFreeNet`:
+
+| App | Local option supported | Anti-Feature and F-Droid's stated reason |
+| :-- | :-- | :-- |
+| [maid](https://f-droid.org/packages/com.danemadsen.maid/) | llama.cpp locally, plus Ollama | `NonFreeNet` — "Remote models rely on Mistral, Google Gemini and OpenAI." |
+| [oxproxion](https://f-droid.org/packages/io.github.stardomains3.oxproxion/) | Ollama, LM Studio, llama.cpp, MLX LM | `NonFreeNet` — "Depends on OpenRouter API servers (OpenRouter LLM endpoints)." |
+| [Kai 9000](https://f-droid.org/packages/com.inspiredandroid.kai/) | Ollama, LM Studio, any OpenAI-compatible API | `NonFreeNet` — "Rely on Gemini and Groq" |
+
+maid is the decisive case: it ships genuine on-device inference via llama.cpp and
+is still flagged, because it also *promotes* proprietary remote models. The
+"promote" limb of the definition does the work, and shipping a prefilled default
+endpoint pointing at a commercial provider is promotion in exactly that sense.
+
+### The precedent that actually points at a solution
+
+Two apps handle an optional proprietary network integration without earning any
+anti-feature, and both do it the same way — a **build flavour**, not a settings
+toggle:
+
+- **[Breezy Weather](https://f-droid.org/packages/org.breezyweather/)** supports
+  more than 50 weather sources, some of them proprietary. The F-Droid build is the
+  `freenet` gradle flavour — the shipped version name is literally `6.2.1_freenet`,
+  and the [fdroiddata metadata](https://gitlab.com/fdroid/fdroiddata/-/raw/master/metadata/org.breezyweather.yml)
+  pins `gradle: [freenet]`. The listing carries **no** anti-features.
+- **[Translate You](https://f-droid.org/packages/com.bnyro.translate/)** supports
+  DeepL among six engines; the [metadata](https://gitlab.com/fdroid/fdroiddata/-/raw/master/metadata/com.bnyro.translate.yml)
+  builds `gradle: [libre]`. Also no anti-features.
+
+So the shape that works is: an `fdroid` product flavour that either omits the
+cloud path entirely or ships the endpoint field with no prefilled commercial
+default. A runtime toggle in Settings is not enough — maid, oxproxion and Kai 9000
+all have one, and all three are flagged.
+
+### Practical relevance today
+
+The [RFP for OpenNutriTracker (#2540)](https://gitlab.com/fdroid/rfp/-/issues/2540)
+is still open and has had no activity since it was filed on 2023-09-11. There is
+nothing in F-Droid to lose right now. The forward-looking point is that if the RFP
+is ever picked up, a `NonFreeNet` label would be the outcome of a prefilled
+commercial default, it would not block inclusion, and a build flavour would avoid
+it if the project cared to.
+
+## GPL-3.0
+
+Primary sources: [GPL FAQ](https://www.gnu.org/licenses/gpl-faq.html),
+[Why the Affero GPL](https://www.gnu.org/licenses/why-affero-gpl.html), and the
+GPLv3 text in this repo's `LICENSE`.
+
+**There is no licence problem, and the expectation in the issue is correct.** The
+FSF's own criterion for whether two pieces of software form one program turns on
+the mechanism and semantics of communication:
+
+> If the modules are included in the same executable file, they are definitely
+> combined in one program. If modules are designed to run linked together in a
+> shared address space, that almost surely means combining them into one program.
+> **By contrast, pipes, sockets and command-line arguments are communication
+> mechanisms normally used between two separate programs. So when they are used for
+> communication, the modules normally are separate programs.**
+
+An HTTPS request carrying JSON to a remote endpoint is a socket, and the semantics
+are an ordinary request/response — not "exchanging complex internal data
+structures". The remote model is not linked, is not conveyed, and is not part of
+the Corresponding Source. Nothing about the GPL is engaged by calling a proprietary
+network API.
+
+### The Affero clause, and why it is misread
+
+The AGPL closes a gap about **running modified software on a server**, not about
+being a client of one. gnu.org states the loophole as: "When D modifies the
+program, he might very likely run it on his own server and never release copies",
+and the trigger as: "If you run a modified program on a server and let other users
+communicate with it there, your server must also allow them to download the source
+code corresponding to the modified version running there."
+
+The FAQ makes the client/server point explicitly — the question is "whether or not
+there is a reasonable expectation that a person will be interacting with the
+program remotely over a network", and:
+
+> If a program is not expressly designed to interact with a user through a network,
+> but is being run in an environment where it happens to do so, then it does not
+> fall into this category.
+
+OpenNutriTracker runs no server. Its users interact with it on their own devices.
+Even if the app were AGPL rather than GPL, nothing would be triggered by making
+outbound API calls.
+
+GPLv3 section 13, the one place "Affero" appears in the licence, is a
+**compatibility** clause, not an obligation:
+
+> Notwithstanding any other provision of this License, you have permission to link
+> or combine any covered work with a work licensed under version 3 of the GNU
+> Affero General Public License into a single combined work, and to convey the
+> resulting work. The terms of this License will continue to apply to the part
+> which is the covered work, but the special requirements of the GNU Affero General
+> Public License, section 13, concerning interaction through a network will apply
+> to the combination as such.
+
+It only bites if you *combine* GPLv3 code with AGPLv3 code. Calling an API does not
+combine anything.
+
+Two real constraints that are adjacent but not licence matters:
+
+- **Never ship a project API key.** That is a credential-distribution problem
+  (and F-Droid would strip or refuse it — see the Inclusion Policy quote above),
+  not a GPL problem.
+- **The endpoint's terms of service** bind whoever agreed to them — the user. If a
+  provider's terms restrict a use case, that is the user's contract, not a
+  condition on the software licence.
+
+## German-specific
+
+The developer appears to be Germany-based. Four instruments add something, and one
+that people expect to add something does not.
+
+### KI-MIG — the German AI Act implementation, in force since 29 July 2026
+
+[Gesetz zur Marktüberwachung und Innovationsförderung von künstlicher Intelligenz
+(KI-MIG)](https://www.gesetze-im-internet.de/ki-mig/BJNR0DF0B0026.html), published
+in the Bundesgesetzblatt on 28 July 2026, in force 29 July 2026
+([BMDS announcement](https://bmds.bund.de/aktuelles/aktuelle-meldungen/detail/neues-ki-gesetz-tritt-in-kraft),
+[legislative record](https://bmds.bund.de/service/gesetzgebungsverfahren/gesetz-zur-durchfuehrung-der-ki-verordnung)).
+
+§ 1 Anwendungsbereich:
+
+> Dieses Gesetz dient der Durchführung der Verordnung (EU) 2024/1689. Es gilt für
+> KI-Systeme im Sinne des Artikels 3 Nummer 1 der Verordnung (EU) 2024/1689 und
+> regelt **ergänzend zu den in der Verordnung enthaltenen Bestimmungen** die
+> zuständigen Behörden gemäß Artikel 70 Absatz 1 Satz 1 …, Maßnahmen zur
+> Innovationsförderung sowie Bußgelder bei Verstößen gegen die Vorschriften der
+> Verordnung gemäß Artikel 99 Absatz 1 Satz 1 …
+
+**It adds no substantive obligation beyond the Regulation.** It is institutional:
+it designates the Bundesnetzagentur as market-surveillance authority, single point
+of contact and complaints body; it provides for regulatory sandboxes; and it
+handles procedure.
+
+§ 15 does create German *Ordnungswidrigkeiten*, but only for AI Act provisions the
+Regulation itself does not fine — Articles 21, 27, 45 and 86 — capped at
+"eine Geldbuße bis zu fünfzigtausend Euro" (§ 15(3)). **Article 50 is not among
+them**; Article 50 breaches are fined under Article 99(4)(g) of the Regulation
+directly, with § 16 KI-MIG applying the Ordnungswidrigkeitengesetz procedure.
+
+Net effect for this project: the German layer changes *who enforces* (BNetzA) and
+*how*, not *what is owed*.
+
+### UWG § 5 — the strongest German argument for the `estimated` marker
+
+[§ 5 UWG, Irreführende geschäftliche Handlungen](https://www.gesetze-im-internet.de/uwg_2004/__5.html):
+
+> (1) Unlauter handelt, wer eine irreführende geschäftliche Handlung vornimmt, die
+> geeignet ist, den Verbraucher … zu einer geschäftlichen Entscheidung zu
+> veranlassen, die er andernfalls nicht getroffen hätte.
+>
+> (2) Eine geschäftliche Handlung ist irreführend, wenn sie unwahre Angaben enthält
+> oder sonstige zur Täuschung geeignete Angaben über folgende Umstände enthält:
+> 1. die wesentlichen Merkmale der Ware oder Dienstleistung wie … Zwecktauglichkeit,
+> Verwendungsmöglichkeit, Menge, Beschaffenheit … **von der Verwendung zu erwartende
+> Ergebnisse** oder die Ergebnisse oder wesentlichen Bestandteile von Tests der
+> Waren oder Dienstleistungen …
+
+This is the realistic German exposure, and it is not about AI as such. The README
+sells the app on "every number is cited". Presenting a model's guess at the
+calories in a home-cooked stew in the same visual register as a BLS-sourced figure
+is capable of misleading about "die wesentlichen Merkmale" and "von der Verwendung
+zu erwartende Ergebnisse".
+
+This is the provision that turns the `estimated` provenance marker from good
+manners into a compliance artefact. It also means the marker must be visible where
+the number is read — the diary row, the day total, the export — not only on the
+review screen where the item was added.
+
+Practical note on enforcement: UWG claims are typically brought by competitors and
+by qualified associations under § 8(3) UWG, which is a far cheaper and more likely
+route than a regulator action.
+
+### DDG § 5 — Impressum
+
+[§ 5 DDG, Allgemeine Informationspflichten](https://www.gesetze-im-internet.de/ddg/__5.html)
+(the successor to TMG § 5) requires providers of "geschäftsmäßige, in der Regel
+gegen Entgelt angebotene digitale Dienste" to keep permanently available, "leicht
+erkennbar und unmittelbar erreichbar":
+
+> 1. den Namen und die Anschrift, unter der sie niedergelassen sind …
+> 2. Angaben, die eine schnelle elektronische Kontaktaufnahme und eine unmittelbare
+> Kommunikation mit ihnen ermöglichen, einschließlich der Adresse für die
+> elektronische Post …
+
+Whether a free open-source app is "geschäftsmäßig" is the usual German argument;
+the presence of a Patreon and paid store presence makes the conservative answer the
+right one. This duty is entirely independent of AI and applies today. Worth
+confirming that an Impressum is reachable from the app and from the project site.
+
+### TDDDG § 25 — terminal-equipment access
+
+[§ 25 TDDDG](https://www.gesetze-im-internet.de/ttdsg/__25.html) requires consent
+for storing information on, or accessing information already stored on, the user's
+terminal equipment, with an exception in § 25(2) Nr. 2:
+
+> … wenn die Speicherung von Informationen in der Endeinrichtung des Endnutzers
+> oder der Zugriff auf bereits in der Endeinrichtung des Endnutzers gespeicherte
+> Informationen **unbedingt erforderlich ist, damit der Anbieter eines digitalen
+> Dienstes einen vom Nutzer ausdrücklich gewünschten digitalen Dienst zur Verfügung
+> stellen kann.**
+
+Reading a photo the user just selected, in order to perform the analysis the user
+just requested, and storing the API key the user just pasted, both fit § 25(2)
+Nr. 2 comfortably. No separate consent banner is needed for the *device access*.
+The *transmission to a third party* is a GDPR question, addressed above, not a
+§ 25 one.
+
+### HWG § 1 — only if the marketing goes medical
+
+[§ 1 HWG](https://www.gesetze-im-internet.de/heilmwerbg/__1.html) applies to
+advertising for medicinal products, for medical devices within Article 2(1) MDR,
+and:
+
+> 2. andere Mittel, Verfahren, Behandlungen und Gegenstände, soweit sich die
+> Werbeaussage bezieht a) auf die **Erkennung, Beseitigung oder Linderung von
+> Krankheiten, Leiden, Körperschäden oder krankhaften Beschwerden beim Menschen** …
+
+The trigger is the *content of the advertising statement*, not the nature of the
+product. This is the same lever as MDR intended purpose: keep the marketing off
+disease-detection and disease-alleviation ground and the HWG never engages. It is
+worth noting that HWG imposes stricter rules than UWG once it does engage, so the
+two sections reinforce each other.
+
+### What does *not* apply: nutrition and health claims law
+
+[Regulation (EC) No 1924/2006](https://eur-lex.europa.eu/legal-content/EN/TXT/HTML/?uri=CELEX:02006R1924-20141213)
+Article 1(2): "This Regulation shall apply to nutrition and health claims made in
+commercial communications, whether in the labelling, presentation or advertising of
+**foods to be delivered as such to the final consumer**." A "claim" under Article
+2(2)(1) is a representation "that a food has particular characteristics". The
+addressees are food business operators marketing foods. An app that reports values
+sourced from public composition databases is not making a claim about a food it
+places on the market. The same reasoning keeps LFGB out of scope. Neither adds a
+duty here.
+
+## Concrete obligations checklist
+
+### Must be built or written — tiers 1–2
+
+| # | Item | Driven by |
+| :-- | :-- | :-- |
+| 1 | **In-app disclosure + explicit consent gate**, shown before the first request and again before the first photo send, naming the default endpoint and stating that the destination is whatever the user configured and that the project sees nothing. Must be screen-reader reachable. | Apple 5.1.2(i); Google Play User Data (Prominent Disclosure); AI Act Art. 50(1)+(5) |
+| 2 | **In-app "report this result" control** on the review screen, routed to the issue tracker or a mail intent, without leaving the app. | Google Play AI-Generated Content policy |
+| 3 | **`estimated` provenance persisted machine-readably** — the new `MealSourceEntity` value in the Hive record and in `docs/export-format.md`, not only rendered on screen. | AI Act Art. 50(2) (machine-readable marking) |
+| 4 | **Visible `estimated` marker on every surface where the number is read** — diary row, day total, nutrient panel, export. | UWG § 5(2) Nr. 1; the README's "every number is cited" claim |
+| 5 | **Privacy-policy section** covering: what is sent (meal text, optionally a photo), to whom (an endpoint the user configures; name the prefilled default), that the project receives and stores nothing, that retention is governed by the chosen endpoint's terms, and that the feature is off by default. | Apple 5.1.1(i); Google Play Health policy privacy-policy requirement; GDPR transparency posture |
+| 6 | **Settings copy** stating plainly: off by default; the key is stored in Keystore/Keychain and never leaves the device except to the endpoint the user named; the project has no visibility into the endpoint; how to turn it off and delete the key. | Apple 5.1.1(ii) withdraw-consent; F-Droid/user-trust posture |
+| 7 | **Data safety form revision**: declare "Photos" and health/fitness info as **collected**, marked **optional**, purpose "App functionality". Declare sharing too, notwithstanding the user-initiated exception. Do not claim the ephemeral carve-out. | Google Play Data safety |
+| 8 | **Health apps declaration** in Play Console kept accurate for the new features. | Google Play Health Content and Services |
+| 9 | **Never log request or response contents to Sentry**, and never introduce a project-operated relay. | The GDPR "not a controller" position depends on both |
+
+### Must be written — independent of AI, applies today
+
+| # | Item | Driven by |
+| :-- | :-- | :-- |
+| 10 | Add to the Play store description: the app "is not a medical device and does not diagnose, treat, cure, or prevent any medical condition", plus a reminder to consult a healthcare professional. The current `full_description.txt` has neither; the in-app `disclaimerText` says "not a medical **application**", which is not the specified phrase and is not in the app description. | Google Play Health Content and Services |
+| 11 | Confirm an Impressum with name, postal address and email is reachable from the app and the project site. | DDG § 5(1) |
+
+### Advisable, not required
+
+- Keep the AI feature out of the store listing's headline feature list, or describe
+  it in a way that cannot be read as a health claim. Every medical-adjacent word
+  in marketing copy is an input to the MDR intended-purpose test and to HWG § 1.
+- Offer an on-device crop before sending a photo. Courtesy toward third parties in
+  frame; not a legal requirement and should not be presented as one.
+- Never ask the model anything about people in the photo. Keeps Annex III(1) and
+  GDPR Article 9 biometrics unambiguously out of scope.
+- If F-Droid inclusion is ever pursued, add an `fdroid` product flavour that omits
+  the cloud path or ships no prefilled commercial endpoint — the Breezy Weather /
+  Translate You pattern. A runtime toggle will not avoid `NonFreeNet`.
+- Document the feature's known failure modes in the repo. This is the cheapest way
+  to discharge AI Act Article 4 and the best evidence against a UWG § 5 claim.
+- Surface the default endpoint's data-handling terms from the settings screen, so
+  a user can see what they are agreeing to before pasting a key.
+
+## What I could not verify
+
+- **Whether a free, non-commercial GPL app is "made available on the market … in
+  the course of a commercial activity"** within AI Act Article 3(10), and therefore
+  whether "placing on the market" in Article 3(3) is met at all. The Blue Guide is
+  the usual authority and reads it broadly, but I did not fetch it. If it is not
+  met, the project is not a provider and Article 50 does not attach.
+- **Whether voluntary donations (the repo's Patreon) count as "monetised"** under
+  recital 103 and so cost the project the Article 2(12) free-software exemption.
+  Since the exemption is disapplied for Article 50 anyway, this matters less than
+  it looks, but it matters for everything else.
+- **Whether the Article 111(4) four-month transitional reaches a feature released
+  after 2 August 2026.** On its face it is scoped to systems already on the market
+  on that date, which would mean no grace period for tiers 1–2.
+- **MDCG 2025-6** (FAQ on the interplay between MDR/IVDR and the AI Act, June 2025)
+  exists and is on the Commission's site, but I did not read it. It is scoped to
+  AI systems that *are* medical devices, so it should not change the analysis here
+  — but that is an assumption, not a verified fact.
+- **CJEU case law on controllership for embedded code** (Fashion ID, C-40/17) and
+  on the household exemption for photographs (Ryneš, C-212/13; Lindqvist,
+  C-101/01). These are the cases that would decide the "does shipping the code make
+  you a controller" question, and I did not read the judgments.
+- **How App Review actually treats a user-supplied endpoint** under 5.1.1(i)'s
+  "confirm that any third party … will provide the same or equal protection"
+  requirement. There is no published guidance and this is unknowable from the text.
+- **Whether Google would read a structured meal list as "AI-generated content"**
+  within the policy's scope. The examples say chatbots and images; the operative
+  sentence is broader. Building the report control moots the question.
+- **Whether the app's Play Console Health apps declaration is currently accurate**
+  — that lives in the Console and is not visible from the repo.
+- **The exact Bundesgesetzblatt citation for KI-MIG.** Entry into force
+  (29 July 2026) and the consolidated text on gesetze-im-internet.de are confirmed;
+  the BGBl. number is not.
+
+## Questions worth paying a lawyer for
+
+1. **Is the project a "provider" of an AI system under Article 3(3) at all, given
+   that the inference component is supplied by the user at runtime and the software
+   is free and open-source?** Everything in the AI Act section downstream of this
+   changes if the answer is no. This is the single highest-leverage question.
+2. **Does Article 50(2) reach a structured nutrition estimate, and does the
+   "do not substantially alter … the semantics" exception cover the tier-1 text
+   path and/or the tier-2 photo path?** If tier 1 is inside the exception and tier
+   2 is not, that is a real scoping decision — it could justify shipping tier 1 and
+   deferring tier 2 on compliance grounds rather than product grounds.
+3. **Is the machine-readable `estimated` provenance marker a defensible Article
+   50(2) technical solution for a project that does not run the model**, given the
+   "as far as this is technically feasible … costs of implementation … state of the
+   art" proportionality language? A short written rationale, reviewed once, is
+   worth having on file before release.
+4. **Does shipping the code that makes the request make the project a controller or
+   joint controller under GDPR Article 4(7), read with recital 18 and the Fashion ID
+   line of cases?** If the answer is yes, the design should change — a project that
+   is a controller for data it never receives is an unmanageable position.
+5. **Does the app's current Play store description satisfy the Google Play Health
+   Content and Services disclaimer requirement**, and if not, is the exact
+   specified wording required or is an equivalent acceptable? This is cheap to fix
+   and applies today, before any AI work lands.
+6. **Is the developer's current publishing arrangement (individual, not a legal
+   entity) a risk under Apple 5.1.1(ix)** as the app accumulates health-adjacent
+   features — and would incorporating change the MDR, UWG or product-liability
+   picture in a way that matters?
+7. **Under UWG § 5, how prominent must the `estimated` marker be to defeat a
+   misleading-advertising claim, given that the project's own marketing leads with
+   "every number is cited"?** This is a German-law judgement about a claim the
+   project chose to make, and it is the most likely source of an actual complaint.

--- a/docs/ai-open-research-questions.md
+++ b/docs/ai-open-research-questions.md
@@ -1,0 +1,970 @@
+# What is still unknown before the AI work starts
+
+A gap analysis, written 2026-08-02 as the fourth and last of the AI research
+documents, after
+[`ai-in-open-source-nutrition-trackers.md`](ai-in-open-source-nutrition-trackers.md)
+(the cohort survey),
+[`ai-legal-constraints.md`](ai-legal-constraints.md) (the legal survey) and
+[`ai-cohort-restrictions.md`](ai-cohort-restrictions.md) (the restrictions
+analysis), against the design in
+[#599](https://github.com/simonoppowa/OpenNutriTracker/issues/599) as revised in
+its three comments, the tier-0 sub-issues
+[#600](https://github.com/simonoppowa/OpenNutriTracker/issues/600) /
+[#601](https://github.com/simonoppowa/OpenNutriTracker/issues/601) /
+[#602](https://github.com/simonoppowa/OpenNutriTracker/issues/602), and the
+approved implementation plan.
+
+The three earlier documents each end with a "Not verified" / "Still open" list.
+Those lists were the starting inventory, not the answer: several items on them
+had already been closed by a later document, several were never research
+questions at all, and the items that actually threaten the build were on none of
+them. This document sorts every open question by **what it blocks**, closes the
+ones that were cheap and decisive to close, and says plainly where a route
+failed.
+
+Every item is labelled:
+
+- **Research** — an answer exists somewhere; we had not found it.
+- **Decision** — no external answer exists. The maintainer has to choose.
+- **Legal** — needs a lawyer, not more reading.
+
+## Bottom line up front
+
+**Tier-0 coding can start today.** Nothing in the legal, licensing, F-Droid or
+provider-terms surface touches #600/#601/#602, and
+[`ai-cohort-restrictions.md`](ai-cohort-restrictions.md) F1 already established
+that. What it did not establish, because nobody read the code the issues depend
+on, is that **three of the tier-0 issues contain spec errors that will produce
+wrong numbers or unusable instructions if they are implemented as written.**
+None of them is a blocker in the sense of "stop"; all three are twenty-minute
+edits to the issue bodies that should happen before a first-time contributor
+picks one up.
+
+The three:
+
+1. **#600 tells the parser to emit `kg` and `l`. The app has no such units.**
+   `UnitDropdownItem` has exactly six members and neither of those is one of
+   them, and its `fromString` falls through to `g/ml`. #600's own headline test
+   case, `1,5 l milk`, therefore logs **1.5 grams of milk instead of 1500 ml** —
+   a 1000× understatement, silently.
+2. **The relevance ranker scores morphological variants at exactly 0.0.** There
+   is no stemming anywhere in the search stack, so the query `eggs` scores
+   `0.0` against a database record named `Egg` while scoring `0.29` against
+   *Cadbury Creme Eggs*. #601 auto-selects the top candidate. The failure mode
+   the plan tells you to test for — a query that matches nothing — is not the
+   dangerous one; the dangerous one is a query that matches the wrong thing
+   confidently.
+3. **The plan's and #602's localization instructions describe a repository that
+   no longer exists.** They say to hand-edit `lib/generated/intl/` and verify
+   with `just check_intl`. That directory does not exist, that recipe is not in
+   the justfile, and the current `AGENTS.md` says the exact opposite. The
+   instructions are copied from a pre-`gen-l10n` AGENTS.md that survives only in
+   a stale worktree.
+
+Beyond tier 0: **five of the six named research gaps closed today**, including
+the one everything else was dated against. The F-Droid blocker
+([RFP #2540](https://gitlab.com/fdroid/rfp/-/issues/2540)) now has a concrete,
+current, working exemplar with the exact build recipe — and it is
+*cheaper* than `ai-cohort-restrictions.md` C7 estimated, and does not use a
+Gradle build flavour at all.
+
+## The table
+
+| # | Gap | Blocks | Kind | Cost to close | Status |
+| :-- | :-- | :-- | :-- | :-- | :-- |
+| **T1** | #600 emits `kg` / `l`; the app's unit vocabulary has neither, and the fallback is a silent 1000× error | **Tier 0 (#600, #602)** | Decision | 20 min issue edit | **Closed today** — diagnosed; the choice remains |
+| **T2** | #600 segments on `,` and accepts `,` as a decimal separator, with no precedence rule | **Tier 0 (#600)** | Decision | 10 min issue edit | Open (found by `ai-cohort-restrictions.md` F2) |
+| **T3** | No stemming anywhere in the search stack; plural queries score 0.0 and sink below noise | **Tier 0 (#601 contract, #602 acceptance)** | Research → Decision | Closed by code reading; one fixture test to size | **Closed today** |
+| **T4** | `addIntake` does an unguarded `double.parse`; a batched "Log all" has no validation, no atomicity, and bypasses the #212 duplicate guard | **Tier 0 (#602)** | Decision | 30 min issue edit | **Closed today** — diagnosed |
+| **T5** | Plan §5 / #602 l10n instructions target a directory and a `just` recipe that do not exist | **Tier 0 (#602)** | Research | Closed by reading the repo | **Closed today** |
+| **T6** | `just ci` cannot pass locally; the plan makes it the verification gate | **Tier 0 (both)** | Research | Closed by reading the repo | **Closed today** |
+| **T7** | Parser emits unbounded decimals; the review field's formatter caps at 2 dp | Tier 0 (#600) | Decision | 5 min | **Closed today** — diagnosed |
+| **S1** | Digital Omnibus deferral, Reg. (EU) 2026/1744 — the timeline everything is dated against | Tier 1 scoping | Research | Closed via EUR-Lex | **Closed today** |
+| **S2** | Anthropic: image content-part + `output_config.format` in one request | Tier 2 build (not tier-1 scoping) | Research | Docs read; one live call (~$0.003) for certainty | **Partially closed today** |
+| **S3** | Decision #5 — Train Libre posture vs. accepting the 1.4.1 risk | Tier 1 scoping | **Decision** | Free; the evidence is already gathered | Open — and no research will close it |
+| **S4** | No request timeout anywhere in the design; a local endpoint needs minutes | Tier 1 scoping | Decision | 10 min | Open (found by `ai-cohort-restrictions.md` E1) |
+| **S5** | OpenAI Services Agreement §2.2 / §3.3(g) — the BYO-key blessing #599 cites | Tier 1 scoping (weakly) | Research | Blocked; route failed | **Open — route failed** |
+| **S6** | OpenAI Usage Policies currency (quoted from a 9-month-old Microsoft mirror) | Tier 1 scoping (weakly) | Research | Blocked by the same 403 | Open |
+| **S7** | Is the project an AI Act "provider" at all? | Tier 1 scoping | **Legal** | Paid consultation | Open |
+| **S8** | Does the Art. 111(4) four-month transitional reach a feature released after 2 Aug 2026? | Release | **Legal** | Same consultation | Open — EUR-Lex truncates |
+| **S9** | Does Art. 50(2)'s "does not substantially alter … the semantics" exception cover tier 1? | Tier 1 scoping | **Legal** | Same consultation | Open |
+| **R1** | Play in-app reporting/flagging requirement for AI-generated content | Release (tiers 1–2) | Research | Closed via Google's support site | **Closed today** |
+| **R2** | Apple 5.1.2(i) and the "third-party AI" clause | Release (tiers 1–2) | Research | Closed via developer.apple.com | **Closed today** |
+| **R3** | MDCG 2019-11 wellness/fitness exclusion | Release | Research | Closed via the Commission's health domain | **Closed today** |
+| **R4** | Play Health disclaimer absent from the store listing | Release — **live today, unrelated to AI** | Decision | One paragraph | Open (found by `ai-legal-constraints.md`) |
+| **R5** | Current Play content rating, Apple age rating, Health apps declaration, Impressum reachability | Release | **Decision, misfiled as research** | 5 min in the consoles | Open |
+| **N1** | The F-Droid ML Kit escape route — what Open Food Facts actually ships | Nothing (but blocks RFP #2540) | Research | Closed via fdroiddata | **Closed today** |
+| **N2** | Whether a free-software scanner covers every symbology the app needs | Nothing | Research | Closed by code reading | **Closed today** |
+| **N3** | Does #602's bloc need a new dev dependency (`bloc_test`)? | Nothing | Research | Closed by reading `test/` | **Closed today** — no |
+| **N4** | `GPL-3.0-only` vs `-or-later`; Unsplash demo assets; `minSdkVersion` resolution | Nothing | Decision ×2, Research ×1 | Cheap | Open |
+
+Twenty-four gaps. **Thirteen closed today**, two of them partially. Of the eleven
+still open, **three need a lawyer, four are decisions with no external answer,
+two are blocked by a 403, and two are cheap lookups the maintainer can do faster
+than any researcher.**
+
+---
+
+## A. What blocks tier 0
+
+Tier 0 is a deterministic parser plus a resolver plus a review screen. No model,
+no key, no network destination that is not already in the README's table, no new
+dependency. `ai-cohort-restrictions.md` F1 verified that no licence, F-Droid or
+provider-terms restriction attaches to any of it, and nothing found today
+changes that.
+
+**So the answer to "can coding start today" is yes.** What follows are not
+reasons to wait. They are errors in the issue text that will cost a contributor
+a wasted PR if they are not fixed first — and one of them ships a wrong number
+to the user.
+
+### T1 — #600's unit set does not exist in this app. Decision.
+
+`UnitDropdownItem`
+([`meal_detail_bloc.dart:248-288`](../lib/features/meal_detail/presentation/bloc/meal_detail_bloc.dart))
+has exactly six members, and its `toString()` — which is what is persisted as
+`IntakeEntity.unit` — yields exactly six strings:
+
+```
+'g'   'ml'   'g/ml'   'oz'   'fl.oz'   'serving'
+```
+
+There is **no `kg` and no `l`**. And `fromString` ends:
+
+```dart
+default:
+  return UnitDropdownItem.gml;
+```
+
+The conversion in `UpdateKcalEvent` (same file, lines 69-80) scales only
+`serving`, `oz` and `flOz`; anything else passes through **unscaled**.
+
+#600 says, twice:
+
+> Key off digits and unit **symbols** (`g`, `kg`, `ml`, `l`, `oz`) …
+
+and its test checklist asks for:
+
+> - [ ] Comma decimal (`1,5 l milk`) and period decimal (`1.5 l milk`)
+
+Put together: `1,5 l milk` parses to `quantity: 1.5, unit: 'l'`. The review row
+cannot render `'l'` in the dropdown (it is not among the items), and whatever
+reaches `addIntake` resolves through `fromString`'s `default` branch to `g/ml`,
+unscaled. **1.5 g of milk is logged where 1500 ml was meant.** Because the
+number is plausible-looking and the unit is not shown prominently on the diary
+row, this is exactly the class of bug that does not get reported.
+
+This is a **decision**, and there are two clean answers:
+
+- **(a) Normalise in the parser.** `kg` → `g` × 1000, `l` → `ml` × 1000, and
+  never emit a unit string the app cannot represent. Roughly five lines, and it
+  keeps `1,5 l milk` working as the test intends. This is the right answer.
+- **(b) Drop `kg` and `l`** from the accepted symbol set and reject those
+  segments with an indexed error.
+
+Either way the choice has to be written into #600 **before** the parser is
+coded, because the acceptance test list currently encodes the broken
+expectation. Add a test asserting the emitted unit is always a member of the
+six-string set — that is the invariant, and it is the one the issue is missing.
+
+Note that `oz` needs no work (`UnitDropdownItem.oz.toString()` is `'oz'`), and
+`fl.oz` is not in #600's symbol list at all, which is fine.
+
+### T2 — The comma still has no precedence rule. Decision.
+
+Already found and correctly characterised at `ai-cohort-restrictions.md` **F2**;
+recorded here only because it is a tier-0 blocker of exactly the same shape as
+T1 and should be fixed in the same edit. The obvious rule — *a comma flanked by
+a digit on both sides is a decimal point; every other comma is a separator* —
+costs one regex and one test (`1,5 l milk, 2 eggs`). Seven of the nine shipped
+locales use the comma decimal, so this is not an edge case.
+
+### T3 — The search stack has no stemming, and the ranker scores plurals at zero. Research, now closed.
+
+**Nobody has looked at this.** #601 assumes `searchOFFProductsByString` +
+`searchFDCFoodByString` + `mergeAndRankMeals` return usable candidates for
+inputs like `toast`, `eggs`, `black coffee`. Reading the code, they do — for
+one of those three, and not for the other two, for a reason that is arithmetic
+rather than empirical.
+
+**The mechanism.** `_textScore`
+([`meal_relevance_ranker.dart:155-177`](../lib/features/add_meal/util/meal_relevance_ranker.dart)):
+exact normalised equality returns `1.0`; otherwise the score is a Dice
+coefficient over token **sets**, plus `0.2` if the text contains the query as a
+substring, plus `0.15` if it starts with it, clamped to `0.9`. `_tokenize`
+splits on `[^\p{L}\p{N}]+`. There is **no stemming, no lemmatisation and no
+singular/plural folding anywhere in the file.**
+
+**The zero case.** Query `eggs` against a record named `Egg`:
+
+- token sets `{eggs}` ∩ `{egg}` = ∅ → Dice `0.0`
+- `'egg'.contains('eggs')` → false → no contains-bonus
+- `'egg'.startsWith('eggs')` → false → no prefix-bonus
+- **score `0.0`**
+
+Meanwhile `Cadbury Creme Eggs` (3 tokens) scores `2·1/(3+1) + 0.2 = 0.45`.
+`rankMealsByRelevance` uses a **stable `mergeSort` and filters nothing**, so the
+correct answer is retained but sinks below the noise. #601's `ResolvedMealItem`
+carries a `selectedIndex`, and the review screen prefills from it. **The plural
+form of a common food auto-selects the wrong food.**
+
+**It compounds in three places.**
+
+1. **Local sources.** `SearchProductsUseCase._buildResult`
+   ([`search_products_usecase.dart:218-222`](../lib/features/add_meal/domain/usecase/search_products_usecase.dart))
+   filters custom meals, recipes, intake history and the 90-day cache with
+   `_mealMatchesSearch`, a plain `String.contains`. Same failure, upstream of
+   the ranker: a user's own custom meal named `Egg` is **invisible** to the
+   query `eggs`. This matters more than the remote case, because own content is
+   the tier `mergeAndRankMeals` deliberately ranks above everything else.
+2. **The remote asymmetry.** [`sp_const.dart:51-52`](../lib/features/add_meal/data/dto/sp/sp_const.dart):
+
+   ```dart
+   static const foodNameFtsConfig = 'english';
+   static const translationFtsConfig = 'simple';
+   ```
+
+   Postgres' `english` text-search configuration **does** stem, so the Supabase
+   name search finds `egg` for the query `eggs` server-side — and the client
+   ranker then scores that row `0.0` and buries it. That is the worst possible
+   shape: the backend does the right thing and the client undoes it. The
+   `simple` configuration used for the eight non-English locales does **not**
+   stem, so those locales lose the match at both ends.
+3. **The score is discarded.** `mergeAndRankMeals` returns a bare
+   `List<MealEntity>`; `scoreMealRelevance` is public but the merge path throws
+   its output away. So #601 as specified **cannot** expose a confidence signal
+   to the review screen even if it wanted to. That is a scoping consequence
+   worth writing into the issue.
+
+**The multi-token degradation, worked from the code.** Query `black coffee`:
+
+| Candidate name | Tokens | Dice | contains | Total |
+| :-- | --: | --: | --: | --: |
+| `Black Coffee` | 2 | — | — | **1.00** (exact) |
+| `Nescafé Black Coffee Instant Refill 200g` | 6 | 2·2/(6+2) = 0.50 | +0.20 | **0.70** |
+| `Coffee` | 1 | 2·1/(1+2) = 0.667 | — | **0.667** |
+
+The six-token branded product **outranks the generic entry**, because the
+contains-bonus rewards names that embed the whole query phrase and the generic
+one-word entry cannot earn it. For a bulk-logging feature whose whole point is
+generic foods, that is backwards.
+
+**But the prompt's hypothesis is only half right.** Dice does *not* degrade for
+short queries in general. For a single-token query it behaves well, because
+`2·1/(n+1)` monotonically penalises long names — which is exactly the
+"shortest matching name wins" heuristic you want:
+
+| Query `toast` vs | Tokens | Score |
+| :-- | --: | --: |
+| `Toast` | 1 | **1.00** (exact) |
+| `Toast bread` | 2 | 0.667 + 0.2 + 0.15 → capped **0.90** |
+| `Nutella Toast Spread Hazelnut 400g` | 5 | 0.333 + 0.2 = **0.53** |
+
+So `toast` is fine. The failure is specific and nameable: **(a) morphological
+variants, where the score collapses to exactly zero, and (b) multi-token generic
+queries, where the contains-bonus rewards long branded names.** `2 eggs` — the
+plan's own worked example, and the first token of the outcome sentence
+*"Type `2 eggs, 100g toast, black coffee`"* — hits both.
+
+**What this blocks.** Not #600, and not #601's *contract* — the resolver is a
+thin wrapper and its signature is unaffected. It blocks **#602 being accepted**,
+and it changes what "done" means for #601. Concretely, the plan's verification
+step 4 says:
+
+> **Check the negative case explicitly** — a query that matches nothing must
+> produce a flagged row with a working fallback, not a silent drop and not a
+> crash.
+
+That is the *safe* negative case. The unsafe one is a query that matches the
+wrong thing with no visible signal that it did. #602 should require a
+candidate-picker affordance on every row (it already does) **and** a rule for
+when not to auto-select.
+
+**The test that would settle it — and it is not a network test.** Build a
+`List<MealEntity>` fixture of ~30 realistic product names (hand-written, or
+captured once from a real search and checked in under `test/fixture/`), then
+assert `mergeAndRankMeals(off, sp, q).first` for `q ∈ {toast, eggs, egg,
+black coffee, coffee, milk, chicken breast}`. Pure unit test, no network, no
+device, and it belongs in #601 as an acceptance criterion. Sizing *recall* —
+whether the OFF and Supabase APIs return the generic entry for `toast` at all —
+does need one live query, but that can be done once by hand and recorded; the
+test suite must not depend on it.
+
+**Cheapest mitigation, no further research required:** singularise the query in
+the parser (strip a trailing `s` when the stem is ≥3 characters and re-query on
+zero results), *or* add the same normalisation inside `_tokenize`. The second is
+better — it fixes the local `_mealMatchesSearch` path too — but it changes the
+ranker's behaviour for every existing search screen, which makes it a bigger
+change than tier 0 wants. This is a **decision**, and it should be taken in
+#601 rather than discovered in review.
+
+### T4 — Batched logging has no validation, no atomicity, and skips the duplicate guard. Decision.
+
+[`meal_detail_bloc.dart:164`](../lib/features/meal_detail/presentation/bloc/meal_detail_bloc.dart):
+
+```dart
+final quantity = double.parse(amountText.replaceAll(',', '.'));
+```
+
+Unguarded `double.parse`, not `tryParse`. In the existing single-item flow this
+is safe because `MealDetailBottomSheet.onAddButtonPressed` validates first
+(lines 255-284: `double.tryParse`, then `<= 0`, then `> 10000`, each with its
+own snackbar). The bloc method itself trusts its caller.
+
+#602 says to call `addIntake` in a loop and explicitly **not** to reach for
+`AddIntakeUsecase`. Three consequences it does not mention:
+
+1. **One malformed row throws mid-batch.** Rows already processed have been
+   written; there is no rollback and no transaction. The user sees a partial log
+   and an exception.
+2. **The `> 10000` and `> 0` bounds live in the widget, not in a reusable
+   validator.** #600 and #602 both say to "lift" them. There is nothing to lift
+   — they are inline `if` statements with `ScaffoldMessenger` calls. The bulk
+   screen has to re-implement the check (or, better, extract it once and have
+   the bottom sheet use it too).
+3. **`_checkForDuplicate` / `_showDuplicateDialog` are bypassed entirely.** That
+   guard exists because of issue #212. A "Log all" button that calls `addIntake`
+   directly silently drops it. Whether a bulk flow *should* prompt per duplicate
+   is a real UX decision — prompting three times in a row is worse than not
+   prompting — but it should be taken deliberately and recorded in #602, not
+   inherited by omission.
+
+The fix is small: validate every row **before** the loop, refuse to start if any
+row fails, and state the duplicate-guard policy in the issue.
+
+### T5 — The localization instructions describe a repository that no longer exists. Research, closed.
+
+Plan §5 and #602's Localization section both say:
+
+> Then edit `lib/generated/intl/` **by hand** — AGENTS.md is explicit that
+> regenerating breaks the 120-char formatting — and confirm with
+> `just check_intl`.
+
+Every clause of that is false today:
+
+| Claim | Reality |
+| :-- | :-- |
+| `lib/generated/intl/` | **Does not exist.** `lib/generated/` contains `l10n.dart` plus nine `l10n_<locale>.dart` files and no subdirectories. |
+| Edit by hand | [`AGENTS.md:150`](../AGENTS.md): "The generated files are **gitignored — never edit them by hand**. Add the key to every ARB (all nine stay at the same key count) and run `just gen_l10n`." |
+| AGENTS.md says regenerating breaks formatting | It says the opposite. The quoted sentence exists only in `.claude/worktrees/agent-a19e62d780bb333aa/AGENTS.md:150`, a stale pre-migration copy. |
+| `just check_intl` | **Not a recipe in the justfile.** The recipes are `install build format gen_l10n test ci create_emulator start_emulator dev dev_seed`. |
+
+The repository migrated from `flutter_intl` (which generated
+`lib/generated/intl/messages_*.dart` and needed hand-maintenance) to
+`flutter gen-l10n` (configured in [`l10n.yaml`](../l10n.yaml), output
+gitignored at [`.gitignore:42`](../.gitignore)). The plan and #602 were written
+against the pre-migration instructions.
+
+**Correct instruction for #602:** add the key to all nine ARBs — verified today
+at **921 keys each, zero drift** — then run `just gen_l10n`. Nothing under
+`lib/generated/` is committed.
+
+**This is also a live repo bug outside this feature.**
+[`CONTRIBUTING.md:58`](../CONTRIBUTING.md) still tells contributors:
+
+> **Verify with `just check_intl`** — this is what CI runs and will fail the PR
+> if any of the above is missing or out of sync.
+
+and [`docs/first-timer-backlog.md:73,79`](first-timer-backlog.md) repeats it
+twice. Both statements are false, and #600 / #602 are explicitly labelled
+first-timer issues, so a new contributor will hit this before they hit anything
+in the plan.
+
+### T6 — `just ci` cannot pass locally. Research, closed.
+
+The plan's Verification step 2:
+
+> **Full gate** — `just ci` (install, format check, intl check, build_runner,
+> analyze, test). Note CI itself skips the format check but runs
+> `flutter analyze` and `flutter test`.
+
+The justfile:
+
+```
+ci: install (format "--set-exit-if-changed") gen_l10n build && test
+  flutter analyze
+```
+
+The format check is *inside* `just ci`, and
+[`.github/workflows/default_workflow.yml`](../.github/workflows/default_workflow.yml)
+explains why CI does not use the recipe:
+
+> `just ci` would also run `dart format --set-exit-if-changed`, but the codebase
+> currently has accumulated pre-existing format drift from the period when CI
+> was disabled. We run the rest of `just ci` (l10n generation, build_runner,
+> analyze, test) and leave the format pass for a dedicated follow-up PR.
+
+CI therefore calls `just install`, `just gen_l10n`, `just build`,
+`flutter analyze` and `just test` individually. A contributor following the plan
+will run `just ci`, watch it fail at step two on files they never touched, and
+have no way to tell that the failure is pre-existing. Both #600 and #602 should
+say: run the individual recipes, matching CI. There is also no "intl check"
+step in `just ci` at all — `gen_l10n` regenerates rather than verifying.
+
+### T7 — Decimal precision round-trip. Decision.
+
+[`meal_detail_bottom_sheet.dart:126-130`](../lib/features/meal_detail/presentation/widgets/meal_detail_bottom_sheet.dart)
+applies `FilteringTextInputFormatter.allow(RegExp(r'^\d+([.,]\d{0,2})?$'))` —
+**at most two decimal places, no leading `.`, no sign**. #600 and #602 both say
+to lift it. #600 states no precision cap on the parser's `double?`, so
+`1.333 kg` parses and then cannot be typed or corrected in the field it lands
+in.
+
+Separately and pre-existing: `UpdateKcalEvent` emits
+`totalQuantityConverted: convertedQuantity.toString()`, an unrounded Dart double
+(1 oz becomes `28.349523125`), which the same formatter would reject. #602
+inherits this the moment it copies the bottom sheet's `addIntake` call shape.
+Cheapest fix: have the parser round to two decimals and say so in #600.
+
+---
+
+## B. What blocks tier 1 being scoped
+
+### S1 — The Digital Omnibus deferral. **Closed today.**
+
+This was flagged in #599's third comment as the one to confirm first:
+
+> The Digital Omnibus deferral (Reg. (EU) 2026/1744) said to push Annex III
+> high-risk obligations to Dec 2027. **This is the timeline claim everything
+> else is dated against — confirm it first.**
+
+**Confirmed against EUR-Lex.** The ELI record
+[`eli/reg/2026/1744/oj/eng`](https://eur-lex.europa.eu/eli/reg/2026/1744/oj/eng)
+resolves to:
+
+> Regulation (EU) 2026/1744 of the European Parliament and of the Council of
+> 8 July 2026 amending Regulations (EU) 2024/1689, (EU) 2018/1139 and
+> (EU) 2023/1230 as regards the simplification of the implementation of
+> harmonised rules on artificial intelligence (Digital Omnibus on AI)
+
+and the deferral dates are as `ai-legal-constraints.md` states:
+
+- Chapter III Sections 1–3 for **Annex III** high-risk systems → **2 December 2027**
+- Chapter III Sections 1–3 for **Annex I** high-risk systems → **2 August 2028**
+
+with the stated rationale, verbatim from recital 40 of the OJ text:
+
+> the delayed availability of standards, common specifications, and alternative
+> guidance and the delayed establishment of national competent authorities lead
+> to challenges that jeopardise the effective entry into application
+
+**And the load-bearing point holds: Article 50 was not deferred.** The only
+change to Article 50 in the Omnibus is to **Article 50(7)** — the Commission's
+implementing-act empowerment over codes of practice, replaced with "The
+Commission shall encourage and facilitate the drawing up of codes of
+practice…". Article 50(1)–(5) are untouched, and the general date of
+application, 2 August 2026, stands. So the marking duty in Article 50(2) is
+**in force as of today** and is not covered by the high-risk deferral.
+
+That is the whole of what the timeline claim needed. `ai-legal-constraints.md`'s
+application-timeline table can be treated as verified on this point.
+
+**What could not be retrieved, and why:** the *operative* amended text of
+Article 113, and the Article 111(4) transitional that
+`ai-legal-constraints.md` quotes. EUR-Lex's HTML rendering truncates
+mid-sentence in Article 63 on every route tried —
+`legal-content/EN/TXT/HTML/?uri=OJ%3AL_202601744` and
+`?uri=CELEX:32026R1744` both stop at the same place ("…without affecting the
+level of protection or the need for compl"). This is the same truncation
+behaviour #599's third comment already recorded for the consolidated AI Act
+text. The confirmation above therefore rests on the ELI record and recital 40,
+both on `eur-lex.europa.eu` and both primary; the Article 111(4) quote in
+`ai-legal-constraints.md` remains **unverified**, and it is a lawyer question
+anyway (see S8).
+
+### S2 — Anthropic: image + `output_config.format` in one request. **Partially closed today.**
+
+The plan calls this "documented only by inference" and "the load-bearing
+assumption of the photo path", and #599 makes it one of two spikes that "must
+land before either tier is scoped". Documentation only was checked today; no
+API call was made and no key was used.
+
+What the three relevant pages say:
+
+- **[Structured outputs](https://platform.claude.com/docs/en/build-with-claude/structured-outputs)**
+  — does not mention images, vision, or content blocks **at all**. Its
+  limitations section is entirely about JSON Schema features (no recursive
+  schemas, no numerical or string constraints, `additionalProperties` must be
+  `false`, `minItems` only 0 or 1, no external `$ref`), and ends "If you use an
+  unsupported feature, you'll receive a 400 error with details." **No content-type
+  restriction is stated.**
+- **[Vision](https://platform.claude.com/docs/en/build-with-claude/vision)** —
+  does not mention structured outputs, `output_config`, or JSON schemas at all.
+  Its Limitations section lists people identification, accuracy, spatial
+  reasoning, counting, AI-generated-image detection, inappropriate content and
+  healthcare. **No request-parameter restriction is stated.**
+- **[Messages API reference](https://platform.claude.com/docs/en/api/messages/create)**
+  — this is the most useful of the three and neither earlier document consulted
+  it. The endpoint description is:
+
+  > Send a structured list of input messages **with text and/or image content**,
+  > and the model will generate the next message in the conversation.
+
+  and `output_config` is documented as a **top-level body parameter**, sibling to
+  `messages`:
+
+  > `output_config: optional OutputConfig` — Configuration options for the
+  > model's output, such as the output format.
+  > … `format: optional JSONOutputFormat` — A schema to specify Claude's output
+  > format in responses.
+
+**Conclusion.** The two things are orthogonal in the documented request schema:
+`output_config` constrains the *response*, image blocks are *request* content,
+and no page in the documentation states or implies an incompatibility. That is
+materially stronger than "documented only by inference" — but it is still not a
+positive statement that the combination is supported, and Anthropic's docs do
+not enumerate valid combinations, so silence is not a guarantee.
+
+**Re-scoping this gap:** it no longer blocks tier 1 being **scoped**, only
+tier 2 being **built**. #599 lists it as a blocker on scoping *either* tier;
+that is now over-cautious. One live call at roughly $0.003 settles it, and it
+should be the first thing the tier-2 branch does, not a prerequisite for
+writing the tier-1 issue.
+
+Two related corrections while on this page, both to `ai-cohort-restrictions.md`
+**E3**, which is otherwise accurate:
+
+- The per-request image cap is **100 for models with a 200k-token context window
+  and 600 for all others**, not 20. The 20 is the threshold *above which* a
+  stricter per-image dimension limit applies ("either resize each image so that
+  neither dimension exceeds 2000 px, or keep the request to 20 or fewer image
+  and document blocks"). Immaterial for single-image requests.
+- The high-resolution tier is described as "Claude 4.7 and later models" at
+  2576 px / 4784 visual tokens; standard is 1568 px / 1568 tokens. The plan's
+  arithmetic for a 1024×1024 WebP still checks out at ⌈1024/28⌉² = 37² = **1369
+  visual tokens**.
+
+The second #599 spike — **WebP q80 vs q90 on nutrition labels** — remains open
+and is not a research question. Anthropic's warning is already quoted verbatim
+in `ai-cohort-restrictions.md` E3 and on the vision page ("this can introduce
+artifacts that are detrimental to model performance… heavy JPEG compression can
+make text difficult to read… Confirm your compression settings are appropriate
+for the task by inspecting the actual images sent to the API"). No amount of
+reading will produce the answer for *our* pipeline; it is an experiment, and it
+belongs to tier 2.
+
+### S3 — Decision #5 is a decision, not a research gap. Open, and no research will close it.
+
+#599's first comment says tier 1 "should not be scoped until decision #5 is
+re-settled — either by adopting the Train Libre posture (model names foods,
+database supplies numbers), or by explicitly accepting the store-review risk
+with a rationale recorded here."
+
+That is stated correctly. It is worth restating here because it is the single
+thing actually blocking tier-1 scoping and it is **not waiting on information**.
+The evidence is complete: the cohort survey established what every comparator
+does (Train Libre bans model-emitted numbers outright, Scranbook computes
+locally from bundled composition data, EatWise ships only ranges); #250's spike
+supplied the measured accuracy argument; `ai-cohort-restrictions.md` E4 supplied
+the only external accuracy datum (fud-ai#157: "the reported calories varied by
+about 900 ± 300 kcal" across ten identical prompts); and #599's second comment
+already narrowed the exposure to database-miss rows. Nobody needs to read
+anything else. **Someone needs to choose.**
+
+### S4 — The timeout. Decision.
+
+`ai-cohort-restrictions.md` **E1** established this and characterised it
+correctly as a hard blocker for the local-endpoint story rather than a bug.
+Recorded here only to keep the tier-1 checklist in one place: the one measured
+cohort datum is 54–100 s server-side, fixed by making the client timeout
+configurable 30–600 s with a **180 s default**. Nothing in the plan, #599, #601
+or #602 mentions a timeout. This needs a number chosen, not a source found.
+
+### S5 / S6 — OpenAI. **Route failed.**
+
+Two items remain unverified because `openai.com` returns HTTP 403 to every
+route. Per the brief this was not re-attempted today, and no first-party path
+outside `openai.com` exists for either document — OpenAI publishes its terms
+nowhere else.
+
+- **Services Agreement §2.2 / §3.3(g)**, which #599's decision table cites as
+  "explicitly blesses the BYO-key architecture". **Unverified.** This matters
+  less than it looks: #599 revision 2 already moved off a hardcoded provider to
+  a generic endpoint field, so OpenAI is no longer a named default, and the
+  clause was cited as a *point in OpenAI's favour* in a comparison OpenAI lost.
+  Nothing in the current design depends on it.
+- **Current Usage Policies.** `ai-cohort-restrictions.md` **D7** quotes them
+  from a Microsoft-hosted PDF marked "Effective: October 29, 2025", printed
+  2025-11-07 — a mirror, now roughly nine months stale. The clause that matters
+  ("automation of high-stakes decisions in sensitive areas without human review
+  … medical") is one of two independent regimes resting on #602's review screen,
+  so it should be re-checked before that argument is relied on in writing. It
+  does not block anything from being built, because the screen is being built
+  regardless.
+
+### S7 / S8 / S9 — The three genuine legal questions. Open.
+
+These need a lawyer, and both `ai-legal-constraints.md` and #599's third comment
+already say so. Restated compactly because they are the only items on this list
+that money rather than time will close:
+
+1. **Is the project a "provider" of an AI system under Article 3(3) at all**,
+   given the inference component arrives at runtime from an address the user
+   typed, and the software is free and open-source? Nearly every downstream
+   conclusion moves on the answer. Highest leverage.
+2. **Does the Article 111(4) four-month transitional reach a feature released
+   after 2 August 2026?** On its face it is scoped to systems already on the
+   market on that date, which would mean no grace period. The operative text
+   could not be retrieved today (see S1).
+3. **Does Article 50(2)'s "do not substantially alter the input data … or the
+   semantics thereof" exception cover the tier-1 text path?** If tier 1 is
+   inside it and tier 2 is not, the tier split becomes a compliance boundary as
+   well as a technical one — which is a better reason for the split than the one
+   it was chosen for.
+
+One point worth adding: **the AI Act questions are dated, not open-ended.**
+Article 50 is in force *today*; the high-risk chapters that were deferred to
+December 2027 were never in play for this app. So there is no schedule pressure
+from the deferral — the pressure, such as it is, is that tiers 1–2 would be
+placed on the market after the Article 50 application date with no transitional.
+
+---
+
+## C. What blocks a release, not development
+
+### R1 — Google Play's in-app reporting requirement. **Closed today.**
+
+Confirmed verbatim from Google's own support site,
+[AI-Generated Content policy](https://support.google.com/googleplay/android-developer/answer/13985936).
+Definition:
+
+> AI-generated content is content that is created by generative AI models based
+> on user prompts.
+
+Operative requirement:
+
+> Apps that generate content using AI must contain in-app user reporting or
+> flagging features that allow users to report or flag offensive content to
+> developers without needing to exit the app.
+
+`ai-legal-constraints.md`'s quotation is accurate and its reasoning stands: the
+operative sentence is **not** scoped to the two listed examples (chatbots,
+image/video generation), so arguing the scope is not worth it — a "Report this
+result" affordance on the review screen settles it. The page carries no
+last-updated date; the only date shown is a "©2026 Google" footer.
+
+**Does not touch tier 0.** Tier 0 generates nothing; it retrieves.
+
+### R2 — Apple Guideline 5.1.2(i). **Closed today.**
+
+Confirmed verbatim from
+[developer.apple.com](https://developer.apple.com/app-store/review/guidelines/):
+
+> Unless otherwise permitted by law, you may not use, transmit, or share
+> someone's personal data without first obtaining their permission. You must
+> provide access to information about how and where the data will be used. You
+> must clearly disclose where personal data will be shared with third parties,
+> **including with third-party AI**, and obtain explicit permission before doing
+> so.
+
+Three further confirmations that matter more than the quote:
+
+- **"third-party AI" appears exactly once in the whole document**, here.
+- **There is no separate AI-specific guideline number.**
+- **There is no requirement anywhere to label AI-generated output.**
+
+So `ai-legal-constraints.md` is right that Apple's entire AI-specific
+requirement for this feature is one sentence: disclose, and get explicit
+permission, before sharing personal data with third-party AI. Every on-screen
+"estimated" marker is driven by UWG § 5 and by the README's own citation claim,
+not by Apple.
+
+### R3 — MDCG 2019-11 rev.1. **Closed today.**
+
+Confirmed verbatim from the European Commission's own health domain
+([`mdcg_2019_11_en.pdf`](https://health.ec.europa.eu/document/download/b45335c5-1679-4c71-a91c-fc7a4d37f12b_en?filename=mdcg_2019_11_en.pdf)).
+Both sentences `ai-legal-constraints.md` relies on are accurate:
+
+> In addition, software only intended for non-medical purposes (excluding MDR
+> Annex XVI devices), such as invoicing, staff planning, e-mailing, web or voice
+> messaging, data parsing, word processing, and back-up, **wellness or fitness
+> apps, do not qualify as MDSW**.
+
+and, in the same section:
+
+> It must be highlighted that the risk of harm to patients, users of the
+> software, or any other person, related to the use of the software within
+> healthcare, including a possible malfunction **is not a criterion on whether
+> the software qualifies as a medical device**.
+
+The second sentence is the important one and it cuts both ways, exactly as
+`ai-legal-constraints.md` argues: an `estimated` flag cannot make a
+medical-purpose product non-medical, and a model's inaccuracy cannot make a
+wellness app medical. **Qualification is decided by the stated intended purpose
+and by nothing else** — which means the store listing and in-app copy are the
+whole game.
+
+### R4 — The Play health disclaimer is missing today. Decision, not research.
+
+Found by `ai-legal-constraints.md`, repeated in #599's third comment, verified by
+inspection: `fastlane/metadata/android/en-US/full_description.txt` contains no
+"not a medical device and does not diagnose, treat, cure, or prevent any medical
+condition" language, and the in-app `disclaimerText` says "not a medical
+**application**", which is a different phrase in a different place from the one
+the policy names. This is live in production, unrelated to AI, and costs one
+paragraph. It should have its own issue.
+
+### R5 — Four items misfiled as "could not verify" that are just lookups. Decision.
+
+`ai-legal-constraints.md`'s "What I could not verify" section lists these as
+research failures. They are not — they are things nobody outside the project
+*can* answer, and things the maintainer can answer in five minutes:
+
+- the app's current **Play content rating** and **App Store age rating**;
+- whether the **Play Console Health apps declaration** is currently accurate;
+- whether an **Impressum** with name, postal address and email is reachable from
+  the app and the project site (DDG § 5).
+
+Listing them under "unverified" implies a researcher could close them. None can.
+They belong on a maintainer checklist.
+
+---
+
+## D. What blocks nothing, but is worth knowing
+
+### N1 — The F-Droid ML Kit escape route. **Closed today, and it is cheaper than we thought.**
+
+`ai-cohort-restrictions.md` **C1** is the biggest finding in the four documents
+and the only present-tense blocker anyone has identified: bundled Google ML Kit
+via `mobile_scanner ^7.2.0` fails F-Droid's Free Software Requirement, so
+[RFP #2540](https://gitlab.com/fdroid/rfp/-/issues/2540) cannot succeed today.
+It says "swap the scanner, as Open Food Facts did" but does not say what the
+replacement actually is. Here it is.
+
+**Open Food Facts' Flutter app is in the F-Droid main repository right now**, at
+version 4.23.0, under the package id `openfoodfacts.github.scrachx.openfood`
+(reused from the legacy native app), licence `Apache-2.0`. The metadata is
+[`openfoodfacts.github.scrachx.openfood.yml`](https://gitlab.com/fdroid/fdroiddata/-/raw/master/metadata/openfoodfacts.github.scrachx.openfood.yml).
+The mechanism, verbatim from the most recent build entry:
+
+```yaml
+subdir: packages/smooth_app
+srclibs:
+  - flutter@stable
+rm:
+  - packages/smooth_app/ios
+  - packages/scanner/ml_kit
+  - packages/app_store/google_play
+  - packages/app_store/apple_app_store
+prebuild:
+  - git -C $$flutter$$ checkout -f $(cat ../../flutter-version.txt)
+  - sed -i -e '/ml_kit/d' -e '/apple_/d' -e '/google_play/d' -e 's/version:.*/version: $$VERSION$$+$$VERCODE$$/' pubspec.yaml
+  - export PUB_CACHE=$(pwd)/.pub-cache
+  - $$flutter$$/bin/flutter config --no-analytics
+  - $$flutter$$/bin/flutter pub get
+scanignore:
+  - packages/scanner/shared/pubspec.yaml
+  - packages/scanner/zxing/pubspec.yaml
+scandelete:
+  - packages/smooth_app/.pub-cache
+build:
+  - export PUB_CACHE=$(pwd)/.pub-cache
+  - export PATH=$$flutter$$/bin:$$flutter$$/bin/cache/dart-sdk/bin/:$PATH
+  - $$flutter$$/bin/flutter build apk -t lib/entrypoints/android/main_fdroid.dart
+output: build/app/outputs/apk/release/app-release-unsigned.apk
+ndk: r28c
+```
+
+And the replacement scanner is
+[`packages/scanner/zxing`](https://github.com/openfoodfacts/smooth-app/blob/develop/packages/scanner/zxing/pubspec.yaml),
+whose only scanning dependency is:
+
+```yaml
+qr_code_scanner: 1.0.1
+```
+
+**Four corrections to `ai-cohort-restrictions.md` follow from this.**
+
+1. **It is not a Gradle build flavour.** C3, C4 and the "build flavour"
+   framing throughout section C assume the lever is
+   `android/app/build.gradle`'s `productFlavors`. Open Food Facts does not use
+   one for this. The lever is a **second Dart entry point**
+   (`lib/entrypoints/android/main_fdroid.dart`) selected with
+   `flutter build apk -t <entrypoint>`, plus fdroiddata-side `rm` and `sed`
+   surgery that physically deletes the ML Kit package and strips its line from
+   `pubspec.yaml` before the build. Our existing `flavorDimensions "version"`
+   with `develop` / `full` is therefore **not** the thing to extend. The work is
+   (a) put the scanner behind an interface, (b) add a second `main_*.dart`, and
+   (c) write the fdroiddata recipe. That is a different, smaller and more
+   self-contained piece of work than "add a third flavour".
+2. **The Flutter SDK does not need vendoring.** C7 describes the maid recipe —
+   `submodules: true`, the SDK checked into the repo as `packages/flutter`,
+   `scanignore: [packages/flutter/bin/cache]`, `--split-per-abi`, and **one
+   metadata entry per ABI with a distinct versionCode**. Open Food Facts uses
+   `srclibs: [flutter@stable]` — F-Droid's own Flutter srclib, pinned per-build
+   by `git -C $$flutter$$ checkout -f $(cat ../../flutter-version.txt)` — and
+   ships a **single universal unsigned APK** with no per-ABI split and no
+   submodules. That is substantially less work, and it comes from a peer Flutter
+   *food* app rather than an LLM client.
+3. **Anti-features survive the swap, and inclusion survives the anti-features.**
+   OFF still carries `NonFreeNet` ("openfoodfacts.net/.org, openproductfacts.org,
+   openstreetmap.org and sentry.io servers") **and** `Tracking` ("Analytics are
+   opt-in but the app connects to sentry.io from the start, and connects even if
+   rejected") — with ML Kit removed — and is in the main repository. This is a
+   direct precedent for our own Sentry posture (**C6**): a peer app with opt-in
+   Sentry earned `Tracking` and stayed listed. It is also the cleanest possible
+   confirmation of **C8**.
+4. **The replacement is licence-clean but stale.**
+   [`qr_code_scanner`](https://pub.dev/packages/qr_code_scanner/license) is
+   **BSD-2-Clause, "Copyright 2018 Julius Canute", version 1.0.1, last published
+   about three years ago.** It is GPL-3.0-compatible and F-Droid-acceptable, but
+   it is not maintained. A better candidate for a fresh integration is
+   [`flutter_zxing`](https://pub.dev/packages/flutter_zxing) — **MIT, v2.3.0,
+   published about three months ago**, ZXing C++ via Dart FFI, Android API 21+,
+   with no Google or otherwise proprietary dependency. Both are viable; neither
+   is `mobile_scanner`, whose unbundled variant only trades a bundled
+   proprietary blob for a runtime Play Services dependency.
+
+**This has nothing to do with AI** and should be its own issue, as C1 already
+argues. It is now costed rather than hypothetical.
+
+### N2 — Does a free-software scanner cover every symbology we need? **Closed today, from the code.**
+
+`ai-cohort-restrictions.md` lists this as unverified. It is answerable without
+any network call. The required set is:
+
+- **EAN-8, UPC-A, EAN-13, GTIN-14** — enumerated explicitly in
+  [`barcode_check_digit.dart`](../lib/features/scanner/util/barcode_check_digit.dart),
+  which accepts exactly lengths `{8, 12, 13, 14}` and validates the shared
+  Modulo-10 check digit. These are the only linear formats the app acts on.
+- **QR Code** — three import screens scan QR
+  (`import_meal_scanner_screen.dart`, `import_recipe_scanner_screen.dart`,
+  `import_activity_scanner_screen.dart`) and `qr_flutter: ^4.1.0` generates it.
+
+`scanner_screen.dart:57` constructs a bare `MobileScannerController()` with no
+`formats:` argument, so nothing narrower is configured. Every format in that set
+— EAN-8, EAN-13, UPC-A, ITF (for GTIN-14) and QR — is core ZXing. **No
+symbology is lost by the swap.** Worth re-confirming against the chosen
+package's own format list at integration time, but there is no reason to expect
+a gap.
+
+### N3 — Does #602 need a new dev dependency? **Closed today: no.**
+
+`mockito: ^5.6.4` is already in `dev_dependencies` (as #601 says).
+`bloc_test` is **not** — but the repo already tests blocs without it
+(`test/features/recipes/presentation/bloc/recipes_bloc_test.dart`,
+`recipe_builder_bloc_test.dart`, `test/unit_test/products_bloc_search_test.dart`
+and others). So the plan's "no new dependency" promise holds for the test tree
+as well as for `lib/`, and #602 should follow the existing hand-rolled pattern
+rather than reaching for `bloc_test`.
+
+### N4 — Three small open items, all decisions or cheap lookups.
+
+- **`GPL-3.0-only` vs `GPL-3.0-or-later`** (`ai-cohort-restrictions.md` A9). A
+  decision, forced whenever the F-Droid metadata is written, and forced earlier
+  if any GPL-3.0-only peer code is absorbed.
+- **The bundled Unsplash demo photos** (C5). A decision: replace the twelve
+  images or accept `NonFreeAssets`. No external ruling exists to find; asking
+  F-Droid is the only way to know in advance, and asking is itself a decision.
+- **`minSdkVersion`**. [`android/app/build.gradle:63`](../android/app/build.gradle)
+  is still `minSdkVersion flutter.minSdkVersion` — unpinned, deferring to
+  whatever the Flutter SDK default is, with Flutter pinned to **3.44.6** in
+  [`.fvmrc`](../.fvmrc). #599's "runs down to minSdk 24" claim is therefore
+  still taken on trust. Irrelevant to tier 0, and `flutter_secure_storage` 10's
+  floor of 23 means E5's conclusion holds either way.
+
+---
+
+## E. Open items that are misfiled
+
+The most useful thing to say about the three existing "Not verified" lists is
+that several entries on them are not research questions at all. Leaving them
+there implies someone could close them by reading harder. Nobody can.
+
+| Item, as filed | Where | What it actually is |
+| :-- | :-- | :-- |
+| "Whether Google would read a structured meal list as AI-generated content" | `ai-legal-constraints.md` | **Already decided.** The same document says "Building the report control moots the question", and #599 accepted that. Not open. |
+| "Whether F-Droid would apply `NonFreeAssets` to the Unsplash demo photos" | `ai-cohort-restrictions.md` | **Decision.** No ruling exists to find. Either replace the images or accept the label. |
+| "Whether `ollama.com`'s Terms reach a locally-run `ollama serve`" | `ai-cohort-restrictions.md` | **Decision** (or legal, if it ever mattered). The Terms are silent; silence will not become an answer by re-reading it. |
+| Play content rating / Apple age rating / Health apps declaration / Impressum | `ai-legal-constraints.md` | **Four maintainer lookups**, five minutes total. Not researchable from outside. |
+| "Whether the app's Play Console Health apps declaration is currently accurate" | `ai-legal-constraints.md` | Same. |
+| "Whether the Article 111(4) transitional reaches a post-2 Aug 2026 feature" | `ai-legal-constraints.md` | **Legal**, correctly identified elsewhere in the same document but listed under "could not verify", which understates it. |
+| Decision #5 re-settlement | #599 comment 1 | **Decision.** Framed as blocking tier-1 scoping, which is right — but it reads as though more evidence is pending. It is not. |
+| "What Kai 9000's `foss` flavour actually removes" | `ai-cohort-restrictions.md` | Genuinely research, but **now moot**: N1 supplies a better, closer and current exemplar from a peer Flutter food app. |
+
+---
+
+## What I could not reach, and why
+
+- **The operative amended text of Article 113, and Article 111(4), of Regulation
+  (EU) 2026/1744.** EUR-Lex's HTML rendering truncates mid-sentence in
+  Article 63 on both
+  [`?uri=OJ%3AL_202601744`](https://eur-lex.europa.eu/legal-content/EN/TXT/HTML/?uri=OJ%3AL_202601744)
+  and [`?uri=CELEX:32026R1744`](https://eur-lex.europa.eu/legal-content/EN/TXT/HTML/?uri=CELEX:32026R1744),
+  stopping at the identical point ("…without affecting the level of protection
+  or the need for compl"). The same behaviour was already recorded for the
+  consolidated AI Act text in #599's third comment. The deferral dates and the
+  Article 50 position were confirmed from the
+  [ELI record](https://eur-lex.europa.eu/eli/reg/2026/1744/oj/eng) and recital
+  40 instead — both primary, both on `eur-lex.europa.eu` — so no mirror was
+  needed for the claim that mattered. **The Article 111(4) quote in
+  `ai-legal-constraints.md` remains unverified.**
+- **OpenAI's Services Agreement §2.2 / §3.3(g) and current Usage Policies.**
+  Not attempted today: `openai.com` returned HTTP 403 to every route on the
+  previous pass, and OpenAI publishes these documents on no other first-party
+  host. **The route failed and remains failed.** The Usage Policies text quoted
+  at `ai-cohort-restrictions.md` D7 is still a nine-month-old Microsoft-hosted
+  mirror.
+- **A positive statement that `output_config.format` and an image content-part
+  are supported together.** Three Anthropic documentation pages were read; none
+  states an incompatibility and none states compatibility. Documentation cannot
+  close this. One live API call can, and none was made.
+- **Whether `flutter.minSdkVersion` resolves to 24 under Flutter 3.44.6.** The
+  Flutter SDK is not on this machine's `PATH` (the repo uses FVM), so the
+  default could not be read out of `flutter.groovy`.
+- **Empirical search recall.** No live query was made against Open Food Facts or
+  the Supabase backend, per the brief. Everything in T3 is derived from the
+  source of `meal_relevance_ranker.dart`, `search_products_usecase.dart` and
+  `sp_food_data_source.dart`, and the arithmetic is reproducible by hand. What
+  the APIs actually *return* for `toast` is still unmeasured; the test that
+  would settle it is described in T3 and does not require the network.
+
+## Sources
+
+Primary, fetched today:
+
+[Regulation (EU) 2026/1744 — ELI record](https://eur-lex.europa.eu/eli/reg/2026/1744/oj/eng) ·
+[Regulation (EU) 2026/1744 — OJ HTML (truncates)](https://eur-lex.europa.eu/legal-content/EN/TXT/HTML/?uri=OJ%3AL_202601744) ·
+[Anthropic structured outputs](https://platform.claude.com/docs/en/build-with-claude/structured-outputs) ·
+[Anthropic vision](https://platform.claude.com/docs/en/build-with-claude/vision) ·
+[Anthropic Messages API reference](https://platform.claude.com/docs/en/api/messages/create) ·
+[Google Play AI-Generated Content policy](https://support.google.com/googleplay/android-developer/answer/13985936) ·
+[Apple App Review Guidelines](https://developer.apple.com/app-store/review/guidelines/) ·
+[MDCG 2019-11 rev.1](https://health.ec.europa.eu/document/download/b45335c5-1679-4c71-a91c-fc7a4d37f12b_en?filename=mdcg_2019_11_en.pdf) ·
+[fdroiddata `openfoodfacts.github.scrachx.openfood.yml`](https://gitlab.com/fdroid/fdroiddata/-/raw/master/metadata/openfoodfacts.github.scrachx.openfood.yml) ·
+[smooth-app `packages/smooth_app/pubspec.yaml`](https://github.com/openfoodfacts/smooth-app/blob/develop/packages/smooth_app/pubspec.yaml) ·
+[smooth-app `packages/scanner/zxing/pubspec.yaml`](https://github.com/openfoodfacts/smooth-app/blob/develop/packages/scanner/zxing/pubspec.yaml) ·
+[`qr_code_scanner` licence](https://pub.dev/packages/qr_code_scanner/license) ·
+[`flutter_zxing`](https://pub.dev/packages/flutter_zxing) ·
+[F-Droid RFP #2540](https://gitlab.com/fdroid/rfp/-/issues/2540)
+
+In-repo files read for sections A and D:
+
+[`AGENTS.md`](../AGENTS.md) ·
+[`CONTRIBUTING.md`](../CONTRIBUTING.md) ·
+[`justfile`](../justfile) ·
+[`l10n.yaml`](../l10n.yaml) ·
+[`.gitignore`](../.gitignore) ·
+[`.fvmrc`](../.fvmrc) ·
+[`pubspec.yaml`](../pubspec.yaml) ·
+[`.github/workflows/default_workflow.yml`](../.github/workflows/default_workflow.yml) ·
+[`android/app/build.gradle`](../android/app/build.gradle) ·
+[`lib/features/add_meal/util/meal_relevance_ranker.dart`](../lib/features/add_meal/util/meal_relevance_ranker.dart) ·
+[`lib/features/add_meal/domain/usecase/search_products_usecase.dart`](../lib/features/add_meal/domain/usecase/search_products_usecase.dart) ·
+[`lib/features/add_meal/data/data_sources/sp_food_data_source.dart`](../lib/features/add_meal/data/data_sources/sp_food_data_source.dart) ·
+[`lib/features/add_meal/data/dto/sp/sp_const.dart`](../lib/features/add_meal/data/dto/sp/sp_const.dart) ·
+[`lib/features/meal_detail/presentation/bloc/meal_detail_bloc.dart`](../lib/features/meal_detail/presentation/bloc/meal_detail_bloc.dart) ·
+[`lib/features/meal_detail/presentation/widgets/meal_detail_bottom_sheet.dart`](../lib/features/meal_detail/presentation/widgets/meal_detail_bottom_sheet.dart) ·
+[`lib/features/meal_detail/meal_detail_screen.dart`](../lib/features/meal_detail/meal_detail_screen.dart) ·
+[`lib/features/scanner/scanner_screen.dart`](../lib/features/scanner/scanner_screen.dart) ·
+[`lib/features/scanner/util/barcode_check_digit.dart`](../lib/features/scanner/util/barcode_check_digit.dart) ·
+[`lib/core/utils/food_name_validator.dart`](../lib/core/utils/food_name_validator.dart) ·
+[`lib/core/utils/json_meal_importer.dart`](../lib/core/utils/json_meal_importer.dart) ·
+[`lib/l10n/*.arb`](../lib/l10n/) (nine files, 921 keys each, zero drift)
+
+Issues and the plan:
+[#599](https://github.com/simonoppowa/OpenNutriTracker/issues/599) (body plus its three comments, the comments controlling) ·
+[#600](https://github.com/simonoppowa/OpenNutriTracker/issues/600) ·
+[#601](https://github.com/simonoppowa/OpenNutriTracker/issues/601) ·
+[#602](https://github.com/simonoppowa/OpenNutriTracker/issues/602) ·
+[#250](https://github.com/simonoppowa/OpenNutriTracker/issues/250)

--- a/docs/fdroid-submission-feasibility.md
+++ b/docs/fdroid-submission-feasibility.md
@@ -1,0 +1,409 @@
+# F-Droid submission: feasibility review of issue #575
+
+Research notes for [#575](https://github.com/simonoppowa/OpenNutriTracker/issues/575) ("Submit OpenNutriTracker to the F-Droid repository") and its parent [#126](https://github.com/simonoppowa/OpenNutriTracker/issues/126). Written against `feat/onboarding-rework` at version `2.0.2+61`, and against a shallow clone of [`fdroid/fdroiddata`](https://gitlab.com/fdroid/fdroiddata) at commit `b3626a167c61d17211c3be8e41a61a97c807ed5c` (2026-08-05). Every fdroiddata path below is relative to that repo.
+
+## Verdict
+
+**Blocked — but not on the thing the issue thread is worried about.**
+
+The `fdcApiKey` that surfaced in the #575 discussion is a nuisance, not a blocker. F-Droid's Inclusion Policy has an explicit line for it, there is a working precedent in the repo for the exact same USDA API, and — as it turns out — the key is wired to dead code in this app anyway.
+
+The actual blocker is **`mobile_scanner`**, which links `com.google.mlkit:barcode-scanning`. ML Kit is on F-Droid's non-free signature list with `"license": "NonFree"`, and fdroiddata's CI runs a binary scanner over the built APK that fails the pipeline when those classes are found. Barcode scanning is a headline feature of this app — it appears in `full_description.txt`, in the recipe builder, and in three separate import screens — so removing it is a product decision, not a packaging detail. That decision belongs to the maintainer, and #575 cannot be completed until it is made.
+
+A second, smaller decision is also maintainer-only: the Supabase project URL and anon key must be published in the clear in fdroiddata, or the F-Droid build ships with a food-search backend that does not work.
+
+Everything else — Flutter buildability, release identity, metadata reuse — is routine and well-precedented.
+
+---
+
+## 1. Inclusion Policy fit
+
+The [current Inclusion Policy](https://f-droid.org/docs/Inclusion_Policy/) has four relevant clauses. Quoting the ones that bite:
+
+> All binary dependencies including JAR files must originate either from source compilation or Debian repository downloads. Prebuilt binaries should only come from authorized trusted sources.
+
+> The implementation of proprietary tracking or advertising libraries and analytics tools such as Google Play Services and Firebase and Crashlytics and proprietary ad/tracking SDKs are strictly forbidden in all applications. Upstream developers must implement either a FLOSS alternative or a build flavour that does not require these dependencies when such features become necessary.
+
+> Non-functional assets including artwork and fonts can utilize less restrictive licenses which include game art specific to the project but must allow redistribution when using non-commercial licenses.
+
+> The application should be functional and implement all the features described in the description.
+
+I enumerated every hosted package in `pubspec.lock` (212 entries), resolved each against the local pub cache, and grepped its `android/**/*.gradle*` and `AndroidManifest.xml` files for Google/Firebase/GMS coordinates. Then I tested each hit against F-Droid's actual scanner signature database, [SUSS](https://fdroid.gitlab.io/fdroid-suss/suss.json), which `fdroidserver/scanner.py` loads at runtime (`scanner.py:553`).
+
+| Finding | Where | Verdict |
+| --- | --- | --- |
+| `mobile_scanner` 7.2.0 → `com.google.mlkit:barcode-scanning:17.3.0` | `pubspec.yaml`, `pubspec.lock:983`; [`mobile_scanner@v7.2.0 android/build.gradle:60`](https://github.com/juliansteenbakker/mobile_scanner/blob/v7.2.0/android/build.gradle#L60) | **Hard blocker** |
+| `sentry_flutter` → sentry.io crash reporting | `pubspec.yaml`, `lib/main.dart:152` | Anti-feature discussion (`Tracking`) |
+| `supabase_flutter` → maintainer's managed Supabase project | `lib/core/utils/locator.dart:142-146` | Anti-feature flag (`NonFreeNet` and/or `TetheredNet`) |
+| Bundled Unsplash demo photos | `assets/demo/`, `lib/core/utils/demo/unsplash_attribution.dart` | Anti-feature risk (`NonFreeAssets`) |
+| `dynamic_color` → `com.google.android.material` | pub cache scan | Pass (Apache-2.0, not in SUSS) |
+| `flutter_local_notifications` → `com.google.code.gson` | pub cache scan | Pass (Apache-2.0, not in SUSS) |
+| `flutter_secure_storage` → `com.google.crypto.tink:tink-android` | pub cache scan | Pass (Apache-2.0, not in SUSS) |
+| `image_picker_android` manifest `com.google.android.gms.metadata.ModuleDependencies` | pub cache scan | Probably pass — see below |
+| No Firebase, no Crashlytics, no Play Services SDK, no ad SDK anywhere in the tree | full pub cache scan | Pass |
+| Android manifest permissions: `INTERNET`, `RECEIVE_BOOT_COMPLETED`, `POST_NOTIFICATIONS` (+ `CAMERA` merged in from `mobile_scanner`) | `android/app/src/main/AndroidManifest.xml` | Pass — fdroiddata CI reports permissions at `info` severity only |
+| License GPL-3.0, `LICENSE` at repo root, fonts under `fonts/OFL.txt` | `LICENSE`, `README.md:253` | Pass |
+
+### The ML Kit blocker in detail
+
+SUSS carries an entry for ML Kit:
+
+```json
+"com.google.mlkit": {
+  "code_signatures": ["com/google/mlkit"],
+  "gradle_signatures": ["com.google.mlkit", "io.github.g00fy2.quickie"],
+  "license": "NonFree",
+  "name": "ML Kit"
+}
+```
+
+That signature is loaded into `err_gradle_signatures` and `err_code_signatures` (`fdroidserver/scanner.py:624-638`). The gradle half fires during `scan_source` on any `.gradle`/`.gradle.kts` file (`scanner.py:1067`) — which the plugin's own `android/build.gradle` inside `.pub-cache` would trip. That half can technically be worked around with `scandelete`. The code half cannot: `scan_binary` walks the built APK's dex classes and has no ignore mechanism at all (`scanner.py:665-680`), and fdroiddata's own pipeline runs it with `--exit-code` and turns every found class into a `critical` code-quality report:
+
+```yaml
+fdroid scanner --verbose --exit-code $file 2>&1 | tee result || {
+  export EXITVALUE=1;
+  for class in $(sed -n "s/.*DEBUG: Problem: found class '\(.*\)'/\1/p" result); do
+    printf "\x1b[31mERROR Found $class in $file\x1b[0m\n";
+```
+
+(`fdroiddata/.gitlab-ci.yml`, "binary scanner" section.)
+
+Two apps in fdroiddata use `mobile_scanner` upstream, and **both** strip it for F-Droid rather than shipping it:
+
+- `metadata/info.zverev.ilya.every_door.yml:375` — `sed -i -e 's/^#f\|^ *mobile_scanner.*$//' pubspec.yaml`, then `mv lib/fields/helpers/qr_code.dart.fdroid lib/fields/helpers/qr_code.dart`. The `.fdroid` variant file is shipped by *upstream* (it exists in `Zverik/every_door` at `lib/fields/helpers/qr_code.dart.fdroid`).
+- `metadata/com.nfcarchiver.banana_split.yml:28` — `sed -i -e '/mobile_scanner/d' pubspec.yaml`, then `mv lib/widgets/shard_scanner.dart.fdroid lib/widgets/shard_scanner.dart`, plus a separate `pubspec.lock.fdroid`.
+
+So the established pattern is: upstream ships a parallel `.fdroid` source file and a stripped lockfile, and the recipe swaps them in. This app would need the same, across every scanner entry point — `lib/features/scanner/scanner_screen.dart`, `lib/features/recipes/presentation/screens/import_recipe_scanner_screen.dart`, `lib/features/home/presentation/screens/import_meal_scanner_screen.dart`, and `lib/features/home/presentation/screens/import_activity_scanner_screen.dart`.
+
+That is not a trivial `sed`. It touches the QR-import path for meals, activities, and recipes, which is a documented export/import feature, and the barcode path, which `full_description.txt` advertises in two bullets ("Search, scan, or add straight as a number" and the whole "📷 Barcode scanner" line). The Inclusion Policy's quality bar — "The application should be functional and implement all the features described in the description" — means the F-Droid description would have to be trimmed to match a scanner-less build.
+
+**The alternative is to replace `mobile_scanner` with a FOSS scanner for all builds.** `flutter_zxing` is MIT-licensed, wraps the ZXing C++ library through FFI/CMake, and pulls no Google dependency ([LICENSE](https://github.com/khoren93/flutter_zxing/blob/main/LICENSE), [android/build.gradle](https://github.com/khoren93/flutter_zxing/blob/main/android/build.gradle) — CMake `externalNativeBuild`, no `implementation 'com.google...'` line). It already builds in fdroiddata: `metadata/business.braid.polycule.yml:50` uses it, with one reproducibility workaround worth copying (`add_link_options("LINKER:--build-id=none")` injected into its `CMakeLists.txt`). Swapping the dependency wholesale is more work up front but removes the fork-maintenance burden of `.fdroid` variant files forever, and it would let the F-Droid listing carry the same feature set and the same description as everywhere else.
+
+### The lesser flags
+
+**Sentry.** `sentry_flutter` is itself FLOSS and is not in SUSS, so the scanner will not object. But `sentry.io` is a proprietary network service and F-Droid routinely attaches `Tracking` for it — `metadata/com.infomaniak.drive.yml:1-6` reads:
+
+```yaml
+AntiFeatures:
+  Tracking:
+    en-US: Uses Sentry for analytics, which is enabled by default.
+```
+
+This app is in a better position than kDrive: Sentry only initialises when `kReleaseMode && hasAcceptedAnonymousData` (`lib/main.dart:114-120`), so it is opt-in and default-off. A reviewer may accept that without a flag; I could not find a policy sentence that settles it either way, so expect a conversation. If it becomes contentious, the clean fix is the same one kDrive uses — strip Sentry in the recipe (`sed -i -e '/sentry/d'`) and ship the F-Droid build without crash reporting.
+
+**Supabase.** The app initialises Supabase unconditionally at startup and routes the entire "Food" search tab through it (`lib/features/add_meal/data/data_sources/sp_food_data_source.dart`). The backend code is open (`OpenNutriTracker-Backend`) but the instance is a single managed Supabase cloud project run by the maintainer — see `docs/supabase-self-hosting.md`. That maps to `TetheredNet` ("depends entirely on a certain instance of a network service") and arguably `NonFreeNet` per the [Anti-Features list](https://f-droid.org/docs/Anti-Features/). `metadata/info.zverev.ilya.every_door.yml:1-7` carries both for less than this. Expect at least one of them. It is a label, not a rejection.
+
+**Unsplash demo assets.** `assets/demo/meals/` and `assets/demo/alex_demo_avatar.jpg` ship JPEGs under the [Unsplash License](https://unsplash.com/license), which grants copy/modify/distribute rights but adds a field-of-use carve-out: "This license does not include the right to compile images from Unsplash to replicate a similar or competing service." A field-of-use restriction fails DFSG §6 and OSD §6, so these are not free assets. The Inclusion Policy is lenient here — non-functional assets only "must allow redistribution" — so this is unlikely to block inclusion, but it is a plausible `NonFreeAssets` flag and the reviewer will ask. Worth pre-empting in the MR description.
+
+**`image_picker_android`.** Its manifest declares `<meta-data android:name="com.google.android.gms.metadata.ModuleDependencies">` for the Android Photo Picker module. SUSS's `com.google.android.gms` entry would match that string, but the gradle scan only reads `.gradle`/`.gradle.kts` files and only lines that look like Gradle dependency declarations (`scanner.py:1067`, `is_used_by_gradle_without_catalog`), and the binary scan matches dex *class* names, not manifest attributes. I believe this is a non-issue; I did not find a fdroiddata app that had to strip `image_picker` for it, which supports that reading, but I have not verified it against an actual scanner run.
+
+---
+
+## 2. The API key problem
+
+Short answer: **the API key is not the blocker, and for `FDC_API_KEY` specifically it is not even needed at runtime.**
+
+### Where the key enters the build
+
+`lib/core/utils/env.dart` declares four compile-time secrets through [`envied`](https://pub.dev/packages/envied):
+
+```dart
+@Envied(path: '.env')
+abstract class Env {
+  @EnviedField(varName: 'FDC_API_KEY', obfuscate: true)
+  static final String fdcApiKey = _Env.fdcApiKey;
+  @EnviedField(varName: 'SENTRY_DNS', obfuscate: true)
+  static final String sentryDns = _Env.sentryDns;
+  @EnviedField(varName: 'SUPABASE_PROJECT_URL', obfuscate: true)
+  static final String supabaseProjectUrl = _Env.supabaseProjectUrl;
+  @EnviedField(varName: 'SUPABASE_PROJECT_ANON_KEY', obfuscate: true)
+  static final String supabaseProjectAnonKey = _Env.supabaseProjectAnonKey;
+}
+```
+
+`env.g.dart` is gitignored (`.gitignore`, "# API Keys" block), so `dart run build_runner build` must regenerate it, and it needs a `.env`. That is exactly what the contributor hit.
+
+The failure mode is worth being precise about, because it determines the fix. `requireEnvFile` defaults to `false` (`envied_generator-1.3.8/lib/src/generator.dart:93-94`), so a *missing* `.env` is silently tolerated. What actually throws is `allowOptionalFields` also defaulting to false: any field whose variable resolves to null raises `Environment variable not found for field ...` (`envied_generator-1.3.8/lib/src/generate_field.dart:28-33`). So the build needs a `.env` containing all four keys with *some* value. It does not need real ones to compile.
+
+The repo already knows this. `.github/workflows/default_workflow.yml:40-47` writes a stub for every CI job:
+
+```yaml
+- name: Generate stub .env for CI
+  uses: ./.github/actions/write-env-file
+  with:
+    fdc_api_key: ci-stub
+    sentry_dns: https://stub@sentry.io/0
+    supabase_project_url: https://stub.supabase.co
+    supabase_project_anon_key: ci-stub
+```
+
+### What F-Droid does about secrets
+
+The Inclusion Policy is explicit:
+
+> F-Droid does not sign up for any API keys. Even if provided by a third party, we include them in both binary and source code releases.
+
+So there is no secret store, no CI variable, no mechanism. Either the upstream developer supplies the value and it is committed in the clear to the public `fdroiddata` metadata, or the build gets a dummy. There is nothing in between.
+
+That is not theoretical. **`metadata/com.flasskamp.energize.yml` — a Flutter nutrition tracker already in F-Droid, using the same USDA FoodData Central API — writes a literal USDA key into `.env` inside the recipe** (`metadata/com.flasskamp.energize.yml:470`, repeated in every one of its 33 build blocks):
+
+```yaml
+build:
+  - export PUB_CACHE=$(pwd)/.pub-cache
+  - echo "API_KEY_USDA='...'" > .env
+  - echo "COPYRIGHT_NAME='Christian Flaßkamp'" >> .env
+  ...
+  - submodules/flutter/bin/flutter pub run build_runner build --delete-conflicting-outputs
+  - submodules/flutter/bin/flutter build apk --split-per-abi --target-platform="android-arm"
+```
+
+This is the precedent to point the contributor at. It is a near-exact template for OpenNutriTracker's problem, from the same domain.
+
+Note also that `obfuscate: true` gives no protection here. `envied`'s obfuscation is a compile-time XOR against a generated key list, both of which are embedded in `env.g.dart` and therefore in the APK. Anyone who wants the values from an existing Play Store or GitHub build already has them.
+
+### Does the key matter at runtime?
+
+**`FDC_API_KEY`: no.** The direct FoodData Central client is dead code in 2.x. `FDCDataSource.fetchSearchWordResults` is the only reader of `Env.fdcApiKey` (`lib/features/add_meal/data/data_sources/fdc_data_source.dart:19`). It is reached only via `ProductsRepository.getFDCFoodsByString` (`lib/features/add_meal/data/repository/products_repository.dart:105`), and a repo-wide grep finds **zero callers** of that method. The FDC tab now goes through Supabase — `SearchProductsUseCase.searchFDCFoodByString` calls `_productsRepository.getSupabaseFoodsByString` (`lib/features/add_meal/domain/usecase/search_products_usecase.dart:71-86`). `FDCDataSource` is still registered in the locator (`lib/core/utils/locator.dart:527`) and injected into `ProductsRepository`, which is why it still compiles and still forces the key.
+
+A stub `FDC_API_KEY` therefore costs the F-Droid build nothing. (Separately: this looks like genuine dead code that could just be deleted, which would remove the whole question. That is out of scope for #575 but worth raising.)
+
+**`SUPABASE_PROJECT_URL` / `SUPABASE_PROJECT_ANON_KEY`: yes, critically.** `Supabase.initialize` runs unconditionally during `initLocator` (`lib/core/utils/locator.dart:142-146`), and the entire multi-source food database — USDA, BLS, and the localized translation table — is served from it. With stub values, the "Food" tab returns nothing on every query. Open Food Facts still works: `OFFDataSource` sends only a User-Agent and no key (`lib/features/add_meal/data/data_sources/off_data_source.dart:90`). So a stubbed F-Droid build degrades to *OFF-only search* — usable, but visibly worse than the Play/GitHub build, and half of what `full_description.txt` promises.
+
+Failure is graceful, at least: `SearchProductsUseCase._safeRemoteCall` catches and returns an empty list, and `SpFoodDataSource` retries and then errors into the same path. The app will not crash; it will just find nothing.
+
+**`SENTRY_DNS`: no.** A stub DSN is fine — the Sentry client is only constructed under opt-in consent, and a build with a dud DSN simply drops events.
+
+### So the decision is
+
+The maintainer must choose, and only the maintainer can:
+
+1. **Publish the Supabase URL + anon key in the fdroiddata recipe.** Both are already in every shipped APK, and the anon key is designed to be public (row-level security is the boundary, not secrecy). This is what Energize did with its USDA key. Cost: the values become greppable in a public GitLab repo, which raises the odds of scripted abuse against the free-tier Supabase project.
+2. **Ship stubs and accept an OFF-only F-Droid build.** Cost: a materially worse app on F-Droid, plus a description that has to be rewritten to match.
+
+Option 1 is the right call, but it is a hosting-cost and abuse-surface question, not an engineering one.
+
+---
+
+## 3. Flutter buildability in fdroiddata
+
+F-Droid builds a lot of Flutter — 482 of the 8,987 metadata files mention it. There is no magic; recipes are hand-written `prebuild:`/`build:` shell.
+
+### How the Flutter SDK gets in
+
+Two conventions, both in wide use:
+
+- **`srclibs: - flutter@<ref>`.** `srclibs/flutter.yml` is one line — `RepoType: git` / `Repo: https://github.com/flutter/flutter.git` — and the ref after `@` is checked out. Across fdroiddata: `flutter@stable` appears 3,434 times, with pinned tags (`flutter@3.3.2`, `flutter@3.10.6`, …) making up most of the rest. The SDK is then referenced as `$$flutter$$/bin/flutter`.
+- **An upstream git submodule**, with `submodules: true`. This is what the contributor's example and Energize do.
+
+The contributor named `metadata/studip_uni_passau.femtopedia.de.unipassaustudip.yml`. Its structure, quoted in full for the build section:
+
+```yaml
+Builds:
+  - versionName: 2.1.3
+    versionCode: 213
+    commit: 9dd94328ca0d4df137c826a11e7d6db43c924c41
+    submodules: true
+    sudo:
+      - mkdir -p /home/runner/work/studipassau
+      - chown -R vagrant /home/runner
+    output: build/app/outputs/flutter-apk/app-release.apk
+    rm:
+      - ios
+    prebuild:
+      - export repo=/home/runner/work/studipassau/studipassau
+      - cd ..
+      - mv studip_uni_passau.femtopedia.de.unipassaustudip $repo
+      - pushd $repo
+      - export PUB_CACHE=$(pwd)/.pub-cache
+      - .flutter/bin/flutter config --no-analytics
+      - .flutter/bin/flutter pub get --enforce-lockfile
+      - popd
+      - mv $repo studip_uni_passau.femtopedia.de.unipassaustudip
+    scanignore:
+      - .flutter/bin/cache
+    scandelete:
+      - .flutter
+      - .pub-cache
+    build:
+      - export repo=/home/runner/work/studipassau/studipassau
+      - cd ..
+      - mv studip_uni_passau.femtopedia.de.unipassaustudip $repo
+      - pushd $repo
+      - export PUB_CACHE=$(pwd)/.pub-cache
+      - .flutter/bin/dart run intl_utils:generate
+      - .flutter/bin/dart run build_runner build
+      - .flutter/bin/flutter build apk --release
+      - popd
+      - mv $repo studip_uni_passau.femtopedia.de.unipassaustudip
+
+AllowedAPKSigningKeys: f17448cfb1bd29bc4b29932de068feab87175654dfac0e1a48605f2aeecebaef
+AutoUpdateMode: Version
+UpdateCheckMode: Tags
+UpdateCheckData: pubspec.yaml|version:\s.+\+(\d+)|.|version:\s(.+)\+
+```
+
+Three things to read out of it. The `.flutter` submodule is upstream's SDK pin. The `mv`-into-`/home/runner/work/...`-and-back dance exists purely to make the build path match upstream's GitHub Actions working directory — [Reproducible Builds](https://f-droid.org/docs/Reproducible_Builds/) names this explicitly: "Embedded build paths are a source of reproducibility issues affecting apps built with e.g. Flutter". And it runs `dart run build_runner build`, so codegen in the recipe is normal and expected.
+
+Note this app has **no** Flutter submodule. `.fvmrc` pins `{"flutter": "3.44.6"}`, which FVM understands and F-Droid does not. Tag `3.44.6` does exist in `flutter/flutter` (`ee80f08bbf97172ec030b8751ceab557177a34a6`), so `srclibs: - flutter@3.44.6` is the right translation. Keeping it in sync with `.fvmrc` is manual, per release.
+
+The Inclusion Policy blesses the prebuilt SDK explicitly: "The Android SDK, Flutter SDK and Hermes have permission to use official prebuilt binaries until Debian provides alternative solutions" — which is why `scanignore: <flutter>/bin/cache` is the standard incantation.
+
+### What makes this repo's build non-trivial
+
+**Flavors.** `android/app/build.gradle` defines a `version` dimension with `develop` (`applicationIdSuffix ".develop"`) and `full` (no suffix). There is no default, so the recipe must pass `--flavor full` — which is what the release job does (`.github/workflows/default_workflow.yml:850`). This also changes the output path: Gradle writes `build/app/outputs/apk/full/release/app-release.apk` (renamed by the `applicationVariants.all` block), while Flutter's post-build copy lands at `build/app/outputs/flutter-apk/app-full-release.apk`. The CI comment at `default_workflow.yml:864-872` spells this out. Either path works as `output:`; the Gradle one is more stable.
+
+**The signing config is unconditional.** `android/app/build.gradle` reads `android/key.properties` and then sets `buildTypes.release.signingConfig = signingConfigs.release` with no guard. F-Droid has no keystore. The repo's own CI confirms the consequence — `default_workflow.yml:427` says "`--release` would need a keystore which CI doesn't have; `--debug` …" and the non-release Android job builds `--debug` for that reason. The recipe will need to strip it, the way `metadata/app.simple.peri.yml:648` does (`sed -i -e '/signingConfigs/,+1d' build.gradle`). This should be verified by an actual build rather than taken on faith.
+
+**Codegen.** `dart run build_runner build` is mandatory — it produces `env.g.dart`, Hive adapters, and JSON serializers — and `flutter gen-l10n` is mandatory too, since `lib/generated/` is gitignored (`justfile`, `gen_l10n` recipe; `.gitignore`). Both are ordinary recipe steps (Energize and studip both do exactly this).
+
+**NDK.** `android/app/build.gradle` sets `ndkVersion flutter.ndkVersion`, which for 3.44.6 resolves to `28.2.13676358` (`flutter_tools/gradle/src/main/kotlin/FlutterExtension.kt:42`). `fdroidserver` supports this through the `ndk:` build field and `auto_install_ndk()` (`fdroidserver/common.py`), so it is a one-line addition, not a blocker.
+
+**Java.** `compileOptions` and `kotlinOptions` want JVM 17; AGP is 8.11.1 and Gradle 8.14 (`android/settings.gradle`, `android/gradle/wrapper/gradle-wrapper.properties`). The buildserver installs `default-jdk-headless` and selects the highest available (`buildserver/provision-apt-get-install`), which on current Debian is 21 — fine for `sourceCompatibility 17`. If it is not, a `sudo:` block pinning a JDK is the standard fix; 5,357 build blocks in fdroiddata already do it for 17.
+
+**APK size.** The published universal APK is ~100 MB (`gh release view v2.0.2`). I found no documented size limit in `fdroidserver`. Most Flutter recipes use `--split-per-abi` with `VercodeOperation` anyway (Energize: `10 * %c + 1/2/3`). Careful: Flutter sets `versionCodeOverride = abiVersionCode * 1000 + base` when splitting (`FlutterPlugin.kt:669-671`), *and* this repo's `applicationVariants.all` rename block forces every `full`-flavor output to the same filename `app-release.apk`, which would collide across ABI splits. Splitting is possible but needs that block neutered. A universal APK is the simpler first submission.
+
+**Native deps.** None beyond what Flutter itself ships — no plugin in the tree has an `externalNativeBuild`. (That changes if `flutter_zxing` replaces `mobile_scanner`; it builds ZXing C++ via CMake, hence polycule's `--build-id=none` workaround.)
+
+---
+
+## 4. Release identity
+
+| Field | Value | Source |
+| --- | --- | --- |
+| Latest stable tag | `v2.0.2` (2026-08-02) | `gh release list` |
+| `versionName` | `2.0.2` | `pubspec.yaml:19` |
+| `versionCode` | `61` | `pubspec.yaml:19` |
+| `applicationId` | `com.opennutritracker.ont.opennutritracker` | `android/app/build.gradle` (`full` flavor, no suffix) |
+| Release APK asset | `app-release.apk`, ~100 MB, at `.../releases/download/v2.0.2/app-release.apk` | `gh release view v2.0.2` |
+| Signing cert SHA-256 | `84e86074ec7edabb10f2017986ddf09e531caf7a73080ac1172b80c49c620827` | `README.md:157`, `docs/site/release-info.json` |
+| Tag objects | Lightweight commits, **not** annotated or GPG-signed | `git cat-file -t v2.0.2` → `commit` |
+
+Version codes are monotonic across the tags that matter — I checked `pubspec.yaml` at every 1.3+ tag and got 49, 50, 56, 57, 58, 59, 60, 61 in order. (The GitHub *release titles* for v1.4.0/v1.4.1 say "build 701"/"build 703", which contradicts `pubspec.yaml`'s 56/57 and the release workflow's lack of `--build-number`. I did not download those APKs to settle it; it does not affect anything going forward.)
+
+Tag naming is historically inconsistent (`v.1.3.0`, `v1.3.2+53-build.629`) but has been clean `vX.Y.Z` since v1.4.0.
+
+**Recommendation:**
+
+```yaml
+UpdateCheckMode: Tags
+UpdateCheckData: pubspec.yaml|version:\s.+\+(\d+)|.|version:\s(.+)\+
+AutoUpdateMode: Version
+CurrentVersion: 2.0.2
+CurrentVersionCode: 61
+```
+
+That `UpdateCheckData` is the literal example the [Build Metadata Reference](https://f-droid.org/docs/Build_Metadata_Reference/) gives for "Flutter app with the pubspec.yaml in the repo root", and it is what both Energize and studip use. `AutoUpdateMode: Version` with no pattern is correct here because with `UpdateCheckMode: Tags` "the checked tag is used directly", so the historic `v.1.3.x` oddities do not matter.
+
+**On reproducible builds / `Binaries`:** do not attempt this for the first submission. Verified builds would require (a) the exact same four `.env` values as the release build, byte for byte, (b) mirroring GitHub Actions' `/home/runner/work/OpenNutriTracker/OpenNutriTracker` working directory to defeat Flutter's embedded build paths, and (c) matching the AGP/NDK/apksigner versions. The `AllowedAPKSigningKeys` value is available if it is ever wanted, but the pragmatic path is an F-Droid-signed build. The cost of that is real and should be stated in #575: **F-Droid-signed APKs cannot upgrade an existing Play Store or GitHub install** — users switching have to uninstall and lose local data unless they export first.
+
+Category: `Diet` and `Sports & Health` both exist in `config/categories.yml`; Energize uses both.
+
+---
+
+## 5. Metadata reuse
+
+F-Droid reads `fastlane/metadata/android/<locale>/` straight out of the app's source repo — it is one of the two supported structures, and the docs actively prefer it ("strongly encouraged", and "the only way to provide images"). It checks out the latest release tag and scans at that state. So the existing directory is usable as-is, with gaps.
+
+Against the [documented requirements](https://f-droid.org/docs/All_About_Descriptions_Graphics_and_Screenshots/):
+
+| Requirement | Present | Status |
+| --- | --- | --- |
+| `short_description.txt`, max 80 chars, mandatory | 76 chars | Pass |
+| `full_description.txt`, max 4000 chars, mandatory | 3,570 chars | Pass |
+| `title.txt`, max 50 chars | 16 chars | Pass |
+| `images/icon.png` | 512×512 | Pass |
+| `images/featureGraphic.png` | 512×250 | Works; half the documented "usually 1024×500" |
+| `images/phoneScreenshots/*.png` | 6 × 1080×2205 | Pass (well under `Image.MAX_IMAGE_PIXELS` = 4096×4096, `update.py:72`) |
+| `changelogs/<versionCode>.txt`, max 500 chars | only `12.txt` | **Gap** |
+| At least one locale beyond en-US | none | **Gap** for the Latest tab |
+| No prohibited HTML tags in description | plain text + emoji only | Pass |
+
+Two concrete problems:
+
+**The changelog is eight years of releases stale.** `fastlane/metadata/android/en-US/changelogs/12.txt` contains ` * Initial Fdroid release` — someone started this work long ago. Current `versionCode` is 61. F-Droid names changelog files by version code "literally, no padding", so it will find nothing for the shipping release. This also costs the Latest tab, whose criteria are: Name, Icon, Summary, Description, License, "a What's New entry for at least one release", at least one graphic, **and at least one of the above translated**. With only `en-US` and only `12.txt`, the app fails two of eight.
+
+Fix: add `61.txt` (and keep adding one per release — this belongs in `RELEASE.md`), and add at least one translated locale directory. The app already ships many locales in `lib/l10n/`, so a translated `short_description.txt` + `full_description.txt` + `changelogs/61.txt` for, say, `de` would clear it.
+
+**`playstore_banner.png` and `appstore_banner.png` are ignored.** `update.py:111` recognises only `featureGraphic`, `icon`, `promoGraphic`, `tvBanner`. Harmless, just dead weight in F-Droid's eyes.
+
+One thing #575 gets right and is worth repeating: do **not** commit F-Droid build metadata to this repo. The `fastlane/` directory is the correct and only place this repo participates.
+
+---
+
+## 6. Verdict on #575 as written
+
+**Scoping: mostly good. The acceptance criteria are in the right order and the "don't commit fdroiddata metadata here" note is correct.** But the issue is mislabelled as a good first issue, and the checklist has three problems.
+
+**It omits the ML Kit blocker entirely.** Criterion 1 says "document any blockers in this issue", which technically covers it, but a first-time contributor reading the list would reasonably expect that step to be a paperwork exercise. It is not — it terminates the task. Every subsequent checkbox is unreachable until the maintainer decides what happens to barcode scanning. This should be hoisted to the top of the issue as a stated precondition.
+
+**It assumes an MR is the entry point.** `fdroiddata/CONTRIBUTING.md` says: "If you are a 'first time' contributor, consider opening an issue at [RFP (Request for Packaging)]". More to the point, **[RFP #2540 for OpenNutriTracker already exists](https://gitlab.com/fdroid/rfp/-/issues/2540)**, filed 2023-09-11, still open, and untouched since the day it was created (`updated_at` is 5 minutes after `created_at`; the only activity is `fdroid-bot`'s auto-labelling: `flutter`, `dart`, `gradle`, `kotlin`, `fastlane`, `in-google-play`, `insecure-gradlew`, `license`). The issue should reference it. Reviving that RFP is a cheaper and more socially correct first move than a cold MR, and it is where a maintainer's "yes, we want this" carries weight.
+
+**"Configure the Flutter build and automatic update checks using stable release tags" understates the build work.** Between the flavor, the unconditional signing config, two codegen steps, an unpinned SDK (`.fvmrc` means nothing to F-Droid), the NDK pin, and a 100 MB universal APK, this is several hours of iteration against fdroiddata CI even once the dependency question is settled.
+
+**What #575 gets right:** reusing `fastlane/metadata/android/`, keeping F-Droid metadata out of this repo, running `fdroid lint`/`rewritemeta`, and linking back to #126.
+
+**The decisions only the maintainer can make:**
+
+1. **Barcode scanning.** Replace `mobile_scanner` with `flutter_zxing` everywhere (my recommendation — one dependency swap, no permanent fork, F-Droid gets feature parity), or maintain `.fdroid` source variants and ship a scanner-less F-Droid build with a trimmed description. There is no third option that keeps ML Kit.
+2. **The Supabase credentials.** Publish the project URL and anon key in public fdroiddata metadata (following Energize's precedent), or ship stubs and accept an Open-Food-Facts-only F-Droid build.
+3. **Sentry**, if a reviewer objects: accept a `Tracking` anti-feature, or strip it from the F-Droid build.
+4. **Signing stance**: F-Droid-signed (simple, but no upgrade path from existing installs) versus reproducible/`Binaries` (preserves the signature, but Flutter build-path reproducibility is a project of its own).
+
+---
+
+## Recommended next steps
+
+1. **Decide #1 and #2 above.** Nothing else is worth starting first.
+2. **Delete the dead FDC client** — `FDCDataSource`, `ProductsRepository.getFDCFoodsByString`, the `FDC_API_KEY` field in `Env`, and its locator registration. It has no callers, and removing it retires one of the four build-time secrets outright. Separate PR in this repo.
+3. **Fix the fastlane gaps** in this repo: add `changelogs/61.txt`, add a translated locale, and add "write the changelog file" to `RELEASE.md` so it does not drift again. Separate PR.
+4. **Revive [RFP #2540](https://gitlab.com/fdroid/rfp/-/issues/2540)** with a current status comment, rather than opening a cold MR.
+5. **Prototype the recipe locally** with `fdroid build --test`, starting from `metadata/com.flasskamp.energize.yml` as the shape and `metadata/studip_uni_passau.femtopedia.de.unipassaustudip.yml` as the Flutter-idiom reference. Sketch:
+
+   ```yaml
+   Builds:
+     - versionName: 2.0.2
+       versionCode: 61
+       commit: <full sha of v2.0.2>
+       srclibs:
+         - flutter@3.44.6
+       ndk: '28.2.13676358'
+       output: build/app/outputs/apk/full/release/app-release.apk
+       rm:
+         - ios
+         - integration_test
+       prebuild:
+         - sed -i -e '/signingConfig signingConfigs.release/d' android/app/build.gradle
+         - export PUB_CACHE=$(pwd)/.pub-cache
+         - $$flutter$$/bin/flutter config --no-analytics
+         - $$flutter$$/bin/flutter pub get --enforce-lockfile
+       scanignore:
+         - $$flutter$$/bin/cache
+       scandelete:
+         - .pub-cache
+       build:
+         - export PUB_CACHE=$(pwd)/.pub-cache
+         - echo "FDC_API_KEY='...'" > .env
+         - echo "SENTRY_DNS='...'" >> .env
+         - echo "SUPABASE_PROJECT_URL='...'" >> .env
+         - echo "SUPABASE_PROJECT_ANON_KEY='...'" >> .env
+         - $$flutter$$/bin/flutter gen-l10n
+         - $$flutter$$/bin/dart run build_runner build --delete-conflicting-outputs
+         - $$flutter$$/bin/flutter build apk --release --flavor full
+   ```
+
+   This is a starting point, not a working recipe — in particular the `signingConfig` sed, the `scanignore` path form for a srclib, and the `output:` path all need to be confirmed by an actual build.
+6. **Re-scope #575** with the ML Kit precondition at the top, a pointer to RFP #2540, and the maintainer decisions listed as blockers. Consider dropping the good-first-issue label until decisions 1 and 2 are made; after that, the remaining work genuinely is approachable.
+
+---
+
+## Open questions / unverified
+
+- **I did not run a build.** Every claim about what the recipe needs to patch — the `signingConfig` strip in particular — is inferred from reading `android/app/build.gradle` and the repo's own CI comment at `default_workflow.yml:427`, not from a failing build log. AGP's exact behaviour with a `signingConfig` whose `storeFile` is null was not tested.
+- **`image_picker_android`'s GMS manifest metadata.** My reading of `scanner.py` says manifest attributes are not scanned by either the gradle or the binary signature path, so it should pass. Not confirmed against a real scanner run.
+- **Whether Sentry draws a `Tracking` flag when it is opt-in and default-off.** kDrive's flag text explicitly says "enabled by default", implying default-off might be treated differently, but I found no policy text or counter-example that settles it.
+- **Whether `NonFreeAssets` gets applied to the bundled Unsplash photos.** The policy's non-functional-assets clause is lenient enough that it may not; the license's field-of-use restriction is real either way.
+- **RFP #2540's discussion.** The GitLab notes API returned `401 Unauthorized` for an anonymous request, so I could only read the issue body and its `updated_at`. The timestamps strongly suggest there is no human discussion on it, but I have not read the comments.
+- **`CustomIcons.ttf` provenance.** `fonts/OFL.txt` covers Poppins and Nunito. I could not determine where `fonts/CustomIcons.ttf` came from or under what licence. Worth pinning down before a reviewer asks.
+- **The v1.4.x versionCode discrepancy** (release titles say 701/703, `pubspec.yaml` says 56/57). Not resolved; irrelevant going forward but noted in case someone trips over it.
+- **APK size limits.** I found none documented in `fdroidserver` or `fdroiddata/.gitlab-ci.yml`. A 100 MB APK may still draw a reviewer comment.
+- **Flutter 3.44.6's exact `flutter build apk` behaviour with two flavors and no `--flavor`.** I assumed it fails or is ambiguous based on the repo always passing `--flavor full`; not tested.


### PR DESCRIPTION
Five research documents written while scoping #599 (AI-assisted meal logging) and #575 (F-Droid submission). No code changes.

They are **already linked from public comments on #599**, where the links are currently dead because the files only ever existed on a local branch. That's the main reason to land this.

## What's here

| Document | Answers |
|---|---|
| `ai-in-open-source-nutrition-trackers.md` | What comparable open-source trackers actually shipped, and which failures they hit first |
| `ai-legal-constraints.md` | EU AI Act, Apple/Google store policies, F-Droid |
| `ai-cohort-restrictions.md` | What those licences and policies *forbid us* from doing — as opposed to what others did |
| `ai-open-research-questions.md` | Gap analysis: what is still unanswered, and which items are decisions rather than research |
| `fdroid-submission-feasibility.md` | Feasibility review for #575 |

## Two things to know before reading

**They correct each other.** Written in the order above, and the later ones supersede the earlier ones in places — the F-Droid conclusions in `ai-legal-constraints.md` are corrected twice, and its Digital Omnibus item has since been verified against EUR-Lex. The two earliest now carry a banner at the top saying what superseded them and where, so nobody acts on a stale conclusion.

**They are research, not decisions.** The decisions live in #599 and its comments. Each document keeps its own "not verified" section rather than presenting everything at one confidence level — notably the OpenAI Services Agreement citation, which still rests on a third-party mirror because `openai.com` returned 403 to every route.

## Worth flagging from the contents

Two present-tense findings in here are **not about AI** and need their own issues:

- **Bundled Google ML Kit blocks the F-Droid RFP** ([fdroid/rfp#2540](https://gitlab.com/fdroid/rfp/-/issues/2540)) today. `mobile_scanner` links it and no `useUnbundled` flag is set anywhere in `android/`. Reached independently by two of these documents, one written for #575 weeks earlier. The escape route is known — Open Food Facts strips it via a second Dart entry point, and `flutter_zxing` (MIT) covers every symbology this app uses.
- **The Play Store listing has no medical-device disclaimer**, which Google's Health apps policy requires.
