### PR TITLE
feat(core): store an endpoint, and generalise what "configured" means

### DIFF
--- a/lib/core/presentation/ai_assist_summary.dart
+++ b/lib/core/presentation/ai_assist_summary.dart
@@ -23,10 +23,11 @@ import 'package:opennutritracker/generated/l10n.dart';
 /// rather than naming a company the user never chose. #753.
 String? aiAssistSubtitle(
   S s, {
-  required bool? hasKey,
+  required bool? configured,
   required bool enabled,
   required AiProvider? provider,
-}) => switch (hasKey) {
+  String? endpoint,
+}) => switch (configured) {
   null => null,
   false => s.settingsAiAssistNotConfiguredLabel,
   true when enabled && provider != null =>
@@ -36,6 +37,9 @@ String? aiAssistSubtitle(
       AiProvider.anthropic => 'Anthropic',
       AiProvider.openrouter => 'OpenRouter',
       AiProvider.openai => 'OpenAI',
+      // No brand to print. #736: the row names where the data goes, and for a
+      // server the user runs that is the address they typed.
+      AiProvider.ownServer => endpoint ?? '',
     }}',
   true => s.settingsAiAssistPausedLabel,
 };

--- a/lib/core/utils/ai_credential_storage.dart
+++ b/lib/core/utils/ai_credential_storage.dart
@@ -8,7 +8,15 @@ import 'package:opennutritracker/core/utils/secure_app_storage_provider.dart';
 enum AiProvider {
   anthropic,
   openrouter,
-  openai;
+  openai,
+
+  /// A server the user runs — Ollama, LM Studio, llama.cpp, vLLM — reached at
+  /// an address they supply.
+  ///
+  /// The odd one out in this store: its credential is an **address**, not a
+  /// key, and a key is optional. Everything below that treats "has a key" as
+  /// the test of usability had to learn a broader question. #755.
+  ownServer;
 
   /// **Nothing stored** reads as Anthropic; **a name this build does not
   /// know** reads as null.
@@ -47,7 +55,14 @@ enum AiProvider {
 /// provider's key to another provider's endpoint.
 class AiSelection {
   final AiProvider provider;
-  final String apiKey;
+
+  /// Null for a destination that wants no credential, which is the normal
+  /// state for a server the user runs. #755.
+  final String? apiKey;
+
+  /// Where the request goes, for the one provider whose address the user
+  /// supplies. Null for the three reached at a compiled-in endpoint.
+  final String? endpoint;
 
   /// Null means "this provider's default". Resolved by `AiModelCatalogue`
   /// rather than here, so retiring a model is a change in one file.
@@ -55,7 +70,8 @@ class AiSelection {
 
   const AiSelection({
     required this.provider,
-    required this.apiKey,
+    this.apiKey,
+    this.endpoint,
     this.modelId,
   });
 }
@@ -73,15 +89,26 @@ class AiAssistSummary {
   /// a row can report the feature unavailable without naming a company that
   /// was never chosen. #753.
   final AiProvider? provider;
-  final bool hasKey;
 
-  /// False whenever [hasKey] is false, so a caller never has to check both.
+  /// Whether this provider has what it needs — a key for the hosted three, an
+  /// address for a server the user runs. Named for the question rather than
+  /// for one provider's answer to it. #755.
+  final bool configured;
+
+  /// False whenever [configured] is false, so a caller never has to check
+  /// both.
   final bool enabled;
+
+  /// The address, for the one provider whose destination has no brand name to
+  /// print. #736 settled that this row must name where the data goes, and for
+  /// a server the user runs the only honest answer is the host they typed.
+  final String? endpoint;
 
   const AiAssistSummary({
     required this.provider,
-    required this.hasKey,
+    required this.configured,
     required this.enabled,
+    this.endpoint,
   });
 }
 
@@ -119,11 +146,18 @@ class AiCredentialStorage {
   static const _providerTag = 'AiProviderTag';
   static const _modelTag = 'AiModelTag';
 
+  /// Where [AiProvider.ownServer] points. Slot-shaped like the others for
+  /// consistency, though only one provider will ever hold one.
+  static const _endpointTag = 'AiEndpointTag';
+
   static String _slotTag(AiProvider provider) =>
       '$_legacyApiKeyTag.${provider.name}';
 
   static String _modelSlotTag(AiProvider provider) =>
       '$_modelTag.${provider.name}';
+
+  static String _endpointSlotTag(AiProvider provider) =>
+      '$_endpointTag.${provider.name}';
 
   final FlutterSecureStorage _storage;
 
@@ -167,19 +201,90 @@ class AiCredentialStorage {
   /// so overlapping them hides the duplicate reads rather than removing them.
   /// A null provider short-circuits the whole thing: there is no slot to read
   /// a key from, so there is nothing to enable. #753.
-  Future<({AiProvider? provider, String? apiKey, bool enabled})>
+  Future<
+    ({AiProvider? provider, String? apiKey, String? endpoint, bool enabled})
+  >
   _readState() async {
     final provider = await activeProvider();
     if (provider == null) {
-      return (provider: null, apiKey: null, enabled: false);
+      return (provider: null, apiKey: null, endpoint: null, enabled: false);
     }
     final apiKey = await readApiKey(provider: provider);
-    // The invariant [isEnabled] has always enforced, stated here once: the
-    // flag alone never means "on" — a provider with no key is off whatever
-    // the tag says.
+    final endpoint = await readEndpoint(provider: provider);
+    // The invariant, stated here once: the flag alone never means "on" — a
+    // provider that is not usable is off whatever the tag says.
     final enabled =
-        apiKey != null && await _storage.read(key: _enabledTag) != 'false';
-    return (provider: provider, apiKey: apiKey, enabled: enabled);
+        _isUsable(provider, apiKey: apiKey, endpoint: endpoint) &&
+        await _storage.read(key: _enabledTag) != 'false';
+    return (
+      provider: provider,
+      apiKey: apiKey,
+      endpoint: endpoint,
+      enabled: enabled,
+    );
+  }
+
+  /// Whether [provider] has what it needs to be used at all.
+  ///
+  /// The generalisation #755 exists for. The rule was never really about
+  /// keys — it is *a provider that is not usable is off whatever the flag
+  /// says* — and what makes one usable differs: a key for the three hosted
+  /// ones, an **address** for a server the user runs, whose key is optional
+  /// and usually absent.
+  ///
+  /// Exhaustive on purpose. A fifth provider must answer this question
+  /// deliberately rather than inherit "has a key" by default.
+  static bool _isUsable(
+    AiProvider provider, {
+    required String? apiKey,
+    required String? endpoint,
+  }) => switch (provider) {
+    AiProvider.anthropic ||
+    AiProvider.openrouter ||
+    AiProvider.openai => apiKey != null,
+    AiProvider.ownServer => endpoint != null,
+  };
+
+  /// Where [AiProvider.ownServer] points, or null when nothing is stored.
+  Future<String?> readEndpoint({AiProvider? provider}) async {
+    final target = await _target(provider);
+    if (target == null) return null;
+    final value = await _storage.read(key: _endpointSlotTag(target));
+    return (value == null || value.isEmpty) ? null : value;
+  }
+
+  /// Points [provider] at [endpoint], and **forgets the stored model when the
+  /// address changes**.
+  ///
+  /// A model id is a statement about a server: `llama3.2:8b` means something
+  /// only relative to the machine answering, and this provider has no curated
+  /// list to fall back to when the id names nothing there. Keeping it would
+  /// carry a claim that is no longer known to be true into the next request —
+  /// the same reason #688 refused to let an unknown provider tag keep meaning
+  /// Anthropic.
+  ///
+  /// Per-endpoint model slots were the consistent-looking alternative and were
+  /// refused: they accumulate one keystore entry per address the user ever
+  /// typed, kept forever, which is a durable record of every machine on their
+  /// network. #738.
+  Future<void> writeEndpoint(String endpoint, {AiProvider? provider}) async {
+    final target = await _target(provider);
+    if (target == null) return;
+    final trimmed = endpoint.trim();
+    if (trimmed.isEmpty) {
+      await clear(provider: target);
+      return;
+    }
+
+    final previous = await _storage.read(key: _endpointSlotTag(target));
+    if (previous != trimmed) {
+      await _storage.delete(key: _modelSlotTag(target));
+    }
+    await _storage.write(key: _endpointSlotTag(target), value: trimmed);
+
+    // Same reasoning as `writeApiKey`: supplying the thing that makes the
+    // provider usable is the user asking for the feature.
+    await _storage.write(key: _enabledTag, value: 'true');
   }
 
   /// The provider these per-provider methods should act on: the one named,
@@ -197,10 +302,14 @@ class AiCredentialStorage {
   /// What a row shows for the feature, in one read of the store.
   Future<AiAssistSummary> readSummary() async {
     final state = await _readState();
+    final provider = state.provider;
     return AiAssistSummary(
-      provider: state.provider,
-      hasKey: state.apiKey != null,
+      provider: provider,
+      configured:
+          provider != null &&
+          _isUsable(provider, apiKey: state.apiKey, endpoint: state.endpoint),
       enabled: state.enabled,
+      endpoint: state.endpoint,
     );
   }
 
@@ -213,14 +322,15 @@ class AiCredentialStorage {
   Future<AiSelection?> readSelection() async {
     final state = await _readState();
     if (!state.enabled) return null;
-    final apiKey = state.apiKey;
     final provider = state.provider;
-    // Both are already implied by `enabled`, which is false without a
-    // provider and without a key. Stated so the types carry it too.
-    if (apiKey == null || provider == null) return null;
+    // Implied by `enabled`, which is false without a usable provider. Stated
+    // so the types carry it too. The **key** is no longer implied: a server
+    // the user runs is usable without one.
+    if (provider == null) return null;
     return AiSelection(
       provider: provider,
-      apiKey: apiKey,
+      apiKey: state.apiKey,
+      endpoint: state.endpoint,
       modelId: await readModel(provider: provider),
     );
   }
@@ -304,6 +414,8 @@ class AiCredentialStorage {
     if (target == null) return;
 
     await _storage.delete(key: _slotTag(target));
+    await _storage.delete(key: _endpointSlotTag(target));
+    await _storage.delete(key: _modelSlotTag(target));
     await _retireLegacyTagFor(target);
 
     // Only once nothing is left: with two slots, clearing one key is often

--- a/lib/core/utils/ai_model_catalogue.dart
+++ b/lib/core/utils/ai_model_catalogue.dart
@@ -189,23 +189,38 @@ abstract final class AiModelCatalogue {
     ),
   ];
 
+  /// Empty for [AiProvider.ownServer], and that is the answer rather than a
+  /// gap. Membership of the lists above requires a behavioural screen the
+  /// project cannot run against a machine it has never seen, and the user
+  /// pulled whatever they pulled — so there is no curated list, and #738
+  /// settled that the model is fetched from the server instead.
   static List<AiModel> forProvider(AiProvider provider) => switch (provider) {
     AiProvider.anthropic => anthropic,
     AiProvider.openrouter => openrouter,
     AiProvider.openai => openai,
+    AiProvider.ownServer => const [],
   };
 
-  static AiModel defaultFor(AiProvider provider) => forProvider(provider).first;
+  /// Null where there is no curated list to take a first element from.
+  ///
+  /// #738: defaulting to something for [AiProvider.ownServer] would mean
+  /// choosing on the user's behalf from a list nobody has screened — on
+  /// Ollama the first pulled entry could be an embedding model. The model is
+  /// part of what "configured" means there instead.
+  static AiModel? defaultFor(AiProvider provider) {
+    final models = forProvider(provider);
+    return models.isEmpty ? null : models.first;
+  }
 
   /// The stored choice, or the default when nothing is stored — and also
   /// when the stored id is no longer on the list, which is what a user sees
   /// after an update that retires a model. Falling back beats leaving them
   /// pointed at an id that can only 404.
-  static AiModel resolve(AiProvider provider, String? id) {
+  static AiModel? resolve(AiProvider provider, String? id) {
     final models = forProvider(provider);
     for (final model in models) {
       if (model.id == id) return model;
     }
-    return models.first;
+    return models.isEmpty ? null : models.first;
   }
 }

--- a/lib/features/add_meal/data/meal_items_api_factory.dart
+++ b/lib/features/add_meal/data/meal_items_api_factory.dart
@@ -17,31 +17,48 @@ import 'package:opennutritracker/features/add_meal/domain/meal_items_api.dart';
 /// be tested directly. The thing worth asserting is that choosing OpenRouter
 /// in settings really produces an OpenRouter request pinned to the vendor
 /// the screen named, and that is not observable through the locator.
+/// Throws [StateError] where the selection cannot name a model. For the three
+/// curated providers that is unreachable — an unknown id falls back to the
+/// list's first entry — and for a server the user runs it is prevented one
+/// layer up, because the model is part of what "configured" means there
+/// (#738) and an unconfigured provider never reaches this function.
 MealItemsApi mealItemsApiFor(http.Client client, AiSelection selection) {
   final model = AiModelCatalogue.resolve(selection.provider, selection.modelId);
+  final modelId = model?.id ?? selection.modelId;
+  if (modelId == null) {
+    throw StateError('no model for ${selection.provider.name}');
+  }
+  // The hosted three cannot be reached without one; only the fourth may have
+  // none, and it must not send an empty bearer.
+  String key() => selection.apiKey ?? '';
 
   return switch (selection.provider) {
-    AiProvider.anthropic => AnthropicMealItemsApi(
-      client,
-      () => selection.apiKey,
-      model: model.id,
-    ),
+    AiProvider.anthropic => AnthropicMealItemsApi(client, key, model: modelId),
     AiProvider.openrouter => OpenAiCompatibleMealItemsApi.openRouter(
       client,
-      () => selection.apiKey,
-      model: model.id,
+      key,
+      model: modelId,
       // Pinned with fallbacks off, so the vendor named in settings is the
       // vendor that served the request rather than the one the slug happens
       // to mention. Unpinned, `anthropic/claude-haiku-4.5` was answered by
       // Amazon Bedrock on every attempt of a three-run probe.
-      providers: model.providers,
+      providers: model?.providers,
     ),
     // No pin and no metadata header: reached directly, so there is no broker
     // to constrain and nobody in between to name.
-    AiProvider.openai => OpenAiMealItemsApi(
+    AiProvider.openai => OpenAiMealItemsApi(client, key, model: modelId),
+    // The user's own address, no broker, and **no forcing by name**: #733
+    // measured that Ollama has no `tool_choice` field at all and llama.cpp
+    // silently downgrades an object to "auto", so asking for a named function
+    // would be a request most of these servers quietly ignore. `required` is
+    // what the app means with one tool defined, and where it is unsupported
+    // the reply lands as the existing no-tool-call refusal.
+    AiProvider.ownServer => OpenAiCompatibleMealItemsApi(
       client,
-      () => selection.apiKey,
-      model: model.id,
+      selection.apiKey == null ? null : key,
+      model: modelId,
+      endpoint: Uri.parse(selection.endpoint!),
+      toolChoice: ToolChoiceMode.anyTool,
     ),
   };
 }

--- a/lib/features/add_meal/presentation/screens/bulk_add_screen.dart
+++ b/lib/features/add_meal/presentation/screens/bulk_add_screen.dart
@@ -89,13 +89,17 @@ class _BulkAddScreenState extends State<BulkAddScreen> {
         final storage = locator<AiCredentialStorage>();
         final provider = await storage.activeProvider();
         if (provider == null) return null;
-        return (
-          provider: provider,
-          model: AiModelCatalogue.resolve(
-            provider,
-            await storage.readModel(provider: provider),
-          ),
+        final model = AiModelCatalogue.resolve(
+          provider,
+          await storage.readModel(provider: provider),
         );
+        // Null for a server the user runs: it has no curated list, and the
+        // photo path there is unresolved — #747 needs a real runtime to
+        // settle which image formats survive, since the encoder emits WebP
+        // and llama.cpp cannot decode it. Until then the camera hides itself,
+        // which is a state this screen already models.
+        if (model == null) return null;
+        return (provider: provider, model: model);
       }();
 
   late BulkAddScreenArguments _args;
@@ -622,6 +626,10 @@ class _BulkAddScreenState extends State<BulkAddScreen> {
       // No placeholder: a direct path has no serving vendor to name, so this
       // string is flat where OpenRouter's is parameterised.
       AiProvider.openai => S.of(context).bulkAddPhotoDisclosureOpenAI,
+      // Unreachable: `_photoDestination` is null for this provider, so the
+      // sheet never opens. Stated rather than wildcarded so a fifth provider
+      // still has to answer the question.
+      AiProvider.ownServer => throw StateError('no photo path for ownServer'),
     };
     final shouldOpenCamera = await showModalBottomSheet<bool>(
       context: context,

--- a/lib/features/onboarding/presentation/widgets/onboarding_other_options_page_body.dart
+++ b/lib/features/onboarding/presentation/widgets/onboarding_other_options_page_body.dart
@@ -76,7 +76,8 @@ class _OnboardingOtherOptionsPageBodyState
   /// Null until the first read completes, so the row shows no subtitle rather
   /// than briefly claiming the feature is off. Same three fields Settings
   /// keeps, read from the same store.
-  bool? _aiHasKey;
+  bool? _aiConfigured;
+  String? _aiEndpoint;
   bool _aiEnabled = false;
   /// Null when the stored name is unrecognised — see #753.
   AiProvider? _aiProvider;
@@ -93,8 +94,9 @@ class _OnboardingOtherOptionsPageBodyState
     final summary = await storage.readSummary();
     if (!mounted) return;
     setState(() {
-      _aiHasKey = summary.hasKey;
+      _aiConfigured = summary.configured;
       _aiEnabled = summary.enabled;
+      _aiEndpoint = summary.endpoint;
       _aiProvider = summary.provider;
     });
   }
@@ -349,7 +351,8 @@ class _OnboardingOtherOptionsPageBodyState
     // so the row would resize under the user as the read came back.
     final subtitle = aiAssistSubtitle(
       s,
-      hasKey: _aiHasKey,
+      configured: _aiConfigured,
+    endpoint: _aiEndpoint,
       enabled: _aiEnabled,
       provider: _aiProvider,
     );

--- a/lib/features/settings/presentation/widgets/ai_assist_dialog.dart
+++ b/lib/features/settings/presentation/widgets/ai_assist_dialog.dart
@@ -67,7 +67,7 @@ class _AiAssistDialogState extends State<AiAssistDialog> {
   AiProvider _provider = AiProvider.anthropic;
   bool _hasKey = false;
   bool _enabled = false;
-  late AiModel _model = AiModelCatalogue.defaultFor(_provider);
+  AiModel? _model = AiModelCatalogue.defaultFor(AiProvider.anthropic);
 
   @override
   void initState() {
@@ -98,7 +98,7 @@ class _AiAssistDialogState extends State<AiAssistDialog> {
     if (!mounted) return;
     setState(() {
       _provider = provider;
-      _hasKey = summary.provider == null ? false : summary.hasKey;
+      _hasKey = summary.provider == null ? false : summary.configured;
       _enabled = summary.enabled;
       _model = AiModelCatalogue.resolve(provider, modelId);
       _loading = false;
@@ -159,6 +159,9 @@ class _AiAssistDialogState extends State<AiAssistDialog> {
     AiProvider.anthropic => 'Anthropic',
     AiProvider.openrouter => 'OpenRouter',
     AiProvider.openai => 'OpenAI',
+    // Not a brand, so not a constant — #756 replaces this with a localized
+    // label. Unreachable until then: the radio is filtered out above.
+    AiProvider.ownServer => 'Your own server',
   };
 
   @override
@@ -205,7 +208,13 @@ class _AiAssistDialogState extends State<AiAssistDialog> {
                     // there was a selection that silently stayed on its
                     // initial value. Deprecated, and still the form that works
                     // here.
-                    ...AiProvider.values.map(
+                    // #756 adds this provider's label, disclosure and
+                    // address field. Until then the enum member exists for
+                    // storage and is not offered, rather than appearing as a
+                    // radio with nothing behind it.
+                    ...AiProvider.values
+                        .where((p) => p != AiProvider.ownServer)
+                        .map(
                       (provider) => Semantics(
                         identifier: 'ai-assist-provider-${provider.name}',
                         // ignore: deprecated_member_use
@@ -366,6 +375,9 @@ class _AiAssistDialogState extends State<AiAssistDialog> {
     AiProvider.anthropic => s.aiAssistDisclosureAnthropic,
     AiProvider.openrouter => s.aiAssistDisclosureOpenRouter,
     AiProvider.openai => s.aiAssistDisclosureOpenAI,
+    // #756 writes this one: it names the configured host and derives an
+    // encryption clause from the scheme (#736). Unreachable until then.
+    AiProvider.ownServer => s.aiAssistDisclosureCommon,
   };
 
   Widget _label(ThemeData theme, String text) => Padding(
@@ -474,7 +486,7 @@ class _AiAssistDialogState extends State<AiAssistDialog> {
                 ),
                 value: model.id,
                 // ignore: deprecated_member_use
-                groupValue: _model.id,
+                groupValue: _model?.id,
                 // ignore: deprecated_member_use
                 onChanged: (value) => value == null
                     ? null

--- a/lib/features/settings/settings_screen.dart
+++ b/lib/features/settings/settings_screen.dart
@@ -66,7 +66,8 @@ class _SettingsScreenState extends State<SettingsScreen> {
 
   /// Null until the first read completes; the tile shows no subtitle rather
   /// than briefly claiming the feature is off.
-  bool? _aiHasKey;
+  bool? _aiConfigured;
+  String? _aiEndpoint;
   bool _aiEnabled = false;
   /// Null when the stored name is unrecognised — see #753.
   AiProvider? _aiProvider;
@@ -944,8 +945,9 @@ class _SettingsScreenState extends State<SettingsScreen> {
     final summary = await _aiCredentials.readSummary();
     if (!mounted) return;
     setState(() {
-      _aiHasKey = summary.hasKey;
+      _aiConfigured = summary.configured;
       _aiEnabled = summary.enabled;
+      _aiEndpoint = summary.endpoint;
       _aiProvider = summary.provider;
     });
   }
@@ -958,7 +960,8 @@ class _SettingsScreenState extends State<SettingsScreen> {
   /// can disagree about who is being sent to.
   String? _aiAssistSubtitle(BuildContext context) => aiAssistSubtitle(
     S.of(context),
-    hasKey: _aiHasKey,
+    configured: _aiConfigured,
+    endpoint: _aiEndpoint,
     enabled: _aiEnabled,
     provider: _aiProvider,
   );

--- a/test/features/add_meal/presentation/bulk_add_screen_test.dart
+++ b/test/features/add_meal/presentation/bulk_add_screen_test.dart
@@ -400,7 +400,7 @@ void main() {
     await tester.tap(find.byIcon(Icons.photo_camera_rounded).first);
     await tester.pumpAndSettle();
 
-    final vendor = AiModelCatalogue.defaultFor(AiProvider.openrouter).servedBy;
+    final vendor = AiModelCatalogue.defaultFor(AiProvider.openrouter)!.servedBy;
     expect(
       find.textContaining(l10nEn.bulkAddPhotoDisclosureOpenRouter(vendor)),
       findsOneWidget,

--- a/test/unit_test/ai_credential_storage_test.dart
+++ b/test/unit_test/ai_credential_storage_test.dart
@@ -385,7 +385,7 @@ void main() {
       expect(summary.provider, isNull);
       expect(summary.enabled, isFalse);
       expect(
-        summary.hasKey,
+        summary.configured,
         isFalse,
         reason: 'there is no active provider whose key this could be',
       );
@@ -471,7 +471,7 @@ void main() {
       final summary = await storage.readSummary();
 
       expect(summary.provider, AiProvider.openai);
-      expect(summary.hasKey, isTrue);
+      expect(summary.configured, isTrue);
       expect(summary.enabled, isTrue);
     });
 
@@ -483,7 +483,7 @@ void main() {
 
       final summary = await storage.readSummary();
 
-      expect(summary.hasKey, isTrue);
+      expect(summary.configured, isTrue);
       expect(summary.enabled, isFalse);
     });
 
@@ -498,7 +498,7 @@ void main() {
       final summary = await storage.readSummary();
 
       expect(summary.provider, AiProvider.openai);
-      expect(summary.hasKey, isFalse);
+      expect(summary.configured, isFalse);
       expect(summary.enabled, isFalse);
     });
 
@@ -542,8 +542,140 @@ void main() {
         final summary = await store.readSummary();
 
         expect(summary.provider, await store.activeProvider());
-        expect(summary.hasKey, await store.hasApiKey());
+        expect(summary.configured, await store.hasApiKey());
         expect(summary.enabled, await store.isEnabled());
+      }
+    });
+  });
+
+  group('a server the user runs', () {
+    // The provider whose credential is an address. Everything here exists
+    // because "has a key" stopped being the test of usability. #755.
+
+    setUp(() => storage.setActiveProvider(AiProvider.ownServer));
+
+    test('an endpoint round-trips and makes the provider usable', () async {
+      await storage.writeEndpoint('http://192.168.1.5:11434');
+
+      expect(await storage.readEndpoint(), 'http://192.168.1.5:11434');
+
+      final summary = await storage.readSummary();
+      expect(summary.provider, AiProvider.ownServer);
+      expect(
+        summary.configured,
+        isTrue,
+        reason: 'an address is what makes this one usable, not a key',
+      );
+      expect(summary.enabled, isTrue);
+    });
+
+    test('no key is needed, and none is invented', () async {
+      await storage.writeEndpoint('http://192.168.1.5:11434');
+      await storage.writeModel('gemma3:4b');
+
+      final selection = await storage.readSelection();
+
+      expect(selection!.apiKey, isNull);
+      expect(selection.endpoint, 'http://192.168.1.5:11434');
+      expect(selection.modelId, 'gemma3:4b');
+    });
+
+    test('an optional key is carried when the user supplied one', () async {
+      // vLLM and llama.cpp both take an optional `--api-key`.
+      await storage.writeEndpoint('http://192.168.1.5:8000');
+      await storage.writeApiKey('sk-local');
+
+      expect((await storage.readSelection())!.apiKey, 'sk-local');
+    });
+
+    test('a key alone never makes it usable', () async {
+      // The mirror of the invariant for the hosted three: the thing that
+      // makes this provider work is the address, so a key without one is not
+      // a configured provider.
+      await storage.writeApiKey('sk-local');
+
+      final summary = await storage.readSummary();
+      expect(summary.configured, isFalse);
+      expect(summary.enabled, isFalse);
+      expect(await storage.readSelection(), isNull);
+    });
+
+    test('the flag alone never means on', () async {
+      await storage.setEnabled(true);
+
+      expect(await storage.isEnabled(), isFalse);
+      expect(await storage.readSelection(), isNull);
+    });
+
+    test('changing the address forgets the model', () async {
+      // A model id is a statement about a server. `gemma3:4b` means something
+      // only relative to the machine answering, and there is no curated list
+      // to fall back to when it names nothing there. #738.
+      await storage.writeEndpoint('http://192.168.1.5:11434');
+      await storage.writeModel('gemma3:4b');
+
+      await storage.writeEndpoint('http://192.168.1.9:11434');
+
+      expect(await storage.readModel(), isNull);
+    });
+
+    test('rewriting the same address keeps the model', () async {
+      // Only a *change* invalidates the claim. Re-saving the same address is
+      // not a change, and dropping the model there would be a papercut every
+      // time the user re-opened settings.
+      await storage.writeEndpoint('http://192.168.1.5:11434');
+      await storage.writeModel('gemma3:4b');
+
+      await storage.writeEndpoint('http://192.168.1.5:11434');
+
+      expect(await storage.readModel(), 'gemma3:4b');
+    });
+
+    test('clearing forgets the address, the model and the key together', () async {
+      await storage.writeEndpoint('http://192.168.1.5:11434');
+      await storage.writeModel('gemma3:4b');
+      await storage.writeApiKey('sk-local');
+
+      await storage.clear();
+
+      expect(await storage.readEndpoint(), isNull);
+      expect(await storage.readModel(), isNull);
+      expect(
+        await storage.readApiKey(),
+        isNull,
+        reason: 'a key that outlives its endpoint means nothing',
+      );
+      expect(await storage.readSummary().then((s) => s.configured), isFalse);
+    });
+
+    test('the address is reported so a row can name the destination', () async {
+      // #736: this destination has no brand, so the only honest name is the
+      // host the user typed.
+      await storage.writeEndpoint('http://192.168.1.5:11434');
+
+      expect(
+        (await storage.readSummary()).endpoint,
+        'http://192.168.1.5:11434',
+      );
+    });
+
+    test('the hosted providers are untouched by any of this', () async {
+      // The generalisation must not have loosened the rule for the three that
+      // still need a key.
+      for (final provider in [
+        AiProvider.anthropic,
+        AiProvider.openrouter,
+        AiProvider.openai,
+      ]) {
+        final fresh = AiCredentialStorage(_MemoryStorage());
+        await fresh.setActiveProvider(provider);
+        await fresh.writeEndpoint('http://192.168.1.5:11434');
+
+        expect(
+          (await fresh.readSummary()).configured,
+          isFalse,
+          reason: '${provider.name} is not usable without a key',
+        );
       }
     });
   });

--- a/test/unit_test/ai_model_catalogue_test.dart
+++ b/test/unit_test/ai_model_catalogue_test.dart
@@ -11,14 +11,27 @@ void main() {
     // cosmetic one, and these tests exist because #726 added a model that is
     // a tenth of the default's price and would have been tempting to promote.
 
-    test('an unset model resolves to the head of the list, per provider', () {
+    test('an unset model resolves to the head of the curated lists', () {
       for (final provider in AiProvider.values) {
+        final models = AiModelCatalogue.forProvider(provider);
+        if (models.isEmpty) continue;
         expect(
-          AiModelCatalogue.resolve(provider, null).id,
-          AiModelCatalogue.forProvider(provider).first.id,
+          AiModelCatalogue.resolve(provider, null)?.id,
+          models.first.id,
           reason: '${provider.name} must not need a stored choice to work',
         );
       }
+    });
+
+    test('a server the user runs has no default, and that is the answer', () {
+      // #738: there is no curated list to take a first element from, and
+      // defaulting to something would mean choosing on the user's behalf from
+      // models nobody has screened — on Ollama the first pulled entry could
+      // be an embedding model. The model is part of what "configured" means
+      // there instead, so "none" has to be representable. #755.
+      expect(AiModelCatalogue.forProvider(AiProvider.ownServer), isEmpty);
+      expect(AiModelCatalogue.defaultFor(AiProvider.ownServer), isNull);
+      expect(AiModelCatalogue.resolve(AiProvider.ownServer, 'gemma3:4b'), isNull);
     });
 
     test('adding cheaper OpenAI models did not move the OpenRouter default', () {
@@ -26,14 +39,14 @@ void main() {
       // opened the picker to a different company, with no interaction, after
       // the photo sheet had named the old one — it interpolates `servedBy`.
       // #688 refused a smaller version of this.
-      final unchosen = AiModelCatalogue.resolve(AiProvider.openrouter, null);
+      final unchosen = AiModelCatalogue.resolve(AiProvider.openrouter, null)!;
       expect(unchosen.id, 'anthropic/claude-sonnet-5');
       expect(unchosen.servedBy, 'Anthropic');
     });
 
     test('a retired id falls back rather than 404ing forever', () {
       expect(
-        AiModelCatalogue.resolve(AiProvider.openrouter, 'anthropic/gone').id,
+        AiModelCatalogue.resolve(AiProvider.openrouter, 'anthropic/gone')!.id,
         'anthropic/claude-sonnet-5',
       );
     });
@@ -43,6 +56,7 @@ void main() {
     test('the head of every list carries no note, and the rest carry one', () {
       for (final provider in AiProvider.values) {
         final models = AiModelCatalogue.forProvider(provider);
+        if (models.isEmpty) continue;
         expect(
           models.first.note,
           isNull,


### PR DESCRIPTION
Closes #755.

Adds `AiProvider.ownServer` — the provider whose credential is an **address** rather than a key, and whose key is optional.

## The invariant was the three-provider spelling of a broader rule

[#731](https://github.com/simonoppowa/OpenNutriTracker/pull/731) consolidated *a provider with no key is off whatever the flag says* into one place. For this provider **having no key is the normal working state**, so as written it could never be enabled.

It generalises to `_isUsable`: a key for the hosted three, an address for a server the user runs. **Exhaustive**, so a fifth provider answers the question deliberately rather than inheriting "has a key" by default. `AiAssistSummary.hasKey` becomes `configured`, named for the question rather than for one provider's answer to it.

## Changing the address forgets the model

A model id is a statement about a server: `gemma3:4b` means something only relative to the machine answering, and there is no curated list to fall back to when it names nothing there.

Per-endpoint model slots were the consistent-looking alternative — [#688](https://github.com/simonoppowa/OpenNutriTracker/issues/688) kept key slots per provider precisely so switching back is cheap — and [#738](https://github.com/simonoppowa/OpenNutriTracker/issues/738) refused them here: they accumulate **one keystore entry per address the user ever typed, kept forever**, which is a durable record of every machine on their network. #688's argument was about a *credential*, expensive to re-obtain; a model name on a server you own is cheap.

Re-saving the *same* address keeps the model — only a change invalidates the claim.

The address lives in the keystore beside everything else, so the pieces cannot disagree and `deleteAll()` cannot clear half of them. It is also the one field here that leaks a home network.

## Three consequences the compiler asked for

The exhaustive switches did their job — every site had to answer for the new member, and none got a wildcard:

- **The catalogue has no curated list**, so `resolve` and `defaultFor` return null. #738 settled that defaulting would mean choosing from models nobody screened — on Ollama the first pulled entry could be an embedding model.
- **The photo path is unavailable there.** [#747](https://github.com/simonoppowa/OpenNutriTracker/issues/747) needs a real runtime to settle image formats, since the encoder emits WebP and llama.cpp cannot decode it. The camera hides itself, a state this screen already models.
- **The factory builds the client** with the stored address, no broker, and `tool_choice: "required"` rather than a named function — because Ollama has no such field at all and llama.cpp silently downgrades an object to `"auto"` ([#733](https://github.com/simonoppowa/OpenNutriTracker/issues/733)).

So the data path is complete end to end. The only missing piece is the surface.

## Not yet offered in Settings

The dialog filters the member out of its provider list. The enum member exists for **storage**; [#756](https://github.com/simonoppowa/OpenNutriTracker/issues/756) gives it a label, a disclosure and an address field, and removes the filter. Shipping a radio with no strings behind it would have dragged half of #756 into this ticket.

## Verification

**1441 tests**, analyzer clean.

Eleven new storage tests, including that the hosted three are **untouched** by the generalisation — an address does not configure a provider that still needs a key.

**Six mutations, all caught:**

| Mutation | Caught by |
| --- | --- |
| make the predicate key-only again | `an endpoint round-trips and makes the provider usable` |
| let a key alone configure the fourth provider | `a key alone never makes it usable` |
| keep the model when the address changes | `changing the address forgets the model` |
| drop the model on every save, not only on a change | `rewriting the same address keeps the model` |
| leave the address behind on `clear` | `clearing forgets the address, the model and the key together` |
| loosen the hosted three to accept an address | `the hosted providers are untouched by any of this` |

No strings, no UI, no migration — the tag is new, so nothing existing reads it.
