### PR TITLE
fix(navigation): keep the stack alive when the unwind target is absent

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,3 +1,3 @@
 {
-  "dart.flutterSdkPath": ".fvm/versions/3.44.6"
+  "dart.flutterSdkPath": ".fvm/flutter_sdk"
 }

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,3 +1,3 @@
 {
-  "dart.flutterSdkPath": ".fvm/flutter_sdk"
+  "dart.flutterSdkPath": ".fvm/versions/3.44.6"
 }

--- a/lib/core/utils/navigation_predicates.dart
+++ b/lib/core/utils/navigation_predicates.dart
@@ -1,0 +1,18 @@
+import 'package:flutter/widgets.dart';
+
+/// Route predicates for the "unwind to a known screen" navigations.
+///
+/// [ModalRoute.withName] on its own is unsafe for this: when the named route
+/// is not on the stack the predicate matches nothing, and both
+/// `popUntil` and `pushNamedAndRemoveUntil` respond by removing *every*
+/// route — leaving an empty navigator, which renders as a black screen.
+///
+/// A stack without the expected name is a normal situation, not a bug to
+/// assert on: the same screen can be reached from the Add Meal flow (which
+/// pushes `addMealRoute`), from the home shortcut's scanner, and from the
+/// voice-add flow, and only the first of those has that route below it.
+/// So the predicates here stop at the first route instead — after the
+/// splash screen replaces itself, the first route is the main screen, which
+/// is exactly the floor these unwinds are aiming for.
+RoutePredicate namedRouteOrFirst(String routeName) =>
+    (route) => route.isFirst || route.settings.name == routeName;

--- a/lib/core/utils/navigation_predicates.dart
+++ b/lib/core/utils/navigation_predicates.dart
@@ -8,11 +8,13 @@ import 'package:flutter/widgets.dart';
 /// route — leaving an empty navigator, which renders as a black screen.
 ///
 /// A stack without the expected name is a normal situation, not a bug to
-/// assert on: the same screen can be reached from the Add Meal flow (which
-/// pushes `addMealRoute`), from the home shortcut's scanner, and from the
-/// voice-add flow, and only the first of those has that route below it.
-/// So the predicates here stop at the first route instead — after the
-/// splash screen replaces itself, the first route is the main screen, which
-/// is exactly the floor these unwinds are aiming for.
+/// assert on: a screen reached through more than one entry point only has
+/// the named route below it on some of those paths — Edit Meal sits under
+/// `addMealRoute` when opened from Add Meal, and directly under the route
+/// that pushed it otherwise. So this predicate stops at the first route as
+/// well: after the splash screen replaces itself the first route is the
+/// main screen, the floor these unwinds are aiming for. Landing there is a
+/// worse-case outcome worth having — an empty navigator renders as a black
+/// screen with nothing to navigate back to.
 RoutePredicate namedRouteOrFirst(String routeName) =>
     (route) => route.isFirst || route.settings.name == routeName;

--- a/lib/features/activity_detail/activity_detail_screen.dart
+++ b/lib/features/activity_detail/activity_detail_screen.dart
@@ -12,6 +12,7 @@ import 'package:opennutritracker/core/utils/energy_display.dart';
 import 'package:opennutritracker/core/utils/energy_unit_provider.dart';
 import 'package:opennutritracker/core/utils/locator.dart';
 import 'package:opennutritracker/core/utils/navigation_options.dart';
+import 'package:opennutritracker/core/utils/navigation_predicates.dart';
 import 'package:opennutritracker/features/activity_detail/presentation/bloc/activity_detail_bloc.dart';
 import 'package:opennutritracker/features/activity_detail/presentation/widget/activity_detail_bottom_sheet.dart';
 import 'package:opennutritracker/features/activity_detail/presentation/widget/activity_info_button.dart';
@@ -320,7 +321,7 @@ class _ActivityDetailScreenState extends State<ActivityDetailScreen> {
     );
     Navigator.of(
       context,
-    ).popUntil(ModalRoute.withName(NavigationOptions.mainRoute));
+    ).popUntil(namedRouteOrFirst(NavigationOptions.mainRoute));
   }
 }
 

--- a/lib/features/edit_meal/presentation/edit_meal_screen.dart
+++ b/lib/features/edit_meal/presentation/edit_meal_screen.dart
@@ -24,6 +24,7 @@ import 'package:opennutritracker/core/utils/extensions.dart';
 import 'package:opennutritracker/core/utils/food_name_validator.dart';
 import 'package:opennutritracker/core/utils/locator.dart';
 import 'package:opennutritracker/core/utils/navigation_options.dart';
+import 'package:opennutritracker/core/utils/navigation_predicates.dart';
 import 'package:opennutritracker/features/add_meal/domain/entity/meal_entity.dart';
 import 'package:opennutritracker/features/edit_meal/presentation/bloc/edit_meal_bloc.dart';
 import 'package:opennutritracker/features/edit_meal/presentation/widgets/default_meal_image.dart';
