### PR TITLE
refactor(core): resolve the active provider once per row refresh

### DIFF
--- a/lib/core/utils/ai_credential_storage.dart
+++ b/lib/core/utils/ai_credential_storage.dart
@@ -42,6 +42,28 @@ class AiSelection {
   });
 }
 
+/// What a row needs to describe the feature without opening it: who would
+/// answer, whether a credential exists for them, and whether the user
+/// currently wants it used.
+///
+/// Deliberately carries no key. Three screens show this and none of them
+/// sends a request, so the credential is read to test its existence and
+/// dropped — the same thing [AiCredentialStorage.hasApiKey] has always done,
+/// kept that way now that the read is shared.
+class AiAssistSummary {
+  final AiProvider provider;
+  final bool hasKey;
+
+  /// False whenever [hasKey] is false, so a caller never has to check both.
+  final bool enabled;
+
+  const AiAssistSummary({
+    required this.provider,
+    required this.hasKey,
+    required this.enabled,
+  });
+}
+
 /// Holds the user's own model-provider API keys, which one is in use, and
 /// whether they currently want it used.
 ///
@@ -104,6 +126,41 @@ class AiCredentialStorage {
   Future<void> setActiveProvider(AiProvider provider) =>
       _storage.write(key: _providerTag, value: provider.name);
 
+  /// Resolves the active provider **once** and answers everything that hangs
+  /// off it, for the callers that want more than one of these values.
+  ///
+  /// The public getters are each other's dependencies — [isEnabled] begins by
+  /// calling [hasApiKey], which resolves [activeProvider] before it can name a
+  /// slot — so asking all three separately resolved the provider three times
+  /// and re-read the key slot twice, for 6-8 platform-channel round trips
+  /// against four distinct keys. Nothing was wrong with any answer; the cost
+  /// was simply invisible from the call site, because each method reads like
+  /// one lookup. #730.
+  ///
+  /// Not fixable by running the three concurrently: they are not independent,
+  /// so overlapping them hides the duplicate reads rather than removing them.
+  Future<({AiProvider provider, String? apiKey, bool enabled})>
+  _readState() async {
+    final provider = await activeProvider();
+    final apiKey = await readApiKey(provider: provider);
+    // The invariant [isEnabled] has always enforced, stated here once: the
+    // flag alone never means "on" — a provider with no key is off whatever
+    // the tag says.
+    final enabled =
+        apiKey != null && await _storage.read(key: _enabledTag) != 'false';
+    return (provider: provider, apiKey: apiKey, enabled: enabled);
+  }
+
+  /// What a row shows for the feature, in one read of the store.
+  Future<AiAssistSummary> readSummary() async {
+    final state = await _readState();
+    return AiAssistSummary(
+      provider: state.provider,
+      hasKey: state.apiKey != null,
+      enabled: state.enabled,
+    );
+  }
+
   /// What the AI features should do right now, or null when they should do
   /// nothing — the feature is off, or the active provider has no key.
   ///
@@ -111,14 +168,14 @@ class AiCredentialStorage {
   /// ask `isEnabled()` then `readApiKey()`, and adding a provider and a model
   /// would have made that four questions asked separately in two places.
   Future<AiSelection?> readSelection() async {
-    if (!await isEnabled()) return null;
-    final provider = await activeProvider();
-    final apiKey = await readApiKey(provider: provider);
+    final state = await _readState();
+    if (!state.enabled) return null;
+    final apiKey = state.apiKey;
     if (apiKey == null) return null;
     return AiSelection(
-      provider: provider,
+      provider: state.provider,
       apiKey: apiKey,
-      modelId: await readModel(provider: provider),
+      modelId: await readModel(provider: state.provider),
     );
   }
 
@@ -229,10 +286,7 @@ class AiCredentialStorage {
   /// Whether the user currently wants the key used. False whenever the
   /// *active* provider has no key, so a caller never has to check both — the
   /// same invariant as before providers existed, restated for two slots.
-  Future<bool> isEnabled() async {
-    if (!await hasApiKey()) return false;
-    return await _storage.read(key: _enabledTag) != 'false';
-  }
+  Future<bool> isEnabled() async => (await _readState()).enabled;
 
   /// Turns the feature off without forgetting the keys, so switching it back
   /// on does not mean finding a credential again. Enabling with no key for

--- a/lib/features/onboarding/presentation/widgets/onboarding_other_options_page_body.dart
+++ b/lib/features/onboarding/presentation/widgets/onboarding_other_options_page_body.dart
@@ -89,14 +89,12 @@ class _OnboardingOtherOptionsPageBodyState
   Future<void> _refreshAiState() async {
     final storage = widget.aiCredentials;
     if (storage == null) return;
-    final hasKey = await storage.hasApiKey();
-    final enabled = await storage.isEnabled();
-    final provider = await storage.activeProvider();
+    final summary = await storage.readSummary();
     if (!mounted) return;
     setState(() {
-      _aiHasKey = hasKey;
-      _aiEnabled = enabled;
-      _aiProvider = provider;
+      _aiHasKey = summary.hasKey;
+      _aiEnabled = summary.enabled;
+      _aiProvider = summary.provider;
     });
   }
 

--- a/lib/features/settings/presentation/widgets/ai_assist_dialog.dart
+++ b/lib/features/settings/presentation/widgets/ai_assist_dialog.dart
@@ -86,16 +86,16 @@ class _AiAssistDialogState extends State<AiAssistDialog> {
   /// provider switch, because every field below the selector belongs to the
   /// provider rather than to the dialog.
   Future<void> _load() async {
-    final provider = await widget.storage.activeProvider();
-    final hasKey = await widget.storage.hasApiKey(provider: provider);
-    final enabled = await widget.storage.isEnabled();
-    final modelId = await widget.storage.readModel(provider: provider);
+    final summary = await widget.storage.readSummary();
+    final modelId = await widget.storage.readModel(
+      provider: summary.provider,
+    );
     if (!mounted) return;
     setState(() {
-      _provider = provider;
-      _hasKey = hasKey;
-      _enabled = enabled;
-      _model = AiModelCatalogue.resolve(provider, modelId);
+      _provider = summary.provider;
+      _hasKey = summary.hasKey;
+      _enabled = summary.enabled;
+      _model = AiModelCatalogue.resolve(summary.provider, modelId);
       _loading = false;
     });
   }

--- a/lib/features/settings/settings_screen.dart
+++ b/lib/features/settings/settings_screen.dart
@@ -940,14 +940,12 @@ class _SettingsScreenState extends State<SettingsScreen> {
   }
 
   Future<void> _refreshAiAssistState() async {
-    final hasKey = await _aiCredentials.hasApiKey();
-    final enabled = await _aiCredentials.isEnabled();
-    final provider = await _aiCredentials.activeProvider();
+    final summary = await _aiCredentials.readSummary();
     if (!mounted) return;
     setState(() {
-      _aiHasKey = hasKey;
-      _aiEnabled = enabled;
-      _aiProvider = provider;
+      _aiHasKey = summary.hasKey;
+      _aiEnabled = summary.enabled;
+      _aiProvider = summary.provider;
     });
   }
 

--- a/test/unit_test/ai_credential_storage_test.dart
+++ b/test/unit_test/ai_credential_storage_test.dart
@@ -3,8 +3,13 @@ import 'package:flutter_test/flutter_test.dart';
 import 'package:opennutritracker/core/utils/ai_credential_storage.dart';
 
 /// In-memory stand-in for the platform keystore.
+///
+/// [reads] counts round trips, because on a real device each one is a
+/// platform channel call and the cost is invisible from the call site — the
+/// defect #730 recorded.
 class _MemoryStorage implements FlutterSecureStorage {
   final store = <String, String>{};
+  final reads = <String>[];
 
   @override
   Future<String?> read({
@@ -15,7 +20,10 @@ class _MemoryStorage implements FlutterSecureStorage {
     WebOptions? webOptions,
     AppleOptions? mOptions,
     WindowsOptions? wOptions,
-  }) async => store[key];
+  }) async {
+    reads.add(key);
+    return store[key];
+  }
 
   @override
   Future<void> write({
@@ -372,6 +380,98 @@ void main() {
 
       expect(backing.store['AiModelTag.anthropic'], 'a/one');
       expect(backing.store.containsKey('AiApiKeyTag.anthropic'), isFalse);
+    });
+  });
+
+  group('readSummary', () {
+    // Everything a row shows about the feature, resolved in one pass. The
+    // three getters it replaces are each other's dependencies — `isEnabled`
+    // opens by calling `hasApiKey`, which resolves `activeProvider` before it
+    // can name a slot — so asking them separately resolved the provider three
+    // times over. #730.
+
+    test('reports the provider, the key and the flag together', () async {
+      await storage.setActiveProvider(AiProvider.openai);
+      await storage.writeApiKey('sk-test', provider: AiProvider.openai);
+      await storage.setEnabled(true);
+
+      final summary = await storage.readSummary();
+
+      expect(summary.provider, AiProvider.openai);
+      expect(summary.hasKey, isTrue);
+      expect(summary.enabled, isTrue);
+    });
+
+    test('a key with the flag off reads as paused, not as absent', () async {
+      // The distinction the settings row is built on: "Paused — key saved"
+      // against "Off — no key saved".
+      await storage.writeApiKey('sk-test');
+      await storage.setEnabled(false);
+
+      final summary = await storage.readSummary();
+
+      expect(summary.hasKey, isTrue);
+      expect(summary.enabled, isFalse);
+    });
+
+    test('enabled is never true without a key for the active provider', () async {
+      // The invariant `isEnabled` has always enforced, now stated in one
+      // place: the flag alone never means "on". Set the flag against a
+      // provider that holds a key, then switch to one that does not.
+      await storage.writeApiKey('sk-test', provider: AiProvider.anthropic);
+      await storage.setEnabled(true);
+      await storage.setActiveProvider(AiProvider.openai);
+
+      final summary = await storage.readSummary();
+
+      expect(summary.provider, AiProvider.openai);
+      expect(summary.hasKey, isFalse);
+      expect(summary.enabled, isFalse);
+    });
+
+    test('resolves the active provider once, not once per value', () async {
+      await storage.setActiveProvider(AiProvider.openai);
+      await storage.writeApiKey('sk-test', provider: AiProvider.openai);
+      backing.reads.clear();
+
+      await storage.readSummary();
+
+      expect(
+        backing.reads.where((k) => k == 'AiProviderTag').length,
+        1,
+        reason: 'the provider decides which slot to read; it is not per value',
+      );
+      expect(
+        backing.reads.length,
+        lessThanOrEqualTo(4),
+        reason: 'four distinct keys exist; asking the three getters '
+            'separately took 6-8 round trips. Got: ${backing.reads}',
+      );
+    });
+
+    test('agrees with the getters it replaces', () async {
+      // The refactor is only safe if it is not a behaviour change. Checked
+      // across the states the row distinguishes rather than on one happy
+      // path.
+      for (final (provider, key, enabled) in [
+        (AiProvider.anthropic, null, true),
+        (AiProvider.anthropic, 'sk-a', true),
+        (AiProvider.anthropic, 'sk-a', false),
+        (AiProvider.openai, 'sk-o', true),
+        (AiProvider.openrouter, null, false),
+      ]) {
+        final fresh = _MemoryStorage();
+        final store = AiCredentialStorage(fresh);
+        await store.setActiveProvider(provider);
+        if (key != null) await store.writeApiKey(key, provider: provider);
+        await store.setEnabled(enabled);
+
+        final summary = await store.readSummary();
+
+        expect(summary.provider, await store.activeProvider());
+        expect(summary.hasKey, await store.hasApiKey());
+        expect(summary.enabled, await store.isEnabled());
+      }
     });
   });
 


### PR DESCRIPTION
Closes #730.

Three screens — the settings tile, onboarding's Other options row and the AI
dialog — asked `hasApiKey()`, `isEnabled()` and `activeProvider()` separately.
Those are each other's dependencies: `isEnabled()` opens by calling
`hasApiKey()`, which resolves `activeProvider()` before it can name a slot.

**Measured with a counting store, not estimated:**

```
three getters = 6 reads [AiProviderTag, AiProviderTag, AiApiKeyTag.x,
                         AiProviderTag, AiApiKeyTag.x, AiAssistEnabledTag]
readSummary   = 3 reads [AiProviderTag, AiApiKeyTag.x, AiAssistEnabledTag]
```

The provider tag went from three reads to one and the key slot from two to
one, against four distinct keys. Each is a platform-channel round trip on a
real device.

## Why not `Future.wait`

That was the shape first suggested, on the premise that the three values are
independent. They are not — `isEnabled()` *calls* `hasApiKey()` — so
overlapping them hides the duplicate reads rather than removing them. The cost
was never serialisation; it was that each method reads like a single lookup
from the call site, so nobody could see the duplication without opening the
storage.

## The shape

`readSummary()` resolves the provider once and answers all three, following the
precedent `readSelection()` set for the request path — *"one method rather than
three calls at each site"*. Both now share one private resolution, and
`isEnabled()` delegates to it instead of re-deriving the answer.

`AiAssistSummary` deliberately carries **no key**. Three screens show this and
none of them sends a request, so the credential is read to test its existence
and dropped — exactly what `hasApiKey()` has always done, kept that way now
that the read is shared.

## No behaviour change, tested rather than asserted

A case table runs `readSummary` against the three getters it replaces across
the states the settings row distinguishes — no key, key with the flag on, key
with the flag off, a second provider, and the flag set against a provider that
holds a key followed by a switch to one that does not.

That last case is the invariant this consolidates: **a provider with no key is
off whatever the flag says**. It used to be enforced inside `isEnabled()` and
restated in prose at each caller; it now lives in one place, with a test that
sets the flag against a keyed provider and then switches away.

**Four mutations, all caught:** dropping the no-key guard, resolving the
provider per value again, inverting the enabled-tag sense, and reporting
`hasKey` unconditionally.

1406 tests, analyzer clean. No strings, no schema change, no migration — the
stored format is untouched, including the legacy-tag fallback on the Anthropic
slot.
