### PR TITLE
fix(l10n): localize the bulk-add parser errors

### DIFF
--- a/lib/features/add_meal/presentation/bloc/bulk_add_state.dart
+++ b/lib/features/add_meal/presentation/bloc/bulk_add_state.dart
@@ -24,10 +24,12 @@ class BulkAddErrorState extends BulkAddState {
 class BulkAddLoadedState extends BulkAddState {
   final List<BulkAddRow> rows;
 
-  /// Per-segment complaints from the parser, already indexed ("Item 2: ...").
-  /// Shown alongside the rows rather than replacing them — a line with one
-  /// bad segment and three good ones should still log the three.
-  final List<String> parseErrors;
+  /// Per-segment complaints from the parser, carrying the item number and
+  /// the reason rather than a message — the string is built at the render
+  /// site so it can be localized (#631). Shown alongside the rows rather
+  /// than replacing them: a line with one bad segment and three good ones
+  /// should still log the three.
+  final List<MealTextParseError> parseErrors;
 
   final bool usesImperialUnits;
 

--- a/lib/features/add_meal/presentation/screens/bulk_add_screen.dart
+++ b/lib/features/add_meal/presentation/screens/bulk_add_screen.dart
@@ -8,6 +8,7 @@ import 'package:opennutritracker/core/utils/energy_display.dart';
 import 'package:opennutritracker/core/utils/locator.dart';
 import 'package:opennutritracker/core/utils/navigation_options.dart';
 import 'package:opennutritracker/features/add_meal/presentation/bloc/bulk_add_bloc.dart';
+import 'package:opennutritracker/features/add_meal/util/meal_text_parser.dart';
 import 'package:opennutritracker/features/add_meal/presentation/widgets/quick_add_bottom_sheet.dart';
 import 'package:opennutritracker/features/diary/presentation/bloc/calendar_day_bloc.dart';
 import 'package:opennutritracker/features/diary/presentation/bloc/diary_bloc.dart';
@@ -149,7 +150,7 @@ class _BulkAddScreenState extends State<BulkAddScreen> {
         context,
         state.parseErrors.isEmpty
             ? S.of(context).bulkAddNothingToLogLabel
-            : state.parseErrors.join('\n'),
+            : _parseErrorsText(context, state.parseErrors),
       );
     }
 
@@ -176,16 +177,41 @@ class _BulkAddScreenState extends State<BulkAddScreen> {
     child: Center(child: Text(message, textAlign: TextAlign.center)),
   );
 
-  Widget _buildParseErrors(BuildContext context, List<String> errors) =>
-      Padding(
-        padding: const EdgeInsets.fromLTRB(16, 12, 16, 12),
-        child: Text(
-          errors.join('\n'),
-          style: Theme.of(context).textTheme.bodySmall?.copyWith(
-            color: Theme.of(context).colorScheme.error,
-          ),
-        ),
-      );
+  /// The parser reports *what* was wrong with *which* item; the sentence is
+  /// built here, where there is a `BuildContext` to localize it with. See
+  /// #631 — these read in English on every locale until they moved.
+  String _parseErrorText(BuildContext context, MealTextParseError error) =>
+      switch (error.kind) {
+        MealTextParseErrorKind.invalidName =>
+          S.of(context).bulkAddErrorInvalidName(error.itemNumber),
+        MealTextParseErrorKind.quantityTooSmall =>
+          S.of(context).bulkAddErrorQuantityTooSmall(error.itemNumber),
+        MealTextParseErrorKind.quantityTooLarge =>
+          S
+              .of(context)
+              .bulkAddErrorQuantityTooLarge(
+                error.itemNumber,
+                (error.bound ?? 0).toInt(),
+              ),
+      };
+
+  String _parseErrorsText(
+    BuildContext context,
+    List<MealTextParseError> errors,
+  ) => errors.map((e) => _parseErrorText(context, e)).join('\n');
+
+  Widget _buildParseErrors(
+    BuildContext context,
+    List<MealTextParseError> errors,
+  ) => Padding(
+    padding: const EdgeInsets.fromLTRB(16, 12, 16, 12),
+    child: Text(
+      _parseErrorsText(context, errors),
+      style: Theme.of(context).textTheme.bodySmall?.copyWith(
+        color: Theme.of(context).colorScheme.error,
+      ),
+    ),
+  );
 
   Widget _buildRow(BuildContext context, BulkAddLoadedState state, int index) {
     final row = state.rows[index];

--- a/lib/features/add_meal/presentation/screens/bulk_add_screen.dart
+++ b/lib/features/add_meal/presentation/screens/bulk_add_screen.dart
@@ -181,18 +181,16 @@ class _BulkAddScreenState extends State<BulkAddScreen> {
   /// built here, where there is a `BuildContext` to localize it with. See
   /// #631 — these read in English on every locale until they moved.
   String _parseErrorText(BuildContext context, MealTextParseError error) =>
-      switch (error.kind) {
-        MealTextParseErrorKind.invalidName =>
+      switch (error) {
+        InvalidFoodNameError() =>
           S.of(context).bulkAddErrorInvalidName(error.itemNumber),
-        MealTextParseErrorKind.quantityTooSmall =>
+        QuantityTooSmallError() =>
           S.of(context).bulkAddErrorQuantityTooSmall(error.itemNumber),
-        MealTextParseErrorKind.quantityTooLarge =>
-          S
-              .of(context)
-              .bulkAddErrorQuantityTooLarge(
-                error.itemNumber,
-                (error.bound ?? 0).toInt(),
-              ),
+        // `bound` is non-null here by construction, so there is nothing to
+        // fall back to and no chance of telling the user their quantity has
+        // to be "0 or less".
+        QuantityTooLargeError(:final bound) =>
+          S.of(context).bulkAddErrorQuantityTooLarge(error.itemNumber, bound),
       };
 
   String _parseErrorsText(

--- a/lib/features/add_meal/util/meal_text_parser.dart
+++ b/lib/features/add_meal/util/meal_text_parser.dart
@@ -26,13 +26,66 @@ class ParsedMealItem {
       'ParsedMealItem(query: $query, quantity: $quantity, unit: $unit)';
 }
 
-/// Result of [parseMealText]. [errors] holds a one-line, item-indexed
-/// reason for each segment that could not be turned into a [ParsedMealItem]
-/// — empty segments (e.g. a trailing comma) are skipped silently and never
-/// produce an error.
+/// Why a segment could not be turned into a [ParsedMealItem].
+enum MealTextParseErrorKind {
+  /// The segment carried no unicode letter, so there is no food to search
+  /// for — a bare `123`, or punctuation on its own.
+  invalidName,
+
+  /// A quantity was stated but is zero or negative.
+  quantityTooSmall,
+
+  /// A quantity was stated but exceeds [MealTextParseError.bound]. Checked
+  /// after kg/l conversion, so `15 kg` is rejected as 15000 g.
+  quantityTooLarge,
+}
+
+/// One rejected segment, identified by its position in the input.
+///
+/// Deliberately not a message. [parseMealText] is a pure function with no
+/// `BuildContext`, so it cannot reach `S.of(context)`; building the string
+/// here shipped English into all nine locales (#631). The kind and the
+/// numbers travel instead, and the render site localizes them.
+class MealTextParseError {
+  /// 1-based position among the segments the parser actually attempted.
+  /// Empty segments never consume a number.
+  final int itemNumber;
+
+  final MealTextParseErrorKind kind;
+
+  /// The limit that was exceeded, set only for
+  /// [MealTextParseErrorKind.quantityTooLarge].
+  final double? bound;
+
+  const MealTextParseError({
+    required this.itemNumber,
+    required this.kind,
+    this.bound,
+  });
+
+  @override
+  String toString() =>
+      'MealTextParseError(item: $itemNumber, kind: ${kind.name}, '
+      'bound: $bound)';
+
+  @override
+  bool operator ==(Object other) =>
+      other is MealTextParseError &&
+      other.itemNumber == itemNumber &&
+      other.kind == kind &&
+      other.bound == bound;
+
+  @override
+  int get hashCode => Object.hash(itemNumber, kind, bound);
+}
+
+/// Result of [parseMealText]. [errors] holds an item-indexed reason for
+/// each segment that could not be turned into a [ParsedMealItem] — empty
+/// segments (e.g. a trailing comma) are skipped silently and never produce
+/// an error.
 class MealTextParseResult {
   final List<ParsedMealItem> items;
-  final List<String> errors;
+  final List<MealTextParseError> errors;
 
   const MealTextParseResult({required this.items, required this.errors});
 
@@ -207,7 +260,7 @@ MealTextParseResult parseMealText(String input) {
   final segments = _segment(input.trim());
 
   final items = <ParsedMealItem>[];
-  final errors = <String>[];
+  final errors = <MealTextParseError>[];
 
   // Numbers only the segments actually attempted, matching "empty segments
   // are skipped, not errors" — a trailing comma doesn't consume an index.
@@ -219,7 +272,12 @@ MealTextParseResult parseMealText(String input) {
     final query = extracted.query.trim();
 
     if (!FoodNameValidator.isValid(query)) {
-      errors.add('Item $itemNum: not a valid food name');
+      errors.add(
+        MealTextParseError(
+          itemNumber: itemNum,
+          kind: MealTextParseErrorKind.invalidName,
+        ),
+      );
       continue;
     }
 
@@ -234,11 +292,22 @@ MealTextParseResult parseMealText(String input) {
     // rather than silently becoming a valid-looking 15.
     if (quantity != null) {
       if (quantity <= 0) {
-        errors.add('Item $itemNum: quantity must be greater than 0');
+        errors.add(
+          MealTextParseError(
+            itemNumber: itemNum,
+            kind: MealTextParseErrorKind.quantityTooSmall,
+          ),
+        );
         continue;
       }
       if (quantity > _maxQuantity) {
-        errors.add('Item $itemNum: quantity must be $_maxQuantity or less');
+        errors.add(
+          MealTextParseError(
+            itemNumber: itemNum,
+            kind: MealTextParseErrorKind.quantityTooLarge,
+            bound: _maxQuantity.toDouble(),
+          ),
+        );
         continue;
       }
     }

--- a/lib/features/add_meal/util/meal_text_parser.dart
+++ b/lib/features/add_meal/util/meal_text_parser.dart
@@ -26,57 +26,84 @@ class ParsedMealItem {
       'ParsedMealItem(query: $query, quantity: $quantity, unit: $unit)';
 }
 
-/// Why a segment could not be turned into a [ParsedMealItem].
-enum MealTextParseErrorKind {
-  /// The segment carried no unicode letter, so there is no food to search
-  /// for — a bare `123`, or punctuation on its own.
-  invalidName,
-
-  /// A quantity was stated but is zero or negative.
-  quantityTooSmall,
-
-  /// A quantity was stated but exceeds [MealTextParseError.bound]. Checked
-  /// after kg/l conversion, so `15 kg` is rejected as 15000 g.
-  quantityTooLarge,
-}
-
 /// One rejected segment, identified by its position in the input.
 ///
 /// Deliberately not a message. [parseMealText] is a pure function with no
 /// `BuildContext`, so it cannot reach `S.of(context)`; building the string
-/// here shipped English into all nine locales (#631). The kind and the
+/// here shipped English into all nine locales (#631). The reason and the
 /// numbers travel instead, and the render site localizes them.
-class MealTextParseError {
+///
+/// Sealed, with the data each reason needs on the subtype rather than a
+/// nullable field beside a kind. Only [QuantityTooLargeError] has a bound,
+/// so only it carries one — which means a bound can never be missing where
+/// it is needed, and the render site never has to invent a stand-in. An
+/// earlier shape allowed `quantityTooLarge` with no bound, and the screen
+/// defaulted it to 0 and told the user their quantity had to be "0 or
+/// less".
+sealed class MealTextParseError {
   /// 1-based position among the segments the parser actually attempted.
   /// Empty segments never consume a number.
   final int itemNumber;
 
-  final MealTextParseErrorKind kind;
+  const MealTextParseError(this.itemNumber);
+}
 
-  /// The limit that was exceeded, set only for
-  /// [MealTextParseErrorKind.quantityTooLarge].
-  final double? bound;
+/// The segment carried no unicode letter, so there is no food to search
+/// for — a bare `123`, or punctuation on its own.
+final class InvalidFoodNameError extends MealTextParseError {
+  const InvalidFoodNameError(super.itemNumber);
 
-  const MealTextParseError({
-    required this.itemNumber,
-    required this.kind,
-    this.bound,
-  });
+  @override
+  String toString() => 'InvalidFoodNameError(item: $itemNumber)';
+
+  @override
+  bool operator ==(Object other) =>
+      other is InvalidFoodNameError && other.itemNumber == itemNumber;
+
+  @override
+  int get hashCode => Object.hash(InvalidFoodNameError, itemNumber);
+}
+
+/// A quantity was stated but is zero or negative.
+final class QuantityTooSmallError extends MealTextParseError {
+  const QuantityTooSmallError(super.itemNumber);
+
+  @override
+  String toString() => 'QuantityTooSmallError(item: $itemNumber)';
+
+  @override
+  bool operator ==(Object other) =>
+      other is QuantityTooSmallError && other.itemNumber == itemNumber;
+
+  @override
+  int get hashCode => Object.hash(QuantityTooSmallError, itemNumber);
+}
+
+/// A quantity was stated but exceeds [bound]. Checked after kg/l
+/// conversion, so `15 kg` is rejected as 15000 g rather than a
+/// valid-looking 15.
+final class QuantityTooLargeError extends MealTextParseError {
+  /// The limit that was exceeded. An `int` because it is a cap rather than
+  /// a measurement, and because the string it feeds takes an integer
+  /// placeholder — keeping the types equal removes a lossy conversion at
+  /// the render site.
+  final int bound;
+
+  const QuantityTooLargeError(super.itemNumber, this.bound);
 
   @override
   String toString() =>
-      'MealTextParseError(item: $itemNumber, kind: ${kind.name}, '
+      'QuantityTooLargeError(item: $itemNumber, '
       'bound: $bound)';
 
   @override
   bool operator ==(Object other) =>
-      other is MealTextParseError &&
+      other is QuantityTooLargeError &&
       other.itemNumber == itemNumber &&
-      other.kind == kind &&
       other.bound == bound;
 
   @override
-  int get hashCode => Object.hash(itemNumber, kind, bound);
+  int get hashCode => Object.hash(QuantityTooLargeError, itemNumber, bound);
 }
 
 /// Result of [parseMealText]. [errors] holds an item-indexed reason for
@@ -272,12 +299,7 @@ MealTextParseResult parseMealText(String input) {
     final query = extracted.query.trim();
 
     if (!FoodNameValidator.isValid(query)) {
-      errors.add(
-        MealTextParseError(
-          itemNumber: itemNum,
-          kind: MealTextParseErrorKind.invalidName,
-        ),
-      );
+      errors.add(InvalidFoodNameError(itemNum));
       continue;
     }
 
@@ -292,22 +314,11 @@ MealTextParseResult parseMealText(String input) {
     // rather than silently becoming a valid-looking 15.
     if (quantity != null) {
       if (quantity <= 0) {
-        errors.add(
-          MealTextParseError(
-            itemNumber: itemNum,
-            kind: MealTextParseErrorKind.quantityTooSmall,
-          ),
-        );
+        errors.add(QuantityTooSmallError(itemNum));
         continue;
       }
       if (quantity > _maxQuantity) {
-        errors.add(
-          MealTextParseError(
-            itemNumber: itemNum,
-            kind: MealTextParseErrorKind.quantityTooLarge,
-            bound: _maxQuantity.toDouble(),
-          ),
-        );
+        errors.add(QuantityTooLargeError(itemNum, _maxQuantity));
         continue;
       }
     }

--- a/lib/l10n/intl_cs.arb
+++ b/lib/l10n/intl_cs.arb
@@ -1115,5 +1115,8 @@
   "bulkAddChooseFoodLabel": "Vybrat jinou potravinu",
   "bulkAddNothingToLogLabel": "Zatím není co zaznamenat",
   "bulkAddSearchFailedLabel": "Vyhledávání potravin selhalo",
-  "bulkAddCheckAmountLabel": "Zkontrolujte jednotku množství"
+  "bulkAddCheckAmountLabel": "Zkontrolujte jednotku množství",
+  "bulkAddErrorInvalidName": "Položka {number}: neplatný název potraviny",
+  "bulkAddErrorQuantityTooSmall": "Položka {number}: množství musí být větší než 0",
+  "bulkAddErrorQuantityTooLarge": "Položka {number}: množství smí být nejvýše {bound}"
 }

--- a/lib/l10n/intl_de.arb
+++ b/lib/l10n/intl_de.arb
@@ -1146,5 +1146,8 @@
   "bulkAddChooseFoodLabel": "Anderes Lebensmittel wählen",
   "bulkAddNothingToLogLabel": "Noch nichts zu speichern",
   "bulkAddSearchFailedLabel": "Suche nach diesen Lebensmitteln fehlgeschlagen",
-  "bulkAddCheckAmountLabel": "Einheit für diese Menge prüfen"
+  "bulkAddCheckAmountLabel": "Einheit für diese Menge prüfen",
+  "bulkAddErrorInvalidName": "Eintrag {number}: kein gültiger Lebensmittelname",
+  "bulkAddErrorQuantityTooSmall": "Eintrag {number}: Menge muss größer als 0 sein",
+  "bulkAddErrorQuantityTooLarge": "Eintrag {number}: Menge darf höchstens {bound} betragen"
 }

--- a/lib/l10n/intl_en.arb
+++ b/lib/l10n/intl_en.arb
@@ -1200,5 +1200,32 @@
   "bulkAddNothingToLogLabel": "Nothing to log yet",
   "bulkAddSearchFailedLabel": "Couldn't search for these foods",
   "@bulkAddSubmitLabel": {"placeholders": {"count": {"type": "int"}}},
-  "bulkAddCheckAmountLabel": "Check the unit for this amount"
+  "bulkAddCheckAmountLabel": "Check the unit for this amount",
+  "bulkAddErrorInvalidName": "Item {number}: not a valid food name",
+  "@bulkAddErrorInvalidName": {
+      "placeholders": {
+          "number": {
+              "type": "int"
+          }
+      }
+  },
+  "bulkAddErrorQuantityTooSmall": "Item {number}: quantity must be greater than 0",
+  "@bulkAddErrorQuantityTooSmall": {
+      "placeholders": {
+          "number": {
+              "type": "int"
+          }
+      }
+  },
+  "bulkAddErrorQuantityTooLarge": "Item {number}: quantity must be {bound} or less",
+  "@bulkAddErrorQuantityTooLarge": {
+      "placeholders": {
+          "number": {
+              "type": "int"
+          },
+          "bound": {
+              "type": "int"
+          }
+      }
+  }
 }

--- a/lib/l10n/intl_it.arb
+++ b/lib/l10n/intl_it.arb
@@ -1115,5 +1115,8 @@
   "bulkAddChooseFoodLabel": "Scegli un altro alimento",
   "bulkAddNothingToLogLabel": "Niente da registrare",
   "bulkAddSearchFailedLabel": "Ricerca degli alimenti non riuscita",
-  "bulkAddCheckAmountLabel": "Controlla l'unità di questa quantità"
+  "bulkAddCheckAmountLabel": "Controlla l'unità di questa quantità",
+  "bulkAddErrorInvalidName": "Voce {number}: nome dell'alimento non valido",
+  "bulkAddErrorQuantityTooSmall": "Voce {number}: la quantità deve essere maggiore di 0",
+  "bulkAddErrorQuantityTooLarge": "Voce {number}: la quantità non può superare {bound}"
 }

--- a/lib/l10n/intl_pl.arb
+++ b/lib/l10n/intl_pl.arb
@@ -1115,5 +1115,8 @@
   "bulkAddChooseFoodLabel": "Wybierz inny produkt",
   "bulkAddNothingToLogLabel": "Nie ma jeszcze nic do zapisania",
   "bulkAddSearchFailedLabel": "Nie udało się wyszukać produktów",
-  "bulkAddCheckAmountLabel": "Sprawdź jednostkę tej ilości"
+  "bulkAddCheckAmountLabel": "Sprawdź jednostkę tej ilości",
+  "bulkAddErrorInvalidName": "Pozycja {number}: nieprawidłowa nazwa produktu",
+  "bulkAddErrorQuantityTooSmall": "Pozycja {number}: ilość musi być większa niż 0",
+  "bulkAddErrorQuantityTooLarge": "Pozycja {number}: ilość nie może przekraczać {bound}"
 }

--- a/lib/l10n/intl_sk.arb
+++ b/lib/l10n/intl_sk.arb
@@ -1146,5 +1146,8 @@
   "bulkAddChooseFoodLabel": "Vybrať inú potravinu",
   "bulkAddNothingToLogLabel": "Zatiaľ nie je čo zaznamenať",
   "bulkAddSearchFailedLabel": "Vyhľadávanie potravín zlyhalo",
-  "bulkAddCheckAmountLabel": "Skontrolujte jednotku množstva"
+  "bulkAddCheckAmountLabel": "Skontrolujte jednotku množstva",
+  "bulkAddErrorInvalidName": "Položka {number}: neplatný názov potraviny",
+  "bulkAddErrorQuantityTooSmall": "Položka {number}: množstvo musí byť väčšie ako 0",
+  "bulkAddErrorQuantityTooLarge": "Položka {number}: množstvo smie byť najviac {bound}"
 }

--- a/lib/l10n/intl_tr.arb
+++ b/lib/l10n/intl_tr.arb
@@ -1146,5 +1146,8 @@
   "bulkAddChooseFoodLabel": "Başka bir yiyecek seç",
   "bulkAddNothingToLogLabel": "Henüz kaydedilecek bir şey yok",
   "bulkAddSearchFailedLabel": "Bu yiyecekler aranamadı",
-  "bulkAddCheckAmountLabel": "Bu miktarın birimini kontrol edin"
+  "bulkAddCheckAmountLabel": "Bu miktarın birimini kontrol edin",
+  "bulkAddErrorInvalidName": "{number}. öğe: geçerli bir besin adı değil",
+  "bulkAddErrorQuantityTooSmall": "{number}. öğe: miktar 0'dan büyük olmalı",
+  "bulkAddErrorQuantityTooLarge": "{number}. öğe: miktar en fazla {bound} olabilir"
 }

--- a/lib/l10n/intl_uk.arb
+++ b/lib/l10n/intl_uk.arb
@@ -1115,5 +1115,8 @@
   "bulkAddChooseFoodLabel": "Вибрати інший продукт",
   "bulkAddNothingToLogLabel": "Поки що нічого записувати",
   "bulkAddSearchFailedLabel": "Не вдалося виконати пошук продуктів",
-  "bulkAddCheckAmountLabel": "Перевірте одиницю для цієї кількості"
+  "bulkAddCheckAmountLabel": "Перевірте одиницю для цієї кількості",
+  "bulkAddErrorInvalidName": "Пункт {number}: некоректна назва продукту",
+  "bulkAddErrorQuantityTooSmall": "Пункт {number}: кількість має бути більшою за 0",
+  "bulkAddErrorQuantityTooLarge": "Пункт {number}: кількість не може перевищувати {bound}"
 }

--- a/lib/l10n/intl_zh.arb
+++ b/lib/l10n/intl_zh.arb
@@ -1116,5 +1116,8 @@
   "bulkAddChooseFoodLabel": "选择其他食物",
   "bulkAddNothingToLogLabel": "暂无可记录的内容",
   "bulkAddSearchFailedLabel": "无法搜索这些食物",
-  "bulkAddCheckAmountLabel": "请核对此数量的单位"
+  "bulkAddCheckAmountLabel": "请核对此数量的单位",
+  "bulkAddErrorInvalidName": "第 {number} 项：食物名称无效",
+  "bulkAddErrorQuantityTooSmall": "第 {number} 项：数量必须大于 0",
+  "bulkAddErrorQuantityTooLarge": "第 {number} 项：数量不能超过 {bound}"
 }

--- a/test/features/add_meal/presentation/bulk_add_screen_test.dart
+++ b/test/features/add_meal/presentation/bulk_add_screen_test.dart
@@ -148,7 +148,7 @@ Future<void> _register(
 /// The screen reads its arguments off the route and pops back to
 /// `mainRoute`, so it needs a real navigator with that route named. The
 /// rows render kcal through `EnergyDisplay`, which reads the provider.
-Widget _app({bool imperial = false}) =>
+Widget _app({bool imperial = false, Locale? locale}) =>
     ChangeNotifierProvider<EnergyUnitProvider>(
       create: (_) => EnergyUnitProvider(usesKilojoules: false),
       child: MaterialApp(
@@ -159,6 +159,7 @@ Widget _app({bool imperial = false}) =>
           GlobalCupertinoLocalizations.delegate,
         ],
         supportedLocales: S.supportedLocales,
+        locale: locale,
         initialRoute: NavigationOptions.mainRoute,
         onGenerateRoute: (settings) {
           if (settings.name == NavigationOptions.mainRoute) {
@@ -189,7 +190,9 @@ Future<void> _parse(WidgetTester tester, String text) async {
   await tester.pumpAndSettle();
 
   await tester.enterText(find.byType(TextField).first, text);
-  await tester.tap(find.text(l10nEn.bulkAddParseLabel));
+  // By icon, not label: these tests also pump a German locale, where the
+  // button reads something else entirely.
+  await tester.tap(find.widgetWithIcon(FilledButton, Icons.search));
   await tester.pumpAndSettle();
 }
 
@@ -334,9 +337,10 @@ void main() {
     await _parse(tester, '100g toast, 123');
 
     // The good row survives and the bad one is named by its position, so a
-    // rejected item is never a silent drop.
+    // rejected item is never a silent drop. Asserted through the ARB string
+    // rather than a literal, so the localized text is what is checked.
     expect(find.text('Toast'), findsOneWidget);
-    expect(find.text('Item 2: not a valid food name'), findsOneWidget);
+    expect(find.text(l10nEn.bulkAddErrorInvalidName(2)), findsOneWidget);
 
     await tester.tap(_submitButton());
     await tester.pumpAndSettle();
@@ -384,5 +388,34 @@ void main() {
 
     expect(find.text('Egg, boxed'), findsOneWidget);
     expect(find.text(l10nEn.bulkAddCheckAmountLabel), findsNothing);
+  });
+
+  testWidgets('parse errors render in the app locale, not English', (
+    tester,
+  ) async {
+    // #631. These were built as English literals inside the parser, so a
+    // German user saw "Item 2: not a valid food name" in an otherwise
+    // translated screen. The parser now reports a kind and an index and the
+    // screen builds the sentence, so this asserts the German text.
+    await _register({
+      'toast': [_meal('Toast')],
+    });
+    await tester.pumpWidget(_app(locale: const Locale('de')));
+    await _parse(tester, '100g toast, 123');
+
+    final de = lookupS(const Locale('de'));
+    expect(find.text(de.bulkAddErrorInvalidName(2)), findsOneWidget);
+    expect(find.text('Item 2: not a valid food name'), findsNothing);
+  });
+
+  testWidgets('a rejected bound is reported with its number', (tester) async {
+    await _register({});
+    await tester.pumpWidget(_app());
+    await _parse(tester, '15kg flour');
+
+    expect(
+      find.text(l10nEn.bulkAddErrorQuantityTooLarge(1, 10000)),
+      findsOneWidget,
+    );
   });
 }

--- a/test/unit_test/bulk_add_hint_test.dart
+++ b/test/unit_test/bulk_add_hint_test.dart
@@ -75,4 +75,34 @@ void main() {
       }
     }
   });
+
+  test('every locale keeps the placeholders in its parser-error strings', () {
+    // #631 moved these out of the parser and into the ARBs. A translation
+    // that drops {number} still compiles and still renders — it just stops
+    // telling the user *which* item was rejected, which is the only part
+    // that makes the message actionable on a multi-item line.
+    for (final file in Directory('lib/l10n').listSync().whereType<File>()) {
+      final locale = file.path.split('intl_').last.replaceAll('.arb', '');
+      final arb = json.decode(file.readAsStringSync()) as Map<String, dynamic>;
+
+      for (final key in const [
+        'bulkAddErrorInvalidName',
+        'bulkAddErrorQuantityTooSmall',
+        'bulkAddErrorQuantityTooLarge',
+      ]) {
+        final value = arb[key] as String?;
+        expect(value, isNotNull, reason: '$locale is missing $key');
+        expect(
+          value,
+          contains('{number}'),
+          reason: '$locale dropped {number} from $key',
+        );
+      }
+      expect(
+        arb['bulkAddErrorQuantityTooLarge'] as String,
+        contains('{bound}'),
+        reason: '$locale dropped {bound} from the upper-bound message',
+      );
+    }
+  });
 }

--- a/test/unit_test/meal_text_parser_test.dart
+++ b/test/unit_test/meal_text_parser_test.dart
@@ -133,7 +133,12 @@ void main() {
 
       expect(result.items.single.quantity, 5000);
       expect(result.items.single.unit, 'ml');
-      expect(result.errors, ['Item 1: not a valid food name']);
+      expect(result.errors, [
+        const MealTextParseError(
+          itemNumber: 1,
+          kind: MealTextParseErrorKind.invalidName,
+        ),
+      ]);
     });
   });
 
