### PR TITLE
fix(core): stop an unknown provider tag meaning Anthropic

### DIFF
--- a/lib/core/presentation/ai_assist_summary.dart
+++ b/lib/core/presentation/ai_assist_summary.dart
@@ -17,15 +17,19 @@ import 'package:opennutritracker/generated/l10n.dart';
 ///
 /// [hasKey] null means "not read yet", which renders no subtitle rather than
 /// a wrong one.
+/// [provider] is null when the stored name is one this build does not know.
+/// That state can only reach the `false` arm — [AiAssistSummary] reports no
+/// key without a provider to hold one — so the row says "not configured"
+/// rather than naming a company the user never chose. #753.
 String? aiAssistSubtitle(
   S s, {
   required bool? hasKey,
   required bool enabled,
-  required AiProvider provider,
+  required AiProvider? provider,
 }) => switch (hasKey) {
   null => null,
   false => s.settingsAiAssistNotConfiguredLabel,
-  true when enabled =>
+  true when enabled && provider != null =>
     // Brand names are not localized, and the em-dash slot is free in this
     // state.
     '${s.settingsAiAssistOnLabel} — ${switch (provider) {

--- a/lib/core/utils/ai_credential_storage.dart
+++ b/lib/core/utils/ai_credential_storage.dart
@@ -10,15 +10,33 @@ enum AiProvider {
   openrouter,
   openai;
 
-  /// Anything unrecognised — including nothing at all — reads as Anthropic.
+  /// **Nothing stored** reads as Anthropic; **a name this build does not
+  /// know** reads as null.
   ///
-  /// That is what makes an existing install valid without writing to it:
-  /// before this existed every key was an Anthropic key, so the absence of a
-  /// pointer already means the right thing and no migration has to run.
-  static AiProvider fromTag(String? value) => AiProvider.values.firstWhere(
-    (provider) => provider.name == value,
-    orElse: () => AiProvider.anthropic,
-  );
+  /// The first half is what makes an existing install valid without writing
+  /// to it: before providers existed every key was an Anthropic key, so the
+  /// absence of a pointer already means the right thing and no migration has
+  /// to run.
+  ///
+  /// The second half used to be the same as the first, and that was the
+  /// defect #688 resolved and #753 fixed. A newer build writes a provider
+  /// name, the user downgrades, and this build reads a word it does not know
+  /// — reading that as Anthropic **silently redirects their requests to a
+  /// company they did not choose**, which in an app that enumerates its
+  /// destinations and names the serving vendor as a guarantee is the one
+  /// failure that cannot be quiet. It sends for real, too: the person most
+  /// likely to be here tried a hosted provider first and moved away from it,
+  /// so their Anthropic key is still in the slot.
+  ///
+  /// Null makes the feature quietly unavailable instead, which is not a new
+  /// state to design — it is what a provider with no key already does.
+  static AiProvider? fromTag(String? value) {
+    if (value == null || value.isEmpty) return AiProvider.anthropic;
+    for (final provider in AiProvider.values) {
+      if (provider.name == value) return provider;
+    }
+    return null;
+  }
 }
 
 /// Everything one request needs in order to be addressed: who is answering,
@@ -51,7 +69,10 @@ class AiSelection {
 /// dropped — the same thing [AiCredentialStorage.hasApiKey] has always done,
 /// kept that way now that the read is shared.
 class AiAssistSummary {
-  final AiProvider provider;
+  /// Null when the stored provider name is one this build does not know, so
+  /// a row can report the feature unavailable without naming a company that
+  /// was never chosen. #753.
+  final AiProvider? provider;
   final bool hasKey;
 
   /// False whenever [hasKey] is false, so a caller never has to check both.
@@ -109,8 +130,13 @@ class AiCredentialStorage {
   AiCredentialStorage([FlutterSecureStorage? storage])
     : _storage = storage ?? SecureAppStorageProvider.secureAppStorage;
 
-  /// Which provider the AI features currently use.
-  Future<AiProvider> activeProvider() async =>
+  /// Which provider the AI features currently use, or **null when the stored
+  /// name is one this build does not know** — see [AiProvider.fromTag].
+  ///
+  /// Null is not "none selected". It is "a selection this build cannot
+  /// honour", and every read below treats it as unusable rather than
+  /// substituting a default.
+  Future<AiProvider?> activeProvider() async =>
       AiProvider.fromTag(await _storage.read(key: _providerTag));
 
   /// Points the AI features at [provider].
@@ -139,9 +165,14 @@ class AiCredentialStorage {
   ///
   /// Not fixable by running the three concurrently: they are not independent,
   /// so overlapping them hides the duplicate reads rather than removing them.
-  Future<({AiProvider provider, String? apiKey, bool enabled})>
+  /// A null provider short-circuits the whole thing: there is no slot to read
+  /// a key from, so there is nothing to enable. #753.
+  Future<({AiProvider? provider, String? apiKey, bool enabled})>
   _readState() async {
     final provider = await activeProvider();
+    if (provider == null) {
+      return (provider: null, apiKey: null, enabled: false);
+    }
     final apiKey = await readApiKey(provider: provider);
     // The invariant [isEnabled] has always enforced, stated here once: the
     // flag alone never means "on" — a provider with no key is off whatever
@@ -150,6 +181,18 @@ class AiCredentialStorage {
         apiKey != null && await _storage.read(key: _enabledTag) != 'false';
     return (provider: provider, apiKey: apiKey, enabled: enabled);
   }
+
+  /// The provider these per-provider methods should act on: the one named,
+  /// or the active one — and **null when the active one is a name this build
+  /// does not know**.
+  ///
+  /// Every read below then answers "nothing" rather than substituting a
+  /// default, which is the whole point of #753: an unknown selection must not
+  /// resolve to somebody. The writes answer nothing too, and that path is
+  /// unreachable in practice — choosing a provider in the dialog passes one
+  /// explicitly and clears the unknown state on the way.
+  Future<AiProvider?> _target(AiProvider? provider) async =>
+      provider ?? await activeProvider();
 
   /// What a row shows for the feature, in one read of the store.
   Future<AiAssistSummary> readSummary() async {
@@ -171,11 +214,14 @@ class AiCredentialStorage {
     final state = await _readState();
     if (!state.enabled) return null;
     final apiKey = state.apiKey;
-    if (apiKey == null) return null;
+    final provider = state.provider;
+    // Both are already implied by `enabled`, which is false without a
+    // provider and without a key. Stated so the types carry it too.
+    if (apiKey == null || provider == null) return null;
     return AiSelection(
-      provider: state.provider,
+      provider: provider,
       apiKey: apiKey,
-      modelId: await readModel(provider: state.provider),
+      modelId: await readModel(provider: provider),
     );
   }
 
@@ -188,13 +234,15 @@ class AiCredentialStorage {
   /// decides what an unknown id means, so retiring a model is a change in
   /// one file rather than a migration here.
   Future<String?> readModel({AiProvider? provider}) async {
-    final target = provider ?? await activeProvider();
+    final target = await _target(provider);
+    if (target == null) return null;
     final value = await _storage.read(key: _modelSlotTag(target));
     return (value == null || value.isEmpty) ? null : value;
   }
 
   Future<void> writeModel(String modelId, {AiProvider? provider}) async {
-    final target = provider ?? await activeProvider();
+    final target = await _target(provider);
+    if (target == null) return;
     await _storage.write(key: _modelSlotTag(target), value: modelId);
   }
 
@@ -207,7 +255,8 @@ class AiCredentialStorage {
   /// moment where a credential exists half-moved, and an older build rolled
   /// back onto the same device still finds the key where it expects it.
   Future<String?> readApiKey({AiProvider? provider}) async {
-    final target = provider ?? await activeProvider();
+    final target = await _target(provider);
+    if (target == null) return null;
 
     final value = await _storage.read(key: _slotTag(target));
     if (value != null && value.isNotEmpty) return value;
@@ -223,7 +272,8 @@ class AiCredentialStorage {
   /// value clears instead of writing an empty credential that would later
   /// fail as a puzzling 401.
   Future<void> writeApiKey(String apiKey, {AiProvider? provider}) async {
-    final target = provider ?? await activeProvider();
+    final target = await _target(provider);
+    if (target == null) return;
     final trimmed = apiKey.trim();
     if (trimmed.isEmpty) {
       await clear(provider: target);
@@ -250,7 +300,8 @@ class AiCredentialStorage {
   /// key they just deleted. Pressing "remove key" and still having a working
   /// key afterwards is the worst failure this class can produce.
   Future<void> clear({AiProvider? provider}) async {
-    final target = provider ?? await activeProvider();
+    final target = await _target(provider);
+    if (target == null) return;
 
     await _storage.delete(key: _slotTag(target));
     await _retireLegacyTagFor(target);

--- a/lib/features/add_meal/presentation/screens/bulk_add_screen.dart
+++ b/lib/features/add_meal/presentation/screens/bulk_add_screen.dart
@@ -81,10 +81,14 @@ class _BulkAddScreenState extends State<BulkAddScreen> {
   ///
   /// Deliberately not `readSelection()`: that carries the API key, and
   /// nothing in the widget layer has any business holding it.
-  late final Future<({AiProvider provider, AiModel model})> _photoDestination =
+  /// Null when the stored provider is a name this build does not know. The
+  /// sheet cannot name a destination it cannot identify, so it does not open
+  /// — the same outcome as a provider with no key, and the point of #753.
+  late final Future<({AiProvider provider, AiModel model})?> _photoDestination =
       () async {
         final storage = locator<AiCredentialStorage>();
         final provider = await storage.activeProvider();
+        if (provider == null) return null;
         return (
           provider: provider,
           model: AiModelCatalogue.resolve(
@@ -605,6 +609,10 @@ class _BulkAddScreenState extends State<BulkAddScreen> {
     FocusScope.of(context).unfocus();
     final destination = await _photoDestination;
     if (!mounted) return;
+    // Refusing rather than guessing: with no identifiable destination there
+    // is no honest sentence to put in the sheet, and the sheet is the last
+    // moment the user can decline.
+    if (destination == null) return;
     final disclosure = switch (destination.provider) {
       AiProvider.anthropic => S.of(context).bulkAddPhotoDisclosureAnthropic,
       AiProvider.openrouter =>

--- a/lib/features/onboarding/presentation/widgets/onboarding_other_options_page_body.dart
+++ b/lib/features/onboarding/presentation/widgets/onboarding_other_options_page_body.dart
@@ -78,7 +78,8 @@ class _OnboardingOtherOptionsPageBodyState
   /// keeps, read from the same store.
   bool? _aiHasKey;
   bool _aiEnabled = false;
-  AiProvider _aiProvider = AiProvider.anthropic;
+  /// Null when the stored name is unrecognised — see #753.
+  AiProvider? _aiProvider;
 
   @override
   void initState() {

--- a/lib/features/settings/presentation/widgets/ai_assist_dialog.dart
+++ b/lib/features/settings/presentation/widgets/ai_assist_dialog.dart
@@ -87,15 +87,20 @@ class _AiAssistDialogState extends State<AiAssistDialog> {
   /// provider rather than to the dialog.
   Future<void> _load() async {
     final summary = await widget.storage.readSummary();
-    final modelId = await widget.storage.readModel(
-      provider: summary.provider,
-    );
+    // A stored name this build does not know leaves nothing to select, so the
+    // radios fall back to the first provider **for display only**. Nothing is
+    // written here — `_load` only reads — so the unrecognised tag survives
+    // until the user chooses, and re-upgrading restores what they picked.
+    // Meanwhile the feature stays unavailable, because `readSelection()`
+    // refuses independently of what this dialog is showing. #753.
+    final provider = summary.provider ?? AiProvider.anthropic;
+    final modelId = await widget.storage.readModel(provider: provider);
     if (!mounted) return;
     setState(() {
-      _provider = summary.provider;
-      _hasKey = summary.hasKey;
+      _provider = provider;
+      _hasKey = summary.provider == null ? false : summary.hasKey;
       _enabled = summary.enabled;
-      _model = AiModelCatalogue.resolve(summary.provider, modelId);
+      _model = AiModelCatalogue.resolve(provider, modelId);
       _loading = false;
     });
   }

--- a/lib/features/settings/settings_screen.dart
+++ b/lib/features/settings/settings_screen.dart
@@ -68,7 +68,8 @@ class _SettingsScreenState extends State<SettingsScreen> {
   /// than briefly claiming the feature is off.
   bool? _aiHasKey;
   bool _aiEnabled = false;
-  AiProvider _aiProvider = AiProvider.anthropic;
+  /// Null when the stored name is unrecognised — see #753.
+  AiProvider? _aiProvider;
 
   @override
   void initState() {

--- a/test/unit_test/ai_credential_storage_test.dart
+++ b/test/unit_test/ai_credential_storage_test.dart
@@ -338,12 +338,85 @@ void main() {
       expect(backing.store['AiProviderTag'], 'openrouter');
     });
 
-    test('reads as Anthropic when it holds something unrecognised', () async {
-      // A downgrade, or a provider removed in a later build. Falling back to
-      // the default beats refusing to start.
+    test('reads as unknown when it holds something unrecognised', () async {
+      // **This is a deliberate reversal of shipped behaviour, not a bug fix.**
+      // This test used to assert the opposite — "reads as Anthropic" — with
+      // the reasoning "falling back to the default beats refusing to start".
+      // #688 rejected exactly that and was never implemented; #753 implements
+      // it. A newer build writes a provider name, the user downgrades, and
+      // reading that word as Anthropic sends their meals to a company they
+      // did not choose.
       backing.store['AiProviderTag'] = 'some-provider-we-dropped';
 
+      expect(await storage.activeProvider(), isNull);
+    });
+
+    test('reads as Anthropic when nothing is stored at all', () async {
+      // The other half of #688, unchanged: absent still defaults. That is what
+      // keeps an install from before providers existed valid without writing
+      // to it, and it is not what this reversal touches.
       expect(await storage.activeProvider(), AiProvider.anthropic);
+    });
+  });
+
+  group('a provider name this build does not know', () {
+    // The scenario is a downgrade after picking a provider a later build
+    // added. The person most likely to be in it tried a hosted provider
+    // first and moved away from it, so the old key is still in its slot —
+    // which is what makes the redirect send for real rather than fail.
+
+    setUp(() async {
+      await storage.writeApiKey('sk-anthropic', provider: AiProvider.anthropic);
+      await storage.setEnabled(true);
+      backing.store['AiProviderTag'] = 'a-provider-from-a-later-build';
+    });
+
+    test('sends nothing, rather than sending to Anthropic', () async {
+      expect(
+        await storage.readSelection(),
+        isNull,
+        reason: 'the one failure #688 said cannot be allowed to be quiet',
+      );
+    });
+
+    test('reports the feature unavailable rather than configured', () async {
+      final summary = await storage.readSummary();
+
+      expect(summary.provider, isNull);
+      expect(summary.enabled, isFalse);
+      expect(
+        summary.hasKey,
+        isFalse,
+        reason: 'there is no active provider whose key this could be',
+      );
+      expect(await storage.isEnabled(), isFalse);
+    });
+
+    test('does not hand back the stranded key through the default path', () async {
+      // `readApiKey()` with no argument resolves the active provider. With
+      // that unknown there is no slot to read, and answering with Anthropic's
+      // key would be the same defect wearing a different method name.
+      expect(await storage.readApiKey(), isNull);
+      expect(await storage.readModel(), isNull);
+    });
+
+    test('leaves the tag in place, so re-upgrading restores the choice', () async {
+      await storage.readSelection();
+      await storage.readSummary();
+
+      expect(
+        backing.store['AiProviderTag'],
+        'a-provider-from-a-later-build',
+        reason: 'destroying the selection makes re-upgrading a second surprise',
+      );
+    });
+
+    test('the key itself survives, and is reachable when named', () async {
+      // Nothing is deleted — only refused while the selection is unreadable.
+      expect(
+        await storage.readApiKey(provider: AiProvider.anthropic),
+        'sk-anthropic',
+      );
     });
   });
 


### PR DESCRIPTION
Closes #753.

[#688](https://github.com/simonoppowa/OpenNutriTracker/issues/688) resolved this and it was never built:

> **absent keeps defaulting; unrecognised makes the feature quietly unavailable.**

`AiProvider.fromTag` still read any name it did not know as Anthropic — and a test **asserted** that, with the exact reasoning #688 rejected: *"Falling back to the default beats refusing to start."*

## Why it matters now

It has been harmless only because nothing writes an unknown tag. Adding a fourth provider writes one.

The exposed user is not hypothetical, and is the likeliest person here: someone who tried a hosted provider first and moved away for privacy. **Their old key is still in its slot**, so the redirect sends for real rather than failing — meals going to a company they deliberately stopped using, while Settings says otherwise. #688 called that *"the one failure mode that cannot be allowed to be quiet"*, in an app whose README enumerates its destinations.

This is also the prefactor for the rest of [map #732](https://github.com/simonoppowa/OpenNutriTracker/issues/732), which is why it lands before the fourth member exists rather than alongside it.

## What changed

`activeProvider()` returns null for a name this build does not know. Every read then answers *nothing* instead of substituting somebody:

- `readSelection()` refuses, so **no request is sent**.
- `readApiKey()` and `readModel()` refuse through the default path — answering with Anthropic's key there would be the same defect wearing a different method name.
- `readSummary()` reports the feature unavailable without naming a company.
- The photo sheet does not open: it cannot name a destination it cannot identify, and that sheet is the last moment a user can decline.

**Absent still defaults to Anthropic.** That is what keeps a pre-provider install valid with no migration, and it is untouched.

**The tag is left in place**, deliberately — destroying the selection would make re-upgrading a second surprise.

One helper resolves the target for the five per-provider methods, rather than nine separate guards. The dialog falls back to the first provider **for display only** and writes nothing on load, so an unrecognised tag survives being looked at.

## The inverted test

`reads as Anthropic when it holds something unrecognised` becomes `reads as unknown`, and carries a comment stating this is a **deliberate reversal of shipped behaviour, not a bug fix** — so the next reader does not helpfully restore it. A second test pins the half that did not change: absent still defaults.

Five new tests cover the downgrade scenario with a key present: nothing sent, feature reported unavailable, the stranded key not returned through the default path, the tag preserved, and the key still reachable when named explicitly.

## Verification

**1412 tests**, analyzer clean.

**Four mutations, all caught:**

| Mutation | Caught by |
| --- | --- |
| restore the old unknown → Anthropic fallback | two named tests |
| let `readApiKey()` fall back to Anthropic | named test |
| clear the tag on reading it | named test |
| drop the photo-sheet guard | **the type system** — the nullable provider makes the guard mandatory |

No strings, no schema change, no migration.
