### PR TITLE
feat(core): give the AI credential store a slot per provider

### DIFF
--- a/lib/core/utils/ai_credential_storage.dart
+++ b/lib/core/utils/ai_credential_storage.dart
@@ -1,78 +1,187 @@
 import 'package:flutter_secure_storage/flutter_secure_storage.dart';
 import 'package:opennutritracker/core/utils/secure_app_storage_provider.dart';
 
-/// Holds the user's own model-provider API key, and whether they currently
-/// want it used.
+/// A model provider the user can point the AI features at.
 ///
-/// The key is a credential the project never sees, never proxies and never
-/// pays for, so it lives in the platform keystore rather than Hive or
+/// The name is persisted, so these identifiers are storage format: renaming
+/// one silently orphans every key stored under the old spelling.
+enum AiProvider {
+  anthropic,
+  openrouter;
+
+  /// Anything unrecognised — including nothing at all — reads as Anthropic.
+  ///
+  /// That is what makes an existing install valid without writing to it:
+  /// before this existed every key was an Anthropic key, so the absence of a
+  /// pointer already means the right thing and no migration has to run.
+  static AiProvider fromTag(String? value) => AiProvider.values.firstWhere(
+    (provider) => provider.name == value,
+    orElse: () => AiProvider.anthropic,
+  );
+}
+
+/// Holds the user's own model-provider API keys, which one is in use, and
+/// whether they currently want it used.
+///
+/// The keys are credentials the project never sees, never proxies and never
+/// pays for, so they live in the platform keystore rather than Hive or
 /// preferences — reusing the hardened options on
 /// [SecureAppStorageProvider.secureAppStorage], including `resetOnError:
-/// false`, so a keystore hiccup cannot silently wipe it.
+/// false`, so a keystore hiccup cannot silently wipe them.
 ///
