### PR TITLE
fix(trends): respect configured day boundary

### DIFF
--- a/lib/core/utils/calc/day_boundary_calc.dart
+++ b/lib/core/utils/calc/day_boundary_calc.dart
@@ -135,8 +135,12 @@ class DayBoundaryCalc {
   }
 
   static DateTime _logicalDayOfTotalMinutes(DateTime moment, int totalMinutes) {
-    final shifted = moment.subtract(Duration(minutes: totalMinutes));
-    return DateTime(shifted.year, shifted.month, shifted.day);
+    final minutesSinceMidnight = moment.hour * 60 + moment.minute;
+    final dayDelta = minutesSinceMidnight < totalMinutes ? -1 : 0;
+    // The setting is a local wall-clock boundary, not an elapsed duration.
+    // Stepping the calendar date avoids shifting an extra hour when a local
+    // timezone enters or leaves daylight saving time.
+    return DateTime(moment.year, moment.month, moment.day + dayDelta);
   }
 
   /// A bare midnight is how this app spells "the calendar day named

--- a/lib/features/trends/presentation/bloc/trends_bloc.dart
+++ b/lib/features/trends/presentation/bloc/trends_bloc.dart
@@ -8,6 +8,7 @@ import 'package:opennutritracker/core/domain/usecase/get_tracked_day_usecase.dar
 import 'package:opennutritracker/core/domain/usecase/get_user_usecase.dart';
 import 'package:opennutritracker/core/domain/usecase/get_water_intake_usecase.dart';
 import 'package:opennutritracker/core/domain/usecase/get_weight_log_usecase.dart';
+import 'package:opennutritracker/core/utils/calc/day_boundary_calc.dart';
 
 part 'trends_event.dart';
 part 'trends_state.dart';
