### PR TITLE
docs(add-meal): fix why strict is skipped, and write down the rule

### DIFF
--- a/lib/features/add_meal/data/openrouter_meal_items_api.dart
+++ b/lib/features/add_meal/data/openrouter_meal_items_api.dart
@@ -83,18 +83,29 @@ class OpenRouterMealItemsApi implements MealItemsApi {
             // Measured — every call to every `openai/*` model failed with a
             // 400, text included.
             //
-            // The optionality it objects to is the point. `quantity` and
-            // `unit` are omitted when the user stated no amount, and making
-            // them required would oblige the model to produce a number for
-            // every item, which is the estimation this whole design exists
-            // to prevent. So the schema cannot bend, and `strict` has to go.
+            // That constraint is *not* the reason to skip it, though this
+            // comment used to say so. A nullable union satisfies strict
+            // while keeping the field optional — OpenAI sanctions exactly
+            // that: "it is possible to emulate an optional parameter by
+            // using a union type with `null`" — and `_mealItemFrom` already
+            // maps an explicit null to null, so absent and null already
+            // produce the identical item. The option exists; it was
+            // rejected for a reason that did not hold.
             //
-            // Nothing is lost. The guarantee was never `strict`: it is that
-            // the schema has no macro fields at all, and that everything
-            // returned goes through `validateParsedMealItems`. OpenRouter
-            // documents no uniform enforcement of `strict` across providers
-            // anyway, so it was buying a promise it could not keep while
-            // costing an entire vendor.
+            // The real reason is that strict buys this design nothing.
+            // Enforcement is in Dart: `_mealItemFrom` reads three keys and
+            // drops the rest, so a model emitting a calorie field loses it
+            // regardless. And what strict would add — constraining the unit
+            // enum, forbidding a missing `query` — `validateParsedMealItems`
+            // already handles *better*, dropping an unrecognised unit and
+            // keeping the food rather than refusing the whole reply.
+            //
+            // Settled in #683, which generalised it: the app never relies on
+            // provider-side constrained decoding. See `mealItemsToolSchema`.
+            //
+            // A direct OpenAI client would have to send `strict: false`
+            // explicitly — on the Responses API, omitting it normalises the
+            // schema into strict mode rather than leaving it alone.
           },
         },
       ],

--- a/lib/features/add_meal/domain/meal_items_api.dart
+++ b/lib/features/add_meal/domain/meal_items_api.dart
@@ -51,6 +51,20 @@ const mealItemsToolDescription = 'Record the food items found.';
 /// The shape is plain JSON Schema, which is what Anthropic's `input_schema`
 /// and OpenAI-compatible `function.parameters` both take, so one constant
 /// serves both wire formats unchanged.
+///
+/// **The app never relies on provider-side constrained decoding.** This
+/// schema is a hint to the model; [_mealItemFrom] and
+/// `validateParsedMealItems` are the enforcement. Every guarantee the app
+/// makes about model output must be checkable in Dart, against a reply that
+/// ignored the schema entirely — which is why `additionalProperties: false`
+/// below is documentation of intent rather than a defence, and why a reply
+/// carrying a `calories` field loses it whether or not any provider agreed
+/// to forbid one.
+///
+/// That is a standing rule for new providers, not a description of one. A
+/// provider offering strict or constrained output may be given it, but
+/// nothing may be *moved* onto it: the checks stay. Settled in #683, which
+/// also records why adopting OpenAI's strict mode buys this design nothing.
 const mealItemsToolSchema = {
   'type': 'object',
   'properties': {


### PR DESCRIPTION
Closes #698. Decided in #683, under the map in #678.

Comments only — no behaviour change, no schema change, no test change.

## The comment was confidently wrong

`openrouter_meal_items_api.dart` explained skipping `strict: true` by saying that putting `quantity` and `unit` in `required` *"would oblige the model to produce a number for every item, which is the estimation this whole design exists to prevent."*

That is true of plain `required` and **false of a nullable union**, which OpenAI sanctions verbatim: *"it is possible to emulate an optional parameter by using a union type with `null`."* And `_mealItemFrom` already maps an explicit null to null for both fields, so an explicit null and an absent field already produce the identical `ParsedMealItem` — the parser would need no change at all.

So the option existed. It was rejected for a reason that did not hold, stated in a tone that would stop anyone checking.

## The decision still stands, for a better reason

Strict buys this design nothing:

- **Enforcement is in Dart.** `_mealItemFrom` reads three keys and drops everything else, so a model emitting a `calories` field loses it whether or not any provider agreed to forbid one. Strict would not strengthen the no-macros guarantee.
- **Validation handles the rest better.** Constraining the unit enum and forbidding a missing `query` is what strict would add; `validateParsedMealItems` already drops an unrecognised unit and keeps the food, and drops a bad row with an indexed error. Refusing the whole reply instead would be worse for the user.

Also noted in place: a direct OpenAI client would have to send `strict: false` **explicitly**, because on the Responses API omitting it normalises the schema into strict mode rather than leaving it alone. That is a silent 400-on-every-request trap for whoever writes that client.

## The rule is now written down

On `mealItemsToolSchema`, where an author of a new provider client will actually meet it:

> The app never relies on provider-side constrained decoding. This schema is a hint to the model; the parser and validator are the enforcement. Every guarantee the app makes about model output must be checkable in Dart, against a reply that ignored the schema entirely.

Stated as a standing rule rather than a description: a provider offering constrained output may be *given* the schema, but nothing may be *moved* onto it — the checks stay. That is what stops this argument recurring once per provider, which is the only reason the comment was wrong long enough to matter.

## Verification

`flutter analyze` clean; the OpenRouter and text-interpreter suites pass unchanged.
