### PR TITLE
feat(onboarding): offer AI meal assistance from Other options

### DIFF
--- a/lib/core/presentation/ai_assist_summary.dart
+++ b/lib/core/presentation/ai_assist_summary.dart
@@ -1,0 +1,37 @@
+import 'package:opennutritracker/core/utils/ai_credential_storage.dart';
+import 'package:opennutritracker/generated/l10n.dart';
+
+/// What the AI meal assistance row says beneath its title, in one place.
+///
+/// Two screens show this row now — Settings and onboarding's Other options —
+/// and it is the only place the destination is visible without opening the
+/// dialog. A second hand-maintained copy would be a second place that can name
+/// the wrong company, which is not hypothetical: the photo sheet once read
+/// *"an Anthropic gesendet"* while OpenRouter was selected.
+///
+/// **The provider switch is exhaustive on purpose.** A wildcard would name
+/// Anthropic for any provider added later and compile silently. Keeping one
+/// exhaustive site means adding a fourth provider is a compile error exactly
+/// once, rather than a compile error in one file and a wrong destination in
+/// another. #728.
+///
+/// [hasKey] null means "not read yet", which renders no subtitle rather than
+/// a wrong one.
+String? aiAssistSubtitle(
+  S s, {
+  required bool? hasKey,
+  required bool enabled,
+  required AiProvider provider,
+}) => switch (hasKey) {
+  null => null,
+  false => s.settingsAiAssistNotConfiguredLabel,
+  true when enabled =>
+    // Brand names are not localized, and the em-dash slot is free in this
+    // state.
+    '${s.settingsAiAssistOnLabel} — ${switch (provider) {
+      AiProvider.anthropic => 'Anthropic',
+      AiProvider.openrouter => 'OpenRouter',
+      AiProvider.openai => 'OpenAI',
+    }}',
+  true => s.settingsAiAssistPausedLabel,
+};

--- a/lib/core/presentation/widgets/badged_title.dart
+++ b/lib/core/presentation/widgets/badged_title.dart
@@ -1,0 +1,109 @@
+import 'package:flutter/material.dart';
+import 'package:opennutritracker/core/styles/app_palette.dart';
+import 'package:opennutritracker/core/styles/dimens.dart';
+
+/// A small muted pill for a word about a feature's *state* rather than its
+/// name — "Experimental" being the one this exists for.
+///
+/// Muted rather than accented on purpose: this is a statement about the
+/// feature's stability, not a call to action, and an accent-coloured pill
+/// beside a title reads as "new — try this".
+class MutedBadge extends StatelessWidget {
+  final String text;
+
+  /// Defaults to the palette for the active brightness; pass one only when
+  /// the caller has already resolved it.
+  final AppPalette? palette;
+
+  const MutedBadge({super.key, required this.text, this.palette});
+
+  @override
+  Widget build(BuildContext context) {
+    final resolved =
+        palette ??
+        (Theme.of(context).brightness == Brightness.dark
+            ? AppPalette.dark
+            : AppPalette.light);
+    final muted = resolved.textMuted;
+    return Container(
+      padding: const EdgeInsets.symmetric(horizontal: 8, vertical: 2),
+      decoration: BoxDecoration(
+        color: muted.withValues(alpha: 0.12),
+        borderRadius: Dimens.borderRadiusS,
+      ),
+      child: Text(
+        text,
+        style: Theme.of(
+          context,
+        ).textTheme.labelSmall?.copyWith(color: muted, height: 1.2),
+      ),
+    );
+  }
+}
+
+/// A row title with an optional [MutedBadge] beside it.
+///
+/// Shared rather than duplicated because it carries a rule, not a layout.
+/// Follows AGENTS.md's "Row titles must not overflow": the title is
+/// line-bounded, so it ellipsizes rather than silently wrapping — the thing
+/// that rule is actually about.
+///
+/// **A `Wrap`, not a `Row`, and that is a fix rather than a preference.** As a
+/// `Row` this bounded the title with `Flexible` and left the badge at its
+/// intrinsic width, on the reasoning that "Experimental" ellipsized to
+/// "Exper…" says nothing while a clipped title is still recognisable. Both
+/// halves of that are right; the conclusion did not survive measurement.
+/// Constraining only the title cannot help when the *badge alone* is wider
+/// than the row: at 2x text scale in German on a 320px phone, "Experimentell"
+/// overflowed the onboarding row by **79 pixels** no matter how far the title
+/// shrank. Ellipsis has no answer to that and neither does `Flexible`.
+///
+/// `Wrap` does: the badge moves to its own line instead of off the screen,
+/// and nothing is truncated in the one case where truncating was the only
+/// option a `Row` had. At ordinary text sizes both still sit on one line, so
+/// the layout is unchanged where it already fitted.
+///
+/// **Untouched when there is no badge**: that path is a bare `Text` outside
+/// any multi-child layout, so rows without a badge keep wrapping as they
+/// always have.
+///
+/// [style] is the caller's, so a settings row and an onboarding row keep their
+/// own typography while sharing the constraint. Extracted for #728, when
+/// onboarding needed the same marker and re-deriving the bound by hand was the
+/// obvious way to get it subtly wrong — which is exactly what the measurement
+/// above then caught in the original.
+class BadgedTitle extends StatelessWidget {
+  final String title;
+  final String? badge;
+  final TextStyle? style;
+  final AppPalette? palette;
+
+  const BadgedTitle({
+    super.key,
+    required this.title,
+    this.badge,
+    this.style,
+    this.palette,
+  });
+
+  @override
+  Widget build(BuildContext context) {
+    final badgeText = badge;
+    if (badgeText == null) return Text(title, style: style);
+
+    return Wrap(
+      crossAxisAlignment: WrapCrossAlignment.center,
+      spacing: 8,
+      runSpacing: 4,
+      children: [
+        Text(
+          title,
+          style: style,
+          maxLines: 1,
+          overflow: TextOverflow.ellipsis,
+        ),
+        MutedBadge(text: badgeText, palette: palette),
+      ],
+    );
+  }
+}