@@ -29,18 +30,20 @@ class TrendsBloc extends Bloc<TrendsEvent, TrendsState> {
     on<LoadTrendsEvent>((event, emit) async {
       emit(const TrendsLoading());
       try {
-        final now = DateTime.now();
-        final today = DateTime(now.year, now.month, now.day);
+        final config = await _getConfigUsecase.getConfig();
+        final today = DayBoundaryCalc.currentLogicalDayMinutes(
+          config.dayStartOffsetTotalMinutes,
+        );
         // Today's tracked day is stamped with the time it was created, so the
         // range end must cover the whole day or today drops out of the result
         // (the range filter is inclusive but compares against this instant).
-        final endOfToday = DateTime(now.year, now.month, now.day, 23, 59, 59);
+        final endOfToday = DateTime(today.year, today.month, today.day, 23, 59, 59);
         // rangeDays 0 is the "All" chip: pull a wide window and let the actual
         // span fall out of the earliest data point below.
         final isAll = event.rangeDays == 0;
         final fetchDays = isAll ? 3650 : event.rangeDays;
         final days = await _getTrackedDayUsecase.getTrackedDaysByRange(
-          today.subtract(Duration(days: fetchDays - 1)),
+          DateTime(today.year, today.month, today.day - (fetchDays - 1)),
           endOfToday,
         );
         // The full weight history; the chart windows it for display. This
@@ -50,17 +53,19 @@ class TrendsBloc extends Bloc<TrendsEvent, TrendsState> {
         weight.sort((a, b) => a.date.compareTo(b.date));
         // The 7 days before this week, for a week-over-week consistency delta.
         final priorWeek = await _getTrackedDayUsecase.getTrackedDaysByRange(
-          today.subtract(const Duration(days: 13)),
-          DateTime(now.year, now.month, now.day - 7, 23, 59, 59),
+          DateTime(today.year, today.month, today.day - 13),
+          DateTime(today.year, today.month, today.day - 7, 23, 59, 59),
         );
         final user = await _getUserUsecase.getUserData();
-        final config = await _getConfigUsecase.getConfig();
 
-        // Water totalled per calendar day; the card fills missing days with 0.
+        // Water follows the same logical-day boundary as food and the diary.
         final waterEntries = await _getWaterIntakeUsecase.getAllEntries();
         final waterByDay = <DateTime, int>{};
         for (final e in waterEntries) {
-          final d = DateTime(e.dateTime.year, e.dateTime.month, e.dateTime.day);
+          final d = DayBoundaryCalc.logicalDayOfMinutes(
+            e.dateTime,
+            config.dayStartOffsetTotalMinutes,
+          );
           waterByDay[d] = (waterByDay[d] ?? 0) + e.amountMl;
         }
 
@@ -85,14 +90,24 @@ class TrendsBloc extends Bloc<TrendsEvent, TrendsState> {
           for (final k in waterByDay.keys) {
             consider(k);
           }
-          windowDays = earliest == null
-              ? 30 // no data yet: a sensible empty-chart width
-              : (today.difference(earliest!).inDays + 1).clamp(2, 3650);
+          if (earliest == null) {
+            windowDays = 30; // no data yet: a sensible empty-chart width
+          } else {
+            // Compare date labels in UTC so a local DST transition cannot
+            // shorten or lengthen the apparent number of calendar days.
+            final first = earliest!;
+            final calendarDays = DateTime.utc(today.year, today.month, today.day)
+                    .difference(DateTime.utc(first.year, first.month, first.day))
+                    .inDays +
+                1;
+            windowDays = calendarDays.clamp(2, 3650);
+          }
         }
 
         emit(TrendsLoaded(
           rangeDays: event.rangeDays,
           windowDays: windowDays,
+          today: today,
           days: days,
           priorWeek: priorWeek,
           weight: weight,

--- a/lib/features/trends/presentation/bloc/trends_state.dart
+++ b/lib/features/trends/presentation/bloc/trends_state.dart
@@ -18,17 +18,19 @@ class TrendsLoading extends TrendsState {
 class TrendsLoaded extends TrendsState {
   final int rangeDays; // the selected range chip: 7, 30, 90, or 0 for "All"
   final int windowDays; // effective span the charts plot over (resolved "All")
+  final DateTime today; // logical today under the configured day boundary
   final List<TrackedDayEntity> days; // tracked days over the selected window
   final List<TrackedDayEntity> priorWeek; // the 7 days before this week
   final List<WeightLogEntity> weight; // full weight history, windowed in the UI
   final BodyWeightUnit bodyWeightUnit;
   final double? targetWeightKg; // user's #119 target, for the chart reference
-  final Map<DateTime, int> waterByDay; // ml logged per calendar day
+  final Map<DateTime, int> waterByDay; // ml logged per logical day
   final int waterGoalMl;
 
   const TrendsLoaded({
     required this.rangeDays,
     required this.windowDays,
+    required this.today,
     required this.days,
     required this.priorWeek,
     required this.weight,
@@ -42,6 +44,7 @@ class TrendsLoaded extends TrendsState {
   List<Object?> get props => [
         rangeDays,
         windowDays,
+        today,
         days,
         priorWeek,
         weight,

--- a/lib/features/trends/presentation/trends_calc.dart
+++ b/lib/features/trends/presentation/trends_calc.dart
@@ -11,7 +11,15 @@
   DateTime windowStart,
   DateTime today,
 ) {
-  final total = today.difference(windowStart).inDays;
+  // These are calendar labels, so compare their UTC spellings rather than
+  // elapsed local time; a DST transition must not add or remove a day.
+  final total = DateTime.utc(today.year, today.month, today.day)
+      .difference(DateTime.utc(
+        windowStart.year,
+        windowStart.month,
+        windowStart.day,
+      ))
+      .inDays;
   if (total < 0) return (current: 0, longest: 0);
 
   var longest = 0;

--- a/lib/features/trends/presentation/trends_page.dart
+++ b/lib/features/trends/presentation/trends_page.dart
@@ -66,13 +66,14 @@ class _TrendsView extends StatelessWidget {
               days: state.days,
               priorWeek: state.priorWeek,
               rangeDays: state.windowDays,
+              today: state.today,
               palette: palette,
             ),
             const SizedBox(height: Dimens.spacing16),
             _RangeSelector(rangeDays: state.rangeDays),
             const SizedBox(height: Dimens.spacing16),
             _CaloriesTrendCard(
-                days: state.days, rangeDays: state.windowDays, palette: palette),
+                days: state.days, rangeDays: state.windowDays, today: state.today, palette: palette),
             const SizedBox(height: Dimens.spacing16),
             _MacrosTrendCard(
                 days: state.days, rangeDays: state.windowDays, palette: palette),
@@ -81,6 +82,7 @@ class _TrendsView extends StatelessWidget {
               waterByDay: state.waterByDay,
               goalMl: state.waterGoalMl,
               rangeDays: state.windowDays,
+              today: state.today,
               palette: palette,
             ),
             const SizedBox(height: Dimens.spacing16),
@@ -131,11 +133,13 @@ class _StreakCard extends StatelessWidget {
   final List<TrackedDayEntity> days;
   final List<TrackedDayEntity> priorWeek;
   final int rangeDays;
+  final DateTime today;
   final AppPalette palette;
   const _StreakCard({
     required this.days,
     required this.priorWeek,
     required this.rangeDays,
+    required this.today,
     required this.palette,
   });
 
@@ -144,12 +148,10 @@ class _StreakCard extends StatelessWidget {
     final accent = Theme.of(context).colorScheme.primary;
     final errorColor = Theme.of(context).colorScheme.error;
     final text = Theme.of(context).textTheme;
-    final now = DateTime.now();
-    final today = DateTime(now.year, now.month, now.day);
     final windowStart =
         DateTime(today.year, today.month, today.day - (rangeDays - 1));
-    final weekEnd = today;
-    final weekStart = weekEnd.subtract(const Duration(days: 6));
+    final dayBeforeWeek = DateTime(today.year, today.month, today.day - 7);
+    final dayAfterWeek = DateTime(today.year, today.month, today.day + 1);
 
     bool onTrack(TrackedDayEntity d) =>
         d.getCalendarDayRatingColor(context) != errorColor;
@@ -166,8 +168,7 @@ class _StreakCard extends StatelessWidget {
     final priorOnTrack = priorWeek.where(onTrack).toList();
     final thisWeek = onTrackDays
         .where((day) =>
-            day.isAfter(weekStart.subtract(const Duration(days: 1))) &&
-            day.isBefore(weekEnd.add(const Duration(days: 1))))
+            day.isAfter(dayBeforeWeek) && day.isBefore(dayAfterWeek))
         .length;
     final delta = priorOnTrack.isNotEmpty
         ? thisWeek - priorOnTrack.length
@@ -248,21 +249,25 @@ class _WeekDeltaChip extends StatelessWidget {
 class _CaloriesTrendCard extends StatelessWidget {
   final List<TrackedDayEntity> days;
   final int rangeDays;
+  final DateTime today;
   final AppPalette palette;
-  const _CaloriesTrendCard({required this.days, required this.rangeDays, required this.palette});
+  const _CaloriesTrendCard({
+    required this.days,
+    required this.rangeDays,
+    required this.today,
+    required this.palette,
+  });
 
   @override
   Widget build(BuildContext context) {
     final text = Theme.of(context).textTheme;
     final accent = Theme.of(context).colorScheme.primary;
-    final now = DateTime.now();
-    final today = DateTime(now.year, now.month, now.day);
     final byDay = {for (final d in days) DateTime(d.day.year, d.day.month, d.day.day): d};
     // Full per-day series across the window; missing days contribute 0 tracked.
     final spots = <FlSpot>[];
     final goals = <double>[];
     for (int i = 0; i < rangeDays; i++) {
-      final day = today.subtract(Duration(days: rangeDays - 1 - i));
+      final day = DateTime(today.year, today.month, today.day - (rangeDays - 1 - i));
       final d = byDay[DateTime(day.year, day.month, day.day)];
       spots.add(FlSpot(i.toDouble(), d?.caloriesTracked ?? 0));
       if (d != null && d.calorieGoal > 0) goals.add(d.calorieGoal);
@@ -339,11 +344,13 @@ class _WaterTrendCard extends StatelessWidget {
   final Map<DateTime, int> waterByDay;
   final int goalMl;
   final int rangeDays;
+  final DateTime today;
   final AppPalette palette;
   const _WaterTrendCard({
     required this.waterByDay,
     required this.goalMl,
     required this.rangeDays,
+    required this.today,
     required this.palette,
   });
 
@@ -351,13 +358,11 @@ class _WaterTrendCard extends StatelessWidget {
   Widget build(BuildContext context) {
     final text = Theme.of(context).textTheme;
     final color = palette.proteinColor;
-    final now = DateTime.now();
-    final today = DateTime(now.year, now.month, now.day);
     final spots = <FlSpot>[];
     var sum = 0;
     var loggedDays = 0;
     for (int i = 0; i < rangeDays; i++) {
-      final day = today.subtract(Duration(days: rangeDays - 1 - i));
+      final day = DateTime(today.year, today.month, today.day - (rangeDays - 1 - i));
       final ml = waterByDay[DateTime(day.year, day.month, day.day)] ?? 0;
       spots.add(FlSpot(i.toDouble(), ml.toDouble()));
       if (ml > 0) {

--- a/test/features/profile/presentation/bloc/profile_bloc_trends_refresh_test.dart
+++ b/test/features/profile/presentation/bloc/profile_bloc_trends_refresh_test.dart
@@ -97,15 +97,16 @@ void main() {
       'weight card)', () async {
     final user = UserEntityFixtures.youngSedentaryMaleWantingToMaintainWeight;
     trendsBloc = _FakeTrendsBloc(
-      const TrendsLoaded(
+      TrendsLoaded(
         rangeDays: 30,
         windowDays: 30,
-        days: <TrackedDayEntity>[],
-        priorWeek: <TrackedDayEntity>[],
-        weight: [],
+        today: DateTime(2026, 1, 1),
+        days: const <TrackedDayEntity>[],
+        priorWeek: const <TrackedDayEntity>[],
+        weight: const [],
         bodyWeightUnit: BodyWeightUnit.kg,
         targetWeightKg: null,
-        waterByDay: {},
+        waterByDay: const {},
         waterGoalMl: 2000,
       ),
     );

--- a/test/unit_test/trends_bloc_test.dart
+++ b/test/unit_test/trends_bloc_test.dart
@@ -14,7 +14,10 @@ import 'package:opennutritracker/core/domain/usecase/get_tracked_day_usecase.dar
 import 'package:opennutritracker/core/domain/usecase/get_user_usecase.dart';
 import 'package:opennutritracker/core/domain/usecase/get_water_intake_usecase.dart';
 import 'package:opennutritracker/core/domain/usecase/get_weight_log_usecase.dart';
+import 'package:opennutritracker/core/utils/calc/day_boundary_calc.dart';
 import 'package:opennutritracker/features/trends/presentation/bloc/trends_bloc.dart';
+import 'package:timezone/data/latest_all.dart' as tzdata;
+import 'package:timezone/timezone.dart' as tz;
 
 /// Records the (start, end) ranges it is asked for so the bloc's date-window
 /// arithmetic can be asserted, and returns a canned list. The bloc calls this
@@ -83,6 +86,8 @@ class _FakeGetUserUsecase implements GetUserUsecase {
 
 class _FakeGetConfigUsecase implements GetConfigUsecase {
   bool usesImperialUnits = false;
+  int dayStartOffsetHours = 0;
+  int dayStartOffsetMinutes = 0;
 
   @override
   Future<ConfigEntity> getConfig() async => ConfigEntity(
@@ -93,6 +98,8 @@ class _FakeGetConfigUsecase implements GetConfigUsecase {
         usesImperialUnits: usesImperialUnits,
         bodyWeightUnit:
             usesImperialUnits ? BodyWeightUnit.lb : BodyWeightUnit.kg,
+        dayStartOffsetHours: dayStartOffsetHours,
+        dayStartOffsetMinutes: dayStartOffsetMinutes,
       );
 
   @override
@@ -115,6 +122,8 @@ WeightLogEntity _wl(DateTime date, double kg) =>
     WeightLogEntity(date: date, weightKg: kg);
 
 void main() {
+  setUpAll(tzdata.initializeTimeZones);
+
   // The bloc anchors every window on midnight-today; mirror that here so the
   // expected ranges line up with what the bloc computes.
   final now = DateTime.now();
@@ -220,6 +229,167 @@ void main() {
     test('a fixed range sets windowDays equal to the chip', () async {
       final emitted = await load(const LoadTrendsEvent(rangeDays: 30));
       expect((emitted.last as TrendsLoaded).windowDays, 30);
+    });
+
+    test('midnight day start preserves normal food and water dates',
+        () async {
+      DayBoundaryCalc.clock = () => DateTime(2026, 8, 12, 0, 30);
+      addTearDown(() => DayBoundaryCalc.clock = DateTime.now);
+      trackedDay.result = [
+        TrackedDayEntity(
+          day: DateTime(2026, 8, 12),
+          calorieGoal: 2000,
+          caloriesTracked: 500,
+        ),
+      ];
+      water.result = [
+        WaterIntakeEntity(
+          id: 'before-midnight',
+          dateTime: DateTime(2026, 8, 11, 23, 59, 59),
+          amountMl: 100,
+        ),
+        WaterIntakeEntity(
+          id: 'at-midnight',
+          dateTime: DateTime(2026, 8, 12),
+          amountMl: 200,
+        ),
+        WaterIntakeEntity(
+          id: 'after-midnight',
+          dateTime: DateTime(2026, 8, 12, 0, 0, 1),
+          amountMl: 300,
+        ),
+      ];
+
+      final emitted = await load(const LoadTrendsEvent());
+      final loaded = emitted.last as TrendsLoaded;
+
+      expect(loaded.today, DateTime(2026, 8, 12));
+      expect(
+        trackedDay.rangeCalls.first,
+        (
+          start: DateTime(2026, 8, 6),
+          end: DateTime(2026, 8, 12, 23, 59, 59),
+        ),
+      );
+      expect(loaded.days, trackedDay.result);
+      expect(loaded.waterByDay, {
+        DateTime(2026, 8, 11): 100,
+        DateTime(2026, 8, 12): 500,
+      });
+    });
+
+    test('08:00 day start keeps pre-boundary food and water on the prior day',
+        () async {
+      DayBoundaryCalc.clock = () => DateTime(2026, 8, 12, 7, 30);
+      addTearDown(() => DayBoundaryCalc.clock = DateTime.now);
+      config.dayStartOffsetHours = 8;
+      trackedDay.result = [
+        TrackedDayEntity(
+          day: DateTime(2026, 8, 11, 23),
+          calorieGoal: 2000,
+          caloriesTracked: 500,
+        ),
+      ];
+      water.result = [
+        WaterIntakeEntity(
+          id: 'before-midnight',
+          dateTime: DateTime(2026, 8, 11, 23, 59),
+          amountMl: 100,
+        ),
+        WaterIntakeEntity(
+          id: 'after-midnight',
+          dateTime: DateTime(2026, 8, 12, 0, 1),
+          amountMl: 200,
+        ),
+        WaterIntakeEntity(
+          id: 'before-boundary',
+          dateTime: DateTime(2026, 8, 12, 7, 59, 59),
+          amountMl: 300,
+        ),
+        WaterIntakeEntity(
+          id: 'at-boundary',
+          dateTime: DateTime(2026, 8, 12, 8),
+          amountMl: 400,
+        ),
+        WaterIntakeEntity(
+          id: 'after-boundary',
+          dateTime: DateTime(2026, 8, 12, 8, 0, 1),
+          amountMl: 500,
+        ),
+      ];
+
+      final emitted = await load(const LoadTrendsEvent());
+      final loaded = emitted.last as TrendsLoaded;
+
+      expect(loaded.today, DateTime(2026, 8, 11));
+      expect(
+        trackedDay.rangeCalls.first,
+        (
+          start: DateTime(2026, 8, 5),
+          end: DateTime(2026, 8, 11, 23, 59, 59),
+        ),
+      );
+      expect(loaded.days, trackedDay.result);
+      expect(loaded.waterByDay, {
+        DateTime(2026, 8, 11): 600,
+        DateTime(2026, 8, 12): 900,
+      });
+    });
+
+    test('08:00 day start follows local wall time across spring DST',
+        () async {
+      final newYork = tz.getLocation('America/New_York');
+      DayBoundaryCalc.clock = () => tz.TZDateTime(
+            newYork,
+            2026,
+            3,
+            8,
+            7,
+            30,
+          );
+      addTearDown(() => DayBoundaryCalc.clock = DateTime.now);
+      config.dayStartOffsetHours = 8;
+      water.result = [
+        WaterIntakeEntity(
+          id: 'before-midnight',
+          dateTime: tz.TZDateTime(newYork, 2026, 3, 7, 23, 59),
+          amountMl: 100,
+        ),
+        WaterIntakeEntity(
+          id: 'before-spring-forward',
+          dateTime: tz.TZDateTime(newYork, 2026, 3, 8, 1, 59),
+          amountMl: 200,
+        ),
+        WaterIntakeEntity(
+          id: 'after-spring-forward',
+          dateTime: tz.TZDateTime(newYork, 2026, 3, 8, 3),
+          amountMl: 300,
+        ),
+        WaterIntakeEntity(
+          id: 'before-boundary',
+          dateTime: tz.TZDateTime(newYork, 2026, 3, 8, 7, 59, 59),
+          amountMl: 400,
+        ),
+        WaterIntakeEntity(
+          id: 'at-boundary',
+          dateTime: tz.TZDateTime(newYork, 2026, 3, 8, 8),
+          amountMl: 500,
+        ),
+        WaterIntakeEntity(
+          id: 'after-boundary',
+          dateTime: tz.TZDateTime(newYork, 2026, 3, 8, 8, 0, 1),
+          amountMl: 600,
+        ),
+      ];
+
+      final emitted = await load(const LoadTrendsEvent());
+      final loaded = emitted.last as TrendsLoaded;
+
+      expect(loaded.today, DateTime(2026, 3, 7));
+      expect(loaded.waterByDay, {
+        DateTime(2026, 3, 7): 1000,
+        DateTime(2026, 3, 8): 1100,
+      });
     });
 
     test('the "All" range (0) spans back to the earliest data', () async {

--- a/test/unit_test/trends_calc_test.dart
+++ b/test/unit_test/trends_calc_test.dart
@@ -1,9 +1,13 @@
 import 'package:flutter_test/flutter_test.dart';
 import 'package:opennutritracker/features/trends/presentation/trends_calc.dart';
+import 'package:timezone/data/latest_all.dart' as tzdata;
+import 'package:timezone/timezone.dart' as tz;
 
 DateTime _d(int y, int m, int day) => DateTime(y, m, day);
 
 void main() {
+  setUpAll(tzdata.initializeTimeZones);
+
   group('streakStats', () {
     final start = _d(2026, 5, 1);
     final today = _d(2026, 5, 10);
@@ -38,6 +42,20 @@ void main() {
       final s = streakStats(<DateTime>{}, start, today);
       expect(s.current, 0);
       expect(s.longest, 0);
+    });
+
+    test('counts local calendar dates across spring DST', () {
+      final newYork = tz.getLocation('America/New_York');
+      final dstStart = tz.TZDateTime(newYork, 2026, 3, 3);
+      final dstToday = tz.TZDateTime(newYork, 2026, 3, 9);
+      final onTrack = {
+        for (var i = 0; i < 7; i++) DateTime(2026, 3, 3 + i),
+      };
+
+      final s = streakStats(onTrack, dstStart, dstToday);
+
+      expect(s.current, 7);
+      expect(s.longest, 7);
     });
   });
 


### PR DESCRIPTION
## Summary

Trends now anchor their date windows to the configured logical day instead of wall-clock midnight. Food totals, water buckets, chart windows, and streak calculations share the existing `DayBoundaryCalc` boundary and use calendar-date arithmetic across DST transitions.

## Type of change
- [x] Bug fix
- [ ] New feature
- [ ] Refactor / cleanup
- [ ] Documentation
- [ ] CI / tooling
- [ ] Localization
- [ ] Other

## Related issues

Fixes #628

## Changes

- Use the configured day-start offset when loading the current and prior trends windows.
- Bucket water entries into the same logical days used by food and diary data.
- Keep chart and streak date ranges aligned with logical today and local calendar dates across DST.
- Cover midnight and 08:00 boundaries, entries around midnight and the boundary, both aggregation paths, and a spring DST transition.

## Screenshots / recordings

Not applicable; there are no visual changes.

## Test plan
- [x] Described steps below were followed locally
- [x] Unit / widget tests added or updated (if applicable)
- [ ] Manual check on Android
- [ ] Manual check on iOS (if applicable)

### Steps
1. Ran the focused day-boundary, trends, and refresh tests: passed, 52 tests.
2. Ran `flutter analyze`: passed with no issues.
3. Ran `just test`: passed, 966 tests.
4. Ran `just format`: completed. The pinned formatter also changes 259 files on an untouched `develop` checkout, so that unrelated repository-wide churn is not included here.
5. Ran `just ci`: stopped at its `format --set-exit-if-changed` gate for the same 259-file baseline mismatch; codegen, tests, and analysis were not reached by that recipe. The separate test and analysis commands above passed.

## Checklist
- [x] Code follows project style (`just format` / 120-char line width)
- [x] No new interactive widgets were added
- [x] No user-facing strings changed
- [x] No DBOs, DTOs, or environment fields changed
- [x] No secrets or `.env` values committed
- [x] PR title follows conventional commit style (e.g. `feat:`, `fix:`, `chore:`)
