### PR TITLE
fix(add-meal): trust the model when it answers "no food here"

### DIFF
--- a/lib/features/add_meal/domain/usecase/read_meal_text_usecase.dart
+++ b/lib/features/add_meal/domain/usecase/read_meal_text_usecase.dart
@@ -54,12 +54,14 @@ class ReadMealTextUseCase {
         apiKey,
       ).interpret(input, localeCode: localeCode);
 
-      // A model that found nothing is not better than a parser that found
-      // something: `100g toast` is unambiguous, and an empty screen after a
-      // network round trip is worse than the offline answer.
-      if (interpreted.items.isEmpty && parsed.items.isNotEmpty) {
-        return MealTextReading(parsed, usedModel: false);
-      }
+      // An empty list is an *answer*, not a failure: the model was asked to
+      // find food and reported there is none. Overriding it with the parser
+      // discards that judgment, and the parser will happily turn any
+      // sentence into a query — on a Pixel 6, "meine Steuererklärung und
+      // ein Tacker" came back as a cheese-roll match the user had to skip.
+      //
+      // The fallback below is for a model that could not answer. This is a
+      // model that did.
       return MealTextReading(interpreted, usedModel: true);
     } on MealTextInterpreterException catch (e) {
       // Logged without the input: the line the user typed is the one thing

--- a/test/unit_test/read_meal_text_usecase_test.dart
+++ b/test/unit_test/read_meal_text_usecase_test.dart
@@ -180,34 +180,36 @@ void main() {
       },
     );
 
-    test(
-      'prefers the parser when the model found nothing it did not',
-      () async {
-        // `100g toast` is unambiguous; an empty screen after a round trip is
-        // worse than the offline answer.
-        final interpreter = _FakeInterpreter(
-          result: const MealTextParseResult(items: [], errors: []),
-        );
+    test('an empty answer is trusted, not overridden by the parser', () async {
+      // Found on a Pixel 6: "meine Steuererklärung und ein Tacker" made the
+      // model correctly return nothing, and the old rule replaced that with
+      // the parser — which turns any sentence into a query and produced a
+      // cheese-roll match the user had to skip. An empty list is a judgment
+      // the model was asked to make.
+      final interpreter = _FakeInterpreter(
+        result: const MealTextParseResult(items: [], errors: []),
+      );
 
-        final reading = await useCaseWith(interpreter).read('100g toast');
+      final reading = await useCaseWith(
+        interpreter,
+      ).read('my tax return and a stapler');
 
-        expect(reading.usedModel, isFalse);
-        expect(reading.result.items.single.query, 'toast');
-      },
-    );
+      expect(reading.result.items, isEmpty);
+      expect(reading.usedModel, isTrue);
+    });
 
-    test(
-      'keeps an empty model result when the parser also found nothing',
-      () async {
-        final interpreter = _FakeInterpreter(
-          result: const MealTextParseResult(items: [], errors: []),
-        );
+    test('a failure still falls back, unlike an empty answer', () async {
+      // The distinction the old rule missed: a model that could not answer
+      // is not a model that answered "nothing".
+      final interpreter = _FakeInterpreter(
+        throws: const MealTextInterpreterException('request failed'),
+      );
 
-        final reading = await useCaseWith(interpreter).read('   ');
+      final reading = await useCaseWith(interpreter).read('100g toast');
 
-        expect(reading.result.items, isEmpty);
-      },
-    );
+      expect(reading.usedModel, isFalse);
+      expect(reading.result.items.single.query, 'toast');
+    });
 
     test('reads text the parser cannot segment at all', () async {
       // #623: a language with no spaces between words. The deterministic


### PR DESCRIPTION
Found on a Pixel 6 with a real key, driving the shipped build.

## What happened

Typing `meine Steuererklärung und ein Tacker` ("my tax return and a stapler") produced a row for **"Meine Käsebrötchen"**, flagged as a doubtful match, which the user then has to skip.

The model had it right — it returned an **empty list**, because a tax return and a stapler are not food. `ReadMealTextUseCase` discarded that and used the parser instead, and the parser will turn any sentence containing a letter into a search query.

## The rule conflated two different things

```dart
if (interpreted.items.isEmpty && parsed.items.isNotEmpty) {
  return MealTextReading(parsed, usedModel: false);   // <- fired on a *successful* empty answer
}
```

A model that **could not answer** — no network, a rejected key, a malformed reply — should fall back, and still does.

A model that **did answer**, with an empty list, made exactly the judgment it was asked to make. Overriding it means the app claims to have found food in a sentence about stationery.

I wrote that rule reasoning about `100g toast`, where an empty screen after a network round trip is worse than the offline answer. I did not consider that empty can be the correct answer.

## The trade, stated rather than buried

The 1000-line corpus returned **29 empty results out of 1000** on lines generated from food templates. So a model answering nothing about real food is not rare — roughly 3%. Those users now see "nothing to log" instead of parser rows.

I think that is the right side of the trade: an honest failure the user can see and act on beats silently substituting a different reader whose output they cannot distinguish from the model's. But it is a real cost and worth a second opinion — if you would rather keep the old behaviour, this is a two-line revert.

## Verification

1162 tests, analyzer and formatter clean. Mutation-checked: restoring the override fails the new test.

Two tests replace the old one — an empty answer is trusted, and a *failure* still falls back — because the distinction between them is the whole point of the change.
