### PR TITLE
fix(l10n): make the Ukrainian and Chinese bulk-add hints parseable

### DIFF
--- a/lib/features/add_meal/util/meal_text_parser.dart
+++ b/lib/features/add_meal/util/meal_text_parser.dart
@@ -54,10 +54,22 @@ class MealTextParseResult {
 /// `Omega 3,6,9 capsules` reached the food search with characters the user
 /// never typed. The decimal comma is now converted only inside the number
 /// actually parsed, in [_parseQuantity].
-final _separator = RegExp(r'[;+\n]|(?<!\d),|,(?!\d)');
+///
+/// The CJK separators — `、` (ideographic comma), `，` and `；` (fullwidth
+/// comma and semicolon) — are here because a Chinese, Japanese or Korean
+/// keyboard emits them by default. Without them a user typing a list the
+/// only way their keyboard offers gets a single unparsed row no matter what
+/// the placeholder demonstrates.
+///
+/// They are punctuation, not vocabulary, so this does not reintroduce the
+/// per-locale word lists this parser was designed to avoid: the set is
+/// fixed, tiny, and does not grow when a language is added. None of them
+/// carries a decimal meaning, so unlike `,` they need no lookaround.
+final _separator = RegExp(r'[;+\n、，；]|(?<!\d),|,(?!\d)');
 
 /// Splits [input] into trimmed, non-empty pieces on `,` / `;` / newline /
-/// `+`, subject to the comma rule on [_separator].
+/// `+` and their CJK equivalents, subject to the comma rule on
+/// [_separator].
 List<String> _segment(String input) => input
     .split(_separator)
     .map((s) => s.trim())

--- a/lib/l10n/intl_uk.arb
+++ b/lib/l10n/intl_uk.arb
@@ -1105,7 +1105,7 @@
   "scannerLockOrientationTooltip": "Зафіксувати вертикально",
   "scannerUnlockOrientationTooltip": "Дозволити обертання",
   "bulkAddTitle": "Додати кілька позицій",
-  "bulkAddInputHint": "2 яйця, 100г тост, чорна кава",
+  "bulkAddInputHint": "2 яйця, 100g тост, чорна кава",
   "bulkAddParseLabel": "Знайти продукти",
   "bulkAddSubmitLabel": "Записати {count} позицій",
   "bulkAddNoMatchLabel": "Не вдалося знайти відповідник",

--- a/lib/l10n/intl_zh.arb
+++ b/lib/l10n/intl_zh.arb
@@ -1106,7 +1106,7 @@
   "scannerLockOrientationTooltip": "锁定为竖屏",
   "scannerUnlockOrientationTooltip": "允许旋转",
   "bulkAddTitle": "批量添加",
-  "bulkAddInputHint": "2个鸡蛋、100克吐司、黑咖啡",
+  "bulkAddInputHint": "100g 吐司, 250ml 牛奶, 黑咖啡",
   "bulkAddParseLabel": "查找食物",
   "bulkAddSubmitLabel": "记录 {count} 项",
   "bulkAddNoMatchLabel": "未找到匹配的食物",

--- a/lib/l10n/intl_zh.arb
+++ b/lib/l10n/intl_zh.arb
@@ -1106,7 +1106,7 @@
   "scannerLockOrientationTooltip": "锁定为竖屏",
   "scannerUnlockOrientationTooltip": "允许旋转",
   "bulkAddTitle": "批量添加",
-  "bulkAddInputHint": "100g 吐司, 250ml 牛奶, 黑咖啡",
+  "bulkAddInputHint": "100g 吐司，250ml 牛奶，黑咖啡",
   "bulkAddParseLabel": "查找食物",
   "bulkAddSubmitLabel": "记录 {count} 项",
   "bulkAddNoMatchLabel": "未找到匹配的食物",

--- a/test/unit_test/bulk_add_hint_test.dart
+++ b/test/unit_test/bulk_add_hint_test.dart
@@ -1,0 +1,78 @@
+import 'dart:convert';
+import 'dart:io';
+
+import 'package:flutter_test/flutter_test.dart';
+import 'package:opennutritracker/features/add_meal/util/meal_text_parser.dart';
+
+/// The placeholder in the bulk-add text field is instructional — it is the
+/// only place the syntax is explained, so a hint the parser cannot read
+/// teaches the user a format that produces nothing.
+///
+/// Two shipped hints did exactly that: the Ukrainian one used a Cyrillic
+/// "г" (U+0433) rather than a Latin "g", and the Chinese one used 克 for
+/// gram and 、 as the separator. Neither is a unit symbol or a separator
+/// the parser recognises, so `100г тост` kept its digits in the food name
+/// and the whole Chinese hint collapsed to a single unparsed item.
+///
+/// This reads the ARBs off disk rather than through the generated
+/// localizations so it covers every locale without needing a widget test.
+void main() {
+  final arbDir = Directory('lib/l10n');
+
+  test('every locale hint parses into three items', () {
+    final files = arbDir
+        .listSync()
+        .whereType<File>()
+        .where((f) => f.path.endsWith('.arb'))
+        .toList();
+
+    expect(files, isNotEmpty, reason: 'no ARB files found');
+
+    for (final file in files) {
+      final locale = file.uri.pathSegments.last;
+      final hint =
+          (jsonDecode(file.readAsStringSync()) as Map)['bulkAddInputHint']
+              as String?;
+      expect(hint, isNotNull, reason: '$locale is missing bulkAddInputHint');
+
+      final result = parseMealText(hint!);
+
+      expect(
+        result.errors,
+        isEmpty,
+        reason: '$locale hint "$hint" produced parse errors',
+      );
+      expect(
+        result.items,
+        hasLength(3),
+        reason:
+            '$locale hint "$hint" parsed into ${result.items.length} items, '
+            'but it depicts three',
+      );
+
+      // At least two of the three must carry a quantity — the hint exists
+      // to demonstrate that amounts are understood. A hint where every
+      // amount is silently dropped looks like it works but teaches nothing.
+      final withQuantity = result.items.where((i) => i.quantity != null);
+      expect(
+        withQuantity,
+        hasLength(greaterThanOrEqualTo(2)),
+        reason:
+            '$locale hint "$hint" only had ${withQuantity.length} item(s) '
+            'with a recognised quantity',
+      );
+
+      // Digits left in a food name mean the amount was not understood and
+      // will be sent to the food search as part of the query.
+      for (final item in result.items) {
+        expect(
+          RegExp(r'\d').hasMatch(item.query),
+          isFalse,
+          reason:
+              '$locale hint "$hint" left digits in the query "${item.query}" '
+              '— the amount was not recognised',
+        );
+      }
+    }
+  });
+}

--- a/test/unit_test/meal_text_parser_test.dart
+++ b/test/unit_test/meal_text_parser_test.dart
@@ -91,6 +91,52 @@ void main() {
     });
   });
 
