### PR TITLE
fix(meal-detail): read a serving the app can actually scale (#629)

### DIFF
--- a/lib/features/add_meal/domain/entity/meal_entity.dart
+++ b/lib/features/add_meal/domain/entity/meal_entity.dart
@@ -11,6 +11,13 @@ import 'package:opennutritracker/features/add_meal/data/dto/sp/sp_food_dto.dart'
 import 'package:opennutritracker/features/add_meal/data/dto/off/off_product_dto.dart';
 import 'package:opennutritracker/features/add_meal/domain/entity/meal_nutriments_entity.dart';
 
+/// A number immediately followed by a metric mass or volume unit, as it
+/// appears inside an Open Food Facts `serving_size` string.
+final _servingSizeMetric = RegExp(
+  r'(\d+(?:[.,]\d+)?)\s*(?:g|ml)\b',
+  caseSensitive: false,
+);
+
 class MealEntity extends Equatable {
   static const liquidUnits = {'ml', 'l', 'dl', 'cl', 'fl oz', 'fl.oz'};
   static const solidUnits = {'kg', 'g', 'mg', 'µg', 'oz'};
@@ -38,6 +45,31 @@ class MealEntity extends Equatable {
   // OFF data is present — the dropdown text in `_getServingDropdownItem`
   // already falls back to `servingSize` when `servingUnit` is missing.
   bool get hasServingValues => servingQuantity != null || servingSize != null;
+
+  /// A number of grams or millilitres per serving, or null when the record
+  /// carries none that can be scaled.
+  ///
+  /// [servingQuantity] is Open Food Facts' parsed numeric, and it is often
+  /// absent while `serving_size` carries the same figure as text — "30 g",
+  /// "2 Tbsp (32 g)", "1 slice (25g)". Reading it back matters because
+  /// [hasServingValues] is true for those records while nothing can scale
+  /// them: the meal-detail screen defaulted them to "1 serving" and logged
+  /// one *gram* (#629).
+  ///
+  /// The last `g`/`ml` figure wins, so a parenthesised metric equivalent
+  /// beats the imperial measure in front of it ("12 oz (355 ml)" is 355).
+  /// A serving with no metric figure at all — "1 egg" — yields null, and
+  /// the caller falls back to a weight the user can see.
+  double? get scalableServingQuantity {
+    final parsed = servingQuantity;
+    if (parsed != null) return parsed;
+
+    final text = servingSize;
+    if (text == null) return null;
+    final matches = _servingSizeMetric.allMatches(text);
+    if (matches.isEmpty) return null;
+    return double.tryParse(matches.last.group(1)!.replaceAll(',', '.'));
+  }
 
   final MealSourceEntity source;
 

--- a/lib/features/meal_detail/meal_detail_screen.dart
+++ b/lib/features/meal_detail/meal_detail_screen.dart
@@ -125,7 +125,10 @@ class _MealDetailScreenState extends State<MealDetailScreen> {
   /// re-run after hydration reveals serving values.
   void _applyInitialSelection() {
     if (_initialUnit == "") {
-      if (meal.hasServingValues) {
+      // `scalableServingQuantity`, not `hasServingValues` (#629): the latter
+      // is true for a record whose serving is unparseable text, and nothing
+      // can scale those — they defaulted to "1 serving" and logged 1 g.
+      if (meal.scalableServingQuantity != null) {
         _initialUnit = UnitDropdownItem.serving.toString();
       } else if (meal.isLiquid) {
         _initialUnit = _usesImperialUnits
@@ -144,7 +147,9 @@ class _MealDetailScreenState extends State<MealDetailScreen> {
     }
 
     if (_initialQuantity == "") {
-      if (meal.hasServingValues) {
+      // Gated the same way as the unit above, so a bare "1" can never end
+      // up beside a weight unit.
+      if (meal.scalableServingQuantity != null) {
         _initialQuantity = "1";
         quantityTextController.text = "1";
       } else if (_usesImperialUnits) {
@@ -191,7 +196,10 @@ class _MealDetailScreenState extends State<MealDetailScreen> {
       child: SafeArea(
         child: Scaffold(
           backgroundColor:
-              (Theme.of(context).brightness == Brightness.dark ? AppPalette.dark : AppPalette.light).canvas,
+              (Theme.of(context).brightness == Brightness.dark
+                      ? AppPalette.dark
+                      : AppPalette.light)
+                  .canvas,
           body: BlocBuilder<MealDetailBloc, MealDetailState>(
             bloc: _mealDetailBloc,
             builder: (context, state) {
@@ -212,20 +220,20 @@ class _MealDetailScreenState extends State<MealDetailScreen> {
               return const Center(child: CircularProgressIndicator());
             },
           ),
-        bottomSheet: BlocSelector<MealDetailBloc, MealDetailState, String>(
-          bloc: _mealDetailBloc,
-          selector: (state) => state.selectedUnit,
-          builder: (context, selectedUnit) {
-            return MealDetailBottomSheet(
-              product: meal,
-              day: _day,
-              intakeTypeEntity: intakeTypeEntity,
-              selectedUnit: selectedUnit,
-              mealDetailBloc: _mealDetailBloc,
-              quantityTextController: quantityTextController,
-              onQuantityOrUnitChanged: onQuantityOrUnitChanged,
-            );
-          },
+          bottomSheet: BlocSelector<MealDetailBloc, MealDetailState, String>(
+            bloc: _mealDetailBloc,
+            selector: (state) => state.selectedUnit,
+            builder: (context, selectedUnit) {
+              return MealDetailBottomSheet(
+                product: meal,
+                day: _day,
+                intakeTypeEntity: intakeTypeEntity,
+                selectedUnit: selectedUnit,
+                mealDetailBloc: _mealDetailBloc,
+                quantityTextController: quantityTextController,
+                onQuantityOrUnitChanged: onQuantityOrUnitChanged,
+              );
+            },
           ),
         ),
       ),
@@ -264,10 +272,9 @@ class _MealDetailScreenState extends State<MealDetailScreen> {
             duration: const Duration(milliseconds: 200),
             child: Text(
               meal.name ?? '',
-              style: Theme.of(context)
-                  .textTheme
-                  .titleLarge
-                  ?.copyWith(fontWeight: FontWeight.w800),
+              style: Theme.of(
+                context,
+              ).textTheme.titleLarge?.copyWith(fontWeight: FontWeight.w800),
               overflow: TextOverflow.ellipsis,
             ),
           ),
@@ -281,9 +288,7 @@ class _MealDetailScreenState extends State<MealDetailScreen> {
           ),
           flexibleSpace: FlexibleSpaceBar(
             background: Padding(
-              padding: EdgeInsets.only(
-                bottom: dayKcalGoal > 0 ? 68 : 0,
-              ),
+              padding: EdgeInsets.only(bottom: dayKcalGoal > 0 ? 68 : 0),
               child: MealTitleExpanded(
                 meal: meal,
                 usesImperialUnits: _usesImperialUnits,
@@ -350,9 +355,7 @@ class _MealDetailScreenState extends State<MealDetailScreen> {
                     children: [
                       Text(
                         EnergyDisplay.formatWithUnit(context, totalKcal),
-                        style: Theme.of(context)
-                            .textTheme
-                            .headlineSmall
+                        style: Theme.of(context).textTheme.headlineSmall
                             ?.copyWith(fontWeight: FontWeight.w800),
                       ),
                       MealValueUnitText(
@@ -360,8 +363,8 @@ class _MealDetailScreenState extends State<MealDetailScreen> {
                         meal: meal,
                         displayUnit:
                             selectedUnit == UnitDropdownItem.serving.toString()
-                                ? meal.servingUnit
-                                : selectedUnit,
+                            ? meal.servingUnit
+                            : selectedUnit,
                         usesImperialUnits: _usesImperialUnits,
                         textStyle: Theme.of(context).textTheme.bodyMedium,
                         prefix: ' / ',
@@ -464,4 +467,3 @@ class MealDetailScreenArguments {
     this.usesImperialUnits,
   );
 }
-

--- a/lib/features/meal_detail/meal_detail_screen.dart
+++ b/lib/features/meal_detail/meal_detail_screen.dart
@@ -196,10 +196,7 @@ class _MealDetailScreenState extends State<MealDetailScreen> {
       child: SafeArea(
         child: Scaffold(
           backgroundColor:
-              (Theme.of(context).brightness == Brightness.dark
-                      ? AppPalette.dark
-                      : AppPalette.light)
-                  .canvas,
+              (Theme.of(context).brightness == Brightness.dark ? AppPalette.dark : AppPalette.light).canvas,
           body: BlocBuilder<MealDetailBloc, MealDetailState>(
             bloc: _mealDetailBloc,
             builder: (context, state) {
@@ -220,20 +217,20 @@ class _MealDetailScreenState extends State<MealDetailScreen> {
               return const Center(child: CircularProgressIndicator());
             },
           ),
-          bottomSheet: BlocSelector<MealDetailBloc, MealDetailState, String>(
-            bloc: _mealDetailBloc,
-            selector: (state) => state.selectedUnit,
-            builder: (context, selectedUnit) {
-              return MealDetailBottomSheet(
-                product: meal,
-                day: _day,
-                intakeTypeEntity: intakeTypeEntity,
-                selectedUnit: selectedUnit,
-                mealDetailBloc: _mealDetailBloc,
-                quantityTextController: quantityTextController,
-                onQuantityOrUnitChanged: onQuantityOrUnitChanged,
-              );
-            },
+        bottomSheet: BlocSelector<MealDetailBloc, MealDetailState, String>(
+          bloc: _mealDetailBloc,
+          selector: (state) => state.selectedUnit,
+          builder: (context, selectedUnit) {
+            return MealDetailBottomSheet(
+              product: meal,
+              day: _day,
+              intakeTypeEntity: intakeTypeEntity,
+              selectedUnit: selectedUnit,
+              mealDetailBloc: _mealDetailBloc,
+              quantityTextController: quantityTextController,
+              onQuantityOrUnitChanged: onQuantityOrUnitChanged,
+            );
+          },
           ),
         ),
       ),
@@ -272,9 +269,10 @@ class _MealDetailScreenState extends State<MealDetailScreen> {
             duration: const Duration(milliseconds: 200),
             child: Text(
               meal.name ?? '',
-              style: Theme.of(
-                context,
-              ).textTheme.titleLarge?.copyWith(fontWeight: FontWeight.w800),
+              style: Theme.of(context)
+                  .textTheme
+                  .titleLarge
+                  ?.copyWith(fontWeight: FontWeight.w800),
               overflow: TextOverflow.ellipsis,
             ),
           ),
@@ -288,7 +286,9 @@ class _MealDetailScreenState extends State<MealDetailScreen> {
           ),
           flexibleSpace: FlexibleSpaceBar(
             background: Padding(
-              padding: EdgeInsets.only(bottom: dayKcalGoal > 0 ? 68 : 0),
+              padding: EdgeInsets.only(
+                bottom: dayKcalGoal > 0 ? 68 : 0,
+              ),
               child: MealTitleExpanded(
                 meal: meal,
                 usesImperialUnits: _usesImperialUnits,
@@ -355,7 +355,9 @@ class _MealDetailScreenState extends State<MealDetailScreen> {
                     children: [
                       Text(
                         EnergyDisplay.formatWithUnit(context, totalKcal),
-                        style: Theme.of(context).textTheme.headlineSmall
+                        style: Theme.of(context)
+                            .textTheme
+                            .headlineSmall
                             ?.copyWith(fontWeight: FontWeight.w800),
                       ),
                       MealValueUnitText(
@@ -363,8 +365,8 @@ class _MealDetailScreenState extends State<MealDetailScreen> {
                         meal: meal,
                         displayUnit:
                             selectedUnit == UnitDropdownItem.serving.toString()
-                            ? meal.servingUnit
-                            : selectedUnit,
+                                ? meal.servingUnit
+                                : selectedUnit,
                         usesImperialUnits: _usesImperialUnits,
                         textStyle: Theme.of(context).textTheme.bodyMedium,
                         prefix: ' / ',
@@ -467,3 +469,4 @@ class MealDetailScreenArguments {
     this.usesImperialUnits,
   );
 }
+

--- a/lib/features/meal_detail/presentation/bloc/meal_detail_bloc.dart
+++ b/lib/features/meal_detail/presentation/bloc/meal_detail_bloc.dart
@@ -42,11 +42,11 @@ class MealDetailBloc extends Bloc<MealDetailEvent, MealDetailState> {
     this._productsRepository,
     this._remoteSearchCacheDataSource,
   ) : super(
-        MealDetailInitial(
-          totalQuantityConverted: '100',
-          selectedUnit: UnitDropdownItem.gml.toString(),
-        ),
-      ) {
+          MealDetailInitial(
+            totalQuantityConverted: '100',
+            selectedUnit: UnitDropdownItem.gml.toString(),
+          ),
+        ) {
     on<UpdateKcalEvent>((event, emit) async {
       try {
         final selectedTotalQuantity =
@@ -72,8 +72,7 @@ class MealDetailBloc extends Bloc<MealDetailEvent, MealDetailState> {
           // `scalableServingQuantity`, not `servingQuantity`: OFF often
           // leaves the numeric field empty while `serving_size` carries the
           // figure as text. Reading only the numeric one left this branch
-          // silently doing nothing, so "1 serving" was logged as one gram
-          // (#629).
+          // silently doing nothing, so "1 serving" logged one gram (#629).
           final serving = event.meal.scalableServingQuantity;
           if (serving != null) {
             convertedQuantity = quantity * serving;
@@ -112,7 +111,12 @@ class MealDetailBloc extends Bloc<MealDetailEvent, MealDetailState> {
           );
         } else {
           final goal = await _getKcalGoalUsecase.getKcalGoal();
-          emit(state.copyWith(dayKcalConsumed: 0, dayKcalGoal: goal));
+          emit(
+            state.copyWith(
+              dayKcalConsumed: 0,
+              dayKcalGoal: goal,
+            ),
+          );
         }
       } catch (e) {
         log.severe('Error loading daily totals: $e');
@@ -197,7 +201,8 @@ class MealDetailBloc extends Bloc<MealDetailEvent, MealDetailState> {
     }
     try {
       final fresh = await _productsRepository.getOFFProductByBarcode(code);
-      await _remoteSearchCacheDataSource.cache(MealDBO.fromMealEntity(fresh));
+      await _remoteSearchCacheDataSource
+          .cache(MealDBO.fromMealEntity(fresh));
     } catch (e, st) {
       log.warning(
         'Background OFF refresh failed for $code; touching cache instead',

--- a/lib/features/meal_detail/presentation/bloc/meal_detail_bloc.dart
+++ b/lib/features/meal_detail/presentation/bloc/meal_detail_bloc.dart
@@ -42,11 +42,11 @@ class MealDetailBloc extends Bloc<MealDetailEvent, MealDetailState> {
     this._productsRepository,
     this._remoteSearchCacheDataSource,
   ) : super(
-          MealDetailInitial(
-            totalQuantityConverted: '100',
-            selectedUnit: UnitDropdownItem.gml.toString(),
-          ),
-        ) {
+        MealDetailInitial(
+          totalQuantityConverted: '100',
+          selectedUnit: UnitDropdownItem.gml.toString(),
+        ),
+      ) {
     on<UpdateKcalEvent>((event, emit) async {
       try {
         final selectedTotalQuantity =
@@ -69,9 +69,14 @@ class MealDetailBloc extends Bloc<MealDetailEvent, MealDetailState> {
         // Convert quantity based on selected unit
         double convertedQuantity = quantity;
         if (selectedUnit == UnitDropdownItem.serving.toString()) {
-          // For serving size, multiply by the product's serving quantity
-          if (event.meal.servingQuantity != null) {
-            convertedQuantity = quantity * event.meal.servingQuantity!;
+          // `scalableServingQuantity`, not `servingQuantity`: OFF often
+          // leaves the numeric field empty while `serving_size` carries the
+          // figure as text. Reading only the numeric one left this branch
+          // silently doing nothing, so "1 serving" was logged as one gram
+          // (#629).
+          final serving = event.meal.scalableServingQuantity;
+          if (serving != null) {
+            convertedQuantity = quantity * serving;
           }
         } else if (selectedUnit == UnitDropdownItem.oz.toString()) {
           convertedQuantity = UnitCalc.ozToG(quantity);
@@ -107,12 +112,7 @@ class MealDetailBloc extends Bloc<MealDetailEvent, MealDetailState> {
           );
         } else {
           final goal = await _getKcalGoalUsecase.getKcalGoal();
-          emit(
-            state.copyWith(
-              dayKcalConsumed: 0,
-              dayKcalGoal: goal,
-            ),
-          );
+          emit(state.copyWith(dayKcalConsumed: 0, dayKcalGoal: goal));
         }
       } catch (e) {
         log.severe('Error loading daily totals: $e');
@@ -197,8 +197,7 @@ class MealDetailBloc extends Bloc<MealDetailEvent, MealDetailState> {
     }
     try {
       final fresh = await _productsRepository.getOFFProductByBarcode(code);
-      await _remoteSearchCacheDataSource
-          .cache(MealDBO.fromMealEntity(fresh));
+      await _remoteSearchCacheDataSource.cache(MealDBO.fromMealEntity(fresh));
     } catch (e, st) {
       log.warning(
         'Background OFF refresh failed for $code; touching cache instead',

--- a/lib/features/meal_detail/presentation/widgets/meal_detail_bottom_sheet.dart
+++ b/lib/features/meal_detail/presentation/widgets/meal_detail_bottom_sheet.dart
@@ -150,7 +150,10 @@ class _MealDetailBottomSheetState extends State<MealDetailBottomSheet> {
                                 labelText: S.of(context).unitLabel,
                               ),
                               items: <DropdownMenuItem<String>>[
-                                if (widget.product.hasServingValues)
+                                // #629: a serving the app cannot scale
+                                // is a no-op dressed as a unit.
+                                if (widget.product.scalableServingQuantity !=
+                                    null)
                                   _getServingDropdownItem(context),
                                 if (widget.product.isSolid ||
                                     !widget.product.isLiquid &&
@@ -181,11 +184,18 @@ class _MealDetailBottomSheetState extends State<MealDetailBottomSheet> {
                             children: [
                               // Quick-quantity presets — one tap to a common
                               // serving size instead of typing.
-                              for (final preset in const [50, 100, 150, 200, 250])
+                              for (final preset in const [
+                                50,
+                                100,
+                                150,
+                                200,
+                                250,
+                              ])
                                 ActionChip(
                                   label: Text('$preset'),
                                   onPressed: () {
-                                    widget.quantityTextController.text = '$preset';
+                                    widget.quantityTextController.text =
+                                        '$preset';
                                     widget.onQuantityOrUnitChanged(
                                       '$preset',
                                       widget.selectedUnit,
@@ -385,11 +395,7 @@ class _MealDetailBottomSheetState extends State<MealDetailBottomSheet> {
         : '${S.of(context).servingLabel} (${widget.product.servingQuantity} ${widget.product.servingUnit})';
     return DropdownMenuItem(
       value: UnitDropdownItem.serving.toString(),
-      child: Text(
-        servingText,
-        overflow: TextOverflow.ellipsis,
-        maxLines: 1,
-      ),
+      child: Text(servingText, overflow: TextOverflow.ellipsis, maxLines: 1),
     );
   }
 

--- a/lib/features/meal_detail/presentation/widgets/meal_detail_bottom_sheet.dart
+++ b/lib/features/meal_detail/presentation/widgets/meal_detail_bottom_sheet.dart
@@ -152,8 +152,7 @@ class _MealDetailBottomSheetState extends State<MealDetailBottomSheet> {
                               items: <DropdownMenuItem<String>>[
                                 // #629: a serving the app cannot scale
                                 // is a no-op dressed as a unit.
-                                if (widget.product.scalableServingQuantity !=
-                                    null)
+                                if (widget.product.scalableServingQuantity != null)
                                   _getServingDropdownItem(context),
                                 if (widget.product.isSolid ||
                                     !widget.product.isLiquid &&
@@ -184,18 +183,11 @@ class _MealDetailBottomSheetState extends State<MealDetailBottomSheet> {
                             children: [
                               // Quick-quantity presets — one tap to a common
                               // serving size instead of typing.
-                              for (final preset in const [
-                                50,
-                                100,
-                                150,
-                                200,
-                                250,
-                              ])
+                              for (final preset in const [50, 100, 150, 200, 250])
                                 ActionChip(
                                   label: Text('$preset'),
                                   onPressed: () {
-                                    widget.quantityTextController.text =
-                                        '$preset';
+                                    widget.quantityTextController.text = '$preset';
                                     widget.onQuantityOrUnitChanged(
                                       '$preset',
                                       widget.selectedUnit,
@@ -395,7 +387,11 @@ class _MealDetailBottomSheetState extends State<MealDetailBottomSheet> {
         : '${S.of(context).servingLabel} (${widget.product.servingQuantity} ${widget.product.servingUnit})';
     return DropdownMenuItem(
       value: UnitDropdownItem.serving.toString(),
-      child: Text(servingText, overflow: TextOverflow.ellipsis, maxLines: 1),
+      child: Text(
+        servingText,
+        overflow: TextOverflow.ellipsis,
+        maxLines: 1,
+      ),
     );
   }
 

--- a/test/unit_test/meal_detail_manual_add_serving_default_test.dart
+++ b/test/unit_test/meal_detail_manual_add_serving_default_test.dart
@@ -39,14 +39,14 @@ class _FakeRemoteSearchCacheDataSource extends Fake
     implements RemoteSearchCacheDataSource {}
 
 MealDetailBloc _buildBloc() => MealDetailBloc(
-      _FakeAddIntakeUsecase(),
-      _FakeAddTrackedDayUsecase(),
-      _FakeGetKcalGoalUsecase(),
-      _FakeGetMacroGoalUsecase(),
-      _FakeGetTrackedDayUsecase(),
-      _FakeProductsRepository(),
-      _FakeRemoteSearchCacheDataSource(),
-    );
+  _FakeAddIntakeUsecase(),
+  _FakeAddTrackedDayUsecase(),
+  _FakeGetKcalGoalUsecase(),
+  _FakeGetMacroGoalUsecase(),
+  _FakeGetTrackedDayUsecase(),
+  _FakeProductsRepository(),
+  _FakeRemoteSearchCacheDataSource(),
+);
 
 MealEntity _meal({
   double? servingQuantity,
@@ -82,7 +82,7 @@ MealEntity _meal({
 // than importing it means the screen and the test can drift only with
 // an explicit code change here.
 String _initialUnitForManualAdd(MealEntity meal) {
-  if (meal.hasServingValues) {
+  if (meal.scalableServingQuantity != null) {
     return UnitDropdownItem.serving.toString();
   } else if (meal.isLiquid) {
     return UnitDropdownItem.ml.toString();
@@ -103,7 +103,10 @@ void main() {
         // tapped this result from the search list, not the barcode
         // scanner. The bottom sheet should still open on "serving".
         final meal = _meal(servingSize: '2 Tbsp (32 g)');
-        expect(meal.hasServingValues, isTrue);
+        // #629: what makes this work is that the 32 g is readable out of
+        // the text. Without it the unit would be "serving" while nothing
+        // could scale it, and the row would log one gram.
+        expect(meal.scalableServingQuantity, 32);
 
         final initialUnit = _initialUnitForManualAdd(meal);
         expect(initialUnit, UnitDropdownItem.serving.toString());
@@ -126,7 +129,7 @@ void main() {
         // servingUnit is derived as null. Before the fix this case
         // dropped through to gml on the manual-add path.
         final meal = _meal(servingQuantity: 30.0);
-        expect(meal.hasServingValues, isTrue);
+        expect(meal.scalableServingQuantity, 30);
 
         final initialUnit = _initialUnitForManualAdd(meal);
         expect(initialUnit, UnitDropdownItem.serving.toString());
@@ -148,7 +151,7 @@ void main() {
         // 100 g/ml baseline so nothing changes for entries where
         // "serving" doesn't make sense.
         final meal = _meal();
-        expect(meal.hasServingValues, isFalse);
+        expect(meal.scalableServingQuantity, isNull);
 
         final initialUnit = _initialUnitForManualAdd(meal);
         expect(initialUnit, UnitDropdownItem.gml.toString());
@@ -161,5 +164,56 @@ void main() {
         await bloc.close();
       },
     );
+  });
+
+  group('a serving the app cannot scale (#629)', () {
+    test('serving text with no metric figure yields no serving', () {
+      // "1 egg" is a serving nobody can convert. hasServingValues is still
+      // true, which is why the screen used to default to "1 serving" and
+      // log one gram.
+      final meal = _meal(servingSize: '1 egg');
+
+      expect(meal.hasServingValues, isTrue);
+      expect(meal.scalableServingQuantity, isNull);
+    });
+
+    test('such a meal falls back to a weight, not to "1 serving"', () {
+      final meal = _meal(servingSize: '1 egg');
+
+      expect(_initialUnitForManualAdd(meal), UnitDropdownItem.gml.toString());
+    });
+
+    test('the metric figure in parentheses wins over the imperial one', () {
+      expect(_meal(servingSize: '12 oz (355 ml)').scalableServingQuantity, 355);
+      expect(_meal(servingSize: '1 slice (25g)').scalableServingQuantity, 25);
+      expect(_meal(servingSize: '30 g').scalableServingQuantity, 30);
+      expect(_meal(servingSize: '240ml').scalableServingQuantity, 240);
+    });
+
+    test('a numeric servingQuantity always wins over the text', () {
+      final meal = _meal(servingQuantity: 40, servingSize: '2 Tbsp (32 g)');
+
+      expect(meal.scalableServingQuantity, 40);
+    });
+
+    test('one serving of a scalable record converts to its grams', () async {
+      // The half that made the bug invisible: the unit said "serving" and
+      // the conversion left the amount alone.
+      final meal = _meal(servingSize: '2 Tbsp (32 g)');
+      final bloc = _buildBloc();
+
+      bloc.add(
+        UpdateKcalEvent(
+          meal: meal,
+          selectedUnit: UnitDropdownItem.serving.toString(),
+          totalQuantity: '1',
+        ),
+      );
+      await Future<void>.delayed(Duration.zero);
+
+      expect(bloc.state.totalQuantityConverted, '32.0');
+      expect(bloc.state.totalKcal, 32.0);
+      await bloc.close();
+    });
   });
 }


### PR DESCRIPTION
Closes #629. Targets `develop` — this is the pre-existing twin of a bug fixed on the AI branch, and it is worse here than the issue described.

## It is the default, not just a dropdown choice

`hasServingValues` is true when *either* serving field is present, but `UpdateKcalEvent` could only scale `servingQuantity`. Open Food Facts frequently leaves that numeric field empty while `serving_size` carries the same figure as text.

For those records:

```dart
if (meal.hasServingValues) {      // true on serving_size text alone
  _initialUnit = serving;
  _initialQuantity = "1";
}
// UpdateKcalEvent: servingQuantity == null -> convertedQuantity stays 1
```

So opening a scanned product defaulted to **"1 serving" that logged one gram**, before the user touched anything. My issue described this as a trap the user could walk into; it is actually the default path.

## Why the obvious fix was wrong

Gating on `servingQuantity` would have undone **#34**, which deliberately makes those records open on "serving" rather than 100 g — and whose test asserts precisely the shape this bug lives in (`servingSize: '2 Tbsp (32 g)'`).

## So read the figure instead

`MealEntity.scalableServingQuantity` returns `servingQuantity` when present, and otherwise pulls the last metric number out of the serving text:

| `serving_size` | scalable |
| :-- | --: |
| `2 Tbsp (32 g)` | 32 |
| `12 oz (355 ml)` | 355 |
| `1 slice (25g)` | 25 |
| `30 g` | 30 |
| `1 egg` | _null_ |

Last match wins, so a parenthesised metric equivalent beats the imperial measure in front of it. #34 keeps its behaviour and the serving now actually scales.

A serving with no metric figure at all — `1 egg` — still yields null, and those fall back to a weight the user can see rather than a unit that silently means grams. That is #629's remainder and cannot be fixed by reading harder.

## One value, three call sites

The initial unit, the initial quantity and the dropdown entry now all read `scalableServingQuantity`. Previously the gate and the conversion disagreed about what a serving was, which is exactly what made the bug invisible.

## Tests

Five new cases plus the existing three updated. The in-test mirror of the screen's logic is updated too — its own comment asks for that, and leaving it would have let the screen and its test drift silently, which is the failure mode it was written to prevent.

Both halves mutation-checked: ignoring the serving text fails three tests, reading `servingQuantity` in the conversion fails one.

967 tests, analyzer clean. Changed lines measured against `develop`: 9, 10, 4 and 32 — the second commit undoes a `dart format` run that had rewritten unrelated code in three of those files.