--- a/lib/features/onboarding/onboarding_screen.dart
+++ b/lib/features/onboarding/onboarding_screen.dart
@@ -17,6 +17,7 @@ import 'package:opennutritracker/features/onboarding/domain/entity/user_goal_sel
 import 'package:opennutritracker/features/onboarding/presentation/bloc/onboarding_bloc.dart';
 import 'package:opennutritracker/features/onboarding/presentation/onboarding_intro_page_body.dart';
 import 'package:opennutritracker/features/onboarding/presentation/widgets/onboarding_goal_page_body.dart';
+import 'package:opennutritracker/core/utils/ai_credential_storage.dart';
 import 'package:opennutritracker/features/onboarding/presentation/widgets/onboarding_other_options_page_body.dart';
 import 'package:opennutritracker/features/onboarding/presentation/widgets/onboarding_overview_page_body.dart';
 import 'package:opennutritracker/features/onboarding/presentation/widgets/onboarding_activity_page_body.dart';
@@ -288,6 +289,10 @@ class _OnboardingScreenState extends State<OnboardingScreen> {
             initialDailyReminderEnabled: selection.dailyReminderEnabled,
             initialUseMaterialYou: selection.useMaterialYou,
             initialAccentColor: selection.accentColor,
+            // The one dependency on this page the bloc does not carry: the AI
+            // row reads and writes the keystore directly rather than staging
+            // through onboarding's save. #728.
+            aiCredentials: locator<AiCredentialStorage>(),
           ),
           // Everything on this page is optional and pre-filled with
           // defaults, so the button is always active.

--- a/lib/features/onboarding/presentation/widgets/onboarding_other_options_page_body.dart
+++ b/lib/features/onboarding/presentation/widgets/onboarding_other_options_page_body.dart
@@ -1,6 +1,10 @@
 import 'package:flutter/material.dart';
 import 'package:opennutritracker/core/domain/entity/app_theme_entity.dart';
 import 'package:opennutritracker/core/presentation/widgets/section_group.dart';
+import 'package:opennutritracker/core/presentation/ai_assist_summary.dart';
+import 'package:opennutritracker/core/presentation/widgets/badged_title.dart';
+import 'package:opennutritracker/core/utils/ai_credential_storage.dart';
+import 'package:opennutritracker/features/settings/presentation/widgets/ai_assist_dialog.dart';
 import 'package:opennutritracker/core/styles/accent_colors.dart';
 import 'package:opennutritracker/core/styles/dimens.dart';
 import 'package:opennutritracker/core/utils/off_const.dart';
@@ -10,10 +14,19 @@ import 'package:opennutritracker/generated/l10n.dart';
 import 'package:provider/provider.dart';
 
 /// Onboarding "Other options" page: app theme, the food databases used by
-/// search, and the daily logging reminder. Everything here is optional —
-/// the page is pre-filled with the defaults (system theme, all sources on,
-/// no reminder) and can be skipped by tapping next; each choice can be
-/// revisited later in Settings.
+/// search, the daily logging reminder, and AI meal assistance. Everything
+/// here is optional — the page is pre-filled with the defaults (system theme,
+/// all sources on, no reminder, no AI key) and can be skipped by tapping next;
+/// each choice can be revisited later in Settings.
+///
+/// **AI meal assistance is the one row that does not follow the page's staging
+/// model**, and deliberately. Every other control publishes to the bloc and is
+/// written only when onboarding completes; the AI dialog persists a provider,
+/// a model and a keystore credential the moment they are touched. Staging a
+/// credential to write later would mean holding it in memory across the rest
+/// of onboarding for no benefit, and the dialog is shared with Settings, where
+/// immediate writes are correct. So the row reads its state directly and
+/// refreshes after the dialog closes. See #728.
 class OnboardingOtherOptionsPageBody extends StatefulWidget {
   final Function(
     AppThemeEntity selectedTheme,
@@ -29,6 +42,12 @@ class OnboardingOtherOptionsPageBody extends StatefulWidget {
   final bool initialUseMaterialYou;
   final int? initialAccentColor;
 
+  /// Injected rather than pulled from the locator inside `build`, matching how
+  /// every other value on this page arrives. Reaching for the locator here
+  /// would make the existing tests on this page need one registered, for a
+  /// dependency none of them exercise.
+  final AiCredentialStorage? aiCredentials;
+
   const OnboardingOtherOptionsPageBody({
     super.key,
     required this.setPageContent,
@@ -37,6 +56,7 @@ class OnboardingOtherOptionsPageBody extends StatefulWidget {
     required this.initialDailyReminderEnabled,
     required this.initialUseMaterialYou,
     required this.initialAccentColor,
+    this.aiCredentials,
   });
 
   @override
@@ -52,6 +72,41 @@ class _OnboardingOtherOptionsPageBodyState
   late bool _dailyReminderEnabled = widget.initialDailyReminderEnabled;
   late bool _useMaterialYou = widget.initialUseMaterialYou;
   late int? _accentColor = widget.initialAccentColor;
+
+  /// Null until the first read completes, so the row shows no subtitle rather
+  /// than briefly claiming the feature is off. Same three fields Settings
+  /// keeps, read from the same store.
+  bool? _aiHasKey;
+  bool _aiEnabled = false;
+  AiProvider _aiProvider = AiProvider.anthropic;
+
+  @override
+  void initState() {
+    super.initState();
+    _refreshAiState();
+  }
+
+  Future<void> _refreshAiState() async {
+    final storage = widget.aiCredentials;
+    if (storage == null) return;
+    final hasKey = await storage.hasApiKey();
+    final enabled = await storage.isEnabled();
+    final provider = await storage.activeProvider();
+    if (!mounted) return;
+    setState(() {
+      _aiHasKey = hasKey;
+      _aiEnabled = enabled;
+      _aiProvider = provider;
+    });
+  }
+
+  /// Refreshed unconditionally rather than only when the dialog reports a
+  /// change: the subtitle is cheap to recompute and a stale one misdescribes
+  /// what leaves the device.
+  Future<void> _openAiDialog(AiCredentialStorage storage) async {
+    await AiAssistDialog.show(context, storage);
+    await _refreshAiState();
+  }
 
   void _publish() {
     widget.setPageContent(
@@ -266,10 +321,60 @@ class _OnboardingOtherOptionsPageBodyState
                 ),
               ],
             ),
+            ...?_buildAiAssistSection(context, s),
           ],
         ),
       ),
     );