@@ -207,21 +212,36 @@ void main() {
       final result = parseMealText('-5g sugar');
 
       expect(result.items, isEmpty);
-      expect(result.errors, ['Item 1: quantity must be greater than 0']);
+      expect(result.errors, [
+        const MealTextParseError(
+          itemNumber: 1,
+          kind: MealTextParseErrorKind.quantityTooSmall,
+        ),
+      ]);
     });
 
     test('a negative trailing quantity is rejected too', () {
       final result = parseMealText('sugar -5g');
 
       expect(result.items, isEmpty);
-      expect(result.errors, ['Item 1: quantity must be greater than 0']);
+      expect(result.errors, [
+        const MealTextParseError(
+          itemNumber: 1,
+          kind: MealTextParseErrorKind.quantityTooSmall,
+        ),
+      ]);
     });
 
     test('a negative kg quantity is rejected after conversion', () {
       final result = parseMealText('-5kg flour');
 
       expect(result.items, isEmpty);
-      expect(result.errors, ['Item 1: quantity must be greater than 0']);
+      expect(result.errors, [
+        const MealTextParseError(
+          itemNumber: 1,
+          kind: MealTextParseErrorKind.quantityTooSmall,
+        ),
+      ]);
     });
 
     test('a lone negative number is still an invalid food name', () {
@@ -231,7 +251,12 @@ void main() {
       final result = parseMealText('-123');
 
       expect(result.items, isEmpty);
-      expect(result.errors, ['Item 1: not a valid food name']);
+      expect(result.errors, [
+        const MealTextParseError(
+          itemNumber: 1,
+          kind: MealTextParseErrorKind.invalidName,
+        ),
+      ]);
     });
 
     test('a hyphen inside a food name is left alone', () {
@@ -364,13 +389,23 @@ void main() {
       final result = parseMealText('123');
 
       expect(result.items, isEmpty);
-      expect(result.errors, ['Item 1: not a valid food name']);
+      expect(result.errors, [
+        const MealTextParseError(
+          itemNumber: 1,
+          kind: MealTextParseErrorKind.invalidName,
+        ),
+      ]);
     });
 
     test('a valid segment after a rejected one keeps its own item number', () {
       final result = parseMealText('123, toast');
 
-      expect(result.errors, ['Item 1: not a valid food name']);
+      expect(result.errors, [
+        const MealTextParseError(
+          itemNumber: 1,
+          kind: MealTextParseErrorKind.invalidName,
+        ),
+      ]);
       expect(result.items.single.query, 'toast');
     });
 
@@ -379,7 +414,12 @@ void main() {
       // so the invalid '123' is still 'Item 1', not 'Item 2'.
       final result = parseMealText(',123');
 
-      expect(result.errors, ['Item 1: not a valid food name']);
+      expect(result.errors, [
+        const MealTextParseError(
+          itemNumber: 1,
+          kind: MealTextParseErrorKind.invalidName,
+        ),
+      ]);
     });
   });
 
