### PR TITLE
feat(add-meal): add OpenAiMealItemsApi, held to the client contract

### DIFF
--- a/lib/features/add_meal/data/openai_meal_items_api.dart
+++ b/lib/features/add_meal/data/openai_meal_items_api.dart
@@ -1,0 +1,236 @@
+import 'dart:convert';
+
+import 'package:http/http.dart' as http;
+import 'package:logging/logging.dart';
+import 'package:opennutritracker/features/add_meal/domain/meal_items_api.dart';
+import 'package:opennutritracker/features/add_meal/util/meal_text_parser.dart';
+
+/// Asks an OpenAI model for food items, reached directly.
+///
+/// A third sibling rather than a shared OpenAI-dialect base with
+/// [OpenRouterMealItemsApi], settled in #685 by measurement: only three
+/// elements transfer between them. OpenRouter speaks *Chat Completions*,
+/// where tools nest inside a `function` object and the system prompt is the
+/// first message; this speaks *Responses*, where tools are flat and the
+/// system prompt is a top-level `instructions` field. The reply shapes agree
+/// on nothing either — one returns `choices[].message.tool_calls`, the other
+/// an `output` list to search for a `function_call`.
+///
+/// **Responses, not Chat Completions**, and not for storage reasons — both
+/// endpoints store by default, and `store: false` is what turns that off.
+/// From GPT-5.4, tool calling is unsupported in Chat Completions with
+/// `reasoning: none`, so the alternative pays reasoning tokens on every meal
+/// line the user types. Settled in #681.
+class OpenAiMealItemsApi implements MealItemsApi {
+  static final _log = Logger('OpenAiMealItemsApi');
+
+  static const _endpoint = 'https://api.openai.com/v1/responses';
+
+  static const _maxOutputTokens = 1024;
+
+  static const defaultTimeout = Duration(seconds: 20);
+
+  final http.Client _client;
+  final String Function() _apiKey;
+
+  /// No default, for the same reason as the OpenRouter client: which model is
+  /// fit for this is a curation question whose answer changes, and a constant
+  /// here would quietly become that answer. The list lives in
+  /// `AiModelCatalogue`, where a behavioural screen justifies each entry.
+  final String model;
+
+  final Duration timeout;
+
+  OpenAiMealItemsApi(
+    this._client,
+    this._apiKey, {
+    required this.model,
+    this.timeout = defaultTimeout,
+  });
+
+  @override
+  Future<MealTextParseResult> requestItems({
+    required MealContent content,
+    required String system,
+  }) async {
+    final body = jsonEncode({
+      'model': model,
+      // Responses carries the system prompt here. There is no system role in
+      // the input array — passing one is silently treated as user text.
+      'instructions': system,
+      'input': [
+        {'role': 'user', 'content': _contentJson(content)},
+      ],
+      'tools': [
+        {
+          // Flat: `name` and `parameters` are siblings of `type`. Chat
+          // Completions nests both inside a `function` object, and sending
+          // that shape here is rejected.
+          'type': 'function',
+          'name': mealItemsToolName,
+          'description': mealItemsToolDescription,
+          'parameters': mealItemsToolSchema,
+          // **Explicit, and the whole reason this line exists.** Omitting
+          // `strict` on Responses does not leave the schema alone — it
+          // normalises it into strict mode, which requires every key in
+          // `properties` to appear in `required` and refuses the request
+          // otherwise. `quantity` and `unit` are deliberately optional, so
+          // doing nothing 400s every call: here the dangerous option is the
+          // one that looks like no option.
+          //
+          // Strict would buy this design nothing anyway. Enforcement is in
+          // Dart — `mealItemsFromJson` reads three keys and drops the rest,
+          // and `validateParsedMealItems` handles an unrecognised unit
+          // better than a refusal would, by dropping the unit and keeping
+          // the food. Settled in #683, generalised there into a standing
+          // rule: the app never relies on provider-side constrained
+          // decoding.
+          'strict': false,
+        },
+      ],
+      'tool_choice': {'type': 'function', 'name': mealItemsToolName},
+      // The app never leaves content on a provider's side that it can avoid
+      // leaving. Responses stores by default, so this is not a no-op.
+      'store': false,
+      'max_output_tokens': _maxOutputTokens,
+    });
+
+    final http.Response response;
+    try {
+      response = await _client
+          .post(
+            Uri.parse(_endpoint),
+            headers: {
+              'content-type': 'application/json',
+              'authorization': 'Bearer ${_apiKey()}',
+            },
+            body: body,
+          )
+          .timeout(timeout);
+    } catch (e) {
+      // Not logging `e`, matching both other clients: a socket error can
+      // carry part of the request, and on the photo path the request is the
+      // photograph.
+      throw const MealInterpreterException('request failed');
+    }
+
+    if (response.statusCode != 200) {
+      _log.warning('Interpreter call failed with ${response.statusCode}');
+      throw MealInterpreterException(
+        'provider returned ${response.statusCode}',
+        failure: _failureFor(response.statusCode, _errorCode(response.body)),
+        statusCode: response.statusCode,
+      );
+    }
+
+    final Map<String, dynamic> decoded;
+    try {
+      decoded = jsonDecode(response.body) as Map<String, dynamic>;
+    } catch (_) {
+      throw const MealInterpreterException('malformed response');
+    }
+
+    return validateParsedMealItems(_itemsFrom(decoded));
+  }
+
+  /// Responses content. **Image before text**, matching the Anthropic client
+  /// and the opposite of OpenRouter's, whose own image documentation asks for
+  /// text first.
+  List<Map<String, Object?>> _contentJson(MealContent content) =>
+      switch (content) {
+        MealTextContent(:final text) => [
+          {'type': 'input_text', 'text': text},
+        ],
+        MealPhotoContent(:final mediaType, :final base64Data) => [
+          {
+            'type': 'input_image',
+            'image_url': 'data:$mediaType;base64,$base64Data',
+          },
+          {'type': 'input_text', 'text': mealPhotoContentPrompt},
+        ],
+      };
+
+  /// The items from the forced tool call.
+  ///
+  /// The call is one element of `output`, which also carries reasoning
+  /// summaries and any prose the model produced, so it has to be searched for
+  /// rather than indexed. Its `arguments` is a JSON *string*, as on the
+  /// OpenRouter path and unlike Anthropic's, which returns an object.
+  List<ParsedMealItem> _itemsFrom(Map<String, dynamic> decoded) {
+    final output = decoded['output'];
+    if (output is! List) {
+      throw const MealInterpreterException('response has no output');
+    }
+
+    for (final entry in output) {
+      if (entry is! Map || entry['type'] != 'function_call') continue;
+      final arguments = entry['arguments'];
+      if (arguments is! String) {
+        throw const MealInterpreterException('tool call has no arguments');
+      }
+      final Object? parsed;
+      try {
+        parsed = jsonDecode(arguments);
+      } catch (_) {
+        // Never the body: on the photo path a malformed reply can still
+        // contain what was sent.
+        throw const MealInterpreterException('tool call arguments malformed');
+      }
+      if (parsed is! Map) {
+        throw const MealInterpreterException('tool call is not an object');
+      }
+      return mealItemsFromJson(parsed['items']);
+    }
+
+    // A forced tool call that came back as prose. Raising beats returning
+    // empty: empty means "no food in this", and reporting that for a
+    // photograph of a meal is the failure #669 found to be worse than a
+    // wrong answer, because the review screen makes a wrong answer visible
+    // and makes an empty one look like a broken feature.
+    throw const MealInterpreterException('response carried no tool call');
+  }
+
+  /// The provider's machine-readable error code, or null.
+  ///
+  /// Only the code — never the message. OpenAI's 401 body echoes the key in
+  /// a partially masked form that still carries its real last four
+  /// characters, so the message is not a safe thing to keep hold of.
+  static String? _errorCode(String body) {
+    try {
+      final decoded = jsonDecode(body);
+      if (decoded is Map && decoded['error'] is Map) {
+        final code = (decoded['error'] as Map)['code'];
+        return code is String ? code : null;
+      }
+    } catch (_) {
+      // Not JSON, or not the shape documented. Classification falls back to
+      // the status alone, which is the pre-#686 behaviour.
+    }
+    return null;
+  }
+
+  /// What a status means here — #695 put this in each client precisely so a
+  /// provider that disagrees has somewhere to say so, and this one disagrees.
+  ///
+  /// **A withdrawn model answers 400, not the 404 both other providers use**,
+  /// and 400 is also what a rejected image returns. The catalogue's promise
+  /// that a stale entry "fails loudly" rests on the difference, so the code
+  /// field carries it: `model_not_found` is `unsupported`, which tells the
+  /// user to choose a different model — advice that works, and that the
+  /// second catalogue entry makes actionable. Classifying it as `rejected`
+  /// instead would tell someone whose model was retired to go and retake
+  /// their photograph, forever. Measured in #684 and #686.
+  static MealInterpreterFailure _failureFor(int statusCode, String? errorCode) =>
+      switch (statusCode) {
+        401 || 403 => MealInterpreterFailure.auth,
+        400 when errorCode == 'model_not_found' =>
+          MealInterpreterFailure.unsupported,
+        400 || 422 => MealInterpreterFailure.rejected,
+        // `insufficient_quota` arrives as 429 rather than 402 on some
+        // accounts, but 429 is also ordinary rate limiting and retrying is
+        // right for that. Only an explicit 402 is called billing.
+        402 => MealInterpreterFailure.billing,
+        404 => MealInterpreterFailure.unsupported,
+        _ => MealInterpreterFailure.transient,
+      };
+}

