### PR TITLE
feat(add-meal): add a model-assisted meal-text interpreter (#633)

### DIFF
--- a/lib/features/add_meal/data/anthropic_meal_text_interpreter.dart
+++ b/lib/features/add_meal/data/anthropic_meal_text_interpreter.dart
@@ -36,16 +36,22 @@ class AnthropicMealTextInterpreter implements MealTextInterpreter {
   /// Matches the other remote data sources in this repo. Without it a
   /// stalled connection hangs until the OS gives up, which in #635 means the
   /// user waits instead of falling back to the deterministic parser.
-  static const _timeout = Duration(seconds: 20);
+  static const defaultTimeout = Duration(seconds: 20);
 
   final http.Client _client;
   final String Function() _apiKey;
   final String model;
 
+  /// Injectable so the stalled-connection test does not spend the real
+  /// twenty seconds proving it. Raising the production value should not
+  /// quietly make the suite slower.
+  final Duration timeout;
+
   AnthropicMealTextInterpreter(
     this._client,
     this._apiKey, {
     this.model = defaultModel,
+    this.timeout = defaultTimeout,
   });
 
   /// The whole contract with the model, in one place.
@@ -152,7 +158,7 @@ Rules:
             },
             body: body,
           )
-          .timeout(_timeout);
+          .timeout(timeout);
     } catch (e) {
       // Deliberately not logging `e`: a socket error can carry the request
       // URL and, on some platforms, part of the payload.

--- a/lib/features/add_meal/data/anthropic_meal_text_interpreter.dart
+++ b/lib/features/add_meal/data/anthropic_meal_text_interpreter.dart
@@ -1,0 +1,224 @@
+import 'dart:convert';
+
+import 'package:http/http.dart' as http;
+import 'package:logging/logging.dart';
+import 'package:opennutritracker/features/add_meal/domain/meal_text_interpreter.dart';
+import 'package:opennutritracker/features/add_meal/util/meal_text_parser.dart';
+
+/// Reads a free-text meal line with Claude, and returns only what the food
+/// search needs: a query per item, plus a quantity when the user stated one.
+///
+/// The provenance guarantee is structural, not a convention. The tool schema
+/// below has **no macro fields** — the model has nowhere to put a calorie
+/// count, so it cannot supply one. Everything it does return then goes
+/// through [validateParsedMealItems], the same bounds `parseMealText`
+/// enforces, so a model can never write to the diary under looser rules than
+/// a regex. Both halves are covered by tests.
+class AnthropicMealTextInterpreter implements MealTextInterpreter {
+  static final _log = Logger('AnthropicMealTextInterpreter');
+
+  static const _endpoint = 'https://api.anthropic.com/v1/messages';
+
+  /// Pinned rather than tracking "latest": a silent model change would move
+  /// behaviour the user never asked to change, and this call is cheap enough
+  /// that the smallest current model is the right default.
+  static const defaultModel = 'claude-haiku-4-5';
+
+  /// The API version header Anthropic requires. Pinned for the same reason.
+  static const _apiVersion = '2023-06-01';
+
+  static const _toolName = 'log_meal_items';
+
+  /// Small on purpose. This returns a short list of short strings; a large
+  /// budget only buys a longer runaway before it is cut off.
+  static const _maxTokens = 1024;
+
+  final http.Client _client;
+  final String Function() _apiKey;
+  final String model;
+
+  AnthropicMealTextInterpreter(
+    this._client,
+    this._apiKey, {
+    this.model = defaultModel,
+  });
+
+  /// The whole contract with the model, in one place.
+  ///
+  /// `quantity` is described as *stated only* deliberately. Inferring that
+  /// half an avocado is about 100 g is estimation, not parsing, and
+  /// estimating mass is the first step back toward estimating nutrition —
+  /// which is what #250 was closed over. When the user states no amount the
+  /// field is left out and the review row's existing serving-size default
+  /// fills it, exactly as it does for the deterministic parser.
+  static const _systemPrompt = '''
+You extract food items from a meal description so they can be looked up in a
+food database. You do not estimate nutrition, and you never invent an amount.
+
+Rules:
+- One entry per distinct food. Split on any punctuation or conjunction the
+  user's language uses.
+- "query" is the food name alone, with no amount in it, in the same language
+  the user wrote. Keep a brand if one is given.
+- Only include "quantity" if the user stated an amount, including as a word
+  ("two eggs" -> 2) or a counter ("2个鸡蛋" -> 2). If no amount is stated,
+  omit both "quantity" and "unit".
+- Only include "unit" if the user stated one. A bare count has no unit.
+- Never convert between units. Report what was written.
+- If nothing in the input is food, return an empty list.''';
+
+  /// No nutrition fields, by construction. Adding one here is the only way a
+  /// model could return a macro through this path, which makes the review
+  /// question "did anyone add a field to this schema?" rather than "did the
+  /// model behave?".
+  static const _toolSchema = {
+    'type': 'object',
+    'properties': {
+      'items': {
+        'type': 'array',
+        'items': {
+          'type': 'object',
+          'properties': {
+            'query': {
+              'type': 'string',
+              'description':
+                  'Food name only, no amount, in the user\'s '
+                  'language.',
+            },
+            'quantity': {
+              'type': 'number',
+              'description': 'Only if the user stated an amount.',
+            },
+            'unit': {
+              'type': 'string',
+              'enum': ['g', 'ml', 'g/ml', 'oz', 'fl.oz', 'serving'],
+              'description': 'Only if the user stated a unit.',
+            },
+          },
+          'required': ['query'],
+          'additionalProperties': false,
+        },
+      },
+    },
+    'required': ['items'],
+    'additionalProperties': false,
+  };
+
+  @override
+  Future<MealTextParseResult> interpret(
+    String input, {
+    String? localeCode,
+  }) async {
+    final trimmed = input.trim();
+    if (trimmed.isEmpty) {
+      return const MealTextParseResult(items: [], errors: []);
+    }
+
+    final body = jsonEncode({
+      'model': model,
+      'max_tokens': _maxTokens,
+      'system': localeCode == null
+          ? _systemPrompt
+          : '$_systemPrompt\nThe user\'s app language is "$localeCode".',
+      'tools': [
+        {
+          'name': _toolName,
+          'description': 'Record the food items found in the description.',
+          'input_schema': _toolSchema,
+        },
+      ],
+      // Forcing the tool is what makes the reply parseable. Without it the
+      // model may answer in prose and every caller needs a fallback parser.
+      'tool_choice': {'type': 'tool', 'name': _toolName},
+      'messages': [
+        {'role': 'user', 'content': trimmed},
+      ],
+    });
+
+    final http.Response response;
+    try {
+      response = await _client.post(
+        Uri.parse(_endpoint),
+        headers: {
+          'content-type': 'application/json',
+          'x-api-key': _apiKey(),
+          'anthropic-version': _apiVersion,
+        },
+        body: body,
+      );
+    } catch (e) {
+      // Deliberately not logging `e`: a socket error can carry the request
+      // URL and, on some platforms, part of the payload.
+      throw const MealTextInterpreterException('request failed');
+    }
+
+    if (response.statusCode != 200) {
+      _log.warning('Interpreter call failed with ${response.statusCode}');
+      throw MealTextInterpreterException(
+        'provider returned ${response.statusCode}',
+        statusCode: response.statusCode,
+      );
+    }
+
+    return validateParsedMealItems(_itemsFrom(response.body));
+  }
+
+  /// Pulls the tool input out of the reply. Every shape that is not the one
+  /// expected raises rather than guessing, so a changed API surfaces as a
+  /// fallback to the deterministic parser instead of silent nonsense.
+  List<ParsedMealItem> _itemsFrom(String responseBody) {
+    final Map<String, dynamic> decoded;
+    try {
+      decoded = jsonDecode(responseBody) as Map<String, dynamic>;
+    } catch (_) {
+      throw const MealTextInterpreterException('malformed response');
+    }
+
+    final content = decoded['content'];
+    if (content is! List) {
+      throw const MealTextInterpreterException('response has no content');
+    }
+
+    for (final block in content) {
+      if (block is! Map) continue;
+      if (block['type'] != 'tool_use' || block['name'] != _toolName) continue;
+
+      final rawItems = (block['input'] as Map?)?['items'];
+      if (rawItems is! List) {
+        throw const MealTextInterpreterException('tool call has no items');
+      }
+
+      return [
+        for (final item in rawItems)
+          if (item is Map) _itemFrom(item),
+      ].nonNulls.toList();
+    }
+
+    throw const MealTextInterpreterException('response has no tool call');
+  }
+
+  /// One item, or null when it carries no usable query. A malformed entry is
+  /// dropped rather than failing the batch — the other items are still
+  /// worth showing, and `validateParsedMealItems` reports what it rejects.
+  ParsedMealItem? _itemFrom(Map<dynamic, dynamic> raw) {
+    final query = raw['query'];
+    if (query is! String) return null;
+
+    // Numbers arrive as int or double depending on how the model wrote
+    // them; a string is accepted too rather than dropping an otherwise fine
+    // item over its JSON type.
+    final rawQuantity = raw['quantity'];
+    final quantity = switch (rawQuantity) {
+      num n => n.toDouble(),
+      String s => double.tryParse(s.replaceAll(',', '.')),
+      _ => null,
+    };
+
+    final rawUnit = raw['unit'];
+    return ParsedMealItem(
+      query: query,
+      quantity: quantity,
+      unit: rawUnit is String ? rawUnit : null,
+    );
+  }
+}

--- a/lib/features/add_meal/data/anthropic_meal_text_interpreter.dart
+++ b/lib/features/add_meal/data/anthropic_meal_text_interpreter.dart
@@ -33,6 +33,11 @@ class AnthropicMealTextInterpreter implements MealTextInterpreter {
   /// budget only buys a longer runaway before it is cut off.
   static const _maxTokens = 1024;
 
+  /// Matches the other remote data sources in this repo. Without it a
+  /// stalled connection hangs until the OS gives up, which in #635 means the
+  /// user waits instead of falling back to the deterministic parser.
+  static const _timeout = Duration(seconds: 20);
+
   final http.Client _client;
   final String Function() _apiKey;
   final String model;
@@ -137,15 +142,17 @@ Rules:
 
     final http.Response response;
     try {
-      response = await _client.post(
-        Uri.parse(_endpoint),
-        headers: {
-          'content-type': 'application/json',
-          'x-api-key': _apiKey(),
-          'anthropic-version': _apiVersion,
-        },
-        body: body,
-      );
+      response = await _client
+          .post(
+            Uri.parse(_endpoint),
+            headers: {
+              'content-type': 'application/json',
+              'x-api-key': _apiKey(),
+              'anthropic-version': _apiVersion,
+            },
+            body: body,
+          )
+          .timeout(_timeout);
     } catch (e) {
       // Deliberately not logging `e`: a socket error can carry the request
       // URL and, on some platforms, part of the payload.
@@ -183,7 +190,11 @@ Rules:
       if (block is! Map) continue;
       if (block['type'] != 'tool_use' || block['name'] != _toolName) continue;
 
-      final rawItems = (block['input'] as Map?)?['items'];
+      // Checked rather than cast: a provider returning something other than
+      // an object here would otherwise throw a TypeError straight past the
+      // exception surface that #635 relies on to fall back.
+      final input = block['input'];
+      final rawItems = input is Map ? input['items'] : null;
       if (rawItems is! List) {
         throw const MealTextInterpreterException('tool call has no items');
       }

--- a/lib/features/add_meal/domain/meal_text_interpreter.dart
+++ b/lib/features/add_meal/domain/meal_text_interpreter.dart
@@ -1,0 +1,50 @@
+import 'package:opennutritracker/features/add_meal/util/meal_text_parser.dart';
+
+/// Turns a free-text meal description into items the existing food search
+/// can resolve.
+///
+/// Deliberately returns the same [MealTextParseResult] `parseMealText`
+/// returns, so an implementation is a drop-in alternative to the
+/// deterministic parser: the resolver, the review screen and the write path
+/// are untouched by which one produced the items.
+///
+/// **An implementation may not produce nutrition values.** Tier 1b of #599
+/// exists so a model can do the *language* work — segmenting a sentence,
+/// reading `two eggs` or `2个鸡蛋` — while every macro still comes from Open
+/// Food Facts / USDA / BLS via the resolver. That is what keeps the app's
+/// "every number is cited" claim true, and it is why #250 does not need
+/// reopening for this tier. See [ParsedMealItem]: it has nowhere to put a
+/// calorie.
+abstract interface class MealTextInterpreter {
+  /// Interprets [input], optionally hinted with the user's [localeCode] so
+  /// food names come back in the language the search is querying.
+  ///
+  /// Implementations must not throw for ordinary failure — no network, a
+  /// rejected key, a rate limit, a malformed reply. Those raise
+  /// [MealTextInterpreterException] so the caller can fall back to the
+  /// deterministic parser rather than showing the user an error.
+  Future<MealTextParseResult> interpret(String input, {String? localeCode});
+}
+
+/// Raised when an interpreter cannot produce a result. Carries no response
+/// body: provider payloads can echo the submitted text, and this ends up in
+/// logs.
+class MealTextInterpreterException implements Exception {
+  final String reason;
+
+  /// Set when the provider answered with an HTTP status, so a caller can
+  /// tell "your key is wrong" (401/403) from "try again later" (429/5xx).
+  final int? statusCode;
+
+  const MealTextInterpreterException(this.reason, {this.statusCode});
+
+  /// True for failures that a retry might survive. An auth failure is not
+  /// one of them.
+  bool get isTransient =>
+      statusCode == null || statusCode == 429 || (statusCode! >= 500);
+
+  @override
+  String toString() =>
+      'MealTextInterpreterException($reason${statusCode == null ? '' : ', '
+                'status: $statusCode'})';
+}

--- a/lib/features/add_meal/util/meal_text_parser.dart
+++ b/lib/features/add_meal/util/meal_text_parser.dart
@@ -163,7 +163,16 @@ MealTextParseResult validateParsedMealItems(List<ParsedMealItem> candidates) {
     // is still usable, and the review row's own default is a better answer
     // than refusing to log the item at all. A *stated* quantity survives
     // with it, since the row shows both and the user can correct the unit.
-    final unit = _validUnits.contains(candidate.unit) ? candidate.unit : null;
+    //
+    // A unit with no quantity is dropped too. [ParsedMealItem] documents the
+    // two as stated together, and `parseMealText` cannot produce one without
+    // the other, so downstream code was written against that. A model can
+    // produce it, and honouring a unit nobody attached a number to would
+    // present a guess as though the user had typed it.
+    final unit =
+        candidate.quantity != null && _validUnits.contains(candidate.unit)
+        ? candidate.unit
+        : null;
 
     items.add(ParsedMealItem(query: query, quantity: quantity, unit: unit));
   }

--- a/lib/features/add_meal/util/meal_text_parser.dart
+++ b/lib/features/add_meal/util/meal_text_parser.dart
@@ -119,6 +119,58 @@ class MealTextParseResult {
   bool get hasErrors => errors.isNotEmpty;
 }
 
+/// Applies the bounds [parseMealText] enforces to items that were extracted
+/// somewhere else.
+///
+/// Exists so a non-deterministic source — a model, an import — can never
+/// reach the diary under looser rules than a regex does. Everything a
+/// caller supplies is treated as untrusted: the food name must satisfy
+/// [FoodNameValidator], a stated quantity must be `> 0` and `<= 10000`, and
+/// a stated unit must be one the app can actually convert. Anything else is
+/// rejected with the same item-indexed reason the parser produces, so the
+/// review screen renders both sources identically.
+///
+/// Unlike [parseMealText] this does no extraction and no kg/l conversion:
+/// the caller is expected to have arrived at a quantity already, and
+/// `kg`/`l` are not accepted here because nothing has normalized them.
+MealTextParseResult validateParsedMealItems(List<ParsedMealItem> candidates) {
+  final items = <ParsedMealItem>[];
+  final errors = <MealTextParseError>[];
+
+  for (var i = 0; i < candidates.length; i++) {
+    final itemNum = i + 1;
+    final candidate = candidates[i];
+    final query = candidate.query.trim();
+
+    if (!FoodNameValidator.isValid(query)) {
+      errors.add(InvalidFoodNameError(itemNum));
+      continue;
+    }
+
+    final quantity = candidate.quantity;
+    if (quantity != null) {
+      if (quantity <= 0) {
+        errors.add(QuantityTooSmallError(itemNum));
+        continue;
+      }
+      if (quantity > _maxQuantity) {
+        errors.add(QuantityTooLargeError(itemNum, _maxQuantity));
+        continue;
+      }
+    }
+
+    // An unrecognized unit is dropped rather than rejected: the food name
+    // is still usable, and the review row's own default is a better answer
+    // than refusing to log the item at all. A *stated* quantity survives
+    // with it, since the row shows both and the user can correct the unit.
+    final unit = _validUnits.contains(candidate.unit) ? candidate.unit : null;
+
+    items.add(ParsedMealItem(query: query, quantity: quantity, unit: unit));
+  }
+
+  return MealTextParseResult(items: items, errors: errors);
+}
+
 /// A comma with a digit immediately before it *and* immediately after it
 /// is a decimal point; every other comma separates items. The lookarounds
 /// express that as "a comma not preceded by a digit, or not followed by

--- a/test/unit_test/anthropic_meal_text_interpreter_test.dart
+++ b/test/unit_test/anthropic_meal_text_interpreter_test.dart
@@ -57,8 +57,10 @@ String toolReply(List<Map<String, dynamic>> items) => jsonEncode({
   ],
 });
 
