### PR TITLE
chore: bump version to 2.1.0+62

### DIFF
--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -15,7 +15,7 @@ publish_to: 'none' # Remove this line if you wish to publish to pub.dev
 # In iOS, build-name is used as CFBundleShortVersionString while build-number is used as CFBundleVersion.
 # Read more about iOS versioning at
 # https://developer.apple.com/library/archive/documentation/General/Reference/InfoPlistKeyReference/Articles/CoreFoundationKeys.html
-version: 2.0.2+61
+version: 2.1.0+62
 
 environment:
   sdk: '>=3.11.0 <4.0.0'


### PR DESCRIPTION
One bump covering today's batch rather than one per PR, since eight branches all editing line 18 of `pubspec.yaml` is a guaranteed conflict.

`2.0.2+61` to `2.1.0+62`. Both `develop` and `main` were sitting at `2.0.2+61` before this, so the build number is exactly one higher than what the stores have.

## Why minor rather than patch

Two of the merged PRs are new user-facing features:

- #651, opt-in workout import from Health Connect and Apple Health, which adds a settings screen and a new import path
- #590, the meal-type suggestion on the add sheet

The rest are bug fixes and the dependency rollup, which on their own would have been a patch.

## What landed

| PR | |
| --- | --- |
| #718 | Black screen after logging an intake from a recipe |
| #712 | A barcode Open Food Facts does not have now says so, instead of offering a Retry that cannot succeed |
| #615 | Stone weights no longer show a full stone of pounds |
| #752 | Dependabot rollup, superseding sixteen bot PRs |
| #590 | Meal type suggested from the time of day |
| #651 | Workout import from Health Connect and Apple Health |
| #672 | Android's per-app language picker, kept in step with the app's own |

## One thing for the release notes

#651 raises `minSdkVersion` from 24 to 26, which Health Connect's client library requires. Anyone still on Android 7.0, 7.1 or 8.0 stops receiving updates at 2.0.2, and the store will not tell them why. That is a real cost to real people and it deserves a line in the notes rather than being left for someone to discover when their app quietly stops updating.