@@ -388,14 +428,25 @@ void main() {
       final result = parseMealText('0g water');
 
       expect(result.items, isEmpty);
-      expect(result.errors, ['Item 1: quantity must be greater than 0']);
+      expect(result.errors, [
+        const MealTextParseError(
+          itemNumber: 1,
+          kind: MealTextParseErrorKind.quantityTooSmall,
+        ),
+      ]);
     });
 
     test('a quantity over 10000 is rejected', () {
       final result = parseMealText('10001g flour');
 
       expect(result.items, isEmpty);
-      expect(result.errors, ['Item 1: quantity must be 10000 or less']);
+      expect(result.errors, [
+        const MealTextParseError(
+          itemNumber: 1,
+          kind: MealTextParseErrorKind.quantityTooLarge,
+          bound: 10000,
+        ),
+      ]);
     });
 
     test('exactly 10000 is accepted', () {
@@ -411,7 +462,13 @@ void main() {
       final result = parseMealText('15kg flour');
 
       expect(result.items, isEmpty);
-      expect(result.errors, ['Item 1: quantity must be 10000 or less']);
+      expect(result.errors, [
+        const MealTextParseError(
+          itemNumber: 1,
+          kind: MealTextParseErrorKind.quantityTooLarge,
+          bound: 10000,
+        ),
+      ]);
     });
   });
 