+  }
+
+  /// Last on the page on purpose: it is the least likely of these to be
+  /// usable at first run — it needs an account and a card at Anthropic,
+  /// OpenAI or OpenRouter — and the most consequential, since it is the only
+  /// option here that changes what leaves the device.
+  ///
+  /// Opens the Settings dialog rather than restating it. The disclosure, the
+  /// provider list and the per-provider retention text are the load-bearing
+  /// part, and a second onboarding-shaped copy would be a second thing to
+  /// keep true in nine languages.
+  ///
+  /// Absent when no storage was injected, which is the case for tests that
+  /// predate this row and do not exercise it.
+  List<Widget>? _buildAiAssistSection(BuildContext context, S s) {
+    final storage = widget.aiCredentials;
+    if (storage == null) return null;
+
+    return [
+      const SizedBox(height: Dimens.spacing24),
+      SectionHeader(label: s.settingsAiAssistLabel),
+      const SizedBox(height: Dimens.spacing12),
+      SectionGroup(
+        tiles: [
+          Semantics(
+            identifier: 'onboarding-ai-assist',
+            child: ListTile(
+              dense: true,
+              title: BadgedTitle(
+                title: s.settingsAiAssistLabel,
+                badge: s.aiAssistExperimentalLabel,
+                style: Theme.of(context).textTheme.bodyLarge,
+              ),
+              subtitle: Text(
+                aiAssistSubtitle(
+                      s,
+                      hasKey: _aiHasKey,
+                      enabled: _aiEnabled,
+                      provider: _aiProvider,
+                    ) ??
+                    '',
+              ),
+              trailing: const Icon(Icons.chevron_right_rounded),
+              onTap: () => _openAiDialog(storage),
+            ),
+          ),
+        ],
+      ),
+    ];
   }
 
   /// The database list is long and every entry is already set sensibly for

--- a/lib/features/onboarding/presentation/widgets/onboarding_other_options_page_body.dart
+++ b/lib/features/onboarding/presentation/widgets/onboarding_other_options_page_body.dart
@@ -344,6 +344,17 @@ class _OnboardingOtherOptionsPageBodyState
     final storage = widget.aiCredentials;
     if (storage == null) return null;
 
+    // Null until the keystore read lands, and it stays a null *widget* rather
+    // than an empty `Text`: the point of the null is that the row says nothing
+    // instead of something wrong, and a blank `Text` still occupies its line,
+    // so the row would resize under the user as the read came back.
+    final subtitle = aiAssistSubtitle(
+      s,
+      hasKey: _aiHasKey,
+      enabled: _aiEnabled,
+      provider: _aiProvider,
+    );
+
     return [
       const SizedBox(height: Dimens.spacing24),
       SectionHeader(label: s.settingsAiAssistLabel),
@@ -359,15 +370,7 @@ class _OnboardingOtherOptionsPageBodyState
                 badge: s.aiAssistExperimentalLabel,
                 style: Theme.of(context).textTheme.bodyLarge,
               ),
-              subtitle: Text(
-                aiAssistSubtitle(
-                      s,
-                      hasKey: _aiHasKey,
-                      enabled: _aiEnabled,
-                      provider: _aiProvider,
-                    ) ??
-                    '',
-              ),
+              subtitle: subtitle == null ? null : Text(subtitle),
               trailing: const Icon(Icons.chevron_right_rounded),
               onTap: () => _openAiDialog(storage),
             ),

