### PR TITLE
feat(add-meal): add deterministic meal text parser

### DIFF
--- a/lib/features/add_meal/util/meal_text_parser.dart
+++ b/lib/features/add_meal/util/meal_text_parser.dart
@@ -1,0 +1,135 @@
+import 'package:opennutritracker/core/utils/food_name_validator.dart';
+
+const _maxQuantity = 10000;
+const _validUnits = {'g', 'ml', 'g/ml', 'oz', 'fl.oz', 'serving'};
+const _unitSymbol = r'(?:kg|ml|oz|g|l)';
+const _number = r'-?\d+(?:[.,]\d+)?';
+
+/// An item parsed from the Tier-0 multi-item entry field.
+class ParsedMealItem {
+  final String query;
+  final double? quantity;
+  final String? unit;
+
+  const ParsedMealItem({required this.query, this.quantity, this.unit});
+}
+
+/// Parsed items plus validation errors for input segments that cannot be
+/// safely passed to the existing food search.
+class MealTextParseResult {
+  final List<ParsedMealItem> items;
+  final List<String> errors;
+
+  const MealTextParseResult({required this.items, required this.errors});
+
+  bool get hasErrors => errors.isNotEmpty;
+}
+
+/// Commas surrounded by digits are decimal marks; every other comma, plus
+/// semicolons, newlines, and plus signs, separates meal items.
+final _separator = RegExp(r'[;+\n]|(?<!\d),|,(?!\d)');
+final _leadingQuantity = RegExp(
+  '^($_number)\\s*($_unitSymbol)?\\s+(.+)$',
+  caseSensitive: false,
+);
+final _trailingQuantity = RegExp(
+  '^(.+?)\\s+($_number)\\s*($_unitSymbol)?\\s*$',
+  caseSensitive: false,
+);
+final _quantityAndUnitOnly = RegExp(
+  '^($_number)\\s*($_unitSymbol)\\s*$',
+  caseSensitive: false,
+);
+
+class _ExtractedItem {
+  final String query;
+  final double? quantity;
+  final String? unit;
+
+  const _ExtractedItem({required this.query, this.quantity, this.unit});
+}
+
+double _parseQuantity(String value) => double.parse(value.replaceAll(',', '.'));
+
+_ExtractedItem _extract(String segment) {
+  final quantityOnly = _quantityAndUnitOnly.firstMatch(segment);
+  if (quantityOnly != null) {
+    return _ExtractedItem(
+      query: '',
+      quantity: _parseQuantity(quantityOnly.group(1)!),
+      unit: quantityOnly.group(2)!.toLowerCase(),
+    );
+  }
+
+  final leading = _leadingQuantity.firstMatch(segment);
+  if (leading != null) {
+    return _ExtractedItem(
+      query: leading.group(3)!,
+      quantity: _parseQuantity(leading.group(1)!),
+      unit: leading.group(2)?.toLowerCase(),
+    );
+  }
+
+  final trailing = _trailingQuantity.firstMatch(segment);
+  if (trailing != null) {
+    return _ExtractedItem(
+      query: trailing.group(1)!,
+      quantity: _parseQuantity(trailing.group(2)!),
+      unit: trailing.group(3)?.toLowerCase(),
+    );
+  }
+
+  return _ExtractedItem(query: segment, quantity: null, unit: null);
+}
+
+(double, String) _normalizeUnit(double quantity, String unit) {
+  return switch (unit) {
+    'kg' => (quantity * 1000, 'g'),
+    'l' => (quantity * 1000, 'ml'),
+    _ => (quantity, unit),
+  };
+}
+
+/// Parses offline text such as `100g toast, 2 eggs; 1,5 l milk` into search
+/// intents. It never estimates nutrition and emits only units accepted by the
+/// existing meal-detail unit selector.
+MealTextParseResult parseMealText(String input) {
+  final segments = input
+      .trim()
+      .split(_separator)
+      .map((segment) => segment.trim())
+      .where((segment) => segment.isNotEmpty);
+  final items = <ParsedMealItem>[];
+  final errors = <String>[];
+  var itemNumber = 0;
+
+  for (final segment in segments) {
+    itemNumber++;
+    final extracted = _extract(segment);
+    final query = extracted.query.trim();
+    if (!FoodNameValidator.isValid(query)) {
+      errors.add('Item $itemNumber: not a valid food name');
+      continue;
+    }
+
+    var quantity = extracted.quantity;
+    var unit = extracted.unit;
+    if (quantity != null && unit != null) {
+      (quantity, unit) = _normalizeUnit(quantity, unit);
+    }
+
+    if (quantity != null && quantity <= 0) {
+      errors.add('Item $itemNumber: quantity must be greater than 0');
+      continue;
+    }
+    if (quantity != null && quantity > _maxQuantity) {
+      errors.add('Item $itemNumber: quantity must be $_maxQuantity or less');
+      continue;
+    }
+
+    assert(unit == null || _validUnits.contains(unit));
+    items.add(ParsedMealItem(query: query, quantity: quantity, unit: unit));
+  }
+
+  return MealTextParseResult(items: items, errors: errors);
+}