--- a/test/unit_test/meal_text_parser_test.dart
+++ b/test/unit_test/meal_text_parser_test.dart
@@ -133,12 +133,7 @@ void main() {
 
       expect(result.items.single.quantity, 5000);
       expect(result.items.single.unit, 'ml');
-      expect(result.errors, [
-        const MealTextParseError(
-          itemNumber: 1,
-          kind: MealTextParseErrorKind.invalidName,
-        ),
-      ]);
+      expect(result.errors, [InvalidFoodNameError(1)]);
     });
   });
 
@@ -212,36 +207,21 @@ void main() {
       final result = parseMealText('-5g sugar');
 
       expect(result.items, isEmpty);
-      expect(result.errors, [
-        const MealTextParseError(
-          itemNumber: 1,
-          kind: MealTextParseErrorKind.quantityTooSmall,
-        ),
-      ]);
+      expect(result.errors, [QuantityTooSmallError(1)]);
     });
 
     test('a negative trailing quantity is rejected too', () {
       final result = parseMealText('sugar -5g');
 
       expect(result.items, isEmpty);
-      expect(result.errors, [
-        const MealTextParseError(
-          itemNumber: 1,
-          kind: MealTextParseErrorKind.quantityTooSmall,
-        ),
-      ]);
+      expect(result.errors, [QuantityTooSmallError(1)]);
     });
 
     test('a negative kg quantity is rejected after conversion', () {
       final result = parseMealText('-5kg flour');
 
       expect(result.items, isEmpty);
-      expect(result.errors, [
-        const MealTextParseError(
-          itemNumber: 1,
-          kind: MealTextParseErrorKind.quantityTooSmall,
-        ),
-      ]);
+      expect(result.errors, [QuantityTooSmallError(1)]);
     });
 
     test('a lone negative number is still an invalid food name', () {
@@ -251,12 +231,7 @@ void main() {
       final result = parseMealText('-123');
 
       expect(result.items, isEmpty);
-      expect(result.errors, [
-        const MealTextParseError(
-          itemNumber: 1,
-          kind: MealTextParseErrorKind.invalidName,
-        ),
-      ]);
+      expect(result.errors, [InvalidFoodNameError(1)]);
     });
 
     test('a hyphen inside a food name is left alone', () {
@@ -389,23 +364,13 @@ void main() {
       final result = parseMealText('123');
 
       expect(result.items, isEmpty);
-      expect(result.errors, [
-        const MealTextParseError(
-          itemNumber: 1,
-          kind: MealTextParseErrorKind.invalidName,
-        ),
-      ]);
+      expect(result.errors, [InvalidFoodNameError(1)]);
     });
 
     test('a valid segment after a rejected one keeps its own item number', () {
       final result = parseMealText('123, toast');
 
-      expect(result.errors, [
-        const MealTextParseError(
-          itemNumber: 1,
-          kind: MealTextParseErrorKind.invalidName,
-        ),
-      ]);
+      expect(result.errors, [InvalidFoodNameError(1)]);
       expect(result.items.single.query, 'toast');
     });
 
@@ -414,12 +379,7 @@ void main() {
       // so the invalid '123' is still 'Item 1', not 'Item 2'.
       final result = parseMealText(',123');
 
-      expect(result.errors, [
-        const MealTextParseError(
-          itemNumber: 1,
-          kind: MealTextParseErrorKind.invalidName,
-        ),
-      ]);
+      expect(result.errors, [InvalidFoodNameError(1)]);
     });
   });
 
