### PR TITLE
fix(add-meal): parse and rank languages that write without spaces (#623)

### DIFF
--- a/lib/core/utils/locator.dart
+++ b/lib/core/utils/locator.dart
@@ -143,10 +143,16 @@ Future<void> initLocator() async {
   locator.registerLazySingleton<AiCredentialStorage>(
     () => AiCredentialStorage(),
   );
+  // One client for the app rather than one per interpret call: a fresh
+  // http.Client carries its own connection pool and is never closed here,
+  // so building one each time the user taps Search would accumulate
+  // sockets for the life of the process.
+  locator.registerLazySingleton<http.Client>(() => http.Client());
   locator.registerLazySingleton<ReadMealTextUseCase>(
     () => ReadMealTextUseCase(
       locator<AiCredentialStorage>(),
-      (apiKey) => AnthropicMealTextInterpreter(http.Client(), () => apiKey),
+      (apiKey) =>
+          AnthropicMealTextInterpreter(locator<http.Client>(), () => apiKey),
     ),
   );
   locator.registerLazySingleton<DeleteAllUserDataUsecase>(
@@ -220,7 +226,8 @@ Future<void> initLocator() async {
   // Singleton so a unit change in Settings can refresh the live Trends page
   // (it lives in the main IndexedStack and isn't recreated on tab switch).
   locator.registerLazySingleton<TrendsBloc>(
-      () => TrendsBloc(locator(), locator(), locator(), locator(), locator()));
+    () => TrendsBloc(locator(), locator(), locator(), locator(), locator()),
+  );
   locator.registerFactory<RecipeBuilderBloc>(
     () => RecipeBuilderBloc(locator(), locator()),
   );
@@ -254,13 +261,8 @@ Future<void> initLocator() async {
   // create-from-popup flow on the same tab — both must mutate / observe the
   // same instance so the list refreshes after a new entry is created.
   locator.registerLazySingleton<CustomMealsBloc>(
-    () => CustomMealsBloc(
-      locator(),
-      locator(),
-      locator(),
-      locator(),
-      locator(),
-    ),
+    () =>
+        CustomMealsBloc(locator(), locator(), locator(), locator(), locator()),
   );
 
   locator.registerFactory<ActivitiesBloc>(() => ActivitiesBloc(locator()));

--- a/lib/features/add_meal/util/meal_text_parser.dart
+++ b/lib/features/add_meal/util/meal_text_parser.dart
@@ -179,8 +179,12 @@ MealTextParseResult validateParsedMealItems(List<ParsedMealItem> candidates) {
     // the other, so downstream code was written against that. A model can
     // produce it, and honouring a unit nobody attached a number to would
     // present a guess as though the user had typed it.
-    final unit =
-        candidate.quantity != null && _validUnits.contains(candidate.unit)
+    // Gated on the *sanitized* quantity, not the raw one. A candidate of
+    // `{quantity: NaN, unit: 'g'}` sanitizes to a null quantity, and reading
+    // the raw value here would have kept the `g` beside it — reintroducing
+    // exactly the unit-without-quantity state the paragraph above exists to
+    // prevent.
+    final unit = quantity != null && _validUnits.contains(candidate.unit)
         ? candidate.unit
         : null;
 

--- a/lib/features/add_meal/util/meal_text_parser.dart
+++ b/lib/features/add_meal/util/meal_text_parser.dart
@@ -232,7 +232,19 @@ List<String> _segment(String input) => input
 /// them explicitly (rather than matching any run of letters) is what lets
 /// the regex engine backtrack to the no-unit reading when the word after
 /// the number simply belongs to the food name — see [_leadingQuantity].
-const _unitSymbol = r'(?:kg|ml|oz|g|l)';
+const _unitSymbol = r'(?:kg|ml|oz|g|l|毫升|千克|克|升)';
+
+/// Scripts that do not put spaces between words. A number and the food it
+/// counts sit flush against each other in all of them, so the whitespace
+/// this parser otherwise requires never appears.
+///
+/// A Unicode *script* property, not a vocabulary list: it does not grow when
+/// a language is added, which is the objection that ruled out number-words
+/// in #600. `2个鸡蛋` splits here for the same reason `2 eggs` splits on a
+/// space.
+const _unspacedScript =
+    r'[\p{Script=Han}\p{Script=Hiragana}\p{Script=Katakana}'
+    r'\p{Script=Hangul}]';
 
 /// A number, accepting either decimal separator. `JsonMealImporter` takes
 /// both the same way; [_parseQuantity] does the conversion.
@@ -258,12 +270,14 @@ const _number = r'-?\d+(?:[.,]\d+)?';
 /// trailing word forced the engine to backtrack. Restricting the group
 /// makes the engine find the no-unit reading itself.
 final _leadingQuantity = RegExp(
-  '^($_number)\\s*($_unitSymbol)?\\s+(.+)\$',
+  '^($_number)\\s*($_unitSymbol)?(?:\\s+|(?=$_unspacedScript))(.+)\$',
   caseSensitive: false,
+  unicode: true,
 );
 final _trailingQuantity = RegExp(
-  '^(.+?)\\s+($_number)\\s*($_unitSymbol)?\\s*\$',
+  '^(.+?)(?:\\s+|(?<=$_unspacedScript))($_number)\\s*($_unitSymbol)?\\s*\$',
   caseSensitive: false,
+  unicode: true,
 );
 
 /// Both decimal separators reach here; `double.parse` only accepts `.`.
@@ -316,9 +330,20 @@ _Extracted _extractQuantityAndUnit(String segment) {
 (double, String) _normalizeUnitAndQuantity(double quantity, String unit) {
   switch (unit) {
     case 'kg':
+    case '千克':
       return (quantity * 1000, 'g');
     case 'l':
+    case '升':
       return (quantity * 1000, 'ml');
+    // The Han forms of gram and millilitre. Symbols with one fixed meaning,
+    // like `g` and `ml`, rather than words that need translating — and
+    // shared across the Han-using locales rather than one entry per
+    // language. Without them `100克吐司` parses as a bare *count* of 100,
+    // which the review row can read as 100 servings.
+    case '克':
+      return (quantity, 'g');
+    case '毫升':
+      return (quantity, 'ml');
     default:
       return (quantity, unit);
   }

--- a/lib/features/add_meal/util/meal_text_parser.dart
+++ b/lib/features/add_meal/util/meal_text_parser.dart
@@ -231,9 +231,10 @@ List<String> _segment(String input) => input
     .where((s) => s.isNotEmpty)
     .toList();
 
-/// The five unit symbols this parser recognizes as *input*, longest-first
-/// so a two-character symbol is never shadowed by its first letter. Naming
-/// them explicitly (rather than matching any run of letters) is what lets
+/// The unit symbols this parser recognizes as *input*, longest-first so a
+/// longer symbol is never shadowed by one that starts the same way: `毫升`
+/// before `升`, `千克` before `克`. Naming them explicitly (rather than
+/// matching any run of letters) is what lets
 /// the regex engine backtrack to the no-unit reading when the word after
 /// the number simply belongs to the food name — see [_leadingQuantity].
 const _unitSymbol = r'(?:kg|ml|oz|g|l|毫升|千克|克|升)';

--- a/lib/features/add_meal/util/meal_text_parser.dart
+++ b/lib/features/add_meal/util/meal_text_parser.dart
@@ -147,7 +147,17 @@ MealTextParseResult validateParsedMealItems(List<ParsedMealItem> candidates) {
       continue;
     }
 
-    final quantity = candidate.quantity;
+    // A non-finite quantity is treated as no quantity at all. Both bounds
+    // below are *false* for NaN, so it would otherwise pass validation
+    // untouched and surface as the literal text "NaN" in the amount field.
+    // `double.tryParse('NaN')` returns NaN, so a model answering with that
+    // string is all it takes. Dropped rather than rejected, matching how an
+    // unrecognized unit is handled: the food is still usable and the row's
+    // own default is a better answer than refusing to log it.
+    final rawQuantity = candidate.quantity;
+    final quantity = (rawQuantity != null && rawQuantity.isFinite)
+        ? rawQuantity
+        : null;
     if (quantity != null) {
       if (quantity <= 0) {
         errors.add(QuantityTooSmallError(itemNum));

--- a/lib/features/add_meal/util/resolver_relevance.dart
+++ b/lib/features/add_meal/util/resolver_relevance.dart
@@ -41,10 +41,46 @@ const _minPrefix = 3;
 const _detailedBonus = 0.03;
 const _machineTranslatedPenalty = 0.03;
 
+/// Characters from scripts that do not separate words with spaces. A
+/// Unicode script property rather than a vocabulary list, so it does not
+/// grow when a language is added.
+final _unspacedScript = RegExp(
+  r'[\p{Script=Han}\p{Script=Hiragana}\p{Script=Katakana}'
+  r'\p{Script=Hangul}]',
+  unicode: true,
+);
+
+/// The character pairs in [text], or the text itself when it is too short
+/// to have any.
+Set<String> _bigrams(String text) {
+  if (text.length < 2) return {text};
+  return {for (var i = 0; i < text.length - 1; i++) text.substring(i, i + 2)};
+}
+
 /// How far [a] and [b] agree, 0.0-1.0. 1.0 only for an exact match; a
 /// suffix difference costs a little rather than everything.
 double _tokenSimilarity(String a, String b) {
   if (a == b) return 1.0;
+
+  // Chinese, Japanese and Korean write without spaces, so `_tokenize`
+  // hands the whole phrase over as one token and the shared-prefix rule
+  // below reads it as a single long word. That scored `鸡蛋` against
+  // `土鸡蛋` — a superstring of the query — at exactly 0.0, and it is why
+  // a `zh` search could miss the product it was looking at.
+  //
+  // Character bigrams compare these the way whitespace tokens compare in
+  // Latin scripts: `鸡蛋` and `土鸡蛋` share one pair out of three, so they
+  // agree rather than disagree. It also makes a leading counter harmless —
+  // `个鸡蛋` still matches `鸡蛋` — which is what removes any need for a
+  // list of measure words.
+  if (_unspacedScript.hasMatch(a) || _unspacedScript.hasMatch(b)) {
+    final aGrams = _bigrams(a);
+    final bGrams = _bigrams(b);
+    final shared = aGrams.intersection(bGrams).length;
+    if (shared == 0) return 0.0;
+    return 2 * shared / (aGrams.length + bGrams.length);
+  }
+
   final shorter = a.length < b.length ? a.length : b.length;
   final longer = a.length > b.length ? a.length : b.length;
 

--- a/test/unit_test/anthropic_meal_text_interpreter_test.dart
+++ b/test/unit_test/anthropic_meal_text_interpreter_test.dart
@@ -188,6 +188,21 @@ void main() {
       expect(result.items[1].quantity, 2.5);
     });
 
+    test('a quantity of "NaN" does not reach the row', () async {
+      // double.tryParse('NaN') succeeds, so this is a shape a model can
+      // actually produce.
+      final client = FakeClient(
+        body: toolReply([
+          {'query': 'toast', 'quantity': 'NaN', 'unit': 'g'},
+        ]),
+      );
+
+      final result = await interpreterWith(client).interpret('anything');
+
+      expect(result.items.single.query, 'toast');
+      expect(result.items.single.quantity, isNull);
+    });
+
     test('drops an unusable entry without failing the batch', () async {
       final client = FakeClient(
         body: toolReply([

--- a/test/unit_test/meal_text_parser_test.dart
+++ b/test/unit_test/meal_text_parser_test.dart
@@ -574,4 +574,69 @@ void main() {
       expect(result.hasErrors, isFalse);
     });
   });
+
+  group('scripts without spaces between words (#623)', () {
+    // Chinese, Japanese and Korean write a number flush against the thing
+    // it counts. The parser found quantities by looking for whitespace, so
+    // none of this parsed at all — including weights written with the very
+    // Latin unit symbols the placeholder used to demonstrate.
+    test('a count reads even with no space after it', () {
+      final result = parseMealText('2个鸡蛋');
+
+      expect(result.items.single.quantity, 2);
+      // The counter stays on the query. `resolver_relevance` matches CJK by
+      // character bigrams, so `个鸡蛋` still finds `鸡蛋` — which is why no
+      // list of measure words is needed.
+      expect(result.items.single.query, contains('鸡蛋'));
+    });
+
+    test('a Latin unit symbol works without a space', () {
+      final result = parseMealText('100g吐司');
+
+      expect(result.items.single.query, '吐司');
+      expect(result.items.single.quantity, 100);
+      expect(result.items.single.unit, 'g');
+    });
+
+    test('the Han forms of gram and millilitre are units', () {
+      final grams = parseMealText('100克吐司').items.single;
+      expect(grams.query, '吐司');
+      expect(grams.quantity, 100);
+      expect(grams.unit, 'g');
+
+      final millis = parseMealText('200毫升牛奶').items.single;
+      expect(millis.quantity, 200);
+      expect(millis.unit, 'ml');
+    });
+
+    test('the Han kilogram and litre convert like kg and l', () {
+      expect(parseMealText('1千克面粉').items.single.quantity, 1000);
+      expect(parseMealText('1升水').items.single.unit, 'ml');
+      expect(parseMealText('1升水').items.single.quantity, 1000);
+    });
+
+    test('a full line splits into its items', () {
+      final result = parseMealText('2个鸡蛋，200ml牛奶，黑咖啡');
+
+      expect(result.items, hasLength(3));
+      expect(result.items[1].quantity, 200);
+      expect(result.items[1].unit, 'ml');
+      expect(result.items[2].quantity, isNull);
+    });
+
+    test('a trailing quantity works without a space too', () {
+      expect(parseMealText('鸡蛋2').items.single.quantity, 2);
+    });
+
+    test('Latin parsing is unchanged by the script boundary', () {
+      // The boundary rule touches the same regex the #616 backtracking bug
+      // lived in, so the cases that bug produced are re-checked here.
+      expect(parseMealText('100g toast').items.single.query, 'toast');
+      expect(parseMealText('2 chicken breasts').items.single.quantity, 2);
+      expect(parseMealText('1,5 l Milch').items.single.quantity, 1500);
+      expect(parseMealText('toast 100g').items.single.unit, 'g');
+      // Still not a unit, so still not a quantity.
+      expect(parseMealText('100xyz Toast').items.single.quantity, isNull);
+    });
+  });
 }

--- a/test/unit_test/meal_text_parser_test.dart
+++ b/test/unit_test/meal_text_parser_test.dart
@@ -558,6 +558,18 @@ void main() {
       expect(result.errors, isEmpty);
     });
 
+    test('a non-finite quantity takes its unit with it', () {
+      // The sanitized quantity is what the unit hangs off. Reading the raw
+      // value would leave `g` beside a null quantity — the very state the
+      // unit-dropping rule above exists to prevent.
+      final result = validateParsedMealItems(const [
+        ParsedMealItem(query: 'toast', quantity: double.nan, unit: 'g'),
+      ]);
+
+      expect(result.items.single.quantity, isNull);
+      expect(result.items.single.unit, isNull);
+    });
+
     test('trims the query so a padded name still reaches the search', () {
       final result = validateParsedMealItems(const [
         ParsedMealItem(query: '  toast  '),

--- a/test/unit_test/meal_text_parser_test.dart
+++ b/test/unit_test/meal_text_parser_test.dart
@@ -532,6 +532,32 @@ void main() {
       expect(result.errors, isEmpty);
     });
 
+    test('a non-finite quantity is dropped, not carried into the row', () {
+      // Both bounds are false for NaN, so without an explicit check it
+      // survives validation and renders as the literal text "NaN".
+      // `double.tryParse('NaN')` returns NaN, so a model answering with
+      // that string is all it takes to get here.
+      final result = validateParsedMealItems(const [
+        ParsedMealItem(query: 'toast', quantity: double.nan, unit: 'g'),
+        ParsedMealItem(query: 'milk', quantity: double.infinity, unit: 'ml'),
+        ParsedMealItem(
+          query: 'flour',
+          quantity: double.negativeInfinity,
+          unit: 'g',
+        ),
+      ]);
+
+      expect(result.items, hasLength(3));
+      for (final item in result.items) {
+        expect(
+          item.quantity,
+          isNull,
+          reason: '${item.query} kept a non-finite',
+        );
+      }
+      expect(result.errors, isEmpty);
+    });
+
     test('trims the query so a padded name still reaches the search', () {
       final result = validateParsedMealItems(const [
         ParsedMealItem(query: '  toast  '),

--- a/test/unit_test/resolver_relevance_test.dart
+++ b/test/unit_test/resolver_relevance_test.dart
@@ -164,4 +164,41 @@ void main() {
       expect(weak, lessThan(0.5));
     });
   });
+
+  group('scripts without spaces between words (#623)', () {
+    // `_tokenize` splits on non-letters, so a CJK phrase arrives as one
+    // token and the shared-prefix rule read it as a single long word.
+    test('a longer product name still matches the query', () {
+      // Scored 0.0 before: `土鸡蛋` contains `鸡蛋` but does not start with
+      // it, so a `zh` search could miss the product it was looking at.
+      expect(scoreMealForResolution(meal('土鸡蛋'), '鸡蛋'), greaterThan(0.3));
+    });
+
+    test('a leading counter does not stop the match', () {
+      // This is what removes any need for a list of measure words: the
+      // parser leaves `个` on the query and the ranker copes.
+      expect(scoreMealForResolution(meal('鸡蛋'), '个鸡蛋'), greaterThan(0.3));
+    });
+
+    test('an exact match still scores highest', () {
+      final exact = scoreMealForResolution(meal('鸡蛋'), '鸡蛋');
+      final partial = scoreMealForResolution(meal('土鸡蛋'), '鸡蛋');
+      expect(exact, greaterThan(partial));
+    });
+
+    test('unrelated foods still score nothing', () {
+      expect(scoreMealForResolution(meal('牛奶'), '鸡蛋'), 0.0);
+    });
+
+    test('Latin scoring is unchanged', () {
+      // The property #601 was built for: a plain food outranks a branded
+      // name that happens to contain the query exactly.
+      final plain = scoreMealForResolution(meal('Egg'), 'eggs');
+      final branded = scoreMealForResolution(
+        meal('Cadbury Creme Eggs'),
+        'eggs',
+      );
+      expect(plain, greaterThan(branded));
+    });
+  });
 }


### PR DESCRIPTION
Closes #623.

## What probing found

I measured the shipped behaviour before designing the fix, and it contradicted the issue in one place.

**#623 says `zh` "currently supports weights with Latin unit symbols". It does not:**

| Input | Before |
|---|---|
| `2个鸡蛋` | no quantity |
| `100克吐司` | no quantity |
| **`100g吐司`** | **no quantity** |

`_leadingQuantity` requires `\s+` between the unit and the food, so a Chinese user got nothing unless they typed a space they would never naturally write.

**And the ranker had the same blind spot, which nobody had looked at:**

```
score(query=个鸡蛋 vs meal=鸡蛋)   = 0.000
score(query=鸡蛋   vs meal=土鸡蛋) = 0.000     <- a superstring of the query
score(query=eggs  vs meal=Egg)   = 0.750
```

`_tokenize` splits on non-letters, so a CJK phrase arrives as one token and the shared-prefix rule reads it as one long word. Even a perfectly clean query could miss the product it was looking at.

Both come from the same assumption: whitespace delimits words.

## The fix, with no vocabulary lists

**1. A Unicode script boundary counts as a token boundary.** `\s+` becomes `(?:\s+|(?=[\p{Script=Han}\p{Script=Hiragana}\p{Script=Katakana}\p{Script=Hangul}]))`. A script *property*, not a word list — it does not grow when a language is added, which was #600's objection to number-words.

**2. CJK tokens are compared by character bigrams** instead of shared prefixes, the way whitespace tokens are compared in Latin scripts.

The second is what removes any need for a list of measure words: `个鸡蛋` now matches `鸡蛋` at 0.667, so the counter the parser leaves on the query stops mattering.

| | Before | After |
|---|---|---|
| `2个鸡蛋` | no quantity | `个鸡蛋` q=2 |
| `100g吐司` | no quantity | `吐司` 100 g |
| `100克吐司` | no quantity | `吐司` 100 g |
| `1千克面粉` | no quantity | `面粉` 1000 g |
| `鸡蛋` vs `土鸡蛋` | 0.000 | 0.667 |
| `eggs` vs `Egg` | 0.750 | 0.750 |

## The one judgment call

`克 / 毫升 / 千克 / 升` are added as unit symbols. **This is a per-script addition, not per-language** — the Han forms are shared across the locales that use Han — but it is closer to a list than the rest of this PR, so flagging it rather than burying it.

Without it, `100克吐司` parses as a bare *count* of 100, which the review row can read as **100 servings**: worse than not parsing at all. That is why it is here rather than deferred.

## Latin is unchanged

Re-checked explicitly, because the boundary rule touches the same regex the #616 backtracking bug lived in: `100g toast`, `2 chicken breasts`, `1,5 l Milch`, `toast 100g` and `100xyz Toast` all behave exactly as before, and the #601 property that a plain food outranks a branded name containing the query still holds.

## Verification

1152 tests, analyzer and formatter clean. All three changes mutation-checked: removing the script boundary fails five tests, the Han symbols two, the bigrams two.

## Why this matters beyond the bug

Tier 1b already let a model read `2个鸡蛋` — but only for the low single-digit percent of users who bring an API key. This fixes the offline path for everyone, which makes the model an improvement rather than the only way a Chinese user can log a count.