--- a/lib/features/add_meal/data/openai_meal_items_api.dart
+++ b/lib/features/add_meal/data/openai_meal_items_api.dart
@@ -164,6 +164,12 @@ class OpenAiMealItemsApi implements MealItemsApi {
 
     for (final entry in output) {
       if (entry is! Map || entry['type'] != 'function_call') continue;
+      // Checked, not assumed, and both other clients check it too. Only one
+      // tool is offered and `tool_choice` names it, so a call by another name
+      // should be impossible — but "impossible" here means parsing whatever
+      // arrived as though it were a meal, and the cost of the check is a
+      // line.
+      if (entry['name'] != mealItemsToolName) continue;
       final arguments = entry['arguments'];
       if (arguments is! String) {
         throw const MealInterpreterException('tool call has no arguments');

--- a/test/unit_test/meal_items_api_contract_test.dart
+++ b/test/unit_test/meal_items_api_contract_test.dart
@@ -5,6 +5,7 @@ import 'package:flutter_test/flutter_test.dart';
 import 'package:http/http.dart' as http;
 import 'package:logging/logging.dart';
 import 'package:opennutritracker/features/add_meal/data/anthropic_meal_items_api.dart';
+import 'package:opennutritracker/features/add_meal/data/openai_meal_items_api.dart';
 import 'package:opennutritracker/features/add_meal/data/openrouter_meal_items_api.dart';
 import 'package:opennutritracker/features/add_meal/domain/meal_items_api.dart';
 
@@ -273,6 +274,47 @@ final _contracts = <_ClientContract>[
         {
           'finish_reason': 'stop',
           'message': {'role': 'assistant', 'content': 'Here are the foods.'},
+        },
+      ],
+    }),
+  ),
+  _ClientContract(
+    name: 'OpenAiMealItemsApi',
+    build: (client, {required timeout}) => OpenAiMealItemsApi(
+      client,
+      () => 'test-key',
+      model: 'gpt-5.6-luna',
+      timeout: timeout,
+    ),
+    // Responses returns a list to search rather than a slot to index, and
+    // the reasoning entry is here on purpose: the client must find the tool
+    // call past it, not assume it is first.
+    toolReply: (items) => jsonEncode({
+      'id': 'resp_1',
+      'object': 'response',
+      'status': 'completed',
+      'output': [
+        {'type': 'reasoning', 'id': 'rs_1', 'summary': []},
+        {
+          'type': 'function_call',
+          'id': 'fc_1',
+          'call_id': 'call_1',
+          'name': mealItemsToolName,
+          'arguments': jsonEncode({'items': items}),
+        },
+      ],
+    }),
+    noToolCall: jsonEncode({
+      'id': 'resp_1',
+      'object': 'response',
+      'status': 'completed',
+      'output': [
+        {
+          'type': 'message',
+          'role': 'assistant',
+          'content': [
+            {'type': 'output_text', 'text': 'Here are the foods I can see.'},
+          ],
         },
       ],
     }),

--- a/test/unit_test/openai_meal_items_api_test.dart
+++ b/test/unit_test/openai_meal_items_api_test.dart
@@ -1,0 +1,367 @@
+import 'dart:convert';
+
+import 'package:flutter_test/flutter_test.dart';
+import 'package:http/http.dart' as http;
+import 'package:http/testing.dart';
+import 'package:opennutritracker/features/add_meal/data/openai_meal_items_api.dart';
+import 'package:opennutritracker/features/add_meal/domain/meal_items_api.dart';
+
+/// What the client sent, so a rule about the request can actually fail.
+class _Captured {
+  late Map<String, dynamic> body;
+  late Map<String, String> headers;
+}
+
+({OpenAiMealItemsApi api, _Captured sent}) subject({
+  int status = 200,
+  String? responseBody,
+  String model = 'gpt-5.6-luna',
+}) {
+  final sent = _Captured();
+  final client = MockClient((request) async {
+    sent.body = jsonDecode(request.body) as Map<String, dynamic>;
+    sent.headers = request.headers;
+    return http.Response(
+      responseBody ?? _toolReply([]),
+      status,
+      headers: {'content-type': 'application/json'},
+    );
+  });
+  return (
+    api: OpenAiMealItemsApi(client, () => 'test-key', model: model),
+    sent: sent,
+  );
+}
+
+String _toolReply(List<Map<String, Object?>> items) => jsonEncode({
+  'id': 'resp_1',
+  'status': 'completed',
+  'output': [
+    {'type': 'reasoning', 'id': 'rs_1', 'summary': []},
+    {
+      'type': 'function_call',
+      'name': mealItemsToolName,
+      'arguments': jsonEncode({'items': items}),
+    },
+  ],
+});
+
+/// The failure a call classifies as, for a given status and error body.
+Future<MealInterpreterException> _failureFrom(
+  int status, {
+  String? code,
+}) async {
+  final client = MockClient(
+    (_) async => http.Response(
+      jsonEncode({
+        'error': {'message': 'something went wrong', 'code': ?code},
+      }),
+      status,
+    ),
+  );
+  final api = OpenAiMealItemsApi(client, () => 'k', model: 'gpt-5.6-luna');
+  try {
+    await api.requestItems(
+      content: const MealTextContent('an egg'),
+      system: 'rules',
+    );
+  } on MealInterpreterException catch (e) {
+    return e;
+  }
+  fail('expected a MealInterpreterException for status $status');
+}
+
+void main() {
+  group('the request Responses actually wants', () {
+    test('the system prompt goes in instructions, not as a message', () async {
+      final s = subject();
+
+      await s.api.requestItems(
+        content: const MealTextContent('2 eggs'),
+        system: 'the rules',
+      );
+
+      expect(s.sent.body['instructions'], 'the rules');
+      final input = s.sent.body['input'] as List;
+      expect(
+        input.map((m) => (m as Map)['role']),
+        everyElement(isNot('system')),
+        reason: 'Responses has no system role; one sent here reads as user '
+            'text and the rules stop being rules',
+      );
+    });
+
+    test('strict is sent, and sent false', () async {
+      // Omitting it does not leave the schema alone — Responses normalises an
+      // absent `strict` into strict mode, which refuses a schema whose
+      // `properties` carry keys missing from `required`. That is exactly this
+      // schema, so an absent field 400s every call.
+      final s = subject();
+
+      await s.api.requestItems(
+        content: const MealTextContent('2 eggs'),
+        system: 'rules',
+      );
+
+      final tool = (s.sent.body['tools'] as List).single as Map;
+      expect(tool.containsKey('strict'), isTrue, reason: 'must be explicit');
+      expect(tool['strict'], isFalse);
+    });
+
+    test('the tool is flat, not nested in a function object', () async {
+      final s = subject();
+
+      await s.api.requestItems(
+        content: const MealTextContent('2 eggs'),
+        system: 'rules',
+      );
+
+      final tool = (s.sent.body['tools'] as List).single as Map;
+      expect(tool['name'], mealItemsToolName);
+      expect(tool['parameters'], mealItemsToolSchema);
+      expect(
+        tool.containsKey('function'),
+        isFalse,
+        reason: 'that is the Chat Completions shape and is rejected here',
+      );
+    });
+
+    test('the tool call is forced by name', () async {
+      final s = subject();
+
+      await s.api.requestItems(
+        content: const MealTextContent('2 eggs'),
+        system: 'rules',
+      );
+
+      expect(s.sent.body['tool_choice'], {
+        'type': 'function',
+        'name': mealItemsToolName,
+      });
+    });
+
+    test('store is false on every request', () async {
+      // Responses stores by default, so this is not a no-op.
+      final s = subject();
+
+      await s.api.requestItems(
+        content: const MealTextContent('2 eggs'),
+        system: 'rules',
+      );
+
+      expect(s.sent.body['store'], isFalse);
+    });
+
+    test('a photo goes image first, then the prompt', () async {
+      final s = subject();
+
+      await s.api.requestItems(
+        content: const MealPhotoContent(
+          mediaType: 'image/webp',
+          base64Data: 'AAAA',
+        ),
+        system: 'rules',
+      );
+
+      final content =
+          ((s.sent.body['input'] as List).single as Map)['content'] as List;
+      expect((content.first as Map)['type'], 'input_image');
+      expect(
+        (content.first as Map)['image_url'],
+        'data:image/webp;base64,AAAA',
+      );
+      expect((content.last as Map)['type'], 'input_text');
+      expect((content.last as Map)['text'], mealPhotoContentPrompt);
+    });
+
+    test('the key is a bearer header and nothing else', () async {
+      final s = subject();
+
+      await s.api.requestItems(
+        content: const MealTextContent('2 eggs'),
+        system: 'rules',
+      );
+
+      expect(s.sent.headers['authorization'], 'Bearer test-key');
+      expect(
+        jsonEncode(s.sent.body),
+        isNot(contains('test-key')),
+        reason: 'a credential in the body would be logged by any proxy',
+      );
+    });
+  });
+
+  group('reading the reply', () {
+    test('finds the tool call past a reasoning entry', () async {
+      // `output` is a list carrying reasoning and prose as well, so the call
+      // has to be searched for rather than indexed.
+      final s = subject(
+        responseBody: _toolReply([
+          {'query': 'egg', 'quantity': 2},
+        ]),
+      );
+
+      final result = await s.api.requestItems(
+        content: const MealTextContent('2 eggs'),
+        system: 'rules',
+      );
+
+      expect(result.items.single.query, 'egg');
+      expect(result.items.single.quantity, 2);
+    });
+
+    test('arguments are a JSON string, not an object', () async {
+      final s = subject(
+        responseBody: jsonEncode({
+          'output': [
+            {
+              'type': 'function_call',
+              'name': mealItemsToolName,
+              // An object here, which is Anthropic's shape, not this one.
+              'arguments': {'items': []},
+            },
+          ],
+        }),
+      );
+
+      expect(
+        () => s.api.requestItems(
+          content: const MealTextContent('2 eggs'),
+          system: 'rules',
+        ),
+        throwsA(isA<MealInterpreterException>()),
+      );
+    });
+
+    test('an empty item list is a reading, not a failure', () async {
+      final s = subject(responseBody: _toolReply([]));
+
+      final result = await s.api.requestItems(
+        content: const MealTextContent('hello'),
+        system: 'rules',
+      );
+
+      expect(result.items, isEmpty);
+    });
+  });
+
+  group('classifying failures', () {
+    test('401 is an auth failure', () async {
+      expect(
+        (await _failureFrom(401)).failure,
+        MealInterpreterFailure.auth,
+      );
+    });
+
+    test('403 is an auth failure', () async {
+      expect(
+        (await _failureFrom(403)).failure,
+        MealInterpreterFailure.auth,
+      );
+    });
+
+    test('a withdrawn model is unsupported, though it arrives as 400', () async {
+      // The finding this client exists to handle. Both other providers answer
+      // 404 for this; OpenAI answers 400 and reuses 400 for a rejected image,
+      // so only the code separates them.
+      final e = await _failureFrom(400, code: 'model_not_found');
+
+      expect(e.failure, MealInterpreterFailure.unsupported);
+      expect(e.statusCode, 400);
+    });
+
+    test('any other 400 is a rejected request', () async {
+      expect(
+        (await _failureFrom(400, code: 'integer_below_min_value')).failure,
+        MealInterpreterFailure.rejected,
+        reason: 'a malformed request must not tell the user to switch model',
+      );
+    });
+
+    test('a 400 with no code at all is rejected, not unsupported', () async {
+      expect(
+        (await _failureFrom(400)).failure,
+        MealInterpreterFailure.rejected,
+      );
+    });
+
+    test('402 is billing', () async {
+      expect(
+        (await _failureFrom(402)).failure,
+        MealInterpreterFailure.billing,
+      );
+    });
+
+    test('404 is still unsupported', () async {
+      expect(
+        (await _failureFrom(404)).failure,
+        MealInterpreterFailure.unsupported,
+      );
+    });
+
+    test('429 is transient, not billing', () async {
+      // `insufficient_quota` can arrive as 429, but so does ordinary rate
+      // limiting, and retrying is right for that. Only an explicit 402 is
+      // called billing.
+      expect(
+        (await _failureFrom(429)).failure,
+        MealInterpreterFailure.transient,
+      );
+    });
+
+    test('503 is transient', () async {
+      expect(
+        (await _failureFrom(503)).failure,
+        MealInterpreterFailure.transient,
+      );
+    });
+
+    test('the provider message never reaches the exception', () async {
+      // OpenAI's 401 body echoes the key in a partially masked form that
+      // still carries its real last four characters, so the message is not a
+      // safe thing to keep hold of. Only the code is read.
+      final client = MockClient(
+        (_) async => http.Response(
+          jsonEncode({
+            'error': {
+              'message': 'Incorrect API key provided: sk-proj-****abcd.',
+              'code': 'invalid_api_key',
+            },
+          }),
+          401,
+        ),
+      );
+      final api = OpenAiMealItemsApi(client, () => 'k', model: 'm');
+
+      try {
+        await api.requestItems(
+          content: const MealTextContent('an egg'),
+          system: 'rules',
+        );
+        fail('expected a failure');
+      } on MealInterpreterException catch (e) {
+        expect(e.toString(), isNot(contains('sk-proj')));
+        expect(e.toString(), isNot(contains('abcd')));
+        expect(e.toString(), isNot(contains('Incorrect API key')));
+      }
+    });
+
+    test('an unparseable error body still classifies on status', () async {
+      final client = MockClient(
+        (_) async => http.Response('<html>502 Bad Gateway</html>', 502),
+      );
+      final api = OpenAiMealItemsApi(client, () => 'k', model: 'm');
+
+      try {
+        await api.requestItems(
+          content: const MealTextContent('an egg'),
+          system: 'rules',
+        );
+        fail('expected a failure');
+      } on MealInterpreterException catch (e) {
+        expect(e.failure, MealInterpreterFailure.transient);
+        expect(e.toString(), isNot(contains('Bad Gateway')));
+      }
+    });
+  });
+}

--- a/test/unit_test/openai_meal_items_api_test.dart
+++ b/test/unit_test/openai_meal_items_api_test.dart
@@ -233,6 +233,35 @@ void main() {
       );
     });
 
