### PR TITLE
test(add-meal): pin the client discipline every provider must obey

### DIFF
--- a/test/unit_test/meal_items_api_contract_test.dart
+++ b/test/unit_test/meal_items_api_contract_test.dart
@@ -1,0 +1,329 @@
+import 'dart:async';
+import 'dart:convert';
+
+import 'package:flutter_test/flutter_test.dart';
+import 'package:http/http.dart' as http;
+import 'package:logging/logging.dart';
+import 'package:opennutritracker/features/add_meal/data/anthropic_meal_items_api.dart';
+import 'package:opennutritracker/features/add_meal/data/openrouter_meal_items_api.dart';
+import 'package:opennutritracker/features/add_meal/domain/meal_items_api.dart';
+
+/// The rules every [MealItemsApi] must obey, whatever wire format it speaks.
+///
+/// The clients are deliberately independent siblings — #681 measured that only
+/// three elements transfer between them — so nothing structural stops a future
+/// client from being perfectly plausible and quietly breaking a guarantee the
+/// app's privacy claim rests on. Until this file existed, the rules lived in
+/// comments:
+///
+/// > Deliberately not logging `e`: a socket error can carry the request URL
+/// > and, on some platforms, part of the payload — which for the photo path
+/// > is the photograph.
+///
+/// Both shipped clients say a version of that in their own words, and nothing
+/// checked either of them. These cases check all of them at once.
+///
+/// **Adding a provider means adding one entry to [_contracts].** Do not give a
+/// client an exemption from a case; an exemption is how the next leak gets
+/// written.
+///
+/// **Not here: the counts-never-measurements rule.** #706 listed it, and it
+/// does not belong — it is enforced by `ModelMealPhotoInterpreter`, of which
+/// there is exactly one, shared by every provider. A per-client suite cannot
+/// pin a rule no client can break. Its tests live with that class.
+void main() {
+  for (final contract in _contracts) {
+    group(contract.name, () {
+      test('a failing send puts the payload in neither the error nor the log', () async {
+        // The transport throws something that carries the submitted text, the
+        // way a real socket error carries the request it failed on.
+        final client = _FakeClient(
+          throwOnSend: _LeakyException('connection reset while sending $_secret'),
+        );
+
+        final logged = await _logsDuring(() async {
+          await expectLater(
+            contract.build(client).requestItems(
+              content: const MealTextContent(_secret),
+              system: 'system',
+            ),
+            throwsA(isA<MealInterpreterException>()),
+          );
+        });
+
+        final raised = await _raisedBy(contract, client);
+        expect(
+          raised.toString(),
+          isNot(contains(_secret)),
+          reason: 'the exception must not carry what the user typed',
+        );
+        expect(
+          logged.join('\n'),
+          isNot(contains(_secret)),
+          reason: 'a socket error must never be logged with its payload',
+        );
+      });
+
+      test('a photo never reaches the error or the log either', () async {
+        final client = _FakeClient(
+          throwOnSend: _LeakyException('send failed: $_photoBytes'),
+        );
+
+        final logged = await _logsDuring(() async {
+          await expectLater(
+            contract.build(client).requestItems(
+              content: const MealPhotoContent(
+                mediaType: 'image/webp',
+                base64Data: _photoBytes,
+              ),
+              system: 'system',
+            ),
+            throwsA(isA<MealInterpreterException>()),
+          );
+        });
+
+        expect(logged.join('\n'), isNot(contains(_photoBytes)));
+      });
+
+      test('a rejected request does not carry the response body', () async {
+        // Provider error payloads routinely echo the submitted text back.
+        final client = _FakeClient(
+          status: 400,
+          body: jsonEncode({
+            'error': {'message': 'could not parse: $_secret'},
+          }),
+        );
+
+        final logged = await _logsDuring(() async {
+          await expectLater(
+            contract.build(client).requestItems(
+              content: const MealTextContent(_secret),
+              system: 'system',
+            ),
+            throwsA(
+              isA<MealInterpreterException>().having(
+                (e) => e.toString(),
+                'toString',
+                isNot(contains(_secret)),
+              ),
+            ),
+          );
+        });
+
+        expect(logged.join('\n'), isNot(contains(_secret)));
+      });
+
+      test('a stalled connection gives up instead of hanging', () async {
+        final client = _FakeClient(hangs: true);
+
+        await expectLater(
+          contract
+              .build(client, timeout: const Duration(milliseconds: 20))
+              .requestItems(
+                content: const MealTextContent('toast'),
+                system: 'system',
+              ),
+          throwsA(isA<MealInterpreterException>()),
+        );
+      });
+
+      test('output is held to the parser bounds, not the model', () async {
+        // 99999 g is past the 10000 ceiling manual entry enforces. No client
+        // may write to the diary under looser rules than a regex does.
+        final client = _FakeClient(
+          body: contract.toolReply([
+            {'query': 'toast', 'quantity': 99999, 'unit': 'g'},
+          ]),
+        );
+
+        final result = await contract.build(client).requestItems(
+          content: const MealTextContent('toast'),
+          system: 'system',
+        );
+
+        expect(result.items, isEmpty);
+        expect(result.errors, isNotEmpty);
+      });
+
+      test('a reply with no tool call raises rather than reading as empty', () async {
+        // "No food in this photo" is only trustworthy if a model that ignored
+        // the tool call cannot be mistaken for one that answered nothing.
+        final client = _FakeClient(body: contract.noToolCall);
+
+        await expectLater(
+          contract.build(client).requestItems(
+            content: const MealTextContent('toast'),
+            system: 'system',
+          ),
+          throwsA(isA<MealInterpreterException>()),
+        );
+      });
+    });
+  }
+}
+
+/// A meal note distinctive enough that any leak of it is unmistakable.
+const _secret = 'zzq-private-meal-note-zzq';
+
+/// Stands in for base64 photo bytes.
+const _photoBytes = 'zzq-photo-payload-zzq';
+
+class _ClientContract {
+  final String name;
+  final MealItemsApi Function(http.Client client, {required Duration timeout})
+  _build;
+
+  /// A 200 body carrying a forced tool call with these raw item maps, in this
+  /// provider's own shape.
+  final String Function(List<Map<String, dynamic>> items) toolReply;
+
+  /// A well-formed 200 that carries no tool call at all.
+  final String noToolCall;
+
+  const _ClientContract({
+    required this.name,
+    required MealItemsApi Function(http.Client, {required Duration timeout})
+    build,
+    required this.toolReply,
+    required this.noToolCall,
+  }) : _build = build;
+
+  MealItemsApi build(
+    http.Client client, {
+    Duration timeout = const Duration(seconds: 20),
+  }) => _build(client, timeout: timeout);
+}
+
+final _contracts = <_ClientContract>[
+  _ClientContract(
+    name: 'AnthropicMealItemsApi',
+    build: (client, {required timeout}) =>
+        AnthropicMealItemsApi(client, () => 'test-key', timeout: timeout),
+    toolReply: (items) => jsonEncode({
+      'id': 'msg_1',
+      'type': 'message',
+      'role': 'assistant',
+      'content': [
+        {
+          'type': 'tool_use',
+          'id': 'tu_1',
+          'name': mealItemsToolName,
+          'input': {'items': items},
+        },
+      ],
+    }),
+    noToolCall: jsonEncode({
+      'id': 'msg_1',
+      'type': 'message',
+      'role': 'assistant',
+      'content': [
+        {'type': 'text', 'text': 'Here are the foods I can see.'},
+      ],
+    }),
+  ),
+  _ClientContract(
+    name: 'OpenRouterMealItemsApi',
+    build: (client, {required timeout}) => OpenRouterMealItemsApi(
+      client,
+      () => 'test-key',
+      model: 'anthropic/claude-haiku-4.5',
+      timeout: timeout,
+    ),
+    toolReply: (items) => jsonEncode({
+      'id': 'gen_1',
+      'choices': [
+        {
+          'finish_reason': 'tool_calls',
+          'message': {
+            'role': 'assistant',
+            'tool_calls': [
+              {
+                'id': 'call_1',
+                'type': 'function',
+                'function': {
+                  'name': mealItemsToolName,
+                  'arguments': jsonEncode({'items': items}),
+                },
+              },
+            ],
+          },
+        },
+      ],
+    }),
+    noToolCall: jsonEncode({
+      'id': 'gen_1',
+      'choices': [
+        {
+          'finish_reason': 'stop',
+          'message': {'role': 'assistant', 'content': 'Here are the foods.'},
+        },
+      ],
+    }),
+  ),
+];
+
+/// Runs [body] and returns everything the app logged while it ran, so a rule
+/// about what must *not* be logged can actually fail.
+Future<List<String>> _logsDuring(Future<void> Function() body) async {
+  final logged = <String>[];
+  final previousLevel = Logger.root.level;
+  Logger.root.level = Level.ALL;
+  final subscription = Logger.root.onRecord.listen(
+    (record) => logged.add('${record.message} ${record.error ?? ''}'),
+  );
+  try {
+    await body();
+  } finally {
+    await subscription.cancel();
+    Logger.root.level = previousLevel;
+  }
+  return logged;
+}
+
+/// The exception a client raises for [client], for asserting on directly.
+Future<Object> _raisedBy(_ClientContract contract, _FakeClient client) async {
+  try {
+    await contract.build(client).requestItems(
+      content: const MealTextContent(_secret),
+      system: 'system',
+    );
+  } catch (e) {
+    return e;
+  }
+  fail('expected the client to raise');
+}
+
+/// An error whose own `toString` carries the payload — what a real socket
+/// failure can do, and the reason clients must not log the caught object.
+class _LeakyException implements Exception {
+  final String message;
+  const _LeakyException(this.message);
+
+  @override
+  String toString() => message;
+}
+
+class _FakeClient extends http.BaseClient {
+  final int status;
+  final String body;
+  final Object? throwOnSend;
+  final bool hangs;
+
+  _FakeClient({
+    this.status = 200,
+    this.body = '{}',
+    this.throwOnSend,
+    this.hangs = false,
+  });
+
+  @override
+  Future<http.StreamedResponse> send(http.BaseRequest request) async {
+    if (throwOnSend != null) throw throwOnSend!;
+    if (hangs) return Completer<http.StreamedResponse>().future;
+    return http.StreamedResponse(
+      Stream.value(utf8.encode(body)),
+      status,
+      request: request,
+    );
+  }
+}