@@ -909,7 +910,7 @@ class _EditMealScreenState extends State<EditMealScreen> {
       } else {
         Navigator.of(context).pushNamedAndRemoveUntil(
           NavigationOptions.mealDetailRoute,
-          ModalRoute.withName(NavigationOptions.addMealRoute),
+          namedRouteOrFirst(NavigationOptions.addMealRoute),
           arguments: MealDetailScreenArguments(
             newMealEntity,
             _intakeTypeEntity,

--- a/lib/features/meal_detail/presentation/widgets/meal_detail_bottom_sheet.dart
+++ b/lib/features/meal_detail/presentation/widgets/meal_detail_bottom_sheet.dart
@@ -8,6 +8,7 @@ import 'package:opennutritracker/core/domain/usecase/get_intake_usecase.dart';
 import 'package:opennutritracker/core/utils/locator.dart';
 import 'package:opennutritracker/core/utils/serving_label_localizer.dart';
 import 'package:opennutritracker/core/utils/navigation_options.dart';
+import 'package:opennutritracker/core/utils/navigation_predicates.dart';
 import 'package:opennutritracker/features/add_meal/domain/entity/meal_entity.dart';
 import 'package:opennutritracker/features/diary/presentation/bloc/calendar_day_bloc.dart';
 import 'package:opennutritracker/features/diary/presentation/bloc/diary_bloc.dart';
@@ -316,7 +317,7 @@ class _MealDetailBottomSheetState extends State<MealDetailBottomSheet> {
     ).showSnackBar(SnackBar(content: Text(S.of(context).infoAddedIntakeLabel)));
     Navigator.of(
       context,
-    ).popUntil(ModalRoute.withName(NavigationOptions.mainRoute));
+    ).popUntil(namedRouteOrFirst(NavigationOptions.mainRoute));
   }
 
   // #212: Check if this meal was already added today for the same meal type

--- a/test/core/utils/navigation_predicates_test.dart
+++ b/test/core/utils/navigation_predicates_test.dart
@@ -1,0 +1,114 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:opennutritracker/core/utils/navigation_predicates.dart';
+
+/// Regression cover for the black screen after logging an intake.
+///
+/// `popUntil(ModalRoute.withName(x))` and `pushNamedAndRemoveUntil(...,
+/// ModalRoute.withName(x))` remove *every* route when `x` is not on the
+/// stack, leaving an empty navigator that renders as a black screen. Both
+/// unwinds can run on a stack that never had the route they name — the
+/// scanner reached from the home shortcut has no Add Meal route below it.
+void main() {
+  /// Pumps a navigator seeded with [routeNames] (first entry is the bottom
+  /// route) and hands back its state. Each route renders its own name.
+  Future<NavigatorState> pumpStack(
+    WidgetTester tester,
+    List<String> routeNames,
+  ) async {
+    final navigatorKey = GlobalKey<NavigatorState>();
+
+    Route<void> routeFor(String name) => MaterialPageRoute<void>(
+          settings: RouteSettings(name: name),
+          builder: (_) => Scaffold(body: Text(name)),
+        );
+
+    await tester.pumpWidget(
+      MaterialApp(
+        navigatorKey: navigatorKey,
+        initialRoute: routeNames.first,
+        onGenerateInitialRoutes: (_) => routeNames.map(routeFor).toList(),
+        onGenerateRoute: (settings) => routeFor(settings.name ?? 'unnamed'),
+      ),
+    );
+    await tester.pumpAndSettle();
+
+    return navigatorKey.currentState!;
+  }
+
+  group('namedRouteOrFirst with popUntil', () {
+    testWidgets('pops back to the named route when it is on the stack',
+        (tester) async {
+      final navigator =
+          await pumpStack(tester, ['main', 'addMeal', 'mealDetail']);
+
+      navigator.popUntil(namedRouteOrFirst('main'));
+      await tester.pumpAndSettle();
+
+      expect(find.text('main'), findsOneWidget);
+      expect(find.text('mealDetail'), findsNothing);
+    });
+
+    testWidgets('stops at the first route when the named one is absent',
+        (tester) async {
+      // The home shortcut's scanner flow: no addMeal route was ever pushed,
+      // and the unwind that wiped `main` left this stack behind.
+      final navigator = await pumpStack(tester, ['scanner', 'mealDetail']);
+
+      navigator.popUntil(namedRouteOrFirst('main'));
+      await tester.pumpAndSettle();
+
+      // The regression was an empty navigator here — a black screen.
+      expect(find.text('scanner'), findsOneWidget);
+      expect(navigator.canPop(), isFalse);
+    });
+  });
+
+  testWidgets('ModalRoute.withName alone empties the stack — the bug',
+      (tester) async {
+    final navigator = await pumpStack(tester, ['scanner', 'mealDetail']);
+
+    navigator.popUntil(ModalRoute.withName('main'));
+    await tester.pumpAndSettle();
+
+    // Nothing left to render: this is what put a black screen on the phone.
+    expect(find.text('scanner'), findsNothing);
+    expect(find.text('mealDetail'), findsNothing);
+  });
+
+  group('namedRouteOrFirst with pushNamedAndRemoveUntil', () {
+    testWidgets('keeps the first route when the named one is absent',
+        (tester) async {
+      final navigator = await pumpStack(tester, ['main', 'editMeal']);
+
+      navigator.pushNamedAndRemoveUntil<void>(
+        'mealDetail',
+        namedRouteOrFirst('addMeal'),
+      );
+      await tester.pumpAndSettle();
+
+      expect(find.text('mealDetail'), findsOneWidget);
+      // `main` has to survive: the intake screen unwinds to it next.
+      navigator.popUntil(namedRouteOrFirst('main'));
+      await tester.pumpAndSettle();
+      expect(find.text('main'), findsOneWidget);
+    });
+
+    testWidgets('still unwinds to the named route when it is present',
+        (tester) async {
+      final navigator =
+          await pumpStack(tester, ['main', 'addMeal', 'editMeal']);
+
+      navigator.pushNamedAndRemoveUntil<void>(
+        'mealDetail',
+        namedRouteOrFirst('addMeal'),
+      );
+      await tester.pumpAndSettle();
+
+      expect(find.text('mealDetail'), findsOneWidget);
+      navigator.popUntil(namedRouteOrFirst('addMeal'));
+      await tester.pumpAndSettle();
+      expect(find.text('addMeal'), findsOneWidget);
+    });
+  });
+}

--- a/test/core/utils/navigation_predicates_test.dart
+++ b/test/core/utils/navigation_predicates_test.dart
@@ -7,8 +7,8 @@ import 'package:opennutritracker/core/utils/navigation_predicates.dart';
 /// `popUntil(ModalRoute.withName(x))` and `pushNamedAndRemoveUntil(...,
 /// ModalRoute.withName(x))` remove *every* route when `x` is not on the
 /// stack, leaving an empty navigator that renders as a black screen. Both
-/// unwinds can run on a stack that never had the route they name — the
-/// scanner reached from the home shortcut has no Add Meal route below it.
+/// unwinds can run on a stack that never had the route they name, because
+/// the screens running them are reachable from more than one entry point.
 void main() {
   /// Pumps a navigator seeded with [routeNames] (first entry is the bottom
   /// route) and hands back its state. Each route renders its own name.
@@ -51,8 +51,8 @@ void main() {
 
     testWidgets('stops at the first route when the named one is absent',
         (tester) async {
-      // The home shortcut's scanner flow: no addMeal route was ever pushed,
-      // and the unwind that wiped `main` left this stack behind.
+      // What Edit Meal's own unwind leaves behind when it runs on a stack
+      // with no addMeal route: `main` is gone, and this pops next.
       final navigator = await pumpStack(tester, ['scanner', 'mealDetail']);
 
       navigator.popUntil(namedRouteOrFirst('main'));

--- a/test/features/edit_meal/presentation/edit_meal_unwind_test.dart
+++ b/test/features/edit_meal/presentation/edit_meal_unwind_test.dart
@@ -3,46 +3,59 @@ import 'package:flutter_cache_manager/flutter_cache_manager.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:get_it/get_it.dart';
 import 'package:opennutritracker/core/data/data_source/custom_meal_data_source.dart';
+import 'package:opennutritracker/core/data/data_source/remote_search_cache_data_source.dart';
 import 'package:opennutritracker/core/data/repository/config_repository.dart';
 import 'package:opennutritracker/core/domain/entity/app_theme_entity.dart';
 import 'package:opennutritracker/core/domain/entity/config_entity.dart';
+import 'package:opennutritracker/core/domain/entity/intake_entity.dart';
 import 'package:opennutritracker/core/domain/entity/intake_type_entity.dart';
 import 'package:opennutritracker/core/domain/entity/recipe_entity.dart';
+import 'package:opennutritracker/core/domain/entity/tracked_day_entity.dart';
+import 'package:opennutritracker/core/domain/usecase/add_intake_usecase.dart';
+import 'package:opennutritracker/core/domain/usecase/add_tracked_day_usecase.dart';
 import 'package:opennutritracker/core/domain/usecase/get_config_usecase.dart';
+import 'package:opennutritracker/core/domain/usecase/get_intake_usecase.dart';
+import 'package:opennutritracker/core/domain/usecase/get_kcal_goal_usecase.dart';
+import 'package:opennutritracker/core/domain/usecase/get_macro_goal_usecase.dart';
+import 'package:opennutritracker/core/domain/usecase/get_tracked_day_usecase.dart';
 import 'package:opennutritracker/core/utils/energy_unit_provider.dart';
 import 'package:opennutritracker/core/utils/navigation_options.dart';
-import 'package:opennutritracker/core/utils/navigation_predicates.dart';
+import 'package:opennutritracker/features/add_meal/data/repository/products_repository.dart';
 import 'package:opennutritracker/features/add_meal/domain/entity/meal_nutriments_entity.dart';
+import 'package:opennutritracker/features/diary/presentation/bloc/calendar_day_bloc.dart';
+import 'package:opennutritracker/features/diary/presentation/bloc/diary_bloc.dart';
 import 'package:opennutritracker/features/edit_meal/presentation/bloc/edit_meal_bloc.dart';
 import 'package:opennutritracker/features/edit_meal/presentation/edit_meal_screen.dart';
+import 'package:opennutritracker/features/home/presentation/bloc/home_bloc.dart';
+import 'package:opennutritracker/features/meal_detail/meal_detail_screen.dart';
+import 'package:opennutritracker/features/meal_detail/presentation/bloc/meal_detail_bloc.dart';
 import 'package:opennutritracker/generated/l10n.dart';
 import 'package:provider/provider.dart';
 
 import '../../../helpers/test_l10n.dart';
 
-/// Reachability cover for the black screen after logging a recipe.
+/// End-to-end cover for the black screen after logging a recipe.
 ///
-/// The Edit Meal save unwind names `addMealRoute`, but Edit Meal is
-/// reachable on stacks that never had one. Recipes tab → recipe → Log →
-/// intake type pushes `mealDetailRoute` straight onto the main screen
-/// (`recipe_detail_screen.dart` `_onLogPressed`), and the meal-detail edit
-/// pencil then pushes `editMealRoute` with an [EditMealScreenArguments]
-/// that leaves `editOnly` at its default — the create-and-log save path
-/// (`meal_detail_screen.dart`, the `meal-detail-edit` action).
+/// The Edit Meal save unwind names `addMealRoute` and the intake sheet's
+/// unwind names `mainRoute`, but both screens are reachable on stacks that
+/// have neither. Recipes tab → recipe → Log → intake type pushes
+/// `mealDetailRoute` straight onto the main screen
+/// (`recipe_detail_screen.dart` `_onLogPressed`), so nothing below it is an
+/// Add Meal route.
 ///
-/// So the save below runs on `[main, mealDetail, editMeal]`. With
-/// `ModalRoute.withName(addMealRoute)` nothing matches, every route under
-/// the new meal-detail is removed — `main` included — and the intake
-/// sheet's own `popUntil(main)` then empties the navigator: a black screen
-/// on a device, with the intake itself already written to the database.
+/// From there this test drives the real screens: the real
+/// [MealDetailScreen]'s edit pencil, the real [EditMealScreen]'s save, and
+/// the real `MealDetailBottomSheet`'s Add. With
+/// `ModalRoute.withName(addMealRoute)` the save removes every route beneath
+/// the new meal detail — `main` included — and Add's `popUntil(mainRoute)`
+/// then finds no match either and empties the navigator: a black screen,
+/// with the intake already written to the database.
 ///
-/// This test drives the real [EditMealScreen] through its real save. The
-/// two screens either side of it are stubs: pushing `editMealRoute` is
-/// four unconditional lines in the pencil's `onPressed`, and standing up
-/// [MealDetailScreen]'s seven-usecase bloc would not make the unwind under
-/// test any more real.
+/// Only the main screen is stubbed, because all these unwinds want from it
+/// is a route named `main` to survive.
 void main() {
   final getIt = GetIt.instance;
+  final loggedIntakes = <IntakeEntity>[];
 
   final recipe = RecipeEntity(
     id: 'a3f1c0de-0000-4000-8000-000000000001',
@@ -70,8 +83,21 @@ void main() {
     updatedAt: DateTime(2026, 8, 1),
     servingsCount: 4,
   );
+  final day = DateTime(2026, 8, 19);
 
   setUp(() {
+    loggedIntakes.clear();
+    getIt.registerFactory<MealDetailBloc>(
+      () => MealDetailBloc(
+        _FakeAddIntakeUsecase(loggedIntakes),
+        _FakeAddTrackedDayUsecase(),
+        _FakeGetKcalGoalUsecase(),
+        _FakeGetMacroGoalUsecase(),
+        _FakeGetTrackedDayUsecase(),
+        _FakeProductsRepository(),
+        _FakeRemoteSearchCacheDataSource(),
+      ),
+    );
     getIt.registerFactory<EditMealBloc>(
       () => EditMealBloc(
         _FakeGetConfigUsecase(),
@@ -79,23 +105,33 @@ void main() {
         _FakeConfigRepository(),
       ),
     );
-    getIt.registerLazySingleton<CacheManager>(() => _FakeCacheManager());
+    getIt.registerLazySingleton<GetConfigUsecase>(_FakeGetConfigUsecase.new);
+    getIt.registerLazySingleton<GetIntakeUsecase>(_FakeGetIntakeUsecase.new);
+    getIt.registerLazySingleton<CacheManager>(_FakeCacheManager.new);
+    getIt.registerLazySingleton<HomeBloc>(_FakeHomeBloc.new);
+    getIt.registerLazySingleton<DiaryBloc>(_FakeDiaryBloc.new);
+    getIt.registerLazySingleton<CalendarDayBloc>(_FakeCalendarDayBloc.new);
   });
 
   tearDown(() async {
-    await getIt.unregister<EditMealBloc>();
-    await getIt.unregister<CacheManager>();
+    await getIt.reset();
   });
 
   /// Pumps `[main, mealDetail]` — the stack a recipe Log leaves behind —
-  /// and returns the navigator so the test can push Edit Meal onto it.
+  /// with the real meal-detail screen on top, and returns its navigator.
   Future<NavigatorState> pumpRecipeLogStack(WidgetTester tester) async {
+    tester.view.physicalSize = const Size(1080, 2400);
+    tester.view.devicePixelRatio = 1.0;
+    addTearDown(tester.view.reset);
+
     final navigatorKey = GlobalKey<NavigatorState>();
 
     Route<void> routeFor(RouteSettings settings) {
-      final builder = settings.name == NavigationOptions.editMealRoute
-          ? (BuildContext _) => const EditMealScreen()
-          : (BuildContext _) => Scaffold(body: Text('${settings.name}-stub'));
+      final WidgetBuilder builder = switch (settings.name) {
+        NavigationOptions.mealDetailRoute => (_) => const MealDetailScreen(),
+        NavigationOptions.editMealRoute => (_) => const EditMealScreen(),
+        _ => (_) => Scaffold(body: Text('${settings.name}-stub')),
+      };
       return MaterialPageRoute<void>(settings: settings, builder: builder);
     }
 
@@ -109,8 +145,17 @@ void main() {
           initialRoute: NavigationOptions.mainRoute,
           onGenerateInitialRoutes: (_) => [
             routeFor(const RouteSettings(name: NavigationOptions.mainRoute)),
+            // What `recipe_detail_screen.dart` `_onLogPressed` pushes.
             routeFor(
-              const RouteSettings(name: NavigationOptions.mealDetailRoute),
+              RouteSettings(
+                name: NavigationOptions.mealDetailRoute,
+                arguments: MealDetailScreenArguments(
+                  recipe.toMealEntity(),
+                  IntakeTypeEntity.dinner,
+                  day,
+                  false,
+                ),
+              ),
             ),
           ],
           onGenerateRoute: routeFor,
@@ -122,63 +167,49 @@ void main() {
     return navigatorKey.currentState!;
   }
 
-  test('the meal-detail edit pencil opens the create-and-log save path', () {
-    // `meal_detail_screen.dart` builds its arguments positionally and never
-    // passes `editOnly`, so the save runs the unwind rather than a `pop()`.
-    // The two Edit Meal entry points that do pass `editOnly: true`
-    // (`recipes_page.dart`, `custom_meals_tab.dart`) are unaffected.
-    final args = EditMealScreenArguments(
-      DateTime(2026, 8, 19),
-      recipe.toMealEntity(),
-      IntakeTypeEntity.dinner,
-      false,
-    );
+  testWidgets(
+    'logging a recipe through Edit Meal leaves the main screen standing',
+    (tester) async {
+      final navigator = await pumpRecipeLogStack(tester);
+      expect(find.text(recipe.name), findsWidgets);
 
-    expect(args.editOnly, isFalse);
-  });
+      // The meal-detail edit pencil. It passes no `editOnly`, so Edit Meal
+      // opens on the create-and-log save path rather than the `pop()` one the
+      // recipe/custom-meal list entry points get.
+      await tester.tap(find.byIcon(Icons.edit_rounded));
+      await tester.pumpAndSettle();
+      expect(find.text(l10nEn.editMealLabel), findsOneWidget);
 
-  testWidgets('saving a logged recipe keeps the main screen on the stack', (
-    tester,
-  ) async {
-    final navigator = await pumpRecipeLogStack(tester);
+      await tester.tap(
+        find.widgetWithText(FilledButton, l10nEn.buttonSaveLabel),
+      );
+      await tester.pumpAndSettle();
 
-    // What the meal-detail edit pencil pushes, argument for argument.
-    navigator.pushNamed<void>(
-      NavigationOptions.editMealRoute,
-      arguments: EditMealScreenArguments(
-        DateTime(2026, 8, 19),
-        recipe.toMealEntity(),
-        IntakeTypeEntity.dinner,
-        false,
-      ),
-    );
-    await tester.pumpAndSettle();
-    expect(find.text(l10nEn.editMealLabel), findsOneWidget);
+      // The save lands on a fresh meal detail either way — the regression is
+      // what it leaves underneath.
+      expect(find.text(l10nEn.editMealLabel), findsNothing);
+      expect(
+        navigator.canPop(),
+        isTrue,
+        reason: 'main must survive the Edit Meal unwind',
+      );
 
-    await tester.tap(find.widgetWithText(FilledButton, l10nEn.buttonSaveLabel));
-    await tester.pumpAndSettle();
+      await tester.tap(find.widgetWithText(FilledButton, l10nEn.addLabel));
+      await tester.pumpAndSettle();
 
-    // The save lands on a fresh meal detail either way — the regression is
-    // what it leaves underneath.
-    expect(
-      find.text('${NavigationOptions.mealDetailRoute}-stub'),
-      findsOneWidget,
-    );
-    expect(
-      navigator.canPop(),
-      isTrue,
-      reason:
-          'main must survive the unwind, or there is nothing to '
-          'return to once the intake is logged',
-    );
+      // The intake is written whatever the navigator does — that is why the
+      // bug reads as "my food was logged and then the app went black".
+      expect(loggedIntakes, hasLength(1));
+      expect(loggedIntakes.single.type, IntakeTypeEntity.dinner);
 
-    // The unwind the intake sheet runs next (`meal_detail_bottom_sheet.dart`,
-    // Add). Before the fix this emptied the navigator: the black screen.
-    navigator.popUntil(namedRouteOrFirst(NavigationOptions.mainRoute));
-    await tester.pumpAndSettle();
-
-    expect(find.text('${NavigationOptions.mainRoute}-stub'), findsOneWidget);
-  });
+      expect(find.text('${NavigationOptions.mainRoute}-stub'), findsOneWidget);
+      expect(
+        find.byType(Scaffold),
+        findsWidgets,
+        reason: 'an empty navigator renders as a black screen',
+      );
+    },
+  );
 }
 
 class _FakeGetConfigUsecase implements GetConfigUsecase {
@@ -207,8 +238,132 @@ class _FakeCustomMealDataSource implements CustomMealDataSource {
       throw UnimplementedError('Unexpected call: ${invocation.memberName}');
 }
 
-/// The Edit Meal header renders a [CachedNetworkImage] for non-custom
-/// meals; an empty stream sends it straight to its error widget.
+class _FakeAddIntakeUsecase implements AddIntakeUsecase {
+  final List<IntakeEntity> logged;
+
+  _FakeAddIntakeUsecase(this.logged);
+
+  @override
+  Future<void> addIntake(IntakeEntity intakeEntity) async {
+    logged.add(intakeEntity);
+  }
+
+  @override
+  dynamic noSuchMethod(Invocation invocation) =>
+      throw UnimplementedError('Unexpected call: ${invocation.memberName}');
+}
+
+class _FakeAddTrackedDayUsecase implements AddTrackedDayUsecase {
+  @override
+  Future<bool> hasTrackedDay(DateTime day) async => true;
+
+  @override
+  Future<void> addDayCaloriesTracked(DateTime day, double kcal) async {}
+
+  @override
+  Future<void> addDayMacrosTracked(
+    DateTime day, {
+    double? carbsTracked,
+    double? fatTracked,
+    double? proteinTracked,
+  }) async {}
+
+  @override
+  dynamic noSuchMethod(Invocation invocation) =>
+      throw UnimplementedError('Unexpected call: ${invocation.memberName}');
+}
+
+class _FakeGetKcalGoalUsecase implements GetKcalGoalUsecase {
+  @override
+  dynamic noSuchMethod(Invocation invocation) =>
+      throw UnimplementedError('Unexpected call: ${invocation.memberName}');
+}
+
+class _FakeGetMacroGoalUsecase implements GetMacroGoalUsecase {
+  @override
+  dynamic noSuchMethod(Invocation invocation) =>
+      throw UnimplementedError('Unexpected call: ${invocation.memberName}');
+}
+
+class _FakeGetTrackedDayUsecase implements GetTrackedDayUsecase {
+  @override
+  Future<TrackedDayEntity?> getTrackedDay(DateTime day) async =>
+      TrackedDayEntity(
+        day: day,
+        calorieGoal: 2200,
+        caloriesTracked: 800,
+        carbsGoal: 250,
+        carbsTracked: 100,
+        fatGoal: 70,
+        fatTracked: 30,
+        proteinGoal: 120,
+        proteinTracked: 50,
+      );
+
+  @override
+  dynamic noSuchMethod(Invocation invocation) =>
+      throw UnimplementedError('Unexpected call: ${invocation.memberName}');
+}
+
+class _FakeProductsRepository implements ProductsRepository {
+  @override
+  dynamic noSuchMethod(Invocation invocation) =>
+      throw UnimplementedError('Unexpected call: ${invocation.memberName}');
+}
+
+class _FakeRemoteSearchCacheDataSource implements RemoteSearchCacheDataSource {
+  @override
+  Future<void> touch(String barcode) async {}
+
+  @override
+  dynamic noSuchMethod(Invocation invocation) =>
+      throw UnimplementedError('Unexpected call: ${invocation.memberName}');
+}
+
+class _FakeGetIntakeUsecase implements GetIntakeUsecase {
+  @override
+  Future<List<IntakeEntity>> getDinnerIntakeByDay(
+    DateTime day, {
+    int dayStartOffsetHours = 0,
+    int dayStartOffsetMinutes = 0,
+  }) async => [];
+
+  @override
+  dynamic noSuchMethod(Invocation invocation) =>
+      throw UnimplementedError('Unexpected call: ${invocation.memberName}');
+}
+
+/// The three refresh blocs the intake sheet pokes on its way out. They only
+/// ever receive an event here, so swallowing it is the whole contract.
+class _FakeHomeBloc implements HomeBloc {
+  @override
+  void add(HomeEvent event) {}
+
+  @override
+  dynamic noSuchMethod(Invocation invocation) =>
+      throw UnimplementedError('Unexpected call: ${invocation.memberName}');
+}
+
+class _FakeDiaryBloc implements DiaryBloc {
+  @override
+  void add(DiaryEvent event) {}
+
+  @override
+  dynamic noSuchMethod(Invocation invocation) =>
+      throw UnimplementedError('Unexpected call: ${invocation.memberName}');
+}
+
+class _FakeCalendarDayBloc implements CalendarDayBloc {
+  @override
+  void add(CalendarDayEvent event) {}
+
+  @override
+  dynamic noSuchMethod(Invocation invocation) =>
+      throw UnimplementedError('Unexpected call: ${invocation.memberName}');
+}
+
+/// The meal screens render a [CachedNetworkImage] for non-custom meals; an
+/// empty stream sends it straight to its error widget.
 class _FakeCacheManager implements CacheManager {
   @override
   Stream<FileResponse> getFileStream(

--- a/test/features/edit_meal/presentation/edit_meal_unwind_test.dart
+++ b/test/features/edit_meal/presentation/edit_meal_unwind_test.dart
@@ -1,0 +1,224 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_cache_manager/flutter_cache_manager.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:get_it/get_it.dart';
+import 'package:opennutritracker/core/data/data_source/custom_meal_data_source.dart';
+import 'package:opennutritracker/core/data/repository/config_repository.dart';
+import 'package:opennutritracker/core/domain/entity/app_theme_entity.dart';
+import 'package:opennutritracker/core/domain/entity/config_entity.dart';
+import 'package:opennutritracker/core/domain/entity/intake_type_entity.dart';
+import 'package:opennutritracker/core/domain/entity/recipe_entity.dart';
+import 'package:opennutritracker/core/domain/usecase/get_config_usecase.dart';
+import 'package:opennutritracker/core/utils/energy_unit_provider.dart';
+import 'package:opennutritracker/core/utils/navigation_options.dart';
+import 'package:opennutritracker/core/utils/navigation_predicates.dart';
+import 'package:opennutritracker/features/add_meal/domain/entity/meal_nutriments_entity.dart';
+import 'package:opennutritracker/features/edit_meal/presentation/bloc/edit_meal_bloc.dart';
+import 'package:opennutritracker/features/edit_meal/presentation/edit_meal_screen.dart';
+import 'package:opennutritracker/generated/l10n.dart';
+import 'package:provider/provider.dart';
+
+import '../../../helpers/test_l10n.dart';
+
+/// Reachability cover for the black screen after logging a recipe.
+///
+/// The Edit Meal save unwind names `addMealRoute`, but Edit Meal is
+/// reachable on stacks that never had one. Recipes tab → recipe → Log →
+/// intake type pushes `mealDetailRoute` straight onto the main screen
+/// (`recipe_detail_screen.dart` `_onLogPressed`), and the meal-detail edit
+/// pencil then pushes `editMealRoute` with an [EditMealScreenArguments]
+/// that leaves `editOnly` at its default — the create-and-log save path
+/// (`meal_detail_screen.dart`, the `meal-detail-edit` action).
+///
+/// So the save below runs on `[main, mealDetail, editMeal]`. With
+/// `ModalRoute.withName(addMealRoute)` nothing matches, every route under
+/// the new meal-detail is removed — `main` included — and the intake
+/// sheet's own `popUntil(main)` then empties the navigator: a black screen
+/// on a device, with the intake itself already written to the database.
+///
+/// This test drives the real [EditMealScreen] through its real save. The
+/// two screens either side of it are stubs: pushing `editMealRoute` is
+/// four unconditional lines in the pencil's `onPressed`, and standing up
+/// [MealDetailScreen]'s seven-usecase bloc would not make the unwind under
+/// test any more real.
+void main() {
+  final getIt = GetIt.instance;
+
+  final recipe = RecipeEntity(
+    id: 'a3f1c0de-0000-4000-8000-000000000001',
+    name: 'Chicken curry',
+    description: null,
+    ingredients: const [],
+    totalWeightG: 800,
+    aggregatedNutrimentsPer100: const MealNutrimentsEntity(
+      energyKcal100: 120,
+      carbohydrates100: 10,
+      fat100: 5,
+      proteins100: 8,
+      sugars100: null,
+      saturatedFat100: null,
+      fiber100: null,
+      sodium100: null,
+      calcium100: null,
+      iron100: null,
+      potassium100: null,
+      magnesium100: null,
+      vitaminD100: null,
+      vitaminB12100: null,
+    ),
+    createdAt: DateTime(2026, 8, 1),
+    updatedAt: DateTime(2026, 8, 1),
+    servingsCount: 4,
+  );
+
+  setUp(() {
+    getIt.registerFactory<EditMealBloc>(
+      () => EditMealBloc(
+        _FakeGetConfigUsecase(),
+        _FakeCustomMealDataSource(),
+        _FakeConfigRepository(),
+      ),
+    );
+    getIt.registerLazySingleton<CacheManager>(() => _FakeCacheManager());
+  });
+
+  tearDown(() async {
+    await getIt.unregister<EditMealBloc>();
+    await getIt.unregister<CacheManager>();
+  });
+
+  /// Pumps `[main, mealDetail]` — the stack a recipe Log leaves behind —
+  /// and returns the navigator so the test can push Edit Meal onto it.
+  Future<NavigatorState> pumpRecipeLogStack(WidgetTester tester) async {
+    final navigatorKey = GlobalKey<NavigatorState>();
+
+    Route<void> routeFor(RouteSettings settings) {
+      final builder = settings.name == NavigationOptions.editMealRoute
+          ? (BuildContext _) => const EditMealScreen()
+          : (BuildContext _) => Scaffold(body: Text('${settings.name}-stub'));
+      return MaterialPageRoute<void>(settings: settings, builder: builder);
+    }
+
+    await tester.pumpWidget(
+      ChangeNotifierProvider<EnergyUnitProvider>(
+        create: (_) => EnergyUnitProvider(),
+        child: MaterialApp(
+          navigatorKey: navigatorKey,
+          localizationsDelegates: const [S.delegate],
+          supportedLocales: S.supportedLocales,
+          initialRoute: NavigationOptions.mainRoute,
+          onGenerateInitialRoutes: (_) => [
+            routeFor(const RouteSettings(name: NavigationOptions.mainRoute)),
+            routeFor(
+              const RouteSettings(name: NavigationOptions.mealDetailRoute),
+            ),
+          ],
+          onGenerateRoute: routeFor,
+        ),
+      ),
+    );
+    await tester.pumpAndSettle();
+
+    return navigatorKey.currentState!;
+  }
+
+  test('the meal-detail edit pencil opens the create-and-log save path', () {
+    // `meal_detail_screen.dart` builds its arguments positionally and never
+    // passes `editOnly`, so the save runs the unwind rather than a `pop()`.
+    // The two Edit Meal entry points that do pass `editOnly: true`
+    // (`recipes_page.dart`, `custom_meals_tab.dart`) are unaffected.
+    final args = EditMealScreenArguments(
+      DateTime(2026, 8, 19),
+      recipe.toMealEntity(),
+      IntakeTypeEntity.dinner,
+      false,
+    );
+
+    expect(args.editOnly, isFalse);
+  });
+
+  testWidgets('saving a logged recipe keeps the main screen on the stack', (
+    tester,
+  ) async {
+    final navigator = await pumpRecipeLogStack(tester);
+
+    // What the meal-detail edit pencil pushes, argument for argument.
+    navigator.pushNamed<void>(
+      NavigationOptions.editMealRoute,
+      arguments: EditMealScreenArguments(
+        DateTime(2026, 8, 19),
+        recipe.toMealEntity(),
+        IntakeTypeEntity.dinner,
+        false,
+      ),
+    );
+    await tester.pumpAndSettle();
+    expect(find.text(l10nEn.editMealLabel), findsOneWidget);
+
+    await tester.tap(find.widgetWithText(FilledButton, l10nEn.buttonSaveLabel));
+    await tester.pumpAndSettle();
+
+    // The save lands on a fresh meal detail either way — the regression is
+    // what it leaves underneath.
+    expect(
+      find.text('${NavigationOptions.mealDetailRoute}-stub'),
+      findsOneWidget,
+    );
+    expect(
+      navigator.canPop(),
+      isTrue,
+      reason:
+          'main must survive the unwind, or there is nothing to '
+          'return to once the intake is logged',
+    );
+
+    // The unwind the intake sheet runs next (`meal_detail_bottom_sheet.dart`,
+    // Add). Before the fix this emptied the navigator: the black screen.
+    navigator.popUntil(namedRouteOrFirst(NavigationOptions.mainRoute));
+    await tester.pumpAndSettle();
+
+    expect(find.text('${NavigationOptions.mainRoute}-stub'), findsOneWidget);
+  });
+}
+
+class _FakeGetConfigUsecase implements GetConfigUsecase {
+  @override
+  Future<ConfigEntity> getConfig() async =>
+      const ConfigEntity(true, true, false, AppThemeEntity.system);
+
+  @override
+  dynamic noSuchMethod(Invocation invocation) =>
+      throw UnimplementedError('Unexpected call: ${invocation.memberName}');
+}
+
+class _FakeConfigRepository implements ConfigRepository {
+  @override
+  Future<String?> getCustomMealFormMode() async =>
+      CustomMealFormMode.simple.name;
+
+  @override
+  dynamic noSuchMethod(Invocation invocation) =>
+      throw UnimplementedError('Unexpected call: ${invocation.memberName}');
+}
+
+class _FakeCustomMealDataSource implements CustomMealDataSource {
+  @override
+  dynamic noSuchMethod(Invocation invocation) =>
+      throw UnimplementedError('Unexpected call: ${invocation.memberName}');
+}
+
+/// The Edit Meal header renders a [CachedNetworkImage] for non-custom
+/// meals; an empty stream sends it straight to its error widget.
+class _FakeCacheManager implements CacheManager {
+  @override
+  Stream<FileResponse> getFileStream(
+    String url, {
+    String? key,
+    Map<String, String>? headers,
+    bool withProgress = false,
+  }) => const Stream<FileResponse>.empty();
+
+  @override
+  dynamic noSuchMethod(Invocation invocation) =>
+      throw UnimplementedError('Unexpected call: ${invocation.memberName}');
+}


### PR DESCRIPTION
## The bug

Logging an intake from a recipe leaves the app on a black screen. The
intake itself is saved correctly — only the screen after it is lost.

The two unwinds that run at the end of the logging flow name a route that
is not always on the stack:

- `edit_meal_screen.dart:911` — `pushNamedAndRemoveUntil(mealDetailRoute, ModalRoute.withName(addMealRoute))`
- `meal_detail_bottom_sheet.dart:319` — `popUntil(ModalRoute.withName(mainRoute))`

`ModalRoute.withName(x)` matches nothing when `x` is absent, and both
`popUntil` and `pushNamedAndRemoveUntil` respond to a predicate that never
matches by removing **every** route. An empty navigator renders as a black
screen with nothing to navigate back to.

### Reachable chain

1. Recipes tab → a recipe → **Log** → pick an intake type.
   `recipe_detail_screen.dart:247` pushes `mealDetailRoute`. Nothing on
   this path pushed `addMealRoute`, so the stack is `[main, mealDetail]`.
2. On that meal detail, the edit pencil
   (`meal_detail_screen.dart:300-311`) pushes `editMealRoute` with an
   `EditMealScreenArguments` that passes no `editOnly`. It defaults to
   `false` → the create-and-log save path.
3. Saving runs the unwind at `edit_meal_screen.dart:911`. No `addMealRoute`
   matches, so every route below the new meal detail is removed — `main`
   included. The stack is now `[mealDetail]`.
4. The intake sheet's **Add** (`meal_detail_bottom_sheet.dart:319`) writes
   the intake, then runs `popUntil(withName(mainRoute))`. No match, so it
   pops the last remaining route. Empty navigator → black screen.

The other Edit Meal entry points are not affected, which is why this went
unnoticed: `recipes_page.dart:164` and `custom_meals_tab.dart:160` both
pass `editOnly: true` and therefore `pop()` instead of unwinding, and
`add_meal_screen.dart:530` reaches Edit Meal with `addMealRoute` genuinely
on the stack.

## The fix

`namedRouteOrFirst(routeName)` — `(route) => route.isFirst || route.settings.name == routeName`.

`isFirst` is the right floor because the main screen *is* the first route
once the app is running: `splash_screen.dart:67` reaches it with
`pushReplacementNamed`, and the onboarding exits
(`onboarding_screen.dart:150`, `:505`,
`onboarding_intro_page_body.dart:220`) replace or clear the stack the same
way. So a stack that has no `mainRoute` by name still has the main screen
at the bottom, and stopping there is what the unwind was aiming for
anyway.

The predicate deliberately does not assert that the first route *is* main.
Landing on the bottom route beats an empty navigator in every case, and
for the `addMealRoute` call site the first route is legitimately something
else.

`activity_detail_screen.dart:323` carried the identical
`popUntil(withName(mainRoute))` and is fixed defensively — it is only
reachable *after* step 3 has already removed `main`, so it cannot empty
the stack on its own today, but it would break the same way if it ever
could.

## Tests

`test/features/edit_meal/presentation/edit_meal_unwind_test.dart` drives
the real chain: the real `MealDetailScreen`'s edit pencil, the real
`EditMealScreen`'s save, and the real `MealDetailBottomSheet`'s Add, on
the `[main, mealDetail]` stack a recipe log leaves behind. Only the main
screen is stubbed — all these unwinds want from it is a route named `main`
to survive.

Run unchanged against `develop` it reproduces the whole bug: the intake is
written, the navigator ends up empty, and nothing renders at all.

`test/core/utils/navigation_predicates_test.dart` covers the predicate
directly, including a test that pins Flutter's stack-emptying behaviour —
kept on purpose, as the signal for when this helper can be deleted.