--- a/test/unit_test/meal_text_parser_test.dart
+++ b/test/unit_test/meal_text_parser_test.dart
@@ -1,0 +1,76 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:opennutritracker/features/add_meal/util/meal_text_parser.dart';
+
+void main() {
+  group('parseMealText', () {
+    test('segments all supported separators and retains decimal commas', () {
+      final result = parseMealText('toast, eggs; bacon\ncoffee+juice,1,5 l milk');
+
+      expect(result.errors, isEmpty);
+      expect(result.items.map((item) => item.query), [
+        'toast',
+        'eggs',
+        'bacon',
+        'coffee',
+        'juice',
+        'milk',
+      ]);
+      expect(result.items.last.quantity, 1500);
+      expect(result.items.last.unit, 'ml');
+    });
+
+    test('extracts leading and trailing quantities without rewriting food names', () {
+      final items = [
+        parseMealText('100g toast').items.single,
+        parseMealText('toast 100g').items.single,
+        parseMealText('2 chicken breasts').items.single,
+        parseMealText('yoghurt 3,5% fat').items.single,
+      ];
+
+      expect(items.map((item) => item.query), [
+        'toast',
+        'toast',
+        'chicken breasts',
+        'yoghurt 3,5% fat',
+      ]);
+      expect(items.map((item) => item.quantity), [100, 100, 2, null]);
+      expect(items.map((item) => item.unit), ['g', 'g', null, null]);
+    });
+
+    test('normalizes only supported input units to app units', () {
+      final items = [
+        parseMealText('1kg flour').items.single,
+        parseMealText('1.5 l milk').items.single,
+        parseMealText('4oz steak').items.single,
+        parseMealText('100ml juice').items.single,
+      ];
+
+      expect(items.map((item) => item.quantity), [1000, 1500, 4, 100]);
+      expect(items.map((item) => item.unit), ['g', 'ml', 'oz', 'ml']);
+      const supportedUnits = {'g', 'ml', 'g/ml', 'oz', 'fl.oz', 'serving'};
+      for (final item in items) {
+        expect(item.unit == null || supportedUnits.contains(item.unit), isTrue);
+      }
+    });
+
+    test('rejects malformed names and invalid quantities without adding items', () {
+      final result = parseMealText('100g, 0g water, -5kg flour, 15kg rice, toast');
+
+      expect(result.items.map((item) => item.query), ['toast']);
+      expect(result.errors, [
+        'Item 1: not a valid food name',
+        'Item 2: quantity must be greater than 0',
+        'Item 3: quantity must be greater than 0',
+        'Item 4: quantity must be 10000 or less',
+      ]);
+    });
+
+    test('keeps unrecognized unit-like text as a food query', () {
+      final item = parseMealText('100xyz toast').items.single;
+
+      expect(item.query, '100xyz toast');
+      expect(item.quantity, isNull);
+      expect(item.unit, isNull);
+    });
+  });
+}


### PR DESCRIPTION
## Summary

Adds the approved Tier-0 offline parser for multi-item meal text. It splits supported item separators while preserving decimal commas, extracts leading or trailing quantities, normalizes `kg` to `g` and `l` to `ml`, and rejects invalid or oversized quantities.

Focused parser tests cover segmentation, decimal commas, quantity placement, unit conversion, bounds, malformed input, and supported-unit invariants.

## Scope

This is limited to the #600 parser milestone. Database resolution (#601), review and atomic logging UI (#602), and all cloud/AI tiers remain deferred.

## Verification

- `git diff --check` passed for both added files.
- The focused Flutter test and `flutter analyze` were not run: the required Docker runner could not start because the Colima Docker socket was unavailable.

Part of #599; implements its approved #600 Tier-0 milestone.
