### PR TITLE
fix(add-meal): reuse one http client, and reject non-finite quantities

### DIFF
--- a/lib/core/utils/locator.dart
+++ b/lib/core/utils/locator.dart
@@ -143,10 +143,16 @@ Future<void> initLocator() async {
   locator.registerLazySingleton<AiCredentialStorage>(
     () => AiCredentialStorage(),
   );
+  // One client for the app rather than one per interpret call: a fresh
+  // http.Client carries its own connection pool and is never closed here,
+  // so building one each time the user taps Search would accumulate
+  // sockets for the life of the process.
+  locator.registerLazySingleton<http.Client>(() => http.Client());
   locator.registerLazySingleton<ReadMealTextUseCase>(
     () => ReadMealTextUseCase(
       locator<AiCredentialStorage>(),
-      (apiKey) => AnthropicMealTextInterpreter(http.Client(), () => apiKey),
+      (apiKey) =>
+          AnthropicMealTextInterpreter(locator<http.Client>(), () => apiKey),
     ),
   );
   locator.registerLazySingleton<DeleteAllUserDataUsecase>(
@@ -220,7 +226,8 @@ Future<void> initLocator() async {
   // Singleton so a unit change in Settings can refresh the live Trends page
   // (it lives in the main IndexedStack and isn't recreated on tab switch).
   locator.registerLazySingleton<TrendsBloc>(
-      () => TrendsBloc(locator(), locator(), locator(), locator(), locator()));
+    () => TrendsBloc(locator(), locator(), locator(), locator(), locator()),
+  );
   locator.registerFactory<RecipeBuilderBloc>(
     () => RecipeBuilderBloc(locator(), locator()),
   );
@@ -254,13 +261,8 @@ Future<void> initLocator() async {
   // create-from-popup flow on the same tab — both must mutate / observe the
   // same instance so the list refreshes after a new entry is created.
   locator.registerLazySingleton<CustomMealsBloc>(
-    () => CustomMealsBloc(
-      locator(),
-      locator(),
-      locator(),
-      locator(),
-      locator(),
-    ),
+    () =>
+        CustomMealsBloc(locator(), locator(), locator(), locator(), locator()),
   );
 
   locator.registerFactory<ActivitiesBloc>(() => ActivitiesBloc(locator()));

--- a/lib/features/add_meal/util/meal_text_parser.dart
+++ b/lib/features/add_meal/util/meal_text_parser.dart
@@ -179,8 +179,12 @@ MealTextParseResult validateParsedMealItems(List<ParsedMealItem> candidates) {
     // the other, so downstream code was written against that. A model can
     // produce it, and honouring a unit nobody attached a number to would
     // present a guess as though the user had typed it.
-    final unit =
-        candidate.quantity != null && _validUnits.contains(candidate.unit)
+    // Gated on the *sanitized* quantity, not the raw one. A candidate of
+    // `{quantity: NaN, unit: 'g'}` sanitizes to a null quantity, and reading
+    // the raw value here would have kept the `g` beside it — reintroducing
+    // exactly the unit-without-quantity state the paragraph above exists to
+    // prevent.
+    final unit = quantity != null && _validUnits.contains(candidate.unit)
         ? candidate.unit
         : null;
 

--- a/lib/features/add_meal/util/meal_text_parser.dart
+++ b/lib/features/add_meal/util/meal_text_parser.dart
@@ -147,7 +147,17 @@ MealTextParseResult validateParsedMealItems(List<ParsedMealItem> candidates) {
       continue;
     }
 
-    final quantity = candidate.quantity;
+    // A non-finite quantity is treated as no quantity at all. Both bounds
+    // below are *false* for NaN, so it would otherwise pass validation
+    // untouched and surface as the literal text "NaN" in the amount field.
+    // `double.tryParse('NaN')` returns NaN, so a model answering with that
+    // string is all it takes. Dropped rather than rejected, matching how an
+    // unrecognized unit is handled: the food is still usable and the row's
+    // own default is a better answer than refusing to log it.
+    final rawQuantity = candidate.quantity;
+    final quantity = (rawQuantity != null && rawQuantity.isFinite)
+        ? rawQuantity
+        : null;
     if (quantity != null) {
       if (quantity <= 0) {
         errors.add(QuantityTooSmallError(itemNum));

--- a/test/unit_test/anthropic_meal_text_interpreter_test.dart
+++ b/test/unit_test/anthropic_meal_text_interpreter_test.dart
@@ -188,6 +188,21 @@ void main() {
       expect(result.items[1].quantity, 2.5);
     });
 
+    test('a quantity of "NaN" does not reach the row', () async {
+      // double.tryParse('NaN') succeeds, so this is a shape a model can
+      // actually produce.
+      final client = FakeClient(
+        body: toolReply([
+          {'query': 'toast', 'quantity': 'NaN', 'unit': 'g'},
+        ]),
+      );
+
+      final result = await interpreterWith(client).interpret('anything');
+
+      expect(result.items.single.query, 'toast');
+      expect(result.items.single.quantity, isNull);
+    });
+
     test('drops an unusable entry without failing the batch', () async {
       final client = FakeClient(
         body: toolReply([

--- a/test/unit_test/meal_text_parser_test.dart
+++ b/test/unit_test/meal_text_parser_test.dart
@@ -558,6 +558,18 @@ void main() {
       expect(result.errors, isEmpty);
     });
 
+    test('a non-finite quantity takes its unit with it', () {
+      // The sanitized quantity is what the unit hangs off. Reading the raw
+      // value would leave `g` beside a null quantity — the very state the
+      // unit-dropping rule above exists to prevent.
+      final result = validateParsedMealItems(const [
+        ParsedMealItem(query: 'toast', quantity: double.nan, unit: 'g'),
+      ]);
+
+      expect(result.items.single.quantity, isNull);
+      expect(result.items.single.unit, isNull);
+    });
+
     test('trims the query so a padded name still reaches the search', () {
       final result = validateParsedMealItems(const [
         ParsedMealItem(query: '  toast  '),

--- a/test/unit_test/meal_text_parser_test.dart
+++ b/test/unit_test/meal_text_parser_test.dart
@@ -532,6 +532,32 @@ void main() {
       expect(result.errors, isEmpty);
     });
 
+    test('a non-finite quantity is dropped, not carried into the row', () {
+      // Both bounds are false for NaN, so without an explicit check it
+      // survives validation and renders as the literal text "NaN".
+      // `double.tryParse('NaN')` returns NaN, so a model answering with
+      // that string is all it takes to get here.
+      final result = validateParsedMealItems(const [
+        ParsedMealItem(query: 'toast', quantity: double.nan, unit: 'g'),
+        ParsedMealItem(query: 'milk', quantity: double.infinity, unit: 'ml'),
+        ParsedMealItem(
+          query: 'flour',
+          quantity: double.negativeInfinity,
+          unit: 'g',
+        ),
+      ]);
+
+      expect(result.items, hasLength(3));
+      for (final item in result.items) {
+        expect(
+          item.quantity,
+          isNull,
+          reason: '${item.query} kept a non-finite',
+        );
+      }
+      expect(result.errors, isEmpty);
+    });
+
     test('trims the query so a padded name still reaches the search', () {
       final result = validateParsedMealItems(const [
         ParsedMealItem(query: '  toast  '),


### PR DESCRIPTION
Two findings from Copilot's review on #643. **#643 was merged before the review was read**, so both are on `feature/ai-assisted-meal-logging` now and this fixes them there.

Both confirmed by running the code, not by reading it.

## A new `http.Client` per interpret call

The locator's interpreter factory built one each time and nothing closes it, so every tap of Search would leave another connection pool behind for the life of the process. Now a lazy singleton, reused.

## NaN slipped past the bounds checks

```
double.tryParse("NaN") = NaN
nan <= 0     : false
nan > 10000  : false
-> items=1 errors=0, quantity survived as NaN
```

Both comparisons are false for NaN, so it passed validation untouched and reached the row, where `_trimZeros` renders it as the literal text **"NaN"** in the amount field.

Reachable in practice: `double.tryParse('NaN')` succeeds, so a model answering `"quantity": "NaN"` is all it takes. Covered by a test at both the validator and the interpreter.

Non-finite values are now treated as *no quantity stated* — dropped rather than rejected, matching how an unrecognized unit is handled, so the food stays usable and the row's own default fills in.

**Scope, stated honestly:** the screen's submit validation (`_quantityPattern`) would have rejected "NaN" before it reached the diary, so this was a broken-looking row rather than a bad number in the log. Fixing it at the validator keeps every source held to one gate instead of relying on the screen to catch it.

## Verification

1140 tests, analyzer clean, formatter leaves the changed lines alone. Mutation-checked: removing the finite check fails two tests.

Changed lines measured against the base — `locator.dart` 20, `meal_text_parser.dart` 12.