-AnthropicMealTextInterpreter interpreterWith(FakeClient client) =>
-    AnthropicMealTextInterpreter(client, () => 'test-key');
+AnthropicMealTextInterpreter interpreterWith(
+  FakeClient client, {
+  Duration timeout = AnthropicMealTextInterpreter.defaultTimeout,
+}) => AnthropicMealTextInterpreter(client, () => 'test-key', timeout: timeout);
 
 void main() {
   group('the request', () {
@@ -332,11 +334,24 @@ void main() {
     });
 
     test('a stalled connection does not hang forever', () async {
+      // A short timeout so this costs milliseconds rather than the real
+      // twenty seconds; `defaultTimeout` is asserted separately.
       final client = FakeClient(hangs: true);
 
       await expectLater(
-        interpreterWith(client).interpret('toast'),
+        interpreterWith(
+          client,
+          timeout: const Duration(milliseconds: 50),
+        ).interpret('toast'),
         throwsA(isA<MealTextInterpreterException>()),
+      );
+    });
+
+    test('the shipped timeout matches the other remote data sources', () {
+      // The injectable timeout is for tests; this pins what production uses.
+      expect(
+        AnthropicMealTextInterpreter.defaultTimeout,
+        const Duration(seconds: 20),
       );
     });
 

--- a/test/unit_test/anthropic_meal_text_interpreter_test.dart
+++ b/test/unit_test/anthropic_meal_text_interpreter_test.dart
@@ -1,0 +1,322 @@
+import 'dart:convert';
+
+import 'package:flutter_test/flutter_test.dart';
+import 'package:http/http.dart' as http;
+import 'package:opennutritracker/features/add_meal/data/anthropic_meal_text_interpreter.dart';
+import 'package:opennutritracker/features/add_meal/domain/meal_text_interpreter.dart';
+import 'package:opennutritracker/features/add_meal/util/meal_text_parser.dart';
+
+/// Captures the outgoing request and replays a canned reply. Nothing in this
+/// file touches the network.
+class FakeClient extends http.BaseClient {
+  final int status;
+  final String body;
+  final Object? throwOnSend;
+
+  Map<String, dynamic>? sentBody;
+  Map<String, String>? sentHeaders;
+
+  FakeClient({this.status = 200, this.body = '{}', this.throwOnSend});
+
+  @override
+  Future<http.StreamedResponse> send(http.BaseRequest request) async {
+    if (throwOnSend != null) throw throwOnSend!;
+    sentHeaders = request.headers;
+    sentBody =
+        jsonDecode((request as http.Request).body) as Map<String, dynamic>;
+    return http.StreamedResponse(
+      Stream.value(utf8.encode(body)),
+      status,
+      request: request,
+    );
+  }
+}
+
+/// A well-formed Messages reply carrying one forced tool call.
+String toolReply(List<Map<String, dynamic>> items) => jsonEncode({
+  'id': 'msg_1',
+  'type': 'message',
+  'role': 'assistant',
+  'content': [
+    {
+      'type': 'tool_use',
+      'id': 'tu_1',
+      'name': 'log_meal_items',
+      'input': {'items': items},
+    },
+  ],
+});
+
+AnthropicMealTextInterpreter interpreterWith(FakeClient client) =>
+    AnthropicMealTextInterpreter(client, () => 'test-key');
+
+void main() {
+  group('the request', () {
+    test('forces the tool so the reply is always parseable', () async {
+      final client = FakeClient(body: toolReply(const []));
+      await interpreterWith(client).interpret('toast');
+
+      expect(client.sentBody!['tool_choice'], {
+        'type': 'tool',
+        'name': 'log_meal_items',
+      });
+    });
+
+    test('sends the key as a header and never in the body', () async {
+      final client = FakeClient(body: toolReply(const []));
+      await interpreterWith(client).interpret('toast');
+
+      expect(client.sentHeaders!['x-api-key'], 'test-key');
+      expect(client.sentHeaders!['anthropic-version'], isNotEmpty);
+      expect(jsonEncode(client.sentBody), isNot(contains('test-key')));
+    });
+
+    test('pins the model rather than tracking a moving alias', () async {
+      final client = FakeClient(body: toolReply(const []));
+      await interpreterWith(client).interpret('toast');
+
+      expect(
+        client.sentBody!['model'],
+        AnthropicMealTextInterpreter.defaultModel,
+      );
+      expect(client.sentBody!['model'], isNot(contains('latest')));
+    });
+
+    test(
+      'passes the locale so names come back in the search language',
+      () async {
+        final client = FakeClient(body: toolReply(const []));
+        await interpreterWith(client).interpret('toast', localeCode: 'de');
+
+        expect(client.sentBody!['system'], contains('de'));
+      },
+    );
+
+    test('does not call out at all for empty input', () async {
+      final client = FakeClient(body: toolReply(const []));
+      final result = await interpreterWith(client).interpret('   ');
+
+      expect(client.sentBody, isNull);
+      expect(result.items, isEmpty);
+    });
+  });
+
+  group('the schema cannot carry nutrition', () {
+    // The provenance guarantee for tier 1b is structural: the model has
+    // nowhere to put a calorie. If someone adds a macro field to the tool
+    // schema, this fails — which is the review question we want asked.
+    test('exposes only query, quantity and unit', () async {
+      final client = FakeClient(body: toolReply(const []));
+      await interpreterWith(client).interpret('toast');
+
+      final schema =
+          (client.sentBody!['tools'] as List).single as Map<String, dynamic>;
+      final itemProps =
+          (((schema['input_schema'] as Map)['properties'] as Map)['items']
+                  as Map)['items']
+              as Map;
+
+      expect(((itemProps['properties']) as Map).keys.toSet(), {
+        'query',
+        'quantity',
+        'unit',
+      });
+      expect(itemProps['additionalProperties'], isFalse);
+    });
+
+    test('a macro smuggled into the reply is discarded, not stored', () async {
+      // Even if a future model returns extra fields, ParsedMealItem has
+      // nowhere to hold them, so they cannot reach the diary.
+      final client = FakeClient(
+        body: toolReply([
+          {'query': 'toast', 'quantity': 100, 'unit': 'g', 'kcal': 265},
+        ]),
+      );
+
+      final result = await interpreterWith(client).interpret('100g toast');
+
+      final item = result.items.single;
+      expect(item.query, 'toast');
+      expect(item.quantity, 100);
+      expect(item.unit, 'g');
+      expect(item.toString(), isNot(contains('265')));
+    });
+  });
+
+  group('the reply', () {
+    test('maps items through to parsed items', () async {
+      final client = FakeClient(
+        body: toolReply([
+          {'query': 'toast', 'quantity': 100, 'unit': 'g'},
+          {'query': 'eggs', 'quantity': 2},
+          {'query': 'black coffee'},
+        ]),
+      );
+
+      final result = await interpreterWith(client).interpret('anything');
+
+      expect(result.items, hasLength(3));
+      expect(result.items[1].quantity, 2);
+      expect(result.items[1].unit, isNull);
+      expect(result.items[2].quantity, isNull);
+      expect(result.errors, isEmpty);
+    });
+
+    test('accepts a quantity written as a string or a decimal', () async {
+      final client = FakeClient(
+        body: toolReply([
+          {'query': 'milk', 'quantity': '1,5', 'unit': 'ml'},
+          {'query': 'flour', 'quantity': 2.5, 'unit': 'g'},
+        ]),
+      );
+
+      final result = await interpreterWith(client).interpret('anything');
+
+      expect(result.items[0].quantity, 1.5);
+      expect(result.items[1].quantity, 2.5);
+    });
+
+    test('drops an unusable entry without failing the batch', () async {
+      final client = FakeClient(
+        body: toolReply([
+          {'quantity': 100},
+          {'query': 'toast', 'quantity': 100, 'unit': 'g'},
+        ]),
+      );
+
+      final result = await interpreterWith(client).interpret('anything');
+
+      expect(result.items.single.query, 'toast');
+    });
+
+    test('drops a unit the app cannot convert, keeping the food', () async {
+      final client = FakeClient(
+        body: toolReply([
+          {'query': 'flour', 'quantity': 2, 'unit': 'cups'},
+        ]),
+      );
+
+      final result = await interpreterWith(client).interpret('2 cups flour');
+
+      expect(result.items.single.query, 'flour');
+      expect(result.items.single.unit, isNull);
+      expect(result.items.single.quantity, 2);
+    });
+  });
+
+  group('model output is held to the parser bounds', () {
+    test('a quantity over the maximum is rejected, not clamped', () async {
+      final client = FakeClient(
+        body: toolReply([
+          {'query': 'flour', 'quantity': 15000, 'unit': 'g'},
+        ]),
+      );
+
+      final result = await interpreterWith(client).interpret('anything');
+
+      expect(result.items, isEmpty);
+      expect(result.errors, [const QuantityTooLargeError(1, 10000)]);
+    });
+
+    test('a zero or negative quantity is rejected', () async {
+      final client = FakeClient(
+        body: toolReply([
+          {'query': 'water', 'quantity': 0, 'unit': 'ml'},
+        ]),
+      );
+
+      final result = await interpreterWith(client).interpret('anything');
+
+      expect(result.errors, [const QuantityTooSmallError(1)]);
+    });
+
+    test('a query with no letters is rejected', () async {
+      final client = FakeClient(
+        body: toolReply([
+          {'query': '123'},
+        ]),
+      );
+
+      final result = await interpreterWith(client).interpret('anything');
+
+      expect(result.errors, [const InvalidFoodNameError(1)]);
+    });
+  });
+
+  group('failures', () {
+    test('a rejected key is reported as not worth retrying', () async {
+      final client = FakeClient(status: 401, body: '{"error":"bad key"}');
+
+      await expectLater(
+        interpreterWith(client).interpret('toast'),
+        throwsA(
+          isA<MealTextInterpreterException>().having(
+            (e) => e.isTransient,
+            'isTransient',
+            isFalse,
+          ),
+        ),
+      );
+    });
+
+    test('a rate limit is reported as transient', () async {
+      final client = FakeClient(status: 429, body: '{}');
+
+      await expectLater(
+        interpreterWith(client).interpret('toast'),
+        throwsA(
+          isA<MealTextInterpreterException>().having(
+            (e) => e.isTransient,
+            'isTransient',
+            isTrue,
+          ),
+        ),
+      );
+    });
+
+    test('a network error raises without echoing the request', () async {
+      final client = FakeClient(throwOnSend: const SocketExceptionStub());
+
+      await expectLater(
+        interpreterWith(client).interpret('my private meal note'),
+        throwsA(
+          isA<MealTextInterpreterException>().having(
+            (e) => e.toString(),
+            'toString',
+            isNot(contains('private')),
+          ),
+        ),
+      );
+    });
+
+    test('a reply with no tool call raises rather than guessing', () async {
+      final client = FakeClient(
+        body: jsonEncode({
+          'content': [
+            {'type': 'text', 'text': 'I think you ate toast.'},
+          ],
+        }),
+      );
+
+      await expectLater(
+        interpreterWith(client).interpret('toast'),
+        throwsA(isA<MealTextInterpreterException>()),
+      );
+    });
+
+    test('a malformed body raises rather than guessing', () async {
+      final client = FakeClient(body: 'not json');
+
+      await expectLater(
+        interpreterWith(client).interpret('toast'),
+        throwsA(isA<MealTextInterpreterException>()),
+      );
+    });
+  });
+}
+
+class SocketExceptionStub implements Exception {
+  const SocketExceptionStub();
+  @override
+  String toString() => 'connection failed to api.anthropic.com';
+}

--- a/test/unit_test/anthropic_meal_text_interpreter_test.dart
+++ b/test/unit_test/anthropic_meal_text_interpreter_test.dart
@@ -1,3 +1,4 @@
+import 'dart:async';
 import 'dart:convert';
 
 import 'package:flutter_test/flutter_test.dart';
@@ -13,14 +14,23 @@ class FakeClient extends http.BaseClient {
   final String body;
   final Object? throwOnSend;
 
+  /// Never completes, standing in for a connection that stalls.
+  final bool hangs;
+
   Map<String, dynamic>? sentBody;
   Map<String, String>? sentHeaders;
 
-  FakeClient({this.status = 200, this.body = '{}', this.throwOnSend});
+  FakeClient({
+    this.status = 200,
+    this.body = '{}',
+    this.throwOnSend,
+    this.hangs = false,
+  });
 
   @override
   Future<http.StreamedResponse> send(http.BaseRequest request) async {
     if (throwOnSend != null) throw throwOnSend!;
+    if (hangs) return Completer<http.StreamedResponse>().future;
     sentHeaders = request.headers;
     sentBody =
         jsonDecode((request as http.Request).body) as Map<String, dynamic>;
@@ -297,6 +307,32 @@ void main() {
           ],
         }),
       );
+
+      await expectLater(
+        interpreterWith(client).interpret('toast'),
+        throwsA(isA<MealTextInterpreterException>()),
+      );
+    });
+
+    test('an unexpected tool-input shape raises, not a TypeError', () async {
+      // Must arrive as MealTextInterpreterException, or #635 cannot fall
+      // back to the deterministic parser and the caller crashes instead.
+      final client = FakeClient(
+        body: jsonEncode({
+          'content': [
+            {'type': 'tool_use', 'name': 'log_meal_items', 'input': 'oops'},
+          ],
+        }),
+      );
+
+      await expectLater(
+        interpreterWith(client).interpret('toast'),
+        throwsA(isA<MealTextInterpreterException>()),
+      );
+    });
+
+    test('a stalled connection does not hang forever', () async {
+      final client = FakeClient(hangs: true);
 
       await expectLater(
         interpreterWith(client).interpret('toast'),

--- a/test/unit_test/meal_text_parser_test.dart
+++ b/test/unit_test/meal_text_parser_test.dart
@@ -458,4 +458,82 @@ void main() {
       },
     );
   });