+  group('parseMealText CJK separators', () {
+    // A Chinese, Japanese or Korean keyboard emits these by default, so
+    // without them a user typing a list the only way their keyboard offers
+    // gets one unparsed row regardless of what the placeholder shows.
+    test('the ideographic comma separates items', () {
+      final result = parseMealText('100g 吐司、250ml 牛奶、黑咖啡');
+
+      expect(result.errors, isEmpty);
+      expect(result.items.map((i) => i.query), ['吐司', '牛奶', '黑咖啡']);
+      expect(result.items.map((i) => i.quantity), [100, 250, null]);
+    });
+
+    test('the fullwidth comma and semicolon separate items', () {
+      expect(parseMealText('100g 吐司，250ml 牛奶').items, hasLength(2));
+      expect(parseMealText('100g 吐司；250ml 牛奶').items, hasLength(2));
+    });
+
+    test('the ideographic space is treated as whitespace', () {
+      // U+3000 is matched by \\s, so a quantity separated from the food by
+      // one is still recognised.
+      final item = parseMealText('100g\u3000吐司').items.single;
+
+      expect(item.query, '吐司');
+      expect(item.quantity, 100);
+      expect(item.unit, 'g');
+    });
+
+    test('CJK and ASCII separators mix in one line', () {
+      final result = parseMealText('100g toast，2 eggs、200ml milk');
+
+      expect(result.items.map((i) => i.query), ['toast', 'eggs', 'milk']);
+    });
+
+    test('none of them carries a decimal meaning', () {
+      // Unlike ',' these never need the digit-on-both-sides guard, so a
+      // number on both sides must still split. The leading '1' then has no
+      // letters and is reported rather than logged, which is the proof the
+      // split happened at all.
+      final result = parseMealText('1，5 l milk');
+
+      expect(result.items.single.quantity, 5000);
+      expect(result.items.single.unit, 'ml');
+      expect(result.errors, ['Item 1: not a valid food name']);
+    });
+  });
+
   group('parseMealText quantity/unit extraction', () {
     test('leading quantity with no space before the unit (100g toast)', () {
       final item = parseMealText('100g toast').items.single;


### PR DESCRIPTION
Fixes #623.

The placeholder in the bulk-add field is the only place the input syntax is explained, so a hint the parser cannot read teaches a format that does not work. Two of the nine did:

| Locale | Was | Result |
|---|---|---|
| `uk` | `2 яйця, 100г тост, чорна кава` | middle item kept its digits: `query="100г тост"`, no quantity |
| `zh` | `2个鸡蛋、100克吐司、黑咖啡` | one unparsed item |

The Ukrainian `г` is Cyrillic ge (U+0433), not Latin `g` — visually identical, functionally not a unit. The Chinese hint uses `克` for gram and `、` as separator, neither recognised.

## The change

Ukrainian swaps to a Latin `g`; the food names are untouched.

Chinese becomes `100g 吐司, 250ml 牛奶, 黑咖啡` — two weights, no count. **A count cannot be demonstrated in Chinese**: the counter sits between number and noun with no spaces, so `2个鸡蛋` is one token and `2 个鸡蛋` merely moves `个` into the food name. Showing an unnatural word order to demonstrate a feature is worse than demonstrating the part that works.

## The test

Reads every ARB off disk and asserts each hint parses into the three items it depicts, with at least two amounts recognised and **no digits stranded in a query** — digits left in a food name are the signature of an amount that was not understood.

It fails on both old strings with the reason spelled out:

```
intl_zh.arb hint "2个鸡蛋、100克吐司、黑咖啡" parsed into 1 items, but it depicts three
```

Reading the ARBs directly rather than going through the generated localizations means it covers all nine locales without a widget test, and it will cover any locale added later for free.

## Verification

`flutter test` → 1055/1055. `flutter analyze` clean. ARB parity holds at 932 keys across all nine.

## Also here: CJK list separators

`、` `，` `；` are now separators, and the Chinese hint uses `，` rather than an ASCII comma.

Fixing the hint alone would have told a Chinese user to reach for a punctuation mark their keyboard does not produce — a CJK keyboard emits the fullwidth forms by default, so the feature was broken for them regardless of what the placeholder said.

This does not reintroduce per-locale word lists: the set is punctuation, fixed, tiny, and does not grow when a language is added. None of them carries a decimal meaning, so unlike `,` they need no lookaround.

Two things fell out for free:

- **U+3000, the ideographic space, is already matched by `\s`** — `100g　吐司` resolves with no further work.
- The original broken hint now yields **three separate rows** the user can fix individually rather than one unparsable row, even though the counts in it still cannot be read.

Tests cover each separator, the ideographic space, CJK and ASCII mixed in one line, and that a number on both sides of a fullwidth comma still splits. Japanese and Korean patterns were verified too, though neither locale ships yet.

## Still not addressed

The parser locates a quantity by looking for a number adjacent to whitespace, so **languages that do not space their words still cannot express counts**. `2个鸡蛋` remains unreadable — the counter sits between number and noun with no separator to key off. For `zh` this feature now supports weights with Latin unit symbols, in either comma style. That gap needs a decision rather than a workaround and stays recorded in #623.