@@ -428,25 +388,14 @@ void main() {
       final result = parseMealText('0g water');
 
       expect(result.items, isEmpty);
-      expect(result.errors, [
-        const MealTextParseError(
-          itemNumber: 1,
-          kind: MealTextParseErrorKind.quantityTooSmall,
-        ),
-      ]);
+      expect(result.errors, [QuantityTooSmallError(1)]);
     });
 
     test('a quantity over 10000 is rejected', () {
       final result = parseMealText('10001g flour');
 
       expect(result.items, isEmpty);
-      expect(result.errors, [
-        const MealTextParseError(
-          itemNumber: 1,
-          kind: MealTextParseErrorKind.quantityTooLarge,
-          bound: 10000,
-        ),
-      ]);
+      expect(result.errors, [QuantityTooLargeError(1, 10000)]);
     });
 
     test('exactly 10000 is accepted', () {
@@ -462,13 +411,7 @@ void main() {
       final result = parseMealText('15kg flour');
 
       expect(result.items, isEmpty);
-      expect(result.errors, [
-        const MealTextParseError(
-          itemNumber: 1,
-          kind: MealTextParseErrorKind.quantityTooLarge,
-          bound: 10000,
-        ),
-      ]);
+      expect(result.errors, [QuantityTooLargeError(1, 10000)]);
     });
   });
 