+
+  group('validateParsedMealItems', () {
+    // The gate every non-deterministic source passes through, so a model
+    // can never reach the diary under looser rules than the regex does.
+    test('keeps a well-formed item unchanged', () {
+      final result = validateParsedMealItems(const [
+        ParsedMealItem(query: 'toast', quantity: 100, unit: 'g'),
+      ]);
+
+      expect(result.items.single.query, 'toast');
+      expect(result.items.single.quantity, 100);
+      expect(result.items.single.unit, 'g');
+      expect(result.errors, isEmpty);
+    });
+
+    test('applies the same bounds parseMealText applies', () {
+      final result = validateParsedMealItems(const [
+        ParsedMealItem(query: '123'),
+        ParsedMealItem(query: 'water', quantity: 0, unit: 'ml'),
+        ParsedMealItem(query: 'flour', quantity: 15000, unit: 'g'),
+      ]);
+
+      expect(result.items, isEmpty);
+      expect(result.errors, const [
+        InvalidFoodNameError(1),
+        QuantityTooSmallError(2),
+        QuantityTooLargeError(3, 10000),
+      ]);
+    });
+
+    test('numbers errors by position so the user can find the item', () {
+      final result = validateParsedMealItems(const [
+        ParsedMealItem(query: 'toast', quantity: 100, unit: 'g'),
+        ParsedMealItem(query: '456'),
+      ]);
+
+      expect(result.items.single.query, 'toast');
+      expect(result.errors, const [InvalidFoodNameError(2)]);
+    });
+
+    test('drops an unconvertible unit but keeps the food and the amount', () {
+      // Refusing the row outright would lose a usable food over a unit the
+      // review row can default better than we can guess.
+      final result = validateParsedMealItems(const [
+        ParsedMealItem(query: 'flour', quantity: 2, unit: 'cups'),
+      ]);
+
+      expect(result.items.single.unit, isNull);
+      expect(result.items.single.quantity, 2);
+      expect(result.errors, isEmpty);
+    });
+
+    test('does not accept kg or l, which nothing has normalized here', () {
+      // parseMealText converts these itself; this entry point does no
+      // extraction, so accepting them would log 2 g for 2 kg.
+      final result = validateParsedMealItems(const [
+        ParsedMealItem(query: 'flour', quantity: 2, unit: 'kg'),
+      ]);
+
+      expect(result.items.single.unit, isNull);
+    });
+
+    test('trims the query so a padded name still reaches the search', () {
+      final result = validateParsedMealItems(const [
+        ParsedMealItem(query: '  toast  '),
+      ]);
+
+      expect(result.items.single.query, 'toast');
+    });
+
+    test('an empty list is not an error', () {
+      final result = validateParsedMealItems(const []);
+
+      expect(result.items, isEmpty);
+      expect(result.errors, isEmpty);
+      expect(result.hasErrors, isFalse);
+    });
+  });
 }