+    test('a call by another name is not read as meal items', () async {
+      // Only one tool is offered and tool_choice names it, so this should be
+      // impossible — but "impossible" here means parsing whatever arrived as
+      // though it were food. Both other clients check the name; so does this.
+      final s = subject(
+        responseBody: jsonEncode({
+          'output': [
+            {
+              'type': 'function_call',
+              'name': 'some_other_tool',
+              'arguments': jsonEncode({
+                'items': [
+                  {'query': 'not food', 'quantity': 99},
+                ],
+              }),
+            },
+          ],
+        }),
+      );
+
+      expect(
+        () => s.api.requestItems(
+          content: const MealTextContent('2 eggs'),
+          system: 'rules',
+        ),
+        throwsA(isA<MealInterpreterException>()),
+      );
+    });
+
     test('an empty item list is a reading, not a failure', () async {
       final s = subject(responseBody: _toolReply([]));
 


### PR DESCRIPTION
Resolves #720. First of two build tickets cut from the map #678, whose spec is complete.

Nothing reaches this client yet — #721 wires it up. This lands green on its own because the contract suite now runs against three implementations instead of two.

## Why a third class and not a shared OpenAI dialect

#685 settled this on measurement, and writing it confirmed the measurement. OpenRouter speaks **Chat Completions**: tools nest inside a `function` object, the system prompt is the first message, the reply is `choices[].message.tool_calls`. This speaks **Responses**: tools are flat, the prompt is a top-level `instructions` field, and the reply is an `output` list you search for a `function_call` past the reasoning entries. Three elements transfer. A shared base would be a chain of provider checks.

## Two lines that are load-bearing and look like noise

**`'strict': false`** — omitting it does not leave the schema alone. Responses normalises an absent `strict` into strict mode, which refuses a schema whose `properties` carry keys missing from `required`. `quantity` and `unit` are deliberately optional, so **doing nothing 400s every call**. The dangerous option is the one that looks like no option (#683).

**`'store': false`** — Responses stores by default, so this is not a no-op. #681 corrected the earlier belief that the endpoint choice was itself about storage; it is not, and this line is what actually turns it off.

Both are pinned by mutation tests, because both would pass review as decoration.

## The classifier takes an error code, and that is the interesting part

| condition | Anthropic | OpenRouter | **OpenAI** |
| :-- | :-- | :-- | :-- |
| withdrawn model | 404 | 404 | **400** `model_not_found` |
| rejected image | 400 | 400 | **400** |

`AiModelCatalogue`'s doc comment promises a stale entry *"fails loudly"* because a withdrawn model answers 404. **That promise is false on this provider**, and the naive mapping makes it worse than silent: a retired model would report *"Couldn't use that image. Try another photo."* — advice that can never work, because no photograph fixes a retired model id.

So `_failureFor` takes the status **and** the code. Measured in #684 and #686; the code is machine-readable, so this is not message-string matching, and a malformed request returns a different code (`integer_below_min_value`) which still maps to `rejected`.

**Only the code is read, never the message.** OpenAI's 401 body echoes the key in a partially masked form that still carries its real last four characters — there is a test asserting no fragment of it reaches the exception.

## Held to the contract, not to its own promises

The suite from #706 says in its own doc comment that adding a provider means adding one entry to `_contracts`. Added — so this client is now held to the same rules as the other two: payload never in a log or an error, response body never in an exception, timeout enforced, parser bounds applied, and a reply with no tool call raising rather than reading as empty.

The fixture deliberately puts a `reasoning` entry **before** the `function_call`, so the test fails if the client indexes `output` rather than searching it.

## Mutation results

All ten fail the suite:

| Mutation | |
| :-- | :-- |
| `model_not_found` no longer maps to unsupported | caught |
| every 400 becomes unsupported (a bad image blamed on the model) | caught |
| `strict` omitted, normalising into strict mode | caught |
| `strict` sent true | caught |
| `store` stops being false | caught |
| system prompt moved into the input array | caught |
| a missing tool call reads as empty instead of raising | caught |
| the provider's error message put in the exception | caught |
| the socket error logged | caught |
| the timeout dropped | caught |

## Verification

- `flutter analyze lib test` — **no issues**
- `flutter test` — **1363 passed**
- contract suite green for all three clients (18 cases, 6 of them new)
- 21 client-specific cases covering the wire format and every classifier arm
- **live-checked through the shipping code path**, not a probe translation — the mistake every probe before #673 made. Both catalogue models parse `2 eggs, 100g toast` correctly, and a retired model id comes back `400 unsupported`:

```
gpt-5.6-luna  -> eggs 2.0 | toast 100.0 g
gpt-5.6-terra -> eggs 2.0 | toast 100.0 g
retired model -> 400 unsupported
```

The committed tests need no key and never reach the network; they use a stubbed client.