### PR DESCRIPTION
Closes #631.

## The problem

`parseMealText` built its complaints as English literals and `bulk_add_screen.dart` rendered them verbatim, so a user on any of the other eight locales saw English error text in an otherwise translated screen. Observed on a Pixel 6 with the app in German:

```
0g Wasser   →  Item 1: quantity must be greater than 0
123         →  Item 2: not a valid food name
15kg Mehl   →  Item 1: quantity must be 10000 or less
```

Not rare paths — a stray number, a trailing separator or a quantity over the bound are exactly the typos a free-text box invites.

## The approach

`parseMealText` cannot reach `S.of(context)`, and that is worth preserving: it is pure by design (#600) so it can be exhaustively unit-tested with no I/O. Making it locale-aware would have cost that.

So it reports *what* was wrong with *which* item instead of a message:

```dart
enum MealTextParseErrorKind { invalidName, quantityTooSmall, quantityTooLarge }

class MealTextParseError {
  final int itemNumber;              // 1-based, empty segments never consume one
  final MealTextParseErrorKind kind;
  final double? bound;               // only for quantityTooLarge
}
```

The screen builds the sentence where a `BuildContext` exists. The parser stays pure and its tests get stricter — they now assert a kind and an index rather than an English sentence, so they no longer break when wording changes and no longer pass when the wording is wrong for the locale.

## Translations

Three keys across nine locales, **with the item number as a placeholder** rather than a concatenated prefix. `Item 2:` is not a prefix everywhere: Turkish reads `2. öğe:` and Chinese `第 2 项：`. Concatenation would have baked English word order into all nine.

## Tests

- A widget test pumps the screen with `Locale('de')` and asserts the German string is shown **and the English one is not**. That second assertion is the one that would have caught this originally.
- An ARB test fails if any locale drops `{number}`, or `{bound}` from the upper-bound message. A translation that loses the index still compiles and still renders — it just stops telling the user which item was rejected, which is the only part that makes the message actionable on a multi-item line.
- `meal_text_parser_test.dart`'s eleven error assertions moved to the typed form.

## Verification

`flutter test` 1082/1082, `flutter analyze` clean, formatter clean, ARB parity 936 translatable keys with zero drift across all nine locales.

Checked the tests fail without the fix rather than trusting green: rendering the raw error objects instead of the localized text fails 2 of them.

## Shape of the error type

`MealTextParseError` is sealed, with the data each reason needs on the subtype rather than a nullable field beside a `kind`:

```dart
sealed class MealTextParseError { final int itemNumber; }
final class InvalidFoodNameError   extends MealTextParseError {}
final class QuantityTooSmallError  extends MealTextParseError {}
final class QuantityTooLargeError  extends MealTextParseError { final int bound; }
```

This came out of review. The first version was an enum plus a nullable `bound`, and the render site defaulted it with `?? 0` — which would have told a user their quantity must be "0 or less" if the two ever disagreed. The compiler now rules that out, verified rather than assumed:

```
QuantityTooLargeError(1)      -> error: 2 positional arguments expected, but 1 found
switch with a branch removed  -> error: non_exhaustive_switch_expression
```

`bound` is an `int` because it is a cap rather than a measurement, and the ARB placeholder takes an integer — so there is no conversion at the render site to lose precision in.