--- a/test/unit_test/meal_items_api_contract_test.dart
+++ b/test/unit_test/meal_items_api_contract_test.dart
@@ -51,7 +51,7 @@ void main() {
           );
         });
 
-        final raised = await _raisedBy(contract, client);
+        final raised = await _raisedBy(contract, client, const MealTextContent(_secret));
         expect(
           raised.toString(),
           isNot(contains(_secret)),
@@ -68,20 +68,26 @@ void main() {
         final client = _FakeClient(
           throwOnSend: _LeakyException('send failed: $_photoBytes'),
         );
+        const photo = MealPhotoContent(
+          mediaType: 'image/webp',
+          base64Data: _photoBytes,
+        );
 
         final logged = await _logsDuring(() async {
           await expectLater(
-            contract.build(client).requestItems(
-              content: const MealPhotoContent(
-                mediaType: 'image/webp',
-                base64Data: _photoBytes,
-              ),
-              system: 'system',
-            ),
+            contract.build(client).requestItems(content: photo, system: 'system'),
             throwsA(isA<MealInterpreterException>()),
           );
         });
 
+        // Mirrors the text case above: a leaky transport error must not
+        // surface the payload via the exception either, not just the log.
+        final raised = await _raisedBy(contract, client, photo);
+        expect(
+          raised.toString(),
+          isNot(contains(_photoBytes)),
+          reason: 'the exception must not carry the photo bytes',
+        );
         expect(logged.join('\n'), isNot(contains(_photoBytes)));
       });
 