--- a/lib/features/settings/settings_screen.dart
+++ b/lib/features/settings/settings_screen.dart
@@ -5,6 +5,8 @@ import 'package:opennutritracker/core/domain/entity/body_weight_unit_entity.dart
 import 'package:opennutritracker/core/presentation/sources_screen.dart';
 import 'package:opennutritracker/core/presentation/widgets/app_banner_version.dart';
 import 'package:opennutritracker/core/presentation/widgets/app_card.dart';
+import 'package:opennutritracker/core/presentation/ai_assist_summary.dart';
+import 'package:opennutritracker/core/presentation/widgets/badged_title.dart';
 import 'package:opennutritracker/core/styles/app_palette.dart';
 import 'package:opennutritracker/core/styles/dimens.dart';
 import 'package:opennutritracker/core/presentation/widgets/disclaimer_dialog.dart';
@@ -950,24 +952,17 @@ class _SettingsScreenState extends State<SettingsScreen> {
   }
 
   /// The tile is the only place the destination is visible without opening
-  /// the dialog, so the "on" state names it. Brand names are not localized,
-  /// and the em-dash slot is free in that state.
-  String? _aiAssistSubtitle(BuildContext context) => switch (_aiHasKey) {
-    null => null,
-    false => S.of(context).settingsAiAssistNotConfiguredLabel,
-    true when _aiEnabled =>
-      // Exhaustive, deliberately. A wildcard here would name Anthropic for
-      // any provider added later, and this tile is the only place the
-      // destination is visible without opening the dialog — the same shape
-      // of defect as the photo sheet that said "an Anthropic gesendet" while
-      // OpenRouter was selected. Listing both makes the compiler ask.
-      '${S.of(context).settingsAiAssistOnLabel} — ${switch (_aiProvider) {
-        AiProvider.anthropic => 'Anthropic',
-        AiProvider.openrouter => 'OpenRouter',
-        AiProvider.openai => 'OpenAI',
-      }}',
-    true => S.of(context).settingsAiAssistPausedLabel,
-  };
+  /// the dialog, so the "on" state names it.
+  ///
+  /// The switch itself lives in [aiAssistSubtitle], shared with onboarding's
+  /// Other options page since #728 — one exhaustive site rather than two that
+  /// can disagree about who is being sent to.
+  String? _aiAssistSubtitle(BuildContext context) => aiAssistSubtitle(
+    S.of(context),
+    hasKey: _aiHasKey,
+    enabled: _aiEnabled,
+    provider: _aiProvider,
+  );
 
   Future<void> _openAiAssistDialog(BuildContext context) async {
     await AiAssistDialog.show(context, _aiCredentials);
@@ -1509,45 +1504,24 @@ class _SettingsTile extends StatelessWidget {
 
   /// The title, with [badge] beside it when one is set.
   ///
-  /// Follows AGENTS.md's "Row titles must not overflow": the title is
-  /// flex-constrained *and* line-bounded, because `Flexible` alone stops the
-  /// overflow stripes without stopping the silent wrap the rule is actually
-  /// about.
-  ///
-  /// The constraint goes on the title rather than the badge. The other way
-  /// round, "Experimental" ellipsizes to "Exper…" on a narrow phone, which
-  /// says nothing — where a clipped title is still recognisable beside its
-  /// icon, and the subtitle underneath repeats the state.
-  ///
-  /// Untouched when there is no badge: that path is a bare `Text` outside any
-  /// `Row`, exactly as before, so the rule does not apply and existing tiles
-  /// keep wrapping as they always have.
+  /// The overflow discipline moved into [BadgedTitle] for #728, when
+  /// onboarding needed the same marker — it is a rule rather than a layout,
+  /// and re-deriving it at a second site was the obvious way to get it subtly
+  /// wrong. The typography stays here, so a settings row still looks like a
+  /// settings row.
   Widget _titleWithBadge(
     BuildContext context,
     TextTheme text,
     AppPalette palette,
-  ) {
-    final style = text.titleMedium?.copyWith(
+  ) => BadgedTitle(
+    title: title,
+    badge: badge,
+    palette: palette,
+    style: text.titleMedium?.copyWith(
       fontWeight: FontWeight.w700,
       color: titleColor,
-    );
-    if (badge == null) return Text(title, style: style);
-
-    return Row(
-      children: [
-        Flexible(
-          child: Text(
-            title,
-            style: style,
-            maxLines: 1,
-            overflow: TextOverflow.ellipsis,
-          ),
-        ),
-        const SizedBox(width: 8),
-        _SettingsBadge(text: badge!, palette: palette),
-      ],
-    );
-  }
+    ),
+  );
 
   @override
   Widget build(BuildContext context) {
@@ -1612,36 +1586,6 @@ class _SettingsSwitchTile extends StatelessWidget {
           : null,
       value: value,
       onChanged: onChanged,
-    );
-  }
-}
-
-/// A short status word beside a tile title, e.g. "Experimental".
-///
-/// Muted rather than accented on purpose: this is a statement about the
-/// feature's stability, not a call to action, and an accent-coloured pill
-/// beside a title reads as "new — try this".
-class _SettingsBadge extends StatelessWidget {
-  final String text;
-  final AppPalette palette;
-
-  const _SettingsBadge({required this.text, required this.palette});
-
-  @override
-  Widget build(BuildContext context) {
-    final muted = palette.textMuted;
-    return Container(
-      padding: const EdgeInsets.symmetric(horizontal: 8, vertical: 2),
-      decoration: BoxDecoration(
-        color: muted.withValues(alpha: 0.12),
-        borderRadius: Dimens.borderRadiusS,
-      ),
-      child: Text(
-        text,
-        style: Theme.of(
-          context,
-        ).textTheme.labelSmall?.copyWith(color: muted, height: 1.2),
-      ),
     );
   }
 }