--- a/test/unit_test/meal_text_parser_test.dart
+++ b/test/unit_test/meal_text_parser_test.dart
@@ -520,6 +520,18 @@ void main() {
       expect(result.items.single.unit, isNull);
     });
 
+    test('a unit with no quantity is dropped, not presented as stated', () {
+      // parseMealText cannot produce this pair, so downstream code was
+      // written assuming it never happens. A model can produce it.
+      final result = validateParsedMealItems(const [
+        ParsedMealItem(query: 'milk', unit: 'ml'),
+      ]);
+
+      expect(result.items.single.unit, isNull);
+      expect(result.items.single.quantity, isNull);
+      expect(result.errors, isEmpty);
+    });
+
     test('trims the query so a padded name still reaches the search', () {
       final result = validateParsedMealItems(const [
         ParsedMealItem(query: '  toast  '),


### PR DESCRIPTION
Closes #633. First of three for tier 1b of #599.

## What tier 1b is

A model does the **language** work — segmenting a sentence, reading `two eggs` or `2个鸡蛋`. The **database still supplies every number**. No macro is ever invented, so "every number is cited" holds and #250 does not need reopening.

This PR is the client only. **Nothing in the app calls it yet** — no UI, no key storage, no wiring. The key is a constructor parameter. Those are #634 and #635.

## The design that makes it safe

`MealTextInterpreter` returns the **same `MealTextParseResult`** the deterministic parser returns. That makes an implementation a drop-in alternative to `parseMealText`: the resolver, review rows and write path are untouched and do not know which produced the items.

Two guarantees, both enforced rather than documented:

**1. The tool schema has no macro fields.** The model has nowhere to put a calorie count, so it cannot supply one. A test asserts the schema exposes exactly `{query, quantity, unit}` and nothing else — so the review question becomes *"did someone add a field to this schema?"* rather than *"did the model behave?"*.

**2. Model output is held to the parser's bounds.** Everything returned passes through the new `validateParsedMealItems`, the same `FoodNameValidator` / `> 0` / `<= 10000` / known-unit rules `parseMealText` enforces. A model cannot write to the diary under looser rules than a regex.

## The boundary I held

The prompt asks for a quantity **only when the user stated one**. Inferring that half an avocado is about 100 g is estimation, not parsing — and estimating mass is the first step back toward estimating nutrition, which is what #250 was closed over. With nothing stated the field is omitted and the review row's existing serving-size default fills it, exactly as for the deterministic parser.

I flagged this as the one open question before starting and proceeded on that answer. **Say if you want it drawn elsewhere** — it is one line of the prompt and one test.

## Failure behaviour

The tool call is forced, so a prose reply is not a shape any caller has to handle. Anything unexpected — no tool call, malformed body, non-200 — raises `MealTextInterpreterException` rather than guessing, so #635 can fall back to the deterministic parser instead of showing an error.

The exception carries **no response body**: provider payloads can echo the submitted text, and this reaches logs. The network-error path deliberately does not log the underlying error for the same reason, and a test asserts the submitted text does not appear in the exception string.

Auth failures are marked non-transient (`isTransient == false`) so a caller can distinguish "your key is wrong" from "try again later".

## Choices worth a second opinion

- **Model pinned to `claude-haiku-4-5`**, not an alias. A silent model change would move behaviour the user never asked to change. Overridable per instance.
- **An unrecognised unit is dropped, not rejected.** `2 cups flour` keeps the food and the `2`, and the row defaults the unit — refusing the row outright would lose a usable food over a unit the review row guesses better than we can.
- **`kg`/`l` are not accepted by `validateParsedMealItems`.** `parseMealText` converts them itself before validating; this entry point does no extraction, so accepting them would log 2 g for 2 kg. Covered by a test.

## Verification

26 new tests (19 for the interpreter, 7 for the validator). `flutter test` 1108/1108, `flutter analyze` clean, formatter clean.

**No live API call has been made.** Every test fakes `http.Client`. The request shape — forced `tool_choice`, `x-api-key` and `anthropic-version` headers — is asserted against the documented contract, not against a real response. One live call before #635 ships would be worth it, and I have not made one.

## No new dependency

`http` was already a direct dependency.