-/// The enabled flag is stored beside the key rather than in `ConfigDBO` on
-/// purpose. It is not a secret, but keeping both in one place means they
-/// cannot disagree: there is no state where the app believes the feature is
-/// on while the key it needs has been cleared, and clearing the credential
-/// clears the intent with it. It also avoids a Hive schema migration for a
-/// single bool.
+/// **A slot per provider, not one slot reassigned.** Switching provider is
+/// the same act [setEnabled] already exists to make cheap: pausing and then
+/// hunting for an API key again is friction worth engineering around, and
+/// comparing two providers — the whole reason to offer a second one — means
+/// switching repeatedly. The cost is accepted knowingly: the app now holds
+/// two billing credentials at rest instead of one, in the same hardened
+/// store, but a larger prize inside it.
+///
+/// The active provider and the enabled flag are stored beside the keys
+/// rather than in `ConfigDBO`. Neither is a secret, but keeping all of it in
+/// one place means they cannot disagree: there is no state where the app
+/// believes the feature is on while the credential it would actually use has
+/// been cleared, and no state where it points at a provider whose slot was
+/// emptied by something that did not update the pointer. It also avoids a
+/// Hive schema migration for a bool and a string.
 class AiCredentialStorage {
-  static const _apiKeyTag = 'AiApiKeyTag';
+  /// The single tag every key used before providers existed. Still read as
+  /// the Anthropic slot's fallback — see [readApiKey] — so an existing
+  /// install is bit-for-bit untouched until the user does something.
+  static const _legacyApiKeyTag = 'AiApiKeyTag';
+
   static const _enabledTag = 'AiAssistEnabledTag';
+  static const _providerTag = 'AiProviderTag';
+
+  static String _slotTag(AiProvider provider) =>
+      '$_legacyApiKeyTag.${provider.name}';
 
   final FlutterSecureStorage _storage;
 
   AiCredentialStorage([FlutterSecureStorage? storage])
     : _storage = storage ?? SecureAppStorageProvider.secureAppStorage;
 
-  /// The stored key, or null when none is set. Read at call time rather than
-  /// cached — nothing should hold a credential in memory longer than the
-  /// request that needs it.
-  Future<String?> readApiKey() async {
-    final value = await _storage.read(key: _apiKeyTag);
-    if (value == null || value.isEmpty) return null;
-    return value;
+  /// Which provider the AI features currently use.
+  Future<AiProvider> activeProvider() async =>
+      AiProvider.fromTag(await _storage.read(key: _providerTag));
+
+  /// Points the AI features at [provider].
+  ///
+  /// Selecting one with no key stored is allowed, and the feature simply
+  /// goes quietly unavailable — the camera action hides itself and the text
+  /// path falls back to the deterministic parser, which is the state
+  /// `MealPhotoUnavailable` already describes and already handles. Gating
+  /// the choice to providers that hold a key would make the state
+  /// unrepresentable rather than merely handled, but it collapses "switch
+  /// provider" and "enter a key" into one action to prevent something that
+  /// is not a fault.
+  Future<void> setActiveProvider(AiProvider provider) =>
+      _storage.write(key: _providerTag, value: provider.name);
+
+  /// The stored key for [provider], defaulting to the active one, or null
+  /// when none is set. Read at call time rather than cached — nothing should
+  /// hold a credential in memory longer than the request that needs it.
+  ///
+  /// The Anthropic slot falls back to [_legacyApiKeyTag]. That fallback is
+  /// the whole migration strategy: nothing is ever copied, so there is no
+  /// moment where a credential exists half-moved, and an older build rolled
+  /// back onto the same device still finds the key where it expects it.
+  Future<String?> readApiKey({AiProvider? provider}) async {
+    final target = provider ?? await activeProvider();
+
+    final value = await _storage.read(key: _slotTag(target));
+    if (value != null && value.isNotEmpty) return value;
+
+    if (target != AiProvider.anthropic) return null;
+
+    final legacy = await _storage.read(key: _legacyApiKeyTag);
+    if (legacy == null || legacy.isEmpty) return null;
+    return legacy;
   }
 
-  /// Stores [apiKey]. A blank value clears instead of writing an empty
-  /// credential that would later fail as a puzzling 401.
-  Future<void> writeApiKey(String apiKey) async {
+  /// Stores [apiKey] for [provider], defaulting to the active one. A blank
+  /// value clears instead of writing an empty credential that would later
+  /// fail as a puzzling 401.
+  Future<void> writeApiKey(String apiKey, {AiProvider? provider}) async {
+    final target = provider ?? await activeProvider();
     final trimmed = apiKey.trim();
     if (trimmed.isEmpty) {
-      await clear();
+      await clear(provider: target);
       return;
     }
-    await _storage.write(key: _apiKeyTag, value: trimmed);
+
+    await _storage.write(key: _slotTag(target), value: trimmed);
+    await _retireLegacyTagFor(target);
+
     // Saving a key is the user asking for the feature. Requiring a second
     // switch afterwards is a step that only exists to be forgotten.
     await _storage.write(key: _enabledTag, value: 'true');
   }
 
-  /// Forgets the key and the intent together.
-  Future<void> clear() async {
-    await _storage.delete(key: _apiKeyTag);
-    await _storage.delete(key: _enabledTag);
+  /// Forgets [provider]'s key, defaulting to the active one, and the intent
+  /// along with it once no key is left anywhere.
+  ///
+  /// **The legacy deletion is load-bearing, not tidiness.** Because
+  /// [readApiKey] falls back, a stale legacy value can resurrect: suppose a
+  /// user replaces their Anthropic key, the new slot is written but the
+  /// legacy delete fails on a keystore hiccup — the exact fault
+  /// `resetOnError: false` exists for — and then they remove their
+  /// credential. Without this, the next read falls back and hands back the
+  /// key they just deleted. Pressing "remove key" and still having a working
+  /// key afterwards is the worst failure this class can produce.
+  Future<void> clear({AiProvider? provider}) async {
+    final target = provider ?? await activeProvider();
+
+    await _storage.delete(key: _slotTag(target));
+    await _retireLegacyTagFor(target);
+
+    // Only once nothing is left: with two slots, clearing one key is often
+    // "I am dropping this provider", not "I am done with the feature". The
+    // invariant that matters is narrower — the flag may never be on with no
+    // credential behind it at all.
+    if (!await _hasAnyKey()) {
+      await _storage.delete(key: _enabledTag);
+    }
   }
 
-  Future<bool> hasApiKey() async => await readApiKey() != null;
+  /// The legacy tag is the Anthropic slot under an older name, so it is
+  /// retired only when Anthropic's own slot is written or cleared. Deleting
+  /// it while acting on another provider would destroy an Anthropic
+  /// credential the user never touched.
+  Future<void> _retireLegacyTagFor(AiProvider provider) async {
+    if (provider != AiProvider.anthropic) return;
+    await _storage.delete(key: _legacyApiKeyTag);
+  }
 
-  /// Whether the user currently wants the key used. False whenever no key is
-  /// stored, so a caller never has to check both.
+  Future<bool> _hasAnyKey() async {
+    for (final provider in AiProvider.values) {
+      if (await readApiKey(provider: provider) != null) return true;
+    }
+    return false;
+  }
+
+  Future<bool> hasApiKey({AiProvider? provider}) async =>
+      await readApiKey(provider: provider) != null;
+
+  /// Whether the user currently wants the key used. False whenever the
+  /// *active* provider has no key, so a caller never has to check both — the
+  /// same invariant as before providers existed, restated for two slots.
   Future<bool> isEnabled() async {
     if (!await hasApiKey()) return false;
     return await _storage.read(key: _enabledTag) != 'false';
   }
 
-  /// Turns the feature off without forgetting the key, so switching it back
-  /// on does not mean finding the credential again. Enabling with no key
-  /// stored is a no-op rather than a state the UI would have to explain.
+  /// Turns the feature off without forgetting the keys, so switching it back
+  /// on does not mean finding a credential again. Enabling with no key for
+  /// the active provider is a no-op rather than a state the UI would have to
+  /// explain.
   Future<void> setEnabled(bool enabled) async {
     if (enabled && !await hasApiKey()) return;
     await _storage.write(key: _enabledTag, value: enabled ? 'true' : 'false');
   }
 
-  /// A fixed-length stand-in for the stored key, for a UI that must never
-  /// show the value. Fixed-length on purpose: rendering the real length
-  /// would leak which provider's key format is in use.
+  /// A fixed-length stand-in for a stored key, for a UI that must never show
+  /// the value. Fixed-length on purpose: rendering the real length would
+  /// leak which provider's key format is in use.
   static const maskedPlaceholder = '••••••••••••';
 }

--- a/test/unit_test/ai_credential_storage_test.dart
+++ b/test/unit_test/ai_credential_storage_test.dart
@@ -136,4 +136,206 @@ void main() {
       isNot('sk-a-very-long-key-value'.length),
     );
   });
+
+  group('two providers', () {
+    test('defaults to Anthropic with nothing stored', () async {
+      expect(await storage.activeProvider(), AiProvider.anthropic);
+    });
+
+    test('holds a key per provider rather than one reassigned', () async {
+      // Switching provider is the same act setEnabled(false) exists to make
+      // cheap. Comparing two providers means switching repeatedly, and
+      // re-finding an API key each time taxes exactly that.
+      await storage.writeApiKey('sk-ant', provider: AiProvider.anthropic);
+      await storage.writeApiKey('sk-or', provider: AiProvider.openrouter);
+
+      expect(
+        await storage.readApiKey(provider: AiProvider.anthropic),
+        'sk-ant',
+      );
+      expect(
+        await storage.readApiKey(provider: AiProvider.openrouter),
+        'sk-or',
+      );
+    });
+
+    test('reads and writes the active provider by default', () async {
+      await storage.setActiveProvider(AiProvider.openrouter);
+      await storage.writeApiKey('sk-or');
+
+      expect(await storage.readApiKey(), 'sk-or');
+      expect(
+        await storage.readApiKey(provider: AiProvider.anthropic),
+        isNull,
+        reason: 'the other slot must not be written by an unqualified save',
+      );
+    });
+
+    test('switching back finds the key still there', () async {
+      await storage.writeApiKey('sk-ant');
+      await storage.setActiveProvider(AiProvider.openrouter);
+      await storage.writeApiKey('sk-or');
+      await storage.setActiveProvider(AiProvider.anthropic);
+
+      expect(await storage.readApiKey(), 'sk-ant');
+      expect(await storage.isEnabled(), isTrue);
+    });
+
+    test('selecting a provider with no key goes quietly unavailable', () async {
+      // A setting, not a fault: the same state MealPhotoUnavailable already
+      // describes, arriving by a new route.
+      await storage.writeApiKey('sk-ant');
+      await storage.setActiveProvider(AiProvider.openrouter);
+
+      expect(await storage.isEnabled(), isFalse);
+      expect(await storage.hasApiKey(), isFalse);
+      expect(
+        await storage.readApiKey(provider: AiProvider.anthropic),
+        'sk-ant',
+        reason: 'and the key it is not using is untouched',
+      );
+    });
+
+    test('cannot be enabled for a provider with no key', () async {
+      await storage.writeApiKey('sk-ant');
+      await storage.setActiveProvider(AiProvider.openrouter);
+      await storage.setEnabled(true);
+
+      expect(await storage.isEnabled(), isFalse);
+    });
+
+    test('clearing one provider leaves the other alone', () async {
+      await storage.writeApiKey('sk-ant', provider: AiProvider.anthropic);
+      await storage.writeApiKey('sk-or', provider: AiProvider.openrouter);
+
+      await storage.clear(provider: AiProvider.openrouter);
+
+      expect(await storage.readApiKey(provider: AiProvider.openrouter), isNull);
+      expect(
+        await storage.readApiKey(provider: AiProvider.anthropic),
+        'sk-ant',
+      );
+      // Dropping one provider is not the same as being done with the
+      // feature, and a credential is still there to back the intent.
+      expect(await storage.isEnabled(), isTrue);
+    });
+
+    test('clearing one provider does not silently un-pause', () async {
+      // An absent flag reads as on, so deleting it is not a neutral act.
+      // If clear() forgot the intent whenever any key went away, a paused
+      // user who dropped one provider would find the feature running again
+      // without having asked for it.
+      await storage.writeApiKey('sk-ant', provider: AiProvider.anthropic);
+      await storage.writeApiKey('sk-or', provider: AiProvider.openrouter);
+      await storage.setEnabled(false);
+
+      await storage.clear(provider: AiProvider.openrouter);
+
+      expect(await storage.isEnabled(), isFalse);
+    });
+
+    test('clearing the last key also forgets the intent', () async {
+      await storage.writeApiKey('sk-ant', provider: AiProvider.anthropic);
+      await storage.writeApiKey('sk-or', provider: AiProvider.openrouter);
+
+      await storage.clear(provider: AiProvider.openrouter);
+      await storage.clear(provider: AiProvider.anthropic);
+
+      expect(await storage.isEnabled(), isFalse);
+      expect(backing.store, isEmpty);
+    });
+  });
+
+  group('a key stored before providers existed', () {
+    // The single tag every install used before this. Spelled out rather than
+    // referenced so the test still fails if the constant is renamed — the
+    // point is the bytes on the device, not the identifier in the source.
+    const legacyTag = 'AiApiKeyTag';
+
+    test('keeps working untouched, with no migration written', () async {
+      backing.store[legacyTag] = 'sk-old';
+      backing.store['AiAssistEnabledTag'] = 'true';
+
+      expect(await storage.readApiKey(), 'sk-old');
+      expect(await storage.isEnabled(), isTrue);
+      expect(backing.store.keys.toSet(), {
+        legacyTag,
+        'AiAssistEnabledTag',
+      }, reason: 'reading must not write anything back');
+    });
+
+    test('is Anthropic\'s, and not visible to the other provider', () async {
+      backing.store[legacyTag] = 'sk-old';
+
+      expect(
+        await storage.readApiKey(provider: AiProvider.anthropic),
+        'sk-old',
+      );
+      expect(await storage.readApiKey(provider: AiProvider.openrouter), isNull);
+    });
+
+    test('is retired the next time an Anthropic key is saved', () async {
+      backing.store[legacyTag] = 'sk-old';
+
+      await storage.writeApiKey('sk-new');
+
+      expect(await storage.readApiKey(), 'sk-new');
+      expect(backing.store.containsKey(legacyTag), isFalse);
+    });
+
+    test('survives saving a key for the other provider', () async {
+      // Retiring the legacy tag on any write would destroy an Anthropic
+      // credential the user never touched.
+      backing.store[legacyTag] = 'sk-old';
+
+      await storage.writeApiKey('sk-or', provider: AiProvider.openrouter);
+
+      expect(
+        await storage.readApiKey(provider: AiProvider.anthropic),
+        'sk-old',
+      );
+    });
+
+    test('is deleted by clear, so it cannot resurrect the key', () async {
+      // The trap the fallback creates. Suppose the legacy delete failed once
+      // on a keystore hiccup — the exact fault resetOnError: false exists
+      // for — leaving a stale value behind a newer slot. If clear() does not
+      // remove it too, the user presses "remove key" and still has a working
+      // key afterwards, which is the worst thing this class can do.
+      backing.store[legacyTag] = 'sk-stale';
+      backing.store['AiApiKeyTag.anthropic'] = 'sk-current';
+
+      await storage.clear();
+
+      expect(await storage.readApiKey(), isNull);
+      expect(await storage.hasApiKey(), isFalse);
+      expect(await storage.isEnabled(), isFalse);
+    });
+
+    test('clearing the other provider does not delete it', () async {
+      backing.store[legacyTag] = 'sk-old';
+
+      await storage.clear(provider: AiProvider.openrouter);
+
+      expect(await storage.readApiKey(), 'sk-old');
+    });
+  });
+
+  group('the provider tag', () {
+    test('is stored as a stable name, not an index', () async {
+      // Persisted format: an ordinal would silently repoint every install at
+      // a different provider the day the enum gains a member.
+      await storage.setActiveProvider(AiProvider.openrouter);
+
+      expect(backing.store['AiProviderTag'], 'openrouter');
+    });
+
+    test('reads as Anthropic when it holds something unrecognised', () async {
+      // A downgrade, or a provider removed in a later build. Falling back to
+      // the default beats refusing to start.
+      backing.store['AiProviderTag'] = 'some-provider-we-dropped';
+
+      expect(await storage.activeProvider(), AiProvider.anthropic);
+    });
+  });
 }