--- a/test/features/onboarding/presentation/widgets/onboarding_ai_assist_row_test.dart
+++ b/test/features/onboarding/presentation/widgets/onboarding_ai_assist_row_test.dart
@@ -1,0 +1,254 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_localizations/flutter_localizations.dart';
+import 'package:flutter_secure_storage/flutter_secure_storage.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:opennutritracker/core/domain/entity/app_theme_entity.dart';
+import 'package:opennutritracker/core/presentation/widgets/badged_title.dart';
+import 'package:opennutritracker/core/presentation/widgets/section_group.dart';
+import 'package:opennutritracker/core/utils/ai_credential_storage.dart';
+import 'package:opennutritracker/core/utils/theme_mode_provider.dart';
+import 'package:opennutritracker/features/onboarding/presentation/widgets/onboarding_other_options_page_body.dart';
+import 'package:opennutritracker/features/settings/presentation/widgets/ai_assist_dialog.dart';
+import 'package:opennutritracker/generated/l10n.dart';
+import 'package:provider/provider.dart';
+
+import '../../../../helpers/test_l10n.dart';
+
+class _MemoryStorage implements FlutterSecureStorage {
+  final store = <String, String>{};
+
+  @override
+  Future<String?> read({
+    required String key,
+    AppleOptions? iOptions,
+    AndroidOptions? aOptions,
+    LinuxOptions? lOptions,
+    WebOptions? webOptions,
+    AppleOptions? mOptions,
+    WindowsOptions? wOptions,
+  }) async => store[key];
+
+  @override
+  Future<void> write({
+    required String key,
+    required String? value,
+    AppleOptions? iOptions,
+    AndroidOptions? aOptions,
+    LinuxOptions? lOptions,
+    WebOptions? webOptions,
+    AppleOptions? mOptions,
+    WindowsOptions? wOptions,
+  }) async {
+    if (value == null) {
+      store.remove(key);
+    } else {
+      store[key] = value;
+    }
+  }
+
+  @override
+  Future<void> delete({
+    required String key,
+    AppleOptions? iOptions,
+    AndroidOptions? aOptions,
+    LinuxOptions? lOptions,
+    WebOptions? webOptions,
+    AppleOptions? mOptions,
+    WindowsOptions? wOptions,
+  }) async => store.remove(key);
+
+  @override
+  dynamic noSuchMethod(Invocation invocation) => super.noSuchMethod(invocation);
+}
+
+/// The AI row on onboarding's Other options page. #728.
+void main() {
+  late AiCredentialStorage storage;
+
+  setUp(() {
+    storage = AiCredentialStorage(_MemoryStorage());
+  });
+
+  Future<void> pumpPage(
+    WidgetTester tester, {
+    AiCredentialStorage? credentials,
+    Locale locale = const Locale('en'),
+    double textScale = 1.0,
+    Size size = const Size(411, 891),
+  }) async {
+    tester.view.physicalSize = size;
+    tester.view.devicePixelRatio = 1.0;
+    addTearDown(tester.view.reset);
+
+    await tester.pumpWidget(
+      ChangeNotifierProvider<ThemeModeProvider>(
+        create: (_) => ThemeModeProvider(appTheme: AppThemeEntity.system),
+        child: MaterialApp(
+          locale: locale,
+          localizationsDelegates: const [
+            S.delegate,
+            GlobalMaterialLocalizations.delegate,
+            GlobalWidgetsLocalizations.delegate,
+            GlobalCupertinoLocalizations.delegate,
+          ],
+          supportedLocales: S.supportedLocales,
+          home: Scaffold(
+            body: MediaQuery(
+              data: MediaQueryData(textScaler: TextScaler.linear(textScale)),
+              child: OnboardingOtherOptionsPageBody(
+                setPageContent: (_, _, _, _, _) {},
+                initialTheme: AppThemeEntity.system,
+                initialFoodSourceToggles: const {},
+                initialDailyReminderEnabled: false,
+                initialUseMaterialYou: true,
+                initialAccentColor: null,
+                aiCredentials: credentials,
+              ),
+            ),
+          ),
+        ),
+      ),
+    );
+    await tester.pumpAndSettle();
+  }
+
+  testWidgets('the row is absent when no storage is wired', (tester) async {
+    // The dependency is injected rather than fetched from the locator, so a
+    // caller that does not supply one gets the page as it was. That is what
+    // keeps the eight tests written before this row from needing a locator.
+    await pumpPage(tester);
+
+    expect(find.byType(SectionHeader), findsNWidgets(3));
+    expect(find.text(l10nEn.aiAssistExperimentalLabel), findsNothing);
+  });
+
+  testWidgets('the row is last, and marked experimental', (tester) async {
+    await pumpPage(tester, credentials: storage);
+
+    expect(find.byType(SectionHeader), findsNWidgets(4));
+    expect(find.text(l10nEn.aiAssistExperimentalLabel), findsOneWidget);
+
+    // Last on the page: it needs an account and a card at a model provider,
+    // so it is the least likely of these to be usable at first run, and the
+    // only one that changes what leaves the device.
+    final headers = tester
+        .widgetList<SectionHeader>(find.byType(SectionHeader))
+        .map((h) => h.label)
+        .toList();
+    expect(headers.last, l10nEn.settingsAiAssistLabel);
+  });
+
+  testWidgets('with no key it says so, rather than saying nothing', (
+    tester,
+  ) async {
+    await pumpPage(tester, credentials: storage);
+
+    expect(
+      find.text(l10nEn.settingsAiAssistNotConfiguredLabel),
+      findsOneWidget,
+    );
+  });
+
+  testWidgets('a key that survived a data wipe is reported, not hidden', (
+    tester,
+  ) async {
+    // `DeleteAllUserDataUsecase.deleteAll()` clears Hive boxes only, and
+    // these credentials live in the platform keystore — so "delete all my
+    // data" returns the user to onboarding with a usable key still stored.
+    // The row saying so is the only place that becomes visible, and it is one
+    // tap from removing it.
+    await storage.setActiveProvider(AiProvider.openai);
+    await storage.writeApiKey('sk-test', provider: AiProvider.openai);
+    await storage.setEnabled(true);
+
+    await pumpPage(tester, credentials: storage);
+
+    expect(find.textContaining(l10nEn.settingsAiAssistOnLabel), findsOneWidget);
+    expect(find.textContaining('OpenAI'), findsOneWidget);
+  });
+
+  testWidgets('a paused key reads as paused, not as off', (tester) async {
+    await storage.writeApiKey('sk-test', provider: AiProvider.anthropic);
+    await storage.setEnabled(false);
+
+    await pumpPage(tester, credentials: storage);
+
+    expect(find.text(l10nEn.settingsAiAssistPausedLabel), findsOneWidget);
+  });
+
+  testWidgets('tapping the row opens the shared settings dialog', (
+    tester,
+  ) async {
+    // The dialog rather than a restatement of it: the disclosure and the
+    // per-provider retention text are the load-bearing part and exist once.
+    await pumpPage(tester, credentials: storage);
+
+    await tester.tap(find.bySemanticsIdentifier('onboarding-ai-assist'));
+    await tester.pumpAndSettle();
+
+    expect(find.byType(AiAssistDialog), findsOneWidget);
+    expect(
+      find.textContaining(l10nEn.aiAssistDisclosureCommon),
+      findsOneWidget,
+      reason: 'the disclosure comes with the dialog, not from a second copy',
+    );
+  });
+
+  testWidgets('the row catches up with what the dialog changed', (
+    tester,
+  ) async {
+    // The reason this row keeps live state at all. The dialog writes
+    // immediately — pausing here is a keystore write, not a staged edit — so
+    // a row that read once at initState would keep claiming the feature is on
+    // after the user turned it off, which is the "stale subtitle
+    // misdescribes what leaves the device" failure Settings refreshes
+    // unconditionally to avoid.
+    //
+    // A mutation caught the absence of this test: deleting the refresh after
+    // `AiAssistDialog.show` left every other test on this page green.
+    await storage.writeApiKey('sk-test', provider: AiProvider.anthropic);
+    await storage.setEnabled(true);
+
+    await pumpPage(tester, credentials: storage);
+    expect(find.textContaining(l10nEn.settingsAiAssistOnLabel), findsOneWidget);
+
+    await tester.tap(find.bySemanticsIdentifier('onboarding-ai-assist'));
+    await tester.pumpAndSettle();
+
+    // Scoped to the dialog: the page underneath has its own Switch for the
+    // daily reminder, and an unscoped `.first` taps that one instead.
+    final dialogSwitch = find.descendant(
+      of: find.byType(AiAssistDialog),
+      matching: find.byType(Switch),
+    );
+    await tester.ensureVisible(dialogSwitch);
+    await tester.pumpAndSettle();
+    await tester.tap(dialogSwitch);
+    await tester.pumpAndSettle();
+    expect(await storage.isEnabled(), isFalse);
+
+    await tester.tap(find.text(l10nEn.dialogCancelLabel));
+    await tester.pumpAndSettle();
+
+    expect(find.text(l10nEn.settingsAiAssistPausedLabel), findsOneWidget);
+    expect(find.textContaining(l10nEn.settingsAiAssistOnLabel), findsNothing);
+  });
+
+  testWidgets('the badged title survives 2x German without overflowing', (
+    tester,
+  ) async {
+    // Where the dialog's own 48px overflow was found, which is why its title
+    // deliberately carries no marker. This row is inside a scroll view, so it
+    // has room the dialog title did not — measured rather than assumed.
+    await pumpPage(
+      tester,
+      credentials: storage,
+      locale: const Locale('de'),
+      textScale: 2.0,
+      size: const Size(320, 800),
+    );
+
+    expect(find.byType(BadgedTitle), findsOneWidget);
+    expect(tester.takeException(), isNull);
+  });
+}