@@ -116,12 +122,23 @@ void main() {
       test('a stalled connection gives up instead of hanging', () async {
         final client = _FakeClient(hangs: true);
 
+        // Wrapped in an explicit short timeout so a client that regresses
+        // its own `.timeout(...)` wiring fails this assertion in ~2s rather
+        // than hanging until the test runner's own default timeout — which
+        // grows every time a provider is added to this suite.
         await expectLater(
           contract
               .build(client, timeout: const Duration(milliseconds: 20))
               .requestItems(
                 content: const MealTextContent('toast'),
                 system: 'system',
+              )
+              .timeout(
+                const Duration(seconds: 2),
+                onTimeout: () => fail(
+                  '${contract.name} did not honour its own timeout — the '
+                  'request should have failed in ~20ms',
+                ),
               ),
           throwsA(isA<MealInterpreterException>()),
         );
@@ -280,13 +297,15 @@ Future<List<String>> _logsDuring(Future<void> Function() body) async {
   return logged;
 }
 
-/// The exception a client raises for [client], for asserting on directly.
-Future<Object> _raisedBy(_ClientContract contract, _FakeClient client) async {
+/// The exception a client raises for [client] against [content], for
+/// asserting on directly.
+Future<Object> _raisedBy(
+  _ClientContract contract,
+  _FakeClient client,
+  MealContent content,
+) async {
   try {
-    await contract.build(client).requestItems(
-      content: const MealTextContent(_secret),
-      system: 'system',
-    );
+    await contract.build(client).requestItems(content: content, system: 'system');
   } catch (e) {
     return e;
   }


### PR DESCRIPTION
Closes #706. Decided in #685, under the map in #678.

One new test file. No production code changed.

## What this pins

The clients are independent siblings by design — #681 measured that only three elements transfer between `AnthropicMealItemsApi` and `OpenRouterMealItemsApi`. Nothing structural stops a third client from being perfectly plausible and quietly breaking a guarantee the app's privacy claim rests on.

Until now, those rules lived in prose:

> `// Deliberately not logging `e`: a socket error can carry the request URL and, on some platforms, part of the payload — which for the photo path is the photograph.`

Both shipped clients say a version of that, in their own words. **Nothing checked either of them.**

This suite runs against every `MealItemsApi` and pins:

- a failing send leaks the payload into **neither the exception nor the log** — checked with a transport whose own `toString()` carries the submitted text, which is what a real socket error does
- the same for a photo's bytes
- a non-200 does not carry the response body, in the exception or the log — provider error payloads routinely echo the submitted text back
- the timeout is applied, and a stall raises
- output is held to the parser's bounds, so no client can write to the diary under looser rules than a regex
- a reply with no tool call raises rather than reading as an empty answer — which is what makes "no food in this photo" trustworthy rather than a guess

Adding a provider is one entry in `_contracts`. The file says explicitly that no client gets an exemption from a case, because an exemption is how the next leak gets written.

## Nine mutations, nine caught

A discipline test that cannot fail is worse than none — it reads as coverage. Each invariant was broken and the suite checked for a failure:

| Mutation | |
|---|---|
| log the caught socket error | caught on both clients |
| log the response body | caught on both clients |
| embed the response body in the exception | caught on both clients |
| drop the timeout | caught on both clients |
| loosen the parser's quantity bound | caught |

## One case from the ticket was dropped, not forced in

#706 listed the counts-never-measurements rule. It does not belong here: it is enforced by `ModelMealPhotoInterpreter`, of which there is **exactly one**, shared by every provider. A per-client suite cannot pin a rule no client is able to break, and adding it would have meant a case that passes for the wrong reason.

That is recorded in the file itself so it is not added back on the next reading of the ticket. Its real tests live with that class.

## Verification

- 12 cases green against both shipped clients — written against what is already shipped, so a failure would have been a finding rather than a reason to soften the test
- Full suite green: **1328 tests**
- `flutter analyze` clean

## Note on ordering

Deliberately branched off `feature/ai-assisted-meal-logging` rather than the taxonomy stack, so it can merge in any order relative to #699/#702. It touches nothing they touch.
