### PR TITLE
fix(ci): make the pod fallback run on the bash it actually gets

### DIFF
--- a/.github/scripts/pod_install_with_targeted_fallback.sh
+++ b/.github/scripts/pod_install_with_targeted_fallback.sh
@@ -63,15 +63,31 @@ while IFS= read -r line; do
   [ -n "$line" ] && parsed_pods+=("$line")
 done < <(extract_pods)
 
-declare -A seen=()
+# Deduplicated with a nested loop rather than an associative array.
+# `declare -A` is a bash 4 feature and this script only ever runs on the
+# macOS runners, whose /bin/bash is 3.2 — so it failed with "declare: -A:
+# invalid option" the first time a CocoaPods CDN hiccup actually took the
+# fallback path. The test suite did not catch it because linux-checks runs
+# on bash 5, the one platform this script never executes on. Keep this file
+# POSIX-ish and bash-3.2 clean; see the guard in the test script.
+#
+# The pod lists here are a handful of names at most, so the quadratic
+# comparison costs nothing.
 root_pods=()
 for pod in "${parsed_pods[@]:-}"; do
   root="${pod%%/*}"
   [ -z "$root" ] && continue
-  if [ -z "${seen[$root]:-}" ]; then
-    seen[$root]=1
-    root_pods+=("$root")
+  duplicate=""
+  for existing in "${root_pods[@]:-}"; do
+    if [ "$existing" = "$root" ]; then
+      duplicate=1
+      break
+    fi
+  done
+  if [ -n "$duplicate" ]; then
+    continue
   fi
+  root_pods+=("$root")
 done
 
 if [ "${#root_pods[@]}" -gt 0 ]; then

--- a/.github/scripts/test_pod_install_with_targeted_fallback.sh
+++ b/.github/scripts/test_pod_install_with_targeted_fallback.sh
@@ -121,6 +121,32 @@ run_case "compatible-versions and none-of-your-sources together still dedup" \
 None of your spec sources contain a spec satisfying the dependency: `Sentry/HybridSDK (= 8.58.0)`.' \
   'Sentry'
 
+# The script under test runs *only* on the macOS runners, whose /bin/bash
+# is 3.2, while these tests run on linux-checks under bash 5. That gap let
+# a `declare -A` sit in the fallback path unnoticed until a CocoaPods CDN
+# outage took that path for the first time and the script died with
+# "declare: -A: invalid option".
+#
+# There is no bash 3.2 on the Linux runner to execute against, so this
+# greps for the bash-4-only constructs instead. It is a lint, not an
+# execution test, but it closes the gap that mattered: the parser tests
+# above can never fail for a reason the target platform would.
+tests_run=$((tests_run + 1))
+# Comment lines are dropped, so the note explaining this rule does not
+# trip it.
+bash4_only=$(grep -nE \
+  '(declare|local|typeset)[[:space:]]+-[A-Za-z]*A|mapfile|readarray|\$\{[A-Za-z_][A-Za-z0-9_]*(\[[^]]*\])?(,,|\^\^)' \
+  "$script_dir/pod_install_with_targeted_fallback.sh" \
+  | grep -vE '^[0-9]+:[[:space:]]*#' || true)
+
+if [ -n "$bash4_only" ]; then
+  tests_failed=$((tests_failed + 1))
+  echo "FAIL: bash 4+ construct in a script that runs on macOS bash 3.2:"
+  echo "$bash4_only"
+else
+  echo "ok: no bash 4+ constructs in pod_install_with_targeted_fallback.sh"
+fi
+
 echo
 echo "Tests run: $tests_run, failures: $tests_failed"
 exit "$tests_failed"


### PR DESCRIPTION
## The bug

`pod_install_with_targeted_fallback.sh` deduplicated pod names with `declare -A`, a bash 4 feature. The script only ever runs on the macOS runners, whose `/bin/bash` is 3.2, so it failed outright:

```
.github/scripts/pod_install_with_targeted_fallback.sh: line 66: declare: -A: invalid option
```

## Why it stayed hidden

It lives in the **fallback** path. `pod install --repo-update` normally succeeds and the fallback never runs — so the one piece of code whose entire job is to recover from a bad day had never had one.

A CocoaPods CDN outage today (429s from `raw.githubusercontent.com` while fetching podspecs) took that path for the first time, and the recovery crashed instead of recovering. That turned a transient upstream hiccup into a hard red on `ios-build` and `ios-integration-tests`.

## Why the tests did not catch it

`test_pod_install_with_targeted_fallback.sh` runs on `linux-checks`, under bash 5. The script it tests runs **only** on macOS, under bash 3.2. The tests were green on the one platform where the bug cannot reproduce.

That gap is the actual defect here — the `declare -A` is just what fell through it.

## The fix

- The dedup is a nested loop instead of an associative array. Pod lists are a handful of names, so the quadratic comparison costs nothing. Written to be safe under `set -e`, which the earlier `[ … ] && x && break` shape would not have been.
- The test suite now greps the script for bash 4+ constructs — `declare/local/typeset -A`, `mapfile`, `readarray`, and the `${x,,}` / `${x^^}` case modifiers. Comment lines are excluded so the note explaining the rule does not trip it.

It is a lint, not an execution test, because there is no bash 3.2 on the Linux runner to run against. It does close the gap that mattered: the parser tests can no longer pass for a reason the target platform would reject.

## Verification

- All 8 existing parser cases still pass, including the dedup case that exercises the rewritten loop
- The new guard passes on the fixed script
- **Proved it catches the original bug**: reintroduced `declare -A seen=()`, watched the guard fail with `76:declare -A seen=()`, then restored. A guard that has never failed is not yet a guard.

## Not addressed here

The CDN 429s themselves, and the `429 Too Many Requests` failures on `actions/setup-java` and `dorny/paths-filter` downloads in the same run. Those are upstream GitHub rate limiting and need a re-run, not a change. This PR only ensures the fallback works the next time something like it happens.