--- a/test/features/onboarding/presentation/widgets/onboarding_ai_assist_row_test.dart
+++ b/test/features/onboarding/presentation/widgets/onboarding_ai_assist_row_test.dart
@@ -61,6 +61,25 @@ class _MemoryStorage implements FlutterSecureStorage {
   dynamic noSuchMethod(Invocation invocation) => super.noSuchMethod(invocation);
 }
 
+/// Reads land after a delay, which the in-memory store cannot reproduce: its
+/// future resolves in the same microtask drain as the first `pump`, so the row
+/// is already populated by the time a test can look at it. The real keystore
+/// is a platform channel and takes frames.
+class _DelayedStorage extends _MemoryStorage {
+  static const delay = Duration(milliseconds: 50);
+
+  @override
+  Future<String?> read({
+    required String key,
+    AppleOptions? iOptions,
+    AndroidOptions? aOptions,
+    LinuxOptions? lOptions,
+    WebOptions? webOptions,
+    AppleOptions? mOptions,
+    WindowsOptions? wOptions,
+  }) => Future.delayed(delay, () => store[key]);
+}
+
 /// The AI row on onboarding's Other options page. #728.
 void main() {
   late AiCredentialStorage storage;
@@ -75,6 +94,7 @@ void main() {
     Locale locale = const Locale('en'),
     double textScale = 1.0,
     Size size = const Size(411, 891),
+    bool settle = true,
   }) async {
     tester.view.physicalSize = size;
     tester.view.devicePixelRatio = 1.0;
@@ -109,8 +129,47 @@ void main() {
         ),
       ),
     );
