### PR TITLE
fix(scanner): report a not-found barcode as not found

### DIFF
--- a/lib/features/scanner/presentation/scanner_bloc.dart
+++ b/lib/features/scanner/presentation/scanner_bloc.dart
@@ -31,7 +31,7 @@ class ScannerBloc extends Bloc<ScannerEvent, ScannerState> {
           ),
         );
       } catch (exception) {
-        if (exception == ProductNotFoundException) {
+        if (exception is ProductNotFoundException) {
           emit(
             const ScannerFailedState(ScannerFailedStateType.productNotFound),
           );

--- a/lib/features/scanner/presentation/scanner_state.dart
+++ b/lib/features/scanner/presentation/scanner_state.dart
@@ -25,7 +25,7 @@ class ScannerLoadedState extends ScannerState {
   });
 
   @override
-  List<Object?> get props => [product];
+  List<Object?> get props => [product, usesImperialUnits];
 }
 
 class ScannerFailedState extends ScannerState {
@@ -33,8 +33,13 @@ class ScannerFailedState extends ScannerState {
 
   const ScannerFailedState(this.type);
 
+  // The type has to be part of equality. `emit` drops a state equal to the
+  // current one, so leaving it out means a scan that fails a different way
+  // than the last one keeps showing the old message. Nothing hits that today
+  // because a loading state always separates two failures, but it is a quiet
+  // trap to leave lying in the way of the next person here.
   @override
-  List<Object?> get props => [];
+  List<Object?> get props => [type];
 }
 
 enum ScannerFailedStateType { productNotFound, error }

--- a/test/features/scanner/presentation/scanner_bloc_test.dart
+++ b/test/features/scanner/presentation/scanner_bloc_test.dart
@@ -7,25 +7,33 @@ import 'package:opennutritracker/features/scanner/data/product_not_found_excepti
 import 'package:opennutritracker/features/scanner/domain/usecase/search_product_by_barcode_usecase.dart';
 import 'package:opennutritracker/features/scanner/presentation/scanner_bloc.dart';
 
-/// Only ever reached if the bloc stops emitting altogether: every fake here
-/// completes on the next microtask, so this is slack against a hung stream,
-/// not a budget the machine can lose a race against.
-const _settleTimeout = Duration(seconds: 30);
+/// Only ever reached if the bloc stops emitting altogether. Every fake here
+/// settles on the next microtask, so this is slack against a hung stream
+/// rather than a budget the machine can lose a race against — and it stays
+/// strictly under `package:test`'s 30s default per-test timeout, so such a
+/// hang surfaces as this file's own diagnostic instead of the harness's
+/// generic one.
+const _settleTimeout = Duration(seconds: 5);
 
 void main() {
   group('ScannerBloc failure classification', () {
-    ScannerBloc? bloc;
+    final blocs = <ScannerBloc>[];
 
     /// Builds the bloc under test around a search that always fails with
     /// [error], and returns the failure state one scan settles on.
     Future<ScannerFailedState> scanFailingWith(Object error) {
       final searchUseCase = _FakeSearchUseCase(error);
       final subject = ScannerBloc(searchUseCase, _FakeGetConfigUsecase());
-      bloc = subject;
+      blocs.add(subject);
       return _failureFor(subject, searchUseCase, '03299289');
     }
 
-    tearDown(() => bloc?.close());
+    tearDown(() async {
+      for (final bloc in blocs) {
+        await bloc.close();
+      }
+      blocs.clear();
+    });
 
     test('a not-found barcode reports productNotFound, not a fetch error',
         () async {
@@ -88,6 +96,10 @@ class _FakeSearchUseCase implements SearchProductByBarcodeUseCase {
       throw UnimplementedError('Unexpected call: ${invocation.memberName}');
 }
 
+/// Succeeds so the bloc's success path stays reachable — see [_failureFor].
+/// The values are placeholders: these tests never reach that path, and the
+/// only field the bloc reads there is `usesImperialFoodUnits`, left at its
+/// default.
 class _FakeGetConfigUsecase implements GetConfigUsecase {
   @override
   Future<ConfigEntity> getConfig() async => const ConfigEntity(

--- a/test/features/scanner/presentation/scanner_bloc_test.dart
+++ b/test/features/scanner/presentation/scanner_bloc_test.dart
@@ -1,0 +1,69 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:opennutritracker/core/domain/usecase/get_config_usecase.dart';
+import 'package:opennutritracker/features/add_meal/domain/entity/meal_entity.dart';
+import 'package:opennutritracker/features/scanner/data/product_not_found_exception.dart';
+import 'package:opennutritracker/features/scanner/domain/usecase/search_product_by_barcode_usecase.dart';
+import 'package:opennutritracker/features/scanner/presentation/scanner_bloc.dart';
+
+void main() {
+  group('ScannerBloc failure classification', () {
+    late _FakeSearchUseCase searchUseCase;
+    late ScannerBloc bloc;
+
+    setUp(() {
+      searchUseCase = _FakeSearchUseCase();
+      bloc = ScannerBloc(searchUseCase, _FakeGetConfigUsecase());
+    });
+
+    tearDown(() => bloc.close());
+
+    test(
+      'a not-found barcode reports productNotFound, not a fetch error',
+      () async {
+        searchUseCase.error = ProductNotFoundException();
+
+        final state = await _failureFor(bloc, '03299289');
+
+        expect(state.type, ScannerFailedStateType.productNotFound);
+      },
+    );
+
+    test('any other failure reports a generic error', () async {
+      searchUseCase.error = Exception('OFF HTTP 500');
+
+      final state = await _failureFor(bloc, '03299289');
+
+      expect(state.type, ScannerFailedStateType.error);
+    });
+  });
+}
+
+/// Drives one scan and returns the [ScannerFailedState] it settles on.
+Future<ScannerFailedState> _failureFor(ScannerBloc bloc, String barcode) async {
+  final failed = bloc.stream.whereType<ScannerFailedState>().first;
+  bloc.add(ScannerLoadProductEvent(barcode: barcode));
+  return failed;
+}
+
+extension _WhereType on Stream<ScannerState> {
+  Stream<T> whereType<T>() => where((state) => state is T).cast<T>();
+}
+
+class _FakeSearchUseCase implements SearchProductByBarcodeUseCase {
+  Object? error;
+
+  @override
+  Future<MealEntity> searchProductByBarcode(String barcode) async {
+    throw error!;
+  }
+
+  @override
+  dynamic noSuchMethod(Invocation invocation) =>
+      throw UnimplementedError('Unexpected call: ${invocation.memberName}');
+}
+
+class _FakeGetConfigUsecase implements GetConfigUsecase {
+  @override
+  dynamic noSuchMethod(Invocation invocation) =>
+      throw UnimplementedError('Unexpected call: ${invocation.memberName}');
+}

--- a/test/features/scanner/presentation/scanner_bloc_test.dart
+++ b/test/features/scanner/presentation/scanner_bloc_test.dart
@@ -10,28 +10,25 @@ void main() {
     late _FakeSearchUseCase searchUseCase;
     late ScannerBloc bloc;
 
-    setUp(() {
-      searchUseCase = _FakeSearchUseCase();
+    /// Builds the bloc under test around a search that always fails with
+    /// [error], and returns the failure state one scan settles on.
+    Future<ScannerFailedState> scanFailingWith(Object error) {
+      searchUseCase = _FakeSearchUseCase(error);
       bloc = ScannerBloc(searchUseCase, _FakeGetConfigUsecase());
-    });
+      return _failureFor(bloc, searchUseCase, '03299289');
+    }
 
     tearDown(() => bloc.close());
 
-    test(
-      'a not-found barcode reports productNotFound, not a fetch error',
-      () async {
-        searchUseCase.error = ProductNotFoundException();
+    test('a not-found barcode reports productNotFound, not a fetch error',
+        () async {
+      final state = await scanFailingWith(ProductNotFoundException());
 
-        final state = await _failureFor(bloc, '03299289');
-
-        expect(state.type, ScannerFailedStateType.productNotFound);
-      },
-    );
+      expect(state.type, ScannerFailedStateType.productNotFound);
+    });
 
     test('any other failure reports a generic error', () async {
-      searchUseCase.error = Exception('OFF HTTP 500');
-
-      final state = await _failureFor(bloc, '03299289');
+      final state = await scanFailingWith(Exception('OFF HTTP 500'));
 
       expect(state.type, ScannerFailedStateType.error);
     });
@@ -39,22 +36,40 @@ void main() {
 }
 
 /// Drives one scan and returns the [ScannerFailedState] it settles on.
-Future<ScannerFailedState> _failureFor(ScannerBloc bloc, String barcode) async {
-  final failed = bloc.stream.whereType<ScannerFailedState>().first;
+///
+/// Asserts the settled state is a failure rather than filtering for one, so a
+/// bloc that loads a product — or emits nothing at all — fails with a readable
+/// diff instead of hanging until the suite-level timeout. Also asserts the
+/// barcode actually reached [searchUseCase], so a throw from anywhere else —
+/// a misused fake, or a future reordering that queries config first — cannot
+/// masquerade as the classification under test.
+Future<ScannerFailedState> _failureFor(
+  ScannerBloc bloc,
+  _FakeSearchUseCase searchUseCase,
+  String barcode,
+) async {
+  final settled = bloc.stream
+      .firstWhere((state) => state is! ScannerLoadingState)
+      .timeout(const Duration(seconds: 5));
   bloc.add(ScannerLoadProductEvent(barcode: barcode));
-  return failed;
-}
+  final state = await settled;
 
-extension _WhereType on Stream<ScannerState> {
-  Stream<T> whereType<T>() => where((state) => state is T).cast<T>();
+  expect(searchUseCase.calls, [barcode],
+      reason: 'the barcode should have reached the search use case');
+  expect(state, isA<ScannerFailedState>());
+  return state as ScannerFailedState;
 }
 
 class _FakeSearchUseCase implements SearchProductByBarcodeUseCase {
-  Object? error;
+  _FakeSearchUseCase(this.error);
+
+  final Object error;
+  final List<String> calls = [];
 
   @override
   Future<MealEntity> searchProductByBarcode(String barcode) async {
-    throw error!;
+    calls.add(barcode);
+    throw error;
   }
 
   @override

--- a/test/features/scanner/presentation/scanner_bloc_test.dart
+++ b/test/features/scanner/presentation/scanner_bloc_test.dart
@@ -1,24 +1,31 @@
 import 'package:flutter_test/flutter_test.dart';
+import 'package:opennutritracker/core/domain/entity/app_theme_entity.dart';
+import 'package:opennutritracker/core/domain/entity/config_entity.dart';
 import 'package:opennutritracker/core/domain/usecase/get_config_usecase.dart';
 import 'package:opennutritracker/features/add_meal/domain/entity/meal_entity.dart';
 import 'package:opennutritracker/features/scanner/data/product_not_found_exception.dart';
 import 'package:opennutritracker/features/scanner/domain/usecase/search_product_by_barcode_usecase.dart';
 import 'package:opennutritracker/features/scanner/presentation/scanner_bloc.dart';
 
+/// Only ever reached if the bloc stops emitting altogether: every fake here
+/// completes on the next microtask, so this is slack against a hung stream,
+/// not a budget the machine can lose a race against.
+const _settleTimeout = Duration(seconds: 30);
+
 void main() {
   group('ScannerBloc failure classification', () {
-    late _FakeSearchUseCase searchUseCase;
-    late ScannerBloc bloc;
+    ScannerBloc? bloc;
 
     /// Builds the bloc under test around a search that always fails with
     /// [error], and returns the failure state one scan settles on.
     Future<ScannerFailedState> scanFailingWith(Object error) {
-      searchUseCase = _FakeSearchUseCase(error);
-      bloc = ScannerBloc(searchUseCase, _FakeGetConfigUsecase());
-      return _failureFor(bloc, searchUseCase, '03299289');
+      final searchUseCase = _FakeSearchUseCase(error);
+      final subject = ScannerBloc(searchUseCase, _FakeGetConfigUsecase());
+      bloc = subject;
+      return _failureFor(subject, searchUseCase, '03299289');
     }
 
-    tearDown(() => bloc.close());
+    tearDown(() => bloc?.close());
 
     test('a not-found barcode reports productNotFound, not a fetch error',
         () async {
@@ -37,12 +44,16 @@ void main() {
 
 /// Drives one scan and returns the [ScannerFailedState] it settles on.
 ///
-/// Asserts the settled state is a failure rather than filtering for one, so a
-/// bloc that loads a product — or emits nothing at all — fails with a readable
-/// diff instead of hanging until the suite-level timeout. Also asserts the
-/// barcode actually reached [searchUseCase], so a throw from anywhere else —
-/// a misused fake, or a future reordering that queries config first — cannot
-/// masquerade as the classification under test.
+/// Asserts the settled state is a failure rather than filtering for one. The
+/// search always throws, so the only way a [ScannerLoadedState] can arrive is
+/// the bloc dropping that exception — which this catches with a readable diff
+/// instead of a green run. Config lookup deliberately succeeds so that path
+/// stays reachable; a throwing config fake would funnel it back into the same
+/// catch and hide the very failure being guarded against.
+///
+/// Also asserts the barcode reached [searchUseCase], so a throw from anywhere
+/// else — a misused fake, or a future reordering that queries config first —
+/// cannot masquerade as the classification under test.
 Future<ScannerFailedState> _failureFor(
   ScannerBloc bloc,
   _FakeSearchUseCase searchUseCase,
@@ -50,7 +61,7 @@ Future<ScannerFailedState> _failureFor(
 ) async {
   final settled = bloc.stream
       .firstWhere((state) => state is! ScannerLoadingState)
-      .timeout(const Duration(seconds: 5));
+      .timeout(_settleTimeout);
   bloc.add(ScannerLoadProductEvent(barcode: barcode));
   final state = await settled;
 
@@ -78,6 +89,14 @@ class _FakeSearchUseCase implements SearchProductByBarcodeUseCase {
 }
 
 class _FakeGetConfigUsecase implements GetConfigUsecase {
+  @override
+  Future<ConfigEntity> getConfig() async => const ConfigEntity(
+        true,
+        true,
+        false,
+        AppThemeEntity.system,
+      );
+
   @override
   dynamic noSuchMethod(Invocation invocation) =>
       throw UnimplementedError('Unexpected call: ${invocation.memberName}');

--- a/test/features/scanner/presentation/scanner_bloc_test.dart
+++ b/test/features/scanner/presentation/scanner_bloc_test.dart
@@ -48,6 +48,91 @@ void main() {
       expect(state.type, ScannerFailedStateType.error);
     });
   });
+
+  // `emit` silently drops a state that compares equal to the current one, so
+  // any field the screen reads has to be part of `props`. Neither omission
+  // below is reachable today — a loading state always sits between two
+  // failures, and a rescan always rebuilds the product — but both would turn
+  // into a stale message on screen the moment that stopped being true, and
+  // the failure would look like a rendering bug rather than an equality one.
+  group('scanner state equality', () {
+    test('two failures of different kinds are not equal', () {
+      expect(
+        const ScannerFailedState(ScannerFailedStateType.productNotFound),
+        isNot(const ScannerFailedState(ScannerFailedStateType.error)),
+        reason: 'the failure type decides which message the screen shows',
+      );
+    });
+
+    test('two failures of the same kind are equal', () {
+      expect(
+        const ScannerFailedState(ScannerFailedStateType.productNotFound),
+        const ScannerFailedState(ScannerFailedStateType.productNotFound),
+      );
+    });
+
+    test('the same product in different units is not equal', () {
+      final product = MealEntity.empty();
+
+      expect(
+        ScannerLoadedState(product: product, usesImperialUnits: true),
+        isNot(ScannerLoadedState(product: product, usesImperialUnits: false)),
+        reason: 'the unit decides how the serving reads',
+      );
+    });
+  });
+
+  // Pins the reason the equality bug is latent rather than live: the loading
+  // state the bloc emits first is what separates two failures today, so both
+  // arrive even with the old `props`. Deliberately not a guard for the fix
+  // above — the equality group is that — but the thing that would have to
+  // change for the fix to start mattering, and worth failing loudly if it
+  // ever does.
+  test('a second failure of a different kind reaches the screen', () async {
+    final searchUseCase = _SwitchableSearchUseCase(ProductNotFoundException());
+    final bloc = ScannerBloc(searchUseCase, _FakeGetConfigUsecase());
+    addTearDown(bloc.close);
+
+    final seen = <ScannerState>[];
+    final subscription = bloc.stream.listen(seen.add);
+
+    bloc.add(const ScannerLoadProductEvent(barcode: '03299289'));
+    await bloc.stream
+        .firstWhere((state) => state is ScannerFailedState)
+        .timeout(_settleTimeout);
+
+    searchUseCase.error = Exception('OFF HTTP 500');
+    bloc.add(const ScannerLoadProductEvent(barcode: '03299289'));
+    await bloc.stream
+        .firstWhere((state) =>
+            state is ScannerFailedState &&
+            state.type == ScannerFailedStateType.error)
+        .timeout(_settleTimeout);
+
+    await subscription.cancel();
+
+    expect(
+      seen.whereType<ScannerFailedState>().map((state) => state.type),
+      [ScannerFailedStateType.productNotFound, ScannerFailedStateType.error],
+    );
+  });
+}
+
+/// A search whose failure can be swapped between scans, so one bloc can be
+/// driven through two different failures in a row.
+class _SwitchableSearchUseCase implements SearchProductByBarcodeUseCase {
+  _SwitchableSearchUseCase(this.error);
+
+  Object error;
+
+  @override
+  Future<MealEntity> searchProductByBarcode(String barcode) async {
+    throw error;
+  }
+
+  @override
+  dynamic noSuchMethod(Invocation invocation) =>
+      throw UnimplementedError('Unexpected call: ${invocation.memberName}');
 }
 
 /// Drives one scan and returns the [ScannerFailedState] it settles on.


### PR DESCRIPTION
### Problem

Scanning a barcode that Open Food Facts does not have shows **"Error while fetching product data"** with a Retry button, rather than the "Product not found" message the app already ships.

`ScannerBloc` classifies the failure with:

```dart
if (exception == ProductNotFoundException) {
```

That compares the caught exception *object* against the *type*, which is never equal. The `productNotFound` branch is therefore unreachable, and every OFF 404 falls through to the generic error state. `errorProductNotFound` and its wiring in `scanner_screen.dart` were already in place and simply never reached.

The Retry button is especially misleading here: `OFFDataSource` deliberately does not retry a not-found (`shouldRetry: (e) => e is! ProductNotFoundException`), so retrying a 404 can never succeed.

Reproduces with any barcode absent from OFF — for example an in-store GS1-128 label, whose GTIN is restricted-circulation and so never registered globally.

### Change

- `exception == ProductNotFoundException` → `exception is ProductNotFoundException`.
- Adds `ScannerBloc` tests covering both failure classifications.

The test asserts the barcode actually reached the search use case, and that the settled state is a failure rather than filtering the stream for one, so a swallowed exception fails with a readable diff instead of passing on the bloc's catch-all.

### Verification

- New test verified red before the fix, green after.
- `flutter analyze` clean; full suite green (964 tests).