### PR DESCRIPTION
Builds wayfinder [#657](https://github.com/simonoppowa/OpenNutriTracker/issues/657) and [#662](https://github.com/simonoppowa/OpenNutriTracker/issues/662). Targets `feature/ai-assisted-meal-logging`, not `develop`.

Independent of [#673](https://github.com/simonoppowa/OpenNutriTracker/pull/673) — no shared files, and the two merge in either order.

## A slot per provider, not one reassigned

`AiCredentialStorage` held one key. Two providers need two, and the decision was a slot each rather than one replaced on switch.

The class already goes out of its way not to make the user re-find a credential — `setEnabled(false)` exists precisely so pausing does not mean hunting for an API key again. Switching provider is the same act, and it will happen *more* often than that reasoning anticipated: the reason to offer a second provider at all is to compare them, so during evaluation a user may switch several times in an afternoon. Replacing the single slot would tax exactly the behaviour the feature is meant to enable.

The cost is taken knowingly: **the app now holds two billing credentials at rest instead of one**, in the same hardened keystore under `resetOnError: false`. Same blast radius, larger prize inside it.

The active provider lives in the keystore beside the keys rather than in `ConfigDBO`, for the reason the enabled flag is already there — not because it is secret, but so they cannot disagree.

## What `isEnabled()` now means

```dart
isEnabled() == flagOn && keyFor(activeProvider) != null
```

The same invariant as before, restated for two slots: the app can never believe the feature is on while the credential it would actually use is absent.

Selecting a provider you have no key for is allowed, and the feature goes quietly unavailable — the camera action hides itself, the text path falls back to the deterministic parser. That needs no new machinery: `MealPhotoUnavailable` is already defined as *"No key stored, or the user has switched the feature off"*, so this is that state arriving by a new route.

## No migration

```
read(anthropic)   → AiApiKeyTag.anthropic ?? AiApiKeyTag   (legacy)
read(openrouter)  → AiApiKeyTag.openrouter
write(anthropic)  → AiApiKeyTag.anthropic, then retire legacy
activeProvider    → AiProviderTag ?? anthropic
```

A fallback read rather than a copy, so there is no moment where a credential exists half-moved and no "write succeeded, delete failed" case to reason about. An existing install is bit-for-bit untouched until the user does something, and an APK rollback still finds the key where an older build looks for it. Absence of a provider tag means Anthropic, so nothing is written to make an existing install valid — it already is.

## The trap the fallback creates

A fallback read means a stale legacy value can be **resurrected**.

Replace an Anthropic key; the new slot is written but the legacy delete fails on a keystore hiccup — the exact fault `resetOnError: false` is set for. Nothing looks wrong, because reads prefer the new slot. Then remove the credential. A naive `clear()` deletes the slot, the next read falls back, and hands back the key that was just deleted.

Pressing "remove key" and still having a working key afterwards is the worst failure this class can produce, so `clear()` retires the legacy tag too. It retires it **only for Anthropic** — the legacy tag *is* the Anthropic slot under an older name, and deleting it while acting on OpenRouter would destroy a credential the user never touched.

## Verification

1232 tests pass, `flutter analyze` clean. 26 in this file, 17 of them new.

Six mutations run against them, all six killed:

| mutation | caught by |
| --- | --- |
| `clear()` stops retiring the legacy tag | the resurrection test |
| legacy retired on *any* write, not just Anthropic's | the other provider's key survives |
| the legacy fallback visible to every provider | it is Anthropic's, not shared |
| provider tag persisted as an index | switching back finds the key |
| `isEnabled()` ignores which provider is active | keyless provider goes unavailable |
| `clear()` always forgets the intent | clearing one provider does not un-pause |

The last one survived the first pass. An absent enabled flag reads as *on*, so deleting it is not a neutral act — a paused user who dropped one provider would have found the feature running again. The test that catches it had to set up the paused state first; added, and the mutation dies.

## Not in this PR

Nothing calls `setActiveProvider` yet — the settings surface waits on [#661](https://github.com/simonoppowa/OpenNutriTracker/issues/661)'s wording and [#668](https://github.com/simonoppowa/OpenNutriTracker/issues/668)'s model list. Every existing call site is unchanged, because the provider argument defaults to the active provider: the settings dialog and both use cases keep working exactly as written.