-    await tester.pumpAndSettle();
+    if (settle) {
+      await tester.pumpAndSettle();
+    } else {
+      // One frame: the keystore read is still in flight, which is the state
+      // the loading case needs to observe.
+      await tester.pump();
+    }
   }
+
+  testWidgets('before the keystore read lands the row has no subtitle line', (
+    tester,
+  ) async {
+    // `aiAssistSubtitle` returns null while `hasKey` is unread so the row says
+    // nothing rather than something wrong. Rendering that null as `Text('')`
+    // honours the letter and loses the point — an empty Text still occupies
+    // its line, so the row resizes under the user as the read comes back.
+    // Caught by review on #729.
+    await pumpPage(
+      tester,
+      credentials: AiCredentialStorage(_DelayedStorage()),
+      settle: false,
+    );
+
+    final tile = tester.widget<ListTile>(
+      find.descendant(
+        of: find.bySemanticsIdentifier('onboarding-ai-assist'),
+        matching: find.byType(ListTile),
+      ),
+    );
+    expect(tile.subtitle, isNull);
+
+    // Stepped rather than `pumpAndSettle`: the three keystore reads are
+    // sequential delays and settling races them.
+    await tester.pump(_DelayedStorage.delay * 10);
+    await tester.pump();
+    expect(
+      find.text(l10nEn.settingsAiAssistNotConfiguredLabel),
+      findsOneWidget,
+      reason: 'and it arrives once the read completes',
+    );
+  });
 
   testWidgets('the row is absent when no storage is wired', (tester) async {
     // The dependency is injected rather than fetched from the locator, so a

--- a/test/unit_test/badged_title_test.dart
+++ b/test/unit_test/badged_title_test.dart
@@ -1,0 +1,104 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:opennutritracker/core/presentation/widgets/badged_title.dart';
+
+/// [BadgedTitle] carries AGENTS.md's "row titles must not overflow" rule for
+/// every screen that shows a badge, so the rule is measured here once rather
+/// than re-argued per row. #728.
+void main() {
+  Future<void> pump(
+    WidgetTester tester, {
+    required double width,
+    required String title,
+    String? badge,
+    double textScale = 1.0,
+  }) async {
+    await tester.pumpWidget(
+      MaterialApp(
+        home: Scaffold(
+          body: MediaQuery(
+            data: MediaQueryData(textScaler: TextScaler.linear(textScale)),
+            child: Center(
+              child: SizedBox(
+                width: width,
+                child: BadgedTitle(title: title, badge: badge),
+              ),
+            ),
+          ),
+        ),
+      ),
+    );
+    await tester.pump();
+  }
+
+  testWidgets('a badge wider than its row drops to a line of its own', (
+    tester,
+  ) async {
+    // The case a `Row` could not answer. Bounding the title does nothing when
+    // the badge alone exceeds the width, which is what happens at 2x text
+    // scale in German: "Experimentell" overflowed the onboarding row by 79
+    // pixels however far the title shrank.
+    await pump(
+      tester,
+      width: 150,
+      title: 'KI-Unterstützung',
+      badge: 'Experimentell',
+      textScale: 2.0,
+    );
+
+    expect(tester.takeException(), isNull);
+    // Both texts intact — the point of wrapping rather than truncating.
+    expect(find.text('Experimentell'), findsOneWidget);
+    expect(find.text('KI-Unterstützung'), findsOneWidget);
+  });
+
+  testWidgets('a long title still ellipsizes rather than wrapping silently', (
+    tester,
+  ) async {
+    // The half of the rule that has not changed: a title may be clipped, but
+    // it may never grow the row by wrapping to a second line.
+    await pump(
+      tester,
+      width: 160,
+      title: 'A settings row title far too long to fit in this width',
+      badge: 'Experimental',
+    );
+
+    expect(tester.takeException(), isNull);
+    final text = tester.widget<Text>(find.textContaining('A settings row'));
+    expect(text.maxLines, 1);
+    expect(text.overflow, TextOverflow.ellipsis);
+  });
+
+  testWidgets('no badge means no wrapper at all', (tester) async {
+    // Rows without a badge must keep behaving exactly as they did before this
+    // widget existed, including their own wrapping.
+    await pump(tester, width: 200, title: 'Plain title');
+
+    expect(find.byType(Wrap), findsNothing);
+    expect(tester.widget<Text>(find.text('Plain title')).maxLines, isNull);
+  });
+
+  testWidgets('both fit on one line at ordinary sizes', (tester) async {
+    // The layout is unchanged where it already fitted; wrapping is a release
+    // valve, not the normal case.
+    // 403px is where this pair stops fitting, measured: the title's
+    // intrinsic width is 256.5, the badge's 138, plus 8 of spacing.
+    await pump(
+      tester,
+      width: 420,
+      title: 'AI meal assistance',
+      badge: 'Experimental',
+    );
+
+    expect(tester.takeException(), isNull);
+    final title = tester.getRect(find.text('AI meal assistance'));
+    final badge = tester.getRect(find.text('Experimental'));
+    expect(
+      badge.left,
+      greaterThan(title.right - 1),
+      reason: 'badge sits beside the title, not beneath it',
+    );
+    expect((badge.center.dy - title.center.dy).abs(), lessThan(2));
+  });
+}


### PR DESCRIPTION
Closes #728.

Adds a row to onboarding's **Other options** page that opens the existing
settings dialog, marked Experimental. Last section, after the daily reminder.

The dialog rather than a second surface: the disclosure and the per-provider
retention text are the load-bearing part, and an onboarding-shaped copy would
be a second thing to keep true in nine languages. **No new strings** — every
label already existed, and the page already repeats a section header's label as
its tile title.

## Extracting the badge found a bug in it

`_titleWithBadge` moved to `BadgedTitle` so onboarding would inherit the
AGENTS.md overflow discipline instead of re-deriving it. Writing the test that
the dialog's own 48px overflow taught us to write turned up a worse one:

```
A RenderFlex overflowed by 79 pixels on the right.
```

2x text scale, German, 320px. As a `Row` it bounded the title with `Flexible`
and left the badge at its intrinsic width, on the reasoning that "Experimental"
ellipsized to "Exper…" says nothing while a clipped title is still
recognisable. **Both halves of that are right and the conclusion did not
survive measurement** — constraining the title cannot help when the *badge
alone* is wider than the row, and no amount of shrinking the title recovers
79px. Ellipsis has no answer to that and neither does `Flexible`.

It is a `Wrap` now: the badge takes its own line rather than leaving the
screen, and nothing is truncated in the one case a `Row` could only answer by
truncating.

**This changes the Settings row too, and that was a deliberate call**, not a
side effect. Measured: the English pair needs ~403px on one line (title 256.5,
badge 138, spacing 8) against a title area of ~289dp on a 411px phone, so in
English the badge now sits under a whole title where it used to sit beside a
clipped one. A complete title carries more than a clipped one, and one
behaviour beats a knob that invites the wrong choice at the next call site.

**Verified on a Pixel 6 (German, dark):** the Settings row is *unchanged* —
`KI-Unterstützung` and `Experimentell` still share one line, title intact,
because the German pair is narrower than the English one. The English case is
measured rather than seen; I did not switch the phone's system language to
confirm it visually.

## The subtitle has one home now

Both screens show the same row, and it is the only place the destination is
visible without opening the dialog. The provider switch is exhaustive on
purpose — a wildcard would name Anthropic for any provider added later — and
two hand-maintained copies would give that protection up, so a fourth provider
would be a compile error in one file and a wrong destination in the other. That
is not hypothetical: the photo sheet once read *"an Anthropic gesendet"* while
OpenRouter was selected.

## The page's first non-staged state, and it says so

Everything else on Other options publishes to the bloc and is written when
onboarding completes. The AI dialog persists a provider, a model and a keystore
credential the moment they are touched. Staging a credential to write later
would mean holding it in memory across the rest of onboarding for no benefit,
and the dialog is shared with Settings where immediate writes are correct — so
the row reads its state directly and refreshes after the dialog closes.

Storage is **injected** rather than fetched from the locator, so the eight
tests written before this row still pass without one, and the row is simply
absent when nothing is wired.

## After "delete all my data", the row tells the truth

`DeleteAllUserDataUsecase.deleteAll()` clears eight Hive boxes; these
credentials live in the platform keystore. So a wiped profile lands back on
onboarding **with a usable API key still stored**, and this row is the first
place that becomes visible — one tap from removing it. `deleteAll` is
unchanged: the keystore is deliberately hardened with `resetOnError: false`
"so a keystore hiccup cannot silently wipe them", and whether "delete all my
data" should mean the credential too is a separate, destructive-behaviour
decision.

## Verification

Driven on a Pixel 6 through **add-profile**, which enters onboarding with a
cancel target and deletes the draft on the way out — so no `pm clear`, and the
device finished in the state it started in (one profile, no logcat errors).

The onboarding row rendered last, badge beside an untruncated title, subtitle
*"Aus — kein Schlüssel gespeichert"*, and opened the shared dialog. That dialog
also confirmed #727 on hardware for the first time: four models, **per-row**
"Bereitgestellt von", Anthropic on the first two and OpenAI on the last two,
`Am günstigsten in dieser Liste` on luna, and `anthropic/claude-sonnet-5` still
the default.

**Tests:** 7 new for the row, 4 for `BadgedTitle`, 1400 total, analyzer clean.

**Eight mutations, all caught** — including one that survived first: deleting
the refresh after the dialog closes left every other test on the page green,
which is the whole reason the row keeps live state. Now pinned by a test that
pauses the feature inside the dialog and asserts the row catches up.
