### PR TITLE
fix(add-meal): read a bare count as servings, not grams

### DIFF
--- a/lib/features/add_meal/presentation/bloc/bulk_add_bloc.dart
+++ b/lib/features/add_meal/presentation/bloc/bulk_add_bloc.dart
@@ -90,7 +90,13 @@ class BulkAddRow extends Equatable {
       meal?.servingQuantity == null;
 
   List<String> get allowedUnits => [
-    if (meal?.hasServingValues ?? false) UnitDropdownItem.serving.toString(),
+    // Only when the serving can actually be scaled. `hasServingValues` is
+    // also true for a record carrying nothing but `servingSize` text, and
+    // `convertQuantityToBaseUnit` leaves those unscaled — so offering
+    // `serving` there is a no-op dressed as a fix. Worse, it is the option
+    // a user reaches for after reading `amountNeedsCheck`: picking it
+    // relabels the row, clears the warning and logs the same wrong number.
+    if (meal?.servingQuantity != null) UnitDropdownItem.serving.toString(),
     if (meal?.isSolid ?? false) ...[
       UnitDropdownItem.g.toString(),
       UnitDropdownItem.oz.toString(),

--- a/lib/features/add_meal/presentation/bloc/bulk_add_bloc.dart
+++ b/lib/features/add_meal/presentation/bloc/bulk_add_bloc.dart
@@ -31,9 +31,9 @@ class BulkAddRow extends Equatable {
   /// decision stays visible and reversible until the batch is logged.
   final bool skipped;
 
-  /// True when the user typed a bare count the app could not interpret —
-  /// see `_amountNeedsCheck`. Purely advisory: the row is still loggable.
-  final bool amountNeedsCheck;
+  /// Set once the user picks a unit from the dropdown themselves, which
+  /// settles [amountNeedsCheck] — they have made the call it was asking for.
+  final bool unitChosenByUser;
 
   const BulkAddRow({
     required this.resolved,
@@ -41,7 +41,7 @@ class BulkAddRow extends Equatable {
     required this.amountText,
     required this.unit,
     this.skipped = false,
-    this.amountNeedsCheck = false,
+    this.unitChosenByUser = false,
   });
 
   bool get isResolved => resolved.isResolved;
@@ -55,6 +55,30 @@ class BulkAddRow extends Equatable {
 
   MealEntity? get meal =>
       isResolved ? resolved.candidates[selectedIndex] : null;
+
+  /// The user stated a count the app cannot interpret: no unit was typed and
+  /// the matched food has no scalable serving, so there is nothing for the
+  /// "2" in `2 eggs` to count. The row still logs — both fields are editable
+  /// — but it is marked so the eye lands on the one row needing a decision
+  /// rather than on a plausible-looking wrong number (#622).
+  ///
+  /// Derived rather than stored, so picking a different candidate
+  /// re-evaluates it against the food actually selected. A stored flag
+  /// survived the switch and could leave a wrong number unflagged.
+  ///
+  /// [MealEntity.hasServingValues] is deliberately *not* the gate: it is
+  /// also true for a record carrying only unparseable `servingSize` text
+  /// ("1 egg"), which `convertQuantityToBaseUnit` cannot scale. Only
+  /// `servingQuantity` makes a count convertible.
+  bool get amountNeedsCheck =>
+      !unitChosenByUser &&
+      // An unresolved row has no food to count, and already says so. A
+      // second complaint about its amount is noise on a row that cannot be
+      // logged anyway.
+      isResolved &&
+      resolved.parsed.quantity != null &&
+      resolved.parsed.unit == null &&
+      meal?.servingQuantity == null;
 
   List<String> get allowedUnits => [
     if (meal?.hasServingValues ?? false) UnitDropdownItem.serving.toString(),
@@ -86,13 +110,14 @@ class BulkAddRow extends Equatable {
     String? amountText,
     String? unit,
     bool? skipped,
+    bool? unitChosenByUser,
   }) => BulkAddRow(
     resolved: resolved,
     selectedIndex: selectedIndex ?? this.selectedIndex,
     amountText: amountText ?? this.amountText,
     unit: unit ?? this.unit,
     skipped: skipped ?? this.skipped,
-    amountNeedsCheck: amountNeedsCheck,
+    unitChosenByUser: unitChosenByUser ?? this.unitChosenByUser,
   );
 
   @override
@@ -102,7 +127,7 @@ class BulkAddRow extends Equatable {
     amountText,
     unit,
     skipped,
-    amountNeedsCheck,
+    unitChosenByUser,
   ];
 }
 
@@ -153,7 +178,6 @@ class BulkAddBloc extends Bloc<BulkAddEvent, BulkAddState> {
                 selectedIndex: item.selectedIndex,
                 amountText: _initialAmount(item, event.usesImperialUnits),
                 unit: _initialUnit(item, event.usesImperialUnits),
-                amountNeedsCheck: _amountNeedsCheck(item),
               ),
           ],
           parseErrors: parsed.errors,
@@ -187,37 +211,31 @@ class BulkAddBloc extends Bloc<BulkAddEvent, BulkAddState> {
     if (parsedUnit != null) return parsedUnit;
 
     final meal = item.selected;
-    final hasServing = meal != null && meal.hasServingValues;
+    final fallback = usesImperialUnits
+        ? UnitDropdownItem.oz.toString()
+        : UnitDropdownItem.gml.toString();
+    if (meal == null) return fallback;
 
-    // A bare count means "N of them", and when the food carries serving
-    // data that is precisely what a serving is — so `2 eggs` is two
+    // A bare count means "N of them", and when the record's serving can be
+    // scaled that is precisely what a serving is — so `2 eggs` is two
     // servings. Falling through to grams instead turned a count into a
     // weight and logged two grams of egg (#622).
-    if (item.parsed.quantity != null && hasServing) {
+    //
+    // Gate on `servingQuantity`, not `hasServingValues`: the latter is also
+    // true for a record with only unparseable `servingSize` text, which
+    // `convertQuantityToBaseUnit` leaves unscaled. Labelling those `serving`
+    // would rename the bug rather than fix it — the row would read
+    // "2 serving" and still log 2 g. Those fall through to the weight
+    // default below and are marked by `BulkAddRow.amountNeedsCheck`.
+    if (item.parsed.quantity != null && meal.servingQuantity != null) {
       return UnitDropdownItem.serving.toString();
     }
 
-    if (hasServing) {
+    if (meal.hasServingValues) {
       return meal.servingUnit ?? UnitDropdownItem.gml.toString();
     }
-    return usesImperialUnits
-        ? UnitDropdownItem.oz.toString()
-        : UnitDropdownItem.gml.toString();
+    return fallback;
   }
-
-  /// A stated count the app cannot interpret: no unit was typed and the
-  /// matched food carries no serving data, so there is nothing for "2" to
-  /// count. The row still logs — the amount and unit are editable — but it
-  /// is marked so the user's eye lands on the one row that needs a decision
-  /// rather than on a plausible-looking wrong number.
-  bool _amountNeedsCheck(ResolvedMealItem item) =>
-      // An unresolved row has no food to count, and already says so. Adding
-      // a second complaint about its amount is noise on a row that cannot
-      // be logged anyway.
-      item.isResolved &&
-      item.parsed.quantity != null &&
-      item.parsed.unit == null &&
-      !(item.selected?.hasServingValues ?? false);
 
   static String _trimZeros(double value) => value == value.roundToDouble()
       ? value.toInt().toString()
@@ -243,7 +261,13 @@ class BulkAddBloc extends Bloc<BulkAddEvent, BulkAddState> {
   }
 
   void _onChangeUnit(ChangeRowUnitEvent event, Emitter<BulkAddState> emit) {
-    _updateRow(event.rowIndex, emit, (row) => row.copyWith(unit: event.unit));
+    _updateRow(
+      event.rowIndex,
+      emit,
+      // Picking a unit answers the question `amountNeedsCheck` was asking,
+      // so the row stops asking it.
+      (row) => row.copyWith(unit: event.unit, unitChosenByUser: true),
+    );
   }
 
   void _onToggleSkipped(

--- a/lib/features/add_meal/presentation/bloc/bulk_add_bloc.dart
+++ b/lib/features/add_meal/presentation/bloc/bulk_add_bloc.dart
@@ -35,6 +35,14 @@ class BulkAddRow extends Equatable {
   /// settles [amountNeedsCheck] — they have made the call it was asking for.
   final bool unitChosenByUser;
 
+  /// Set once the user types in the amount field.
+  final bool amountEditedByUser;
+
+  /// True while the amount and unit are still what the bloc derived, so
+  /// re-deriving them against a newly picked candidate cannot overwrite
+  /// anything the user typed or chose.
+  bool get isPristine => !unitChosenByUser && !amountEditedByUser;
+
   const BulkAddRow({
     required this.resolved,
     required this.selectedIndex,
@@ -42,6 +50,7 @@ class BulkAddRow extends Equatable {
     required this.unit,
     this.skipped = false,
     this.unitChosenByUser = false,
+    this.amountEditedByUser = false,
   });
 
   bool get isResolved => resolved.isResolved;
@@ -111,6 +120,7 @@ class BulkAddRow extends Equatable {
     String? unit,
     bool? skipped,
     bool? unitChosenByUser,
+    bool? amountEditedByUser,
   }) => BulkAddRow(
     resolved: resolved,
     selectedIndex: selectedIndex ?? this.selectedIndex,
@@ -118,6 +128,7 @@ class BulkAddRow extends Equatable {
     unit: unit ?? this.unit,
     skipped: skipped ?? this.skipped,
     unitChosenByUser: unitChosenByUser ?? this.unitChosenByUser,
+    amountEditedByUser: amountEditedByUser ?? this.amountEditedByUser,
   );
 
   @override
@@ -128,6 +139,7 @@ class BulkAddRow extends Equatable {
     unit,
     skipped,
     unitChosenByUser,
+    amountEditedByUser,
   ];
 }
 
@@ -176,8 +188,16 @@ class BulkAddBloc extends Bloc<BulkAddEvent, BulkAddState> {
               BulkAddRow(
                 resolved: item,
                 selectedIndex: item.selectedIndex,
-                amountText: _initialAmount(item, event.usesImperialUnits),
-                unit: _initialUnit(item, event.usesImperialUnits),
+                amountText: _initialAmount(
+                  item.parsed,
+                  item.selected,
+                  event.usesImperialUnits,
+                ),
+                unit: _initialUnit(
+                  item.parsed,
+                  item.selected,
+                  event.usesImperialUnits,
+                ),
               ),
           ],
           parseErrors: parsed.errors,
@@ -194,11 +214,14 @@ class BulkAddBloc extends Bloc<BulkAddEvent, BulkAddState> {
   /// The parser leaves quantity null when the user stated none. Fall back to
   /// the same defaults the meal-detail screen already applies, so a bulk row
   /// and a hand-added row of the same food start from the same number.
-  String _initialAmount(ResolvedMealItem item, bool usesImperialUnits) {
-    final parsedQuantity = item.parsed.quantity;
+  String _initialAmount(
+    ParsedMealItem parsed,
+    MealEntity? meal,
+    bool usesImperialUnits,
+  ) {
+    final parsedQuantity = parsed.quantity;
     if (parsedQuantity != null) return _trimZeros(parsedQuantity);
 
-    final meal = item.selected;
     if (meal != null && meal.hasServingValues) {
       final serving = meal.servingQuantity;
       if (serving != null) return _trimZeros(serving);
@@ -206,11 +229,14 @@ class BulkAddBloc extends Bloc<BulkAddEvent, BulkAddState> {
     return usesImperialUnits ? '1' : '100';
   }
 
-  String _initialUnit(ResolvedMealItem item, bool usesImperialUnits) {
-    final parsedUnit = item.parsed.unit;
+  String _initialUnit(
+    ParsedMealItem parsed,
+    MealEntity? meal,
+    bool usesImperialUnits,
+  ) {
+    final parsedUnit = parsed.unit;
     if (parsedUnit != null) return parsedUnit;
 
-    final meal = item.selected;
     final fallback = usesImperialUnits
         ? UnitDropdownItem.oz.toString()
         : UnitDropdownItem.gml.toString();
@@ -227,7 +253,7 @@ class BulkAddBloc extends Bloc<BulkAddEvent, BulkAddState> {
     // would rename the bug rather than fix it — the row would read
     // "2 serving" and still log 2 g. Those fall through to the weight
     // default below and are marked by `BulkAddRow.amountNeedsCheck`.
-    if (item.parsed.quantity != null && meal.servingQuantity != null) {
+    if (parsed.quantity != null && meal.servingQuantity != null) {
       return UnitDropdownItem.serving.toString();
     }
 
@@ -245,18 +271,31 @@ class BulkAddBloc extends Bloc<BulkAddEvent, BulkAddState> {
     ChangeRowCandidateEvent event,
     Emitter<BulkAddState> emit,
   ) {
-    _updateRow(
-      event.rowIndex,
-      emit,
-      (row) => row.copyWith(selectedIndex: event.candidateIndex),
-    );
+    final current = state;
+    final imperial = current is BulkAddLoadedState && current.usesImperialUnits;
+
+    _updateRow(event.rowIndex, emit, (row) {
+      final moved = row.copyWith(selectedIndex: event.candidateIndex);
+      // A different food means different defaults. Re-derive them, or the
+      // row keeps the previous candidate's unit — picking a countable
+      // record after an uncountable one cleared the "check the unit"
+      // warning while the amount stayed a weight, which is the #622
+      // failure again with the warning switched off. Only for a pristine
+      // row: anything the user typed or chose outranks a default.
+      if (!moved.isPristine) return moved;
+      return moved.copyWith(
+        amountText: _initialAmount(row.resolved.parsed, moved.meal, imperial),
+        unit: _initialUnit(row.resolved.parsed, moved.meal, imperial),
+      );
+    });
   }
 
   void _onChangeAmount(ChangeRowAmountEvent event, Emitter<BulkAddState> emit) {
     _updateRow(
       event.rowIndex,
       emit,
-      (row) => row.copyWith(amountText: event.amountText),
+      (row) =>
+          row.copyWith(amountText: event.amountText, amountEditedByUser: true),
     );
   }
 

--- a/lib/features/add_meal/presentation/bloc/bulk_add_bloc.dart
+++ b/lib/features/add_meal/presentation/bloc/bulk_add_bloc.dart
@@ -31,12 +31,17 @@ class BulkAddRow extends Equatable {
   /// decision stays visible and reversible until the batch is logged.
   final bool skipped;
 
+  /// True when the user typed a bare count the app could not interpret —
+  /// see `_amountNeedsCheck`. Purely advisory: the row is still loggable.
+  final bool amountNeedsCheck;
+
   const BulkAddRow({
     required this.resolved,
     required this.selectedIndex,
     required this.amountText,
     required this.unit,
     this.skipped = false,
+    this.amountNeedsCheck = false,
   });
 
   bool get isResolved => resolved.isResolved;
@@ -87,6 +92,7 @@ class BulkAddRow extends Equatable {
     amountText: amountText ?? this.amountText,
     unit: unit ?? this.unit,
     skipped: skipped ?? this.skipped,
+    amountNeedsCheck: amountNeedsCheck,
   );
 
   @override
@@ -96,6 +102,7 @@ class BulkAddRow extends Equatable {
     amountText,
     unit,
     skipped,
+    amountNeedsCheck,
   ];
 }
 
@@ -146,6 +153,7 @@ class BulkAddBloc extends Bloc<BulkAddEvent, BulkAddState> {
                 selectedIndex: item.selectedIndex,
                 amountText: _initialAmount(item, event.usesImperialUnits),
                 unit: _initialUnit(item, event.usesImperialUnits),
+                amountNeedsCheck: _amountNeedsCheck(item),
               ),
           ],
           parseErrors: parsed.errors,
@@ -179,13 +187,37 @@ class BulkAddBloc extends Bloc<BulkAddEvent, BulkAddState> {
     if (parsedUnit != null) return parsedUnit;
 
     final meal = item.selected;
-    if (meal != null && meal.hasServingValues) {
+    final hasServing = meal != null && meal.hasServingValues;
+
+    // A bare count means "N of them", and when the food carries serving
+    // data that is precisely what a serving is — so `2 eggs` is two
+    // servings. Falling through to grams instead turned a count into a
+    // weight and logged two grams of egg (#622).
+    if (item.parsed.quantity != null && hasServing) {
+      return UnitDropdownItem.serving.toString();
+    }
+
+    if (hasServing) {
       return meal.servingUnit ?? UnitDropdownItem.gml.toString();
     }
     return usesImperialUnits
         ? UnitDropdownItem.oz.toString()
         : UnitDropdownItem.gml.toString();
   }
+
+  /// A stated count the app cannot interpret: no unit was typed and the
+  /// matched food carries no serving data, so there is nothing for "2" to
+  /// count. The row still logs — the amount and unit are editable — but it
+  /// is marked so the user's eye lands on the one row that needs a decision
+  /// rather than on a plausible-looking wrong number.
+  bool _amountNeedsCheck(ResolvedMealItem item) =>
+      // An unresolved row has no food to count, and already says so. Adding
+      // a second complaint about its amount is noise on a row that cannot
+      // be logged anyway.
+      item.isResolved &&
+      item.parsed.quantity != null &&
+      item.parsed.unit == null &&
+      !(item.selected?.hasServingValues ?? false);
 
   static String _trimZeros(double value) => value == value.roundToDouble()
       ? value.toInt().toString()

--- a/lib/features/add_meal/presentation/screens/bulk_add_screen.dart
+++ b/lib/features/add_meal/presentation/screens/bulk_add_screen.dart
@@ -239,6 +239,16 @@ class _BulkAddScreenState extends State<BulkAddScreen> {
                               color: theme.colorScheme.tertiary,
                             ),
                           )
+                        // A bare count the app could not interpret. Shown
+                        // below a doubtful match, because a wrong food
+                        // matters more than a wrong unit on the right one.
+                        else if (row.amountNeedsCheck)
+                          Text(
+                            S.of(context).bulkAddCheckAmountLabel,
+                            style: theme.textTheme.bodySmall?.copyWith(
+                              color: theme.colorScheme.tertiary,
+                            ),
+                          )
                         else if (meal?.brands != null)
                           Text(meal!.brands!, style: theme.textTheme.bodySmall),
                       ],

--- a/lib/l10n/intl_cs.arb
+++ b/lib/l10n/intl_cs.arb
@@ -1114,5 +1114,6 @@
   "bulkAddIncludeLabel": "Zahrnout",
   "bulkAddChooseFoodLabel": "Vybrat jinou potravinu",
   "bulkAddNothingToLogLabel": "Zatím není co zaznamenat",
-  "bulkAddSearchFailedLabel": "Vyhledávání potravin selhalo"
+  "bulkAddSearchFailedLabel": "Vyhledávání potravin selhalo",
+  "bulkAddCheckAmountLabel": "Zkontrolujte jednotku množství"
 }

--- a/lib/l10n/intl_de.arb
+++ b/lib/l10n/intl_de.arb
@@ -1145,5 +1145,6 @@
   "bulkAddIncludeLabel": "Einschließen",
   "bulkAddChooseFoodLabel": "Anderes Lebensmittel wählen",
   "bulkAddNothingToLogLabel": "Noch nichts zu speichern",
-  "bulkAddSearchFailedLabel": "Suche nach diesen Lebensmitteln fehlgeschlagen"
+  "bulkAddSearchFailedLabel": "Suche nach diesen Lebensmitteln fehlgeschlagen",
+  "bulkAddCheckAmountLabel": "Einheit für diese Menge prüfen"
 }

--- a/lib/l10n/intl_en.arb
+++ b/lib/l10n/intl_en.arb
@@ -1199,5 +1199,6 @@
   "bulkAddChooseFoodLabel": "Choose another food",
   "bulkAddNothingToLogLabel": "Nothing to log yet",
   "bulkAddSearchFailedLabel": "Couldn't search for these foods",
-  "@bulkAddSubmitLabel": {"placeholders": {"count": {"type": "int"}}}
+  "@bulkAddSubmitLabel": {"placeholders": {"count": {"type": "int"}}},
+  "bulkAddCheckAmountLabel": "Check the unit for this amount"
 }

--- a/lib/l10n/intl_it.arb
+++ b/lib/l10n/intl_it.arb
@@ -1114,5 +1114,6 @@
   "bulkAddIncludeLabel": "Includi",
   "bulkAddChooseFoodLabel": "Scegli un altro alimento",
   "bulkAddNothingToLogLabel": "Niente da registrare",
-  "bulkAddSearchFailedLabel": "Ricerca degli alimenti non riuscita"
+  "bulkAddSearchFailedLabel": "Ricerca degli alimenti non riuscita",
+  "bulkAddCheckAmountLabel": "Controlla l'unità di questa quantità"
 }

--- a/lib/l10n/intl_pl.arb
+++ b/lib/l10n/intl_pl.arb
@@ -1114,5 +1114,6 @@
   "bulkAddIncludeLabel": "Uwzględnij",
   "bulkAddChooseFoodLabel": "Wybierz inny produkt",
   "bulkAddNothingToLogLabel": "Nie ma jeszcze nic do zapisania",
-  "bulkAddSearchFailedLabel": "Nie udało się wyszukać produktów"
+  "bulkAddSearchFailedLabel": "Nie udało się wyszukać produktów",
+  "bulkAddCheckAmountLabel": "Sprawdź jednostkę tej ilości"
 }

--- a/lib/l10n/intl_sk.arb
+++ b/lib/l10n/intl_sk.arb
@@ -1145,5 +1145,6 @@
   "bulkAddIncludeLabel": "Zahrnúť",
   "bulkAddChooseFoodLabel": "Vybrať inú potravinu",
   "bulkAddNothingToLogLabel": "Zatiaľ nie je čo zaznamenať",
-  "bulkAddSearchFailedLabel": "Vyhľadávanie potravín zlyhalo"
+  "bulkAddSearchFailedLabel": "Vyhľadávanie potravín zlyhalo",
+  "bulkAddCheckAmountLabel": "Skontrolujte jednotku množstva"
 }

--- a/lib/l10n/intl_tr.arb
+++ b/lib/l10n/intl_tr.arb
@@ -1145,5 +1145,6 @@
   "bulkAddIncludeLabel": "Dahil et",
   "bulkAddChooseFoodLabel": "Başka bir yiyecek seç",
   "bulkAddNothingToLogLabel": "Henüz kaydedilecek bir şey yok",
-  "bulkAddSearchFailedLabel": "Bu yiyecekler aranamadı"
+  "bulkAddSearchFailedLabel": "Bu yiyecekler aranamadı",
+  "bulkAddCheckAmountLabel": "Bu miktarın birimini kontrol edin"
 }

--- a/lib/l10n/intl_uk.arb
+++ b/lib/l10n/intl_uk.arb
@@ -1114,5 +1114,6 @@
   "bulkAddIncludeLabel": "Включити",
   "bulkAddChooseFoodLabel": "Вибрати інший продукт",
   "bulkAddNothingToLogLabel": "Поки що нічого записувати",
-  "bulkAddSearchFailedLabel": "Не вдалося виконати пошук продуктів"
+  "bulkAddSearchFailedLabel": "Не вдалося виконати пошук продуктів",
+  "bulkAddCheckAmountLabel": "Перевірте одиницю для цієї кількості"
 }

--- a/lib/l10n/intl_zh.arb
+++ b/lib/l10n/intl_zh.arb
@@ -1115,5 +1115,6 @@
   "bulkAddIncludeLabel": "包含",
   "bulkAddChooseFoodLabel": "选择其他食物",
   "bulkAddNothingToLogLabel": "暂无可记录的内容",
-  "bulkAddSearchFailedLabel": "无法搜索这些食物"
+  "bulkAddSearchFailedLabel": "无法搜索这些食物",
+  "bulkAddCheckAmountLabel": "请核对此数量的单位"
 }

--- a/test/unit_test/bulk_add_bloc_test.dart
+++ b/test/unit_test/bulk_add_bloc_test.dart
@@ -133,6 +133,72 @@ void main() {
     expect(state.rows.single.effectiveUnit, 'g/ml');
   });
 
+  group('a bare count (#622)', () {
+    test('counts a food that has serving data as servings', () async {
+      // "2 eggs" means two of them. When the record carries serving data
+      // that is exactly a serving, so the unit must be `serving` and not
+      // grams — logging 2 g of egg was the bug.
+      final bloc = blocWith({
+        'eggs': [meal('Egg', servingQuantity: 50)],
+      });
+
+      final row = (await parse(bloc, '2 eggs')).rows.single;
+
+      expect(row.amountText, '2');
+      expect(row.unit, 'serving');
+      expect(row.amountNeedsCheck, isFalse);
+    });
+
+    test('flags a count when the food has no serving data', () async {
+      // Nothing to count, so the amount falls back to a weight. The row
+      // still logs — it is editable — but it is marked.
+      final bloc = blocWith({
+        'eggs': [meal('Egg')],
+      });
+
+      final row = (await parse(bloc, '2 eggs')).rows.single;
+
+      expect(row.amountText, '2');
+      expect(row.amountNeedsCheck, isTrue);
+      expect(row.willBeLogged, isTrue);
+    });
+
+    test('a stated unit is never second-guessed', () async {
+      final bloc = blocWith({
+        'toast': [meal('Toast', servingQuantity: 30)],
+      });
+
+      final row = (await parse(bloc, '100g toast')).rows.single;
+
+      expect(row.unit, 'g');
+      expect(row.amountNeedsCheck, isFalse);
+    });
+
+    test('no quantity at all keeps the serving default, not a count', () async {
+      // Distinct from a bare count: nothing was stated, so the row falls
+      // back to one serving expressed the way the record expresses it.
+      final bloc = blocWith({
+        'yoghurt': [meal('Yoghurt', servingQuantity: 125, servingUnit: 'g')],
+      });
+
+      final row = (await parse(bloc, 'yoghurt')).rows.single;
+
+      expect(row.amountText, '125');
+      expect(row.unit, 'g');
+      expect(row.amountNeedsCheck, isFalse);
+    });
+
+    test('an unresolved row is never flagged for its amount', () async {
+      final bloc = blocWith({});
+
+      final row = (await parse(bloc, '2 unicorn steaks')).rows.single;
+
+      expect(row.isResolved, isFalse);
+      expect(row.amountNeedsCheck, isFalse);
+      expect(row.willBeLogged, isFalse);
+    });
+  });
+
   test('unresolved rows are kept and are not loggable', () async {
     final bloc = blocWith({
       'toast': [meal('Toast')],

--- a/test/unit_test/bulk_add_bloc_test.dart
+++ b/test/unit_test/bulk_add_bloc_test.dart
@@ -251,6 +251,59 @@ void main() {
       expect(after.amountNeedsCheck, isTrue);
     });
 
+    test(
+      'switching candidates re-derives the unit, not just the flag',
+      () async {
+        // Found on a Pixel 6: clearing the warning while the row kept the
+        // previous candidate's weight unit left "2 chicken breasts" reading
+        // 2 oz with no warning — #622 again, minus the signal.
+        final bloc = blocWith({
+          'eggs': [meal('Eggs plain'), meal('Eggs boxed', servingQuantity: 60)],
+        });
+        final before = (await parse(bloc, '2 eggs')).rows.single;
+        expect(before.unit, isNot('serving'));
+
+        bloc.add(ChangeRowCandidateEvent(0, _indexOf(before, 'Eggs boxed')));
+        final after =
+            (await bloc.stream.first as BulkAddLoadedState).rows.single;
+
+        expect(after.unit, 'serving');
+        expect(after.amountText, '2');
+        expect(after.amountNeedsCheck, isFalse);
+      },
+    );
+
+    test('a hand-typed amount is never reinterpreted as a count', () async {
+      // The dangerous case: re-deriving the unit under an amount the user
+      // typed would turn "150" grams into 150 servings.
+      final bloc = blocWith({
+        'eggs': [meal('Eggs plain'), meal('Eggs boxed', servingQuantity: 60)],
+      });
+      final before = (await parse(bloc, '2 eggs')).rows.single;
+
+      bloc.add(const ChangeRowAmountEvent(0, '150'));
+      await bloc.stream.first;
+      bloc.add(ChangeRowCandidateEvent(0, _indexOf(before, 'Eggs boxed')));
+      final after = (await bloc.stream.first as BulkAddLoadedState).rows.single;
+
+      expect(after.amountText, '150');
+      expect(after.unit, isNot('serving'));
+    });
+
+    test('a chosen unit survives a candidate switch', () async {
+      final bloc = blocWith({
+        'eggs': [meal('Eggs plain'), meal('Eggs boxed', servingQuantity: 60)],
+      });
+      final before = (await parse(bloc, '2 eggs')).rows.single;
+
+      bloc.add(const ChangeRowUnitEvent(0, 'oz'));
+      await bloc.stream.first;
+      bloc.add(ChangeRowCandidateEvent(0, _indexOf(before, 'Eggs boxed')));
+      final after = (await bloc.stream.first as BulkAddLoadedState).rows.single;
+
+      expect(after.unit, 'oz');
+    });
+
     test('choosing a unit settles the flag', () async {
       final bloc = blocWith({
         'eggs': [meal('Egg')],

--- a/test/unit_test/bulk_add_bloc_test.dart
+++ b/test/unit_test/bulk_add_bloc_test.dart
@@ -203,6 +203,21 @@ void main() {
       expect(row.willBeLogged, isFalse);
     });
 
+    test('a serving that cannot be scaled is not offered as a unit', () async {
+      // The trap this closes: the row is flagged, the user reads "check the
+      // unit", picks the one that obviously means "two of them" — and the
+      // app relabels the row, drops the warning and logs the same 2 g.
+      final bloc = blocWith({
+        'eggs': [meal('Egg', servingSize: '1 egg')],
+        'yoghurt': [meal('Yoghurt', servingQuantity: 125)],
+      });
+
+      final rows = (await parse(bloc, '2 eggs, yoghurt')).rows;
+
+      expect(rows[0].allowedUnits, isNot(contains('serving')));
+      expect(rows[1].allowedUnits, contains('serving'));
+    });
+
     test('unparseable serving text is not read as a count', () async {
       // OFF derives `serving_quantity` by parsing the `serving_size` text;
       // strings like "1 egg" do not parse, so quantity stays null while

--- a/test/unit_test/bulk_add_bloc_test.dart
+++ b/test/unit_test/bulk_add_bloc_test.dart
@@ -54,6 +54,11 @@ class _FakeSearch implements SearchProductsUseCase {
 BulkAddBloc blocWith(Map<String, List<MealEntity>> results) =>
     BulkAddBloc(ResolveParsedMealsUseCase(_FakeSearch(results)));
 
+/// Candidates come back ranked, not in the order they were faked, so tests
+/// that switch candidates have to look the wanted one up by name.
+int _indexOf(BulkAddRow row, String name) =>
+    row.resolved.candidates.indexWhere((c) => c.name == name);
+
 Future<BulkAddLoadedState> parse(
   BulkAddBloc bloc,
   String text, {
@@ -196,6 +201,66 @@ void main() {
       expect(row.isResolved, isFalse);
       expect(row.amountNeedsCheck, isFalse);
       expect(row.willBeLogged, isFalse);
+    });
+
+    test('unparseable serving text is not read as a count', () async {
+      // OFF derives `serving_quantity` by parsing the `serving_size` text;
+      // strings like "1 egg" do not parse, so quantity stays null while
+      // hasServingValues is still true. convertQuantityToBaseUnit cannot
+      // scale such a record, so calling the unit `serving` would leave
+      // "2 eggs" logging 2 g under a label that reads correct.
+      final bloc = blocWith({
+        'eggs': [meal('Egg', servingSize: '1 egg')],
+      });
+
+      final row = (await parse(bloc, '2 eggs')).rows.single;
+
+      expect(row.unit, isNot('serving'));
+      expect(row.amountNeedsCheck, isTrue);
+    });
+
+    test('switching to a countable candidate clears the flag', () async {
+      final bloc = blocWith({
+        'eggs': [meal('Eggs plain'), meal('Eggs boxed', servingQuantity: 60)],
+      });
+      final before = (await parse(bloc, '2 eggs')).rows.single;
+      // Guard the premise: the ranker, not the list order, decides what is
+      // selected, and the test only means anything from the flagged one.
+      expect(before.meal?.name, 'Eggs plain');
+      expect(before.amountNeedsCheck, isTrue);
+
+      bloc.add(ChangeRowCandidateEvent(0, _indexOf(before, 'Eggs boxed')));
+      final after = (await bloc.stream.first as BulkAddLoadedState).rows.single;
+
+      expect(after.amountNeedsCheck, isFalse);
+    });
+
+    test('switching to an uncountable candidate raises the flag', () async {
+      // The direction that matters: correcting the food must not carry a
+      // stale "all clear" forward and leave 2 g unmarked.
+      final bloc = blocWith({
+        'eggs': [meal('Eggs boxed', servingQuantity: 60), meal('Eggs plain')],
+      });
+      final before = (await parse(bloc, '2 eggs')).rows.single;
+      expect(before.meal?.name, 'Eggs boxed');
+      expect(before.amountNeedsCheck, isFalse);
+
+      bloc.add(ChangeRowCandidateEvent(0, _indexOf(before, 'Eggs plain')));
+      final after = (await bloc.stream.first as BulkAddLoadedState).rows.single;
+
+      expect(after.amountNeedsCheck, isTrue);
+    });
+
+    test('choosing a unit settles the flag', () async {
+      final bloc = blocWith({
+        'eggs': [meal('Egg')],
+      });
+      await parse(bloc, '2 eggs');
+
+      bloc.add(const ChangeRowUnitEvent(0, 'oz'));
+      final state = await bloc.stream.first as BulkAddLoadedState;
+
+      expect(state.rows.single.amountNeedsCheck, isFalse);
     });
   });
 


### PR DESCRIPTION
Closes #622.

Typing `2 eggs` logged two **grams** of egg — 3 kcal — because a quantity stated without a unit fell through to the metric default. Confirmed on a Pixel 6: the diary read `Eier — 0.07 oz — 3 kcal`.

## The fix

A bare count means "N of them", and when the matched food carries serving data that is precisely what a serving is. A stated quantity with no unit now selects `serving`, so **two eggs is two servings**.

This invents nothing: `BulkAddRow.allowedUnits` already offers `serving` only for foods that have the data, so this picks something the user could have selected from the dropdown anyway.

| Input | Food record | Before | After |
|---|---|---|---|
| `2 eggs` | has serving data | 2 g | 2 servings |
| `2 eggs` | no serving data | 2 g | 2 g, **flagged** |
| `100g toast` | either | 100 g | 100 g (unchanged) |
| `yoghurt` | serving 125 g | 125 g | 125 g (unchanged) |

## When there is nothing to count

If the food carries no serving data there is nothing for the count to count, and no guess is better than another. Those rows keep the weight fallback and are **flagged** instead — "Check the unit for this amount" — so the eye lands on the one row needing a decision rather than on a plausible-looking wrong number.

They stay loggable. The amount and unit are editable inline, and blocking a batch over a unit would be worse than the wrong unit.

**The flag is not raised on unresolved rows.** Those already say they matched nothing and cannot be logged; a second complaint about their amount is noise. There is a test for that specifically — I first wrote the condition without it and caught the contradiction when the test name and its assertion disagreed.

## Scope

Rows with no stated quantity are untouched: still one serving expressed the way the record expresses it, matching `MealDetailScreen._applyInitialSelection`. The deliberate alignment between a bulk row and a hand-added row of the same food is preserved for that case, and only diverges where the single-item screen has no equivalent — it never sees a parsed count.

## Verification

`flutter test` → 1054/1054. `flutter analyze` clean. ARB parity holds at 933 keys across nine locales.

Five new tests: the serving case, the flagged case, that a stated unit is never second-guessed, that the no-quantity default did not move, and that unresolved rows stay unflagged.

Not verified on a device — the change is in the bloc and covered by unit tests, but the flag's appearance on the row is untested on hardware.
