### PR TITLE
feat(add-meal): point the OpenAI-compatible client at any endpoint

### DIFF
--- a/lib/features/add_meal/data/meal_items_api_factory.dart
+++ b/lib/features/add_meal/data/meal_items_api_factory.dart
@@ -3,7 +3,7 @@ import 'package:opennutritracker/core/utils/ai_credential_storage.dart';
 import 'package:opennutritracker/core/utils/ai_model_catalogue.dart';
 import 'package:opennutritracker/features/add_meal/data/anthropic_meal_items_api.dart';
 import 'package:opennutritracker/features/add_meal/data/openai_meal_items_api.dart';
-import 'package:opennutritracker/features/add_meal/data/openrouter_meal_items_api.dart';
+import 'package:opennutritracker/features/add_meal/data/openai_compatible_meal_items_api.dart';
 import 'package:opennutritracker/features/add_meal/domain/meal_items_api.dart';
 
 /// Turns a stored selection into the client that will carry it.
@@ -26,7 +26,7 @@ MealItemsApi mealItemsApiFor(http.Client client, AiSelection selection) {
       () => selection.apiKey,
       model: model.id,
     ),
-    AiProvider.openrouter => OpenRouterMealItemsApi(
+    AiProvider.openrouter => OpenAiCompatibleMealItemsApi.openRouter(
       client,
       () => selection.apiKey,
       model: model.id,

--- a/lib/features/add_meal/data/openai_compatible_meal_items_api.dart
+++ b/lib/features/add_meal/data/openai_compatible_meal_items_api.dart
@@ -16,23 +16,40 @@ import 'package:opennutritracker/features/add_meal/util/meal_text_parser.dart';
 /// generation arrives as HTTP 200. Every one of those is a place a shared
 /// class would need a provider check, and a class that is a chain of provider
 /// checks is two classes with extra steps.
-class OpenRouterMealItemsApi implements MealItemsApi {
-  static final _log = Logger('OpenRouterMealItemsApi');
+/// How hard the request insists on a tool call, which is the one thing the
+/// OpenAI-compatible runtimes genuinely disagree about.
+///
+/// Measured in #733: only vLLM honours a named function. llama.cpp parses
+/// `tool_choice` as a *string* and silently downgrades an object to `"auto"`
+/// — no error, the forcing simply discarded. **Ollama has no such field at
+/// all.** With one tool defined, `"required"` says what the app means
+/// wherever it exists.
+///
+/// An explicit mode rather than an `if`, because this is a behavioural fork
+/// and not a formatting one: it changes what the model is asked to do, and a
+/// shared class is exactly where that would otherwise grow into a chain of
+/// provider checks.
+enum ToolChoiceMode {
+  /// `{"type": "function", "function": {"name": ...}}`.
+  namedFunction,
 
-  static const _endpoint = 'https://openrouter.ai/api/v1/chat/completions';
+  /// `"required"` — any tool, and there is only one.
+  anyTool,
 
-  static const _maxTokens = 1024;
+  /// Omitted. The model may answer in prose, which surfaces as the existing
+  /// *no tool call* failure rather than as a wrong number.
+  unforced,
+}
 
-  static const defaultTimeout = Duration(seconds: 20);
-
-  final http.Client _client;
-  final String Function() _apiKey;
-
-  /// No default. Which model is fit for this is a curation question with an
-  /// answer that will change, and a constant here would quietly become that
-  /// answer.
-  final String model;
-
+/// The facts that are true only when OpenRouter is in the path.
+///
+/// Grouped rather than passed as three parameters because they are one
+/// thing: the routing block, the metadata header and the pin check all exist
+/// to constrain and then verify a **broker**. Pointed at a machine in the
+/// user's house there is no broker, and a request asserting
+/// `data_collection: "deny"` to their own server is a claim the app cannot
+/// mean.
+class OpenRouterBroker {
   /// Providers this request may be served by, or null to let OpenRouter
   /// route freely.
   ///
@@ -43,15 +60,88 @@ class OpenRouterMealItemsApi implements MealItemsApi {
   /// Bedrock on all three attempts.
   final List<String>? providers;
 
+  const OpenRouterBroker({this.providers});
+}
+
+/// Asks a model for food items over the OpenAI-compatible wire format.
+///
+/// One class for OpenRouter **and** for a server the user runs, because #733
+/// measured that everything below the wire format is byte-identical across
+/// OpenRouter, Ollama, LM Studio, llama.cpp and vLLM: the tool wrapper, the
+/// data-URI image, arguments-as-a-string, and every guarantee enforced in
+/// Dart afterwards. Only *policy* differs, and policy is what a parameter is
+/// for.
+///
+/// That is the opposite of the split from [AnthropicMealItemsApi], which
+/// exists because those two agree on nothing about shape.
+class OpenAiCompatibleMealItemsApi implements MealItemsApi {
+  static final _log = Logger('OpenAiCompatibleMealItemsApi');
+
+  static final openRouterEndpoint = Uri.parse(
+    'https://openrouter.ai/api/v1/chat/completions',
+  );
+
+  static const _maxTokens = 1024;
+
+  static const defaultTimeout = Duration(seconds: 20);
+
+  final http.Client _client;
+
+  /// Null when the destination wants no credential, which is the normal state
+  /// for a locally-run server. No `authorization` header is sent then — the
+  /// runtimes ignore a stray one, but sending a bearer token to a machine
+  /// that never asked for one is not something to do by accident.
+  final String Function()? _apiKey;
+
+  /// Where the request goes. A field rather than a constant, which is the
+  /// whole of what makes a user-supplied server reachable.
+  final Uri endpoint;
+
+  /// Null when nothing is brokering the request.
+  final OpenRouterBroker? broker;
+
+  final ToolChoiceMode toolChoice;
+
+  /// What a status code means here. A parameter because the same number does
+  /// not mean the same thing to every destination — #695 — and a local
+  /// runtime's 404 is "that model is not pulled", not "that model was
+  /// retired".
+  final MealInterpreterFailure Function(int statusCode) failureFor;
+
+  /// No default. Which model is fit for this is a curation question with an
+  /// answer that will change, and a constant here would quietly become that
+  /// answer.
+  final String model;
+
   final Duration timeout;
 
-  OpenRouterMealItemsApi(
+  OpenAiCompatibleMealItemsApi(
     this._client,
     this._apiKey, {
     required this.model,
-    this.providers,
+    required this.endpoint,
+    this.broker,
+    this.toolChoice = ToolChoiceMode.namedFunction,
+    this.failureFor = openRouterFailureFor,
     this.timeout = defaultTimeout,
   });
+
+  /// The OpenRouter configuration, named so call sites read as intent rather
+  /// than as five arguments.
+  factory OpenAiCompatibleMealItemsApi.openRouter(
+    http.Client client,
+    String Function() apiKey, {
+    required String model,
+    List<String>? providers,
+    Duration timeout = defaultTimeout,
+  }) => OpenAiCompatibleMealItemsApi(
+    client,
+    apiKey,
+    model: model,
+    endpoint: openRouterEndpoint,
+    broker: OpenRouterBroker(providers: providers),
+    timeout: timeout,
+  );
 
   @override
   Future<MealTextParseResult> requestItems({
@@ -109,11 +199,14 @@ class OpenRouterMealItemsApi implements MealItemsApi {
           },
         },
       ],
-      'tool_choice': {
-        'type': 'function',
-        'function': {'name': mealItemsToolName},
-      },
-      'provider': {
+      if (toolChoice == ToolChoiceMode.namedFunction)
+        'tool_choice': {
+          'type': 'function',
+          'function': {'name': mealItemsToolName},
+        }
+      else if (toolChoice == ToolChoiceMode.anyTool)
+        'tool_choice': 'required',
+      if (broker != null) 'provider': {
         // Without this, OpenRouter documents that a provider which does not
         // support a parameter still receives the request and ignores it —
         // and `tool_choice` is not in the set it steers by. A dropped
@@ -131,7 +224,10 @@ class OpenRouterMealItemsApi implements MealItemsApi {
         // suffix, so slug inspection would be a check that looks like one
         // and is not.
         'data_collection': 'deny',
-        if (providers != null) ...{'only': providers, 'allow_fallbacks': false},
+        if (broker?.providers case final only?) ...{
+          'only': only,
+          'allow_fallbacks': false,
+        },
       },
     });
 
@@ -139,16 +235,18 @@ class OpenRouterMealItemsApi implements MealItemsApi {
     try {
       response = await _client
           .post(
-            Uri.parse(_endpoint),
+            endpoint,
             headers: {
               'content-type': 'application/json',
-              'authorization': 'Bearer ${_apiKey()}',
+              if (_apiKey?.call() case final key? when key.isNotEmpty)
+                'authorization': 'Bearer $key',
               // Opts the reply into `openrouter_metadata`, which names the
               // provider that actually served the request. Without it the
               // response says nothing about who received the payload, and a
               // project that invites you to verify its destination list
-              // cannot be structurally unable to name one.
-              'x-openrouter-metadata': 'enabled',
+              // cannot be structurally unable to name one. Meaningless to a
+              // server the user runs, so it is not sent there.
+              if (broker != null) 'x-openrouter-metadata': 'enabled',
               // Deliberately no HTTP-Referer or X-Title. Those are
               // OpenRouter's app-attribution headers and they put the app on
               // a public leaderboard, which is not something to opt a user
@@ -168,7 +266,7 @@ class OpenRouterMealItemsApi implements MealItemsApi {
       _log.warning('Interpreter call failed with ${response.statusCode}');
       throw MealInterpreterException(
         'provider returned ${response.statusCode}',
-        failure: _failureFor(response.statusCode),
+        failure: failureFor(response.statusCode),
         statusCode: response.statusCode,
       );
     }
@@ -198,7 +296,7 @@ class OpenRouterMealItemsApi implements MealItemsApi {
   /// absent on cache hits and on failures that never reached the router, so
   /// absence is not a finding.
   void _warnIfThePinDidNotHold(Map<String, dynamic> decoded) {
-    final pinned = providers;
+    final pinned = broker?.providers;
     if (pinned == null) return;
 
     final metadata = decoded['openrouter_metadata'];
@@ -291,7 +389,7 @@ class OpenRouterMealItemsApi implements MealItemsApi {
     throw MealInterpreterException(
       'generation failed',
       failure: code is int
-          ? _failureFor(code)
+          ? failureFor(code)
           : MealInterpreterFailure.transient,
       statusCode: code is int ? code : null,
     );
@@ -315,7 +413,7 @@ class OpenRouterMealItemsApi implements MealItemsApi {
   /// client: a corpus of real photographs found JPEGs carrying Adobe APP14
   /// markers refused with a 400 every time, while the same picture re-encoded
   /// went through.
-  static MealInterpreterFailure _failureFor(int statusCode) =>
+  static MealInterpreterFailure openRouterFailureFor(int statusCode) =>
       switch (statusCode) {
         401 => MealInterpreterFailure.auth,
         // **403 is not auth here**, unlike on the direct client, where it is

--- a/lib/features/add_meal/data/openai_meal_items_api.dart
+++ b/lib/features/add_meal/data/openai_meal_items_api.dart
@@ -8,7 +8,7 @@ import 'package:opennutritracker/features/add_meal/util/meal_text_parser.dart';
 /// Asks an OpenAI model for food items, reached directly.
 ///
 /// A third sibling rather than a shared OpenAI-dialect base with
-/// [OpenRouterMealItemsApi], settled in #685 by measurement: only three
+/// [OpenAiCompatibleMealItemsApi], settled in #685 by measurement: only three
 /// elements transfer between them. OpenRouter speaks *Chat Completions*,
 /// where tools nest inside a `function` object and the system prompt is the
 /// first message; this speaks *Responses*, where tools are flat and the

--- a/test/unit_test/meal_items_api_contract_test.dart
+++ b/test/unit_test/meal_items_api_contract_test.dart
@@ -6,7 +6,7 @@ import 'package:http/http.dart' as http;
 import 'package:logging/logging.dart';
 import 'package:opennutritracker/features/add_meal/data/anthropic_meal_items_api.dart';
 import 'package:opennutritracker/features/add_meal/data/openai_meal_items_api.dart';
-import 'package:opennutritracker/features/add_meal/data/openrouter_meal_items_api.dart';
+import 'package:opennutritracker/features/add_meal/data/openai_compatible_meal_items_api.dart';
 import 'package:opennutritracker/features/add_meal/domain/meal_items_api.dart';
 
 /// The rules every [MealItemsApi] must obey, whatever wire format it speaks.
@@ -240,11 +240,56 @@ final _contracts = <_ClientContract>[
     }),
   ),
   _ClientContract(
-    name: 'OpenRouterMealItemsApi',
-    build: (client, {required timeout}) => OpenRouterMealItemsApi(
+    name: 'OpenAiCompatibleMealItemsApi (OpenRouter)',
+    build: (client, {required timeout}) => OpenAiCompatibleMealItemsApi.openRouter(
       client,
       () => 'test-key',
       model: 'anthropic/claude-haiku-4.5',
+      timeout: timeout,
+    ),
+    toolReply: (items) => jsonEncode({
+      'id': 'gen_1',
+      'choices': [
+        {
+          'finish_reason': 'tool_calls',
+          'message': {
+            'role': 'assistant',
+            'tool_calls': [
+              {
+                'id': 'call_1',
+                'type': 'function',
+                'function': {
+                  'name': mealItemsToolName,
+                  'arguments': jsonEncode({'items': items}),
+                },
+              },
+            ],
+          },
+        },
+      ],
+    }),
+    noToolCall: jsonEncode({
+      'id': 'gen_1',
+      'choices': [
+        {
+          'finish_reason': 'stop',
+          'message': {'role': 'assistant', 'content': 'Here are the foods.'},
+        },
+      ],
+    }),
+  ),
+  _ClientContract(
+    name: 'OpenAiCompatibleMealItemsApi (a server the user runs)',
+    // No broker, no credential, and no forcing by name — the configuration
+    // #733 measured against Ollama, which has no `tool_choice` field at all.
+    // The guarantees below must hold identically, because none of them was
+    // ever the destination's to keep. #754.
+    build: (client, {required timeout}) => OpenAiCompatibleMealItemsApi(
+      client,
+      null,
+      model: 'gemma3:4b',
+      endpoint: Uri.parse('http://192.168.1.5:11434/v1/chat/completions'),
+      toolChoice: ToolChoiceMode.unforced,
       timeout: timeout,
     ),
     toolReply: (items) => jsonEncode({

--- a/test/unit_test/openai_compatible_endpoint_test.dart
+++ b/test/unit_test/openai_compatible_endpoint_test.dart
@@ -1,0 +1,222 @@
+import 'dart:convert';
+
+import 'package:flutter_test/flutter_test.dart';
+import 'package:http/http.dart' as http;
+import 'package:opennutritracker/features/add_meal/data/openai_compatible_meal_items_api.dart';
+import 'package:opennutritracker/features/add_meal/domain/meal_items_api.dart';
+
+import 'openrouter_meal_items_api_test.dart' show FakeClient;
+
+/// The client pointed at a server the user runs. #754.
+///
+/// The OpenRouter configuration is covered by its own suite and is unchanged;
+/// what is new here is everything that must **not** be sent when there is no
+/// broker in the path, and the forcing mode, which is the one thing the
+/// runtimes genuinely disagree about (#733).
+void main() {
+  final endpoint = Uri.parse('http://192.168.1.5:11434/v1/chat/completions');
+
+  String replyWith(String query) => jsonEncode({
+    'choices': [
+      {
+        'message': {
+          'tool_calls': [
+            {
+              'function': {
+                'name': mealItemsToolName,
+                'arguments': jsonEncode({
+                  'items': [
+                    {'query': query},
+                  ],
+                }),
+              },
+            },
+          ],
+        },
+      },
+    ],
+  });
+
+  OpenAiCompatibleMealItemsApi apiFor(
+    http.Client client, {
+    String Function()? apiKey,
+    ToolChoiceMode toolChoice = ToolChoiceMode.anyTool,
+    MealInterpreterFailure Function(int)? failureFor,
+  }) => OpenAiCompatibleMealItemsApi(
+    client,
+    apiKey,
+    model: 'gemma3:4b',
+    endpoint: endpoint,
+    toolChoice: toolChoice,
+    failureFor:
+        failureFor ?? OpenAiCompatibleMealItemsApi.openRouterFailureFor,
+  );
+
+  Future<void> send(OpenAiCompatibleMealItemsApi api) => api.requestItems(
+    content: const MealTextContent('two eggs'),
+    system: 'system',
+  );
+
+  test('posts to the endpoint it was given, not a compiled-in one', () async {
+    final client = FakeClient(body: replyWith('eggs'));
+
+    final result = await apiFor(client).requestItems(
+      content: const MealTextContent('two eggs'),
+      system: 'system',
+    );
+
+    expect(client.sentUrl, endpoint);
+    expect(result.items.single.query, 'eggs');
+  });
+
+  group('what must not be sent to a machine in the user\'s house', () {
+    test('no routing block', () async {
+      // Nothing rejects it — #733 found all four runtimes ignore unknown
+      // top-level keys — but every key in it asserts something about a broker
+      // that is not in the path. `data_collection: "deny"` addressed to the
+      // user's own server is a claim the app cannot mean.
+      final client = FakeClient(body: replyWith('eggs'));
+
+      await send(apiFor(client));
+
+      expect(client.sentBody, isNot(contains('provider')));
+    });
+
+    test('no OpenRouter metadata header', () async {
+      final client = FakeClient(body: replyWith('eggs'));
+
+      await send(apiFor(client));
+
+      expect(client.sentHeaders, isNot(contains('x-openrouter-metadata')));
+    });
+
+    test('no authorization header when there is no key', () async {
+      // The runtimes ignore a stray bearer token, but sending a credential to
+      // a machine that never asked for one is not something to do by
+      // accident.
+      final client = FakeClient(body: replyWith('eggs'));
+
+      await send(apiFor(client, apiKey: null));
+
+      expect(client.sentHeaders, isNot(contains('authorization')));
+    });
+
+    test('nor when the key is present but blank', () async {
+      final client = FakeClient(body: replyWith('eggs'));
+
+      await send(apiFor(client, apiKey: () => ''));
+
+      expect(client.sentHeaders, isNot(contains('authorization')));
+    });
+
+    test('but it is sent when the user supplied one', () async {
+      // vLLM and llama.cpp both take an optional `--api-key`.
+      final client = FakeClient(body: replyWith('eggs'));
+
+      await send(apiFor(client, apiKey: () => 'sk-local'));
+
+      expect(client.sentHeaders?['authorization'], 'Bearer sk-local');
+    });
+  });
+
+  group('the forcing mode, which is the real fork', () {
+    test('anyTool asks for "required"', () async {
+      // What the app means with one tool defined, and what vLLM, llama.cpp
+      // (with --jinja) and LM Studio's llama.cpp engine accept.
+      final client = FakeClient(body: replyWith('eggs'));
+
+      await send(apiFor(client, toolChoice: ToolChoiceMode.anyTool));
+
+      expect(client.sentBody?['tool_choice'], 'required');
+    });
+
+    test('namedFunction asks for the tool by name', () async {
+      // Only vLLM enforces this. llama.cpp parses `tool_choice` as a string
+      // and silently downgrades an object to "auto".
+      final client = FakeClient(body: replyWith('eggs'));
+
+      await send(apiFor(client, toolChoice: ToolChoiceMode.namedFunction));
+
+      expect(
+        client.sentBody?['tool_choice'],
+        {
+          'type': 'function',
+          'function': {'name': mealItemsToolName},
+        },
+      );
+    });
+
+    test('unforced omits the field entirely', () async {
+      // Ollama has no `tool_choice` field at all, so there is nothing to ask
+      // for and sending one would be noise.
+      final client = FakeClient(body: replyWith('eggs'));
+
+      await send(apiFor(client, toolChoice: ToolChoiceMode.unforced));
+
+      expect(client.sentBody, isNot(contains('tool_choice')));
+    });
+
+    test('an unforced model answering in prose is a handled failure', () async {
+      // The usefulness cliff on Ollama. It must surface as the existing "no
+      // tool call" refusal — never as a malformed response, and never as an
+      // invented number.
+      final client = FakeClient(
+        body: jsonEncode({
+          'choices': [
+            {
+              'message': {'content': 'You ate two eggs, about 140 kcal.'},
+            },
+          ],
+        }),
+      );
+
+      await expectLater(
+        send(apiFor(client, toolChoice: ToolChoiceMode.unforced)),
+        throwsA(isA<MealInterpreterException>()),
+      );
+    });
+  });
+
+  test('the schema still carries no macro fields on this path', () async {
+    // The provenance guarantee does not depend on the destination, and a
+    // fourth destination is exactly when that is worth re-asserting.
+    final client = FakeClient(body: replyWith('eggs'));
+
+    await send(apiFor(client));
+
+    final tool = (client.sentBody?['tools'] as List).single as Map;
+    final params =
+        (tool['function'] as Map)['parameters'] as Map<String, dynamic>;
+    final item =
+        ((params['properties'] as Map)['items'] as Map)['items'] as Map;
+    expect(
+      (item['properties'] as Map).keys,
+      unorderedEquals(['query', 'quantity', 'unit']),
+    );
+  });
+
+  test('the failure table is the caller\'s, not a static one', () async {
+    // #695: the same number does not mean the same thing to every
+    // destination. A local runtime's 404 is "that model is not pulled", not
+    // "that model was retired".
+    final client = FakeClient(status: 404, body: '{}');
+
+    await expectLater(
+      send(
+        apiFor(
+          client,
+          failureFor: (status) => status == 404
+              ? MealInterpreterFailure.rejected
+              : MealInterpreterFailure.transient,
+        ),
+      ),
+      throwsA(
+        isA<MealInterpreterException>().having(
+          (e) => e.failure,
+          'failure',
+          MealInterpreterFailure.rejected,
+        ),
+      ),
+    );
+  });
+}

--- a/test/unit_test/openrouter_meal_items_api_test.dart
+++ b/test/unit_test/openrouter_meal_items_api_test.dart
@@ -6,7 +6,7 @@ import 'package:flutter_test/flutter_test.dart';
 import 'package:http/http.dart' as http;
 import 'package:logging/logging.dart';
 import 'package:opennutritracker/features/add_meal/data/model_meal_photo_interpreter.dart';
-import 'package:opennutritracker/features/add_meal/data/openrouter_meal_items_api.dart';
+import 'package:opennutritracker/features/add_meal/data/openai_compatible_meal_items_api.dart';
 import 'package:opennutritracker/features/add_meal/domain/meal_items_api.dart';
 import 'package:opennutritracker/features/add_meal/domain/meal_photo_interpreter.dart';
 import 'package:opennutritracker/features/add_meal/util/meal_text_parser.dart';
@@ -96,12 +96,12 @@ String toolReply(
   ],
 });
 
-OpenRouterMealItemsApi apiWith(
+OpenAiCompatibleMealItemsApi apiWith(
   FakeClient client, {
   String model = 'anthropic/claude-haiku-4.5',
   List<String>? providers,
-  Duration timeout = OpenRouterMealItemsApi.defaultTimeout,
-}) => OpenRouterMealItemsApi(
+  Duration timeout = OpenAiCompatibleMealItemsApi.defaultTimeout,
+}) => OpenAiCompatibleMealItemsApi.openRouter(
   client,
   () => 'test-key',
   model: model,
@@ -110,7 +110,7 @@ OpenRouterMealItemsApi apiWith(
 );
 
 Future<MealTextParseResult> request(
-  OpenRouterMealItemsApi api, {
+  OpenAiCompatibleMealItemsApi api, {
   MealContent content = const MealTextContent('toast'),
 }) => api.requestItems(content: content, system: 'system prompt');
 


### PR DESCRIPTION
Closes #754.

[#733](https://github.com/simonoppowa/OpenNutriTracker/issues/733) measured that a fourth sibling client is **not** needed. Across OpenRouter, Ollama, LM Studio, llama.cpp and vLLM, everything below the wire format is byte-identical — the tool wrapper, the data-URI image, arguments-as-a-string, and every guarantee enforced in Dart afterwards. Only **policy** differs, and policy is what a parameter is for.

That is the opposite of the Anthropic/OpenRouter split, which exists because those two *"agree on nothing"* about shape.

## The rename

`OpenRouterMealItemsApi` → **`OpenAiCompatibleMealItemsApi`**. The old name becomes a lie the moment it serves Ollama, and this project has spent too long making names carry guarantees to ship one that does not. An `.openRouter` factory keeps that call site reading as intent rather than as five arguments, so the existing behaviour is unchanged and its tests pass untouched.

## Five deltas, four parameters

Three of the five are **one fact**. The routing block, the metadata header and the pin check all exist to constrain and then verify a **broker** — pointed at a machine in the user's house there is no broker, so they travel together as a nullable `OpenRouterBroker` rather than as three independent flags.

Nothing rejects the block; #733 found all four runtimes ignore unknown top-level keys. It comes off because `data_collection: "deny"` addressed to the user's own server is **a claim the app cannot mean**.

`tool_choice` becomes an explicit **mode**, not an `if`, because it is a behavioural fork rather than a formatting one:

| Runtime | What it does with a named function |
| --- | --- |
| vLLM | honours and enforces it |
| llama.cpp | parses `tool_choice` as a *string* — **silently downgrades an object to `"auto"`** |
| Ollama | **no such field at all** |
| LM Studio | `auto` / `none` / `required` only |

So the modes are `namedFunction`, `anyTool` (`"required"`, which is what the app means with one tool defined) and `unforced`. An unforced model answering in prose stays a **handled failure** — the existing no-tool-call refusal, never an invented number.

The auth header is sent only when a key exists and is non-blank. The failure table is the caller's, since [#695](https://github.com/simonoppowa/OpenNutriTracker/issues/695) already established that the same number does not mean the same thing to every destination.

## Tests

**The contract test now runs both configurations of the class** — brokered and user-run — so the six guarantees are proven against the shape that has no key, no broker and no forcing, not only against the one that has all three.

Twelve new tests, organised around what must **not** be sent to a machine in the user's house, plus the forcing modes and the caller-supplied failure table. The no-macro-fields assertion is repeated on this path deliberately: a fourth destination is exactly when that is worth re-asserting.

**1430 tests**, analyzer clean.

**Six mutations, all caught:**

| Mutation | Caught by |
| --- | --- |
| send the routing block unconditionally | `no routing block` |
| always send the metadata header | `no OpenRouter metadata header` |
| send an empty bearer when there is no key | `no authorization header when there is no key` |
| ignore the mode, always force by name | two tests |
| hard-code the endpoint again | `posts to the endpoint it was given` |

No UI, no strings, no storage change — the fourth provider member arrives in #755.
