### PR TITLE
feat(add-meal): send JPEG to a server the user runs

### DIFF
--- a/lib/features/add_meal/presentation/screens/bulk_add_screen.dart
+++ b/lib/features/add_meal/presentation/screens/bulk_add_screen.dart
@@ -682,7 +682,12 @@ class _BulkAddScreenState extends State<BulkAddScreen> {
       // Discards the picker's cache copy once it has been encoded — see
       // [MealPhotoEncoder.encodeAndDiscardSource]. Without it the app leaves
       // the photo on disk, which the settings disclosure says it does not.
-      photo = await MealPhotoEncoder.encodeAndDiscardSource(picked.path);
+      photo = await MealPhotoEncoder.encodeAndDiscardSource(
+        picked.path,
+        // Per destination, not per app: a server the user runs may be
+        // llama.cpp, which cannot decode WebP at all (#747).
+        format: MealPhotoFormat.forProvider(destination.provider),
+      );
     } catch (e, stackTrace) {
       // Never logged with the path: on Android the picker's temp filename
       // can carry the original image name.

--- a/lib/features/add_meal/util/meal_photo_encoder.dart
+++ b/lib/features/add_meal/util/meal_photo_encoder.dart
@@ -2,7 +2,47 @@ import 'dart:io';
 
 import 'package:flutter/foundation.dart';
 import 'package:flutter_image_compress/flutter_image_compress.dart';
+import 'package:opennutritracker/core/utils/ai_credential_storage.dart';
 import 'package:opennutritracker/features/add_meal/domain/meal_photo_interpreter.dart';
+
+/// The container a photo is encoded into. **Quality and size are identical
+/// either way** — only the container changes.
+///
+/// It is a per-destination choice because the destinations genuinely
+/// disagree, and #747 measured where: llama.cpp decodes with `stb_image`,
+/// whose format list has no WebP, and ships a WebP-to-PNG converter in its
+/// own web UI to work around exactly that. Ollama accepts WebP but refuses a
+/// GIF; vLLM opens whatever Pillow opens.
+enum MealPhotoFormat {
+  /// What the hosted three get. Anthropic accepts it natively so nothing
+  /// transcodes on arrival, and the payload crosses the internet, where the
+  /// smaller of two lossy formats is worth having.
+  webp(CompressFormat.webp, 'image/webp'),
+
+  /// What a server the user runs gets. **All four runtimes decode JPEG**, so
+  /// choosing it removes the incompatibility rather than detecting it.
+  ///
+  /// It costs roughly 1.5-2x the bytes at the same quality. That is the
+  /// cheapest resource in this picture: the request crosses a LAN to hardware
+  /// the user owns, to a model that will then spend twenty seconds thinking
+  /// about it (#774).
+  jpeg(CompressFormat.jpeg, 'image/jpeg');
+
+  final CompressFormat compress;
+
+  final String mediaType;
+
+  const MealPhotoFormat(this.compress, this.mediaType);
+
+  /// Exhaustive on purpose. A fifth provider has to answer this question
+  /// rather than inherit whichever answer a wildcard happened to give it.
+  static MealPhotoFormat forProvider(AiProvider provider) => switch (provider) {
+    AiProvider.anthropic ||
+    AiProvider.openrouter ||
+    AiProvider.openai => webp,
+    AiProvider.ownServer => jpeg,
+  };
+}
 
 /// Turns a photo the user just picked into bytes that can be sent, without
 /// ever writing it to disk.
@@ -14,20 +54,21 @@ import 'package:opennutritracker/features/add_meal/domain/meal_photo_interpreter
 /// the documents directory is a photo the export zip picks up and the user
 /// never asked to keep.
 ///
-/// The encoding — WebP, quality 80, longest edge 1024 px — matches
+/// The encoding — quality 80, longest edge 1024 px — matches
 /// `UserImageStorage` on purpose. It is the pipeline this app already trusts
-/// for food photography, the provider accepts WebP natively so nothing
-/// transcodes it on arrival, and a 1024 px image is about 1400 visual tokens,
-/// which is what makes this cost fractions of a cent.
+/// for food photography, and a 1024 px image is about 1400 visual tokens,
+/// which is what makes this cost fractions of a cent where anyone is charging
+/// for it. Only the container varies, per [MealPhotoFormat].
 class MealPhotoEncoder {
   /// Raw bytes we will hand to the provider, before base64 inflates them by
   /// a third. Chosen to stay comfortably inside the per-image limit rather
   /// than to sit on it.
   ///
-  /// In practice a 1024 px WebP is 80–200 KB, so this never fires on the
-  /// normal path. It exists for [_rawBytes], where a device with no WebP
-  /// encoder sends the camera's original file — which on a recent phone can
-  /// be eight megabytes of full-resolution JPEG.
+  /// In practice a 1024 px WebP is 80–200 KB and a JPEG at the same quality
+  /// is under half a megabyte, so this never fires on the normal path. It
+  /// exists for [_rawBytes], where a device whose encoder failed sends the
+  /// camera's original file — which on a recent phone can be eight megabytes
+  /// of full-resolution JPEG.
   @visibleForTesting
   static const maxBytes = 3 * 1024 * 1024;
 
@@ -51,9 +92,12 @@ class MealPhotoEncoder {
   /// That copy is what makes "the app keeps no photo" false, so the app
   /// removes it. The deletion runs even when encoding failed, because a photo
   /// the provider rejected is exactly as unwelcome on disk as one it read.
-  static Future<MealPhoto?> encodeAndDiscardSource(String sourcePath) async {
+  static Future<MealPhoto?> encodeAndDiscardSource(
+    String sourcePath, {
+    required MealPhotoFormat format,
+  }) async {
     try {
-      return await encode(sourcePath);
+      return await encode(sourcePath, format: format);
     } finally {
       try {
         final file = File(sourcePath);
@@ -72,15 +116,24 @@ class MealPhotoEncoder {
   ///
   /// Leaves [sourcePath] alone. Callers holding a picker temp file want
   /// [encodeAndDiscardSource] instead.
-  static Future<MealPhoto?> encode(String sourcePath) async {
-    final compressed = await _compressToWebP(sourcePath);
+  /// [format] has no default. Which container a destination can read is the
+  /// whole of what #747 settled, and a default here would quietly become the
+  /// answer for a caller that forgot to ask — which is precisely how a
+  /// llama.cpp user ends up sent a WebP it cannot decode.
+  static Future<MealPhoto?> encode(
+    String sourcePath, {
+    required MealPhotoFormat format,
+  }) async {
+    final compressed = await _compress(sourcePath, format);
     if (compressed != null) {
-      return _fitting(compressed, 'image/webp');
+      return _fitting(compressed, format.mediaType);
     }
 
-    // No WebP encoder on this device. Send the original if the provider
-    // takes that format, rather than failing over an encoder the user has
-    // no way to install.
+    // The encoder failed. Send the original if the destination takes that
+    // format, rather than failing over an encoder the user has no way to
+    // install. Far rarer on the JPEG path — JPEG encoders are universal
+    // where WebP's are not — which is why Ollama's refusal of a GIF here
+    // stops being a problem worth its own rule (#747).
     final mediaType = mediaTypeForPath(sourcePath);
     if (mediaType == null) return null;
     final raw = await _rawBytes(sourcePath);
@@ -103,11 +156,18 @@ class MealPhotoEncoder {
     return MealPhoto(bytes: bytes, mediaType: mediaType);
   }
 
-  static Future<Uint8List?> _compressToWebP(String sourcePath) async {
+  static Future<Uint8List?> _compress(
+    String sourcePath,
+    MealPhotoFormat format,
+  ) async {
     try {
       return await FlutterImageCompress.compressWithFile(
         sourcePath,
-        format: CompressFormat.webp,
+        format: format.compress,
+        // Identical for both containers. A photo that reads well at q80 as a
+        // WebP is not a different photograph because it went to a machine in
+        // the user's house, and varying quality per destination would make
+        // "the model misread it" unanswerable.
         quality: 80,
         minWidth: 1024,
         minHeight: 1024,
@@ -123,8 +183,8 @@ class MealPhotoEncoder {
   static Future<Uint8List?> _rawBytes(String sourcePath) async {
     try {
       final file = File(sourcePath);
-      // Checked before reading, not after. This path exists for devices with
-      // no WebP encoder, where the file is the camera's own output — a
+      // Checked before reading, not after. This path exists for a device
+      // whose encoder failed, where the file is the camera's own output — a
       // recent phone produces eight megabytes of it, and pulling all of that
       // into memory only to hand it to `_fitting` and have it thrown away is
       // a burst of allocation on the device least able to absorb one.

--- a/test/unit_test/meal_photo_encoder_test.dart
+++ b/test/unit_test/meal_photo_encoder_test.dart
@@ -1,11 +1,65 @@
 import 'dart:io';
 
+import 'package:flutter_image_compress/flutter_image_compress.dart';
 import 'package:flutter_test/flutter_test.dart';
+import 'package:opennutritracker/core/utils/ai_credential_storage.dart';
 import 'package:opennutritracker/features/add_meal/util/meal_photo_encoder.dart';
 
 /// Only the decisions that need no platform channel. The compression itself
 /// runs in the device encoder and is covered by driving the real flow.
 void main() {
+  group('the container each destination gets (#747)', () {
+    test('a server the user runs gets JPEG', () {
+      // The one runtime that cannot decode WebP is llama.cpp, whose
+      // `stb_image` format list has no entry for it — and the app cannot
+      // tell which runtime is behind a user-supplied address. All four
+      // decode JPEG, so the incompatibility is removed rather than detected.
+      expect(
+        MealPhotoFormat.forProvider(AiProvider.ownServer),
+        MealPhotoFormat.jpeg,
+      );
+    });
+
+    test('the hosted three keep WebP', () {
+      // Anthropic accepts it natively so nothing transcodes on arrival, and
+      // these payloads cross the internet rather than a LAN.
+      for (final provider in const [
+        AiProvider.anthropic,
+        AiProvider.openrouter,
+        AiProvider.openai,
+      ]) {
+        expect(
+          MealPhotoFormat.forProvider(provider),
+          MealPhotoFormat.webp,
+          reason: '$provider must not have moved off WebP',
+        );
+      }
+    });
+
+    test('every provider is answered, so a fifth cannot inherit one', () {
+      // The switch is exhaustive in the source; this is the runtime half of
+      // the same guarantee, and it fails the moment a member is added
+      // without the format question being asked.
+      for (final provider in AiProvider.values) {
+        expect(
+          () => MealPhotoFormat.forProvider(provider),
+          returnsNormally,
+          reason: '$provider has no format',
+        );
+      }
+    });
+
+    test('each container declares the media type it actually is', () {
+      // The declared type is what Ollama's decodeImageURL checks the data URI
+      // prefix against, so a mismatch here is a 400 rather than a wrong-looking
+      // image.
+      expect(MealPhotoFormat.webp.mediaType, 'image/webp');
+      expect(MealPhotoFormat.jpeg.mediaType, 'image/jpeg');
+      expect(MealPhotoFormat.webp.compress, CompressFormat.webp);
+      expect(MealPhotoFormat.jpeg.compress, CompressFormat.jpeg);
+    });
+  });
+
   group('mediaTypeForPath', () {
     test('maps the formats the provider accepts', () {
       expect(MealPhotoEncoder.mediaTypeForPath('/tmp/a.webp'), 'image/webp');
@@ -57,34 +111,66 @@ void main() {
       if (await dir.exists()) await dir.delete(recursive: true);
     });
 
-    test('deletes the source even though encoding fails in a unit test', () async {
+    test('deletes the source, whichever container was asked for', () async {
       // `image_picker` returns a copy it made in the app cache and never
       // cleans it up — on a Pixel 6 the full JPEG was still there after a
-      // pick. Leaving it makes the settings disclosure false.
-      final file = File('${dir.path}/picked.jpg')
-        ..writeAsBytesSync(List.filled(2000, 0));
+      // pick. Leaving it makes the settings disclosure false, and that is
+      // true of a photo headed for the user's own machine too.
+      for (final format in MealPhotoFormat.values) {
+        final file = File('${dir.path}/picked_${format.name}.jpg')
+          ..writeAsBytesSync(List.filled(2000, 0));
 
-      // No platform channel here, so the encode itself returns null. The
-      // point is that the file goes regardless.
-      await MealPhotoEncoder.encodeAndDiscardSource(file.path);
+        await MealPhotoEncoder.encodeAndDiscardSource(
+          file.path,
+          format: format,
+        );
 
-      expect(file.existsSync(), isFalse);
+        expect(file.existsSync(), isFalse, reason: format.name);
+      }
     });
 
     test('an oversized source is rejected without being read', () async {
-      // The fallback path exists for devices with no WebP encoder, where the
+      // The fallback path exists for a device whose encoder failed, where the
       // file is the camera's raw output. Reading eight megabytes into memory
       // only to discard it is a burst of allocation on the device least able
       // to absorb one, so the length is checked first.
       final file = File('${dir.path}/huge.jpg')
         ..writeAsBytesSync(List.filled(MealPhotoEncoder.maxBytes + 1, 0));
 
-      expect(await MealPhotoEncoder.encode(file.path), isNull);
+      for (final format in MealPhotoFormat.values) {
+        expect(
+          await MealPhotoEncoder.encode(file.path, format: format),
+          isNull,
+          reason: '${format.name} must respect the ceiling too',
+        );
+      }
+    });
+
+    test('the fallback declares the file it sent, not the one asked for', () async {
+      // There is no platform channel in a unit test, so the compressor fails
+      // and `encode` takes the raw-bytes path — which is the real behaviour
+      // on a device whose encoder is missing. What it sends is the original
+      // file, so the media type has to describe *that*, not the container
+      // that was requested and never produced. Declaring `image/webp` over
+      // JPEG bytes is a 400 from Ollama, whose decodeImageURL checks the
+      // data-URI prefix.
+      final file = File('${dir.path}/original.jpg')
+        ..writeAsBytesSync(List.filled(2000, 0));
+
+      final photo = await MealPhotoEncoder.encode(
+        file.path,
+        format: MealPhotoFormat.webp,
+      );
+
+      expect(photo?.mediaType, 'image/jpeg');
     });
 
     test('a missing source is not an error', () async {
       await expectLater(
-        MealPhotoEncoder.encodeAndDiscardSource('${dir.path}/gone.jpg'),
+        MealPhotoEncoder.encodeAndDiscardSource(
+          '${dir.path}/gone.jpg',
+          format: MealPhotoFormat.jpeg,
+        ),
         completion(isNull),
       );
     });


### PR DESCRIPTION
Closes #778. Targets `feature/ai-assisted-meal-logging`. Implements the decision in #747.

## What changed

`MealPhotoEncoder` produced WebP for every destination. Right for the hosted three — Anthropic accepts it natively so nothing transcodes on arrival, and those payloads cross the internet — and wrong for the fourth, because **llama.cpp cannot decode WebP at all**: it uses `stb_image`, whose format list has no entry for it, and ships a WebP-to-PNG converter in its own web UI to work around exactly that. The app cannot know which runtime is behind a user-supplied address.

All four runtimes decode JPEG, so #747 chose to **remove** the incompatibility rather than detect it — no probe, no negotiation, no per-endpoint format to store, invalidate and test forever.

`MealPhotoFormat` carries the container, the `CompressFormat` and the media type together, and `forProvider` is an exhaustive switch so a fifth provider has to answer the question rather than inherit whichever answer a wildcard gave it. **The format parameter has no default** — a caller cannot inherit WebP by forgetting to ask, which is precisely how a llama.cpp user would end up sent bytes they cannot read.

Quality (80) and the 1024 px longest-edge bound are identical either way; only the container changes.

## The other half of #747, closed without a rule of its own

The encoder falls back to sending the camera's original file when the device encoder fails, and Ollama's `decodeImageURL` refuses anything outside `jpeg`/`jpg`/`png`/`webp` — a GIF among them. JPEG encoders are universal where WebP's are not, so on this provider that fallback stops firing rather than needing handling.

One subtlety this surfaced and now has a test: the fallback sends the *original file*, so it must declare **that file's** media type, not the container that was requested and never produced. Declaring `image/webp` over JPEG bytes is a 400 from Ollama, which checks the data-URI prefix.

## Nothing visible changes yet

This is the prefactor the ticket says it is. The camera does not open for this provider until #781, so the JPEG branch is not reachable from the UI. It is exercised the moment #779 lands, because the probe sends its test image through this same encoder — which is the point of sequencing it first rather than letting the probe validate a canned image the real path would never send.

## Mutations

Six applied, six caught. Each reverted before the next.

| # | mutation | caught by |
|---|---|---|
| 1 | `ownServer` sent WebP again | *a server the user runs gets JPEG* |
| 2 | JPEG leaked onto the hosted three | *the hosted three keep WebP* |
| 3 | JPEG member declared `image/webp` | *each container declares the media type it actually is* |
| 4 | JPEG member compressed to PNG | *each container declares the media type it actually is* |
| 5 | fallback declared the requested container instead of the file it sent | *the fallback declares the file it sent, not the one asked for* |
| 6 | picker's cache copy left on disk | *deletes the source, whichever container was asked for* |

## Two things tests do not cover, stated rather than implied

- **The call site's one wiring line.** The screen passes `MealPhotoFormat.forProvider(destination.provider)`, and that line is unreachable from any test because `_photoDestination` is null for this provider until #781. A mutation hardcoding a format there would survive. #781's acceptance criteria cover it, and the required parameter removes the *omission* failure mode in the meantime — only a deliberate edit can get it wrong.
- **Quality and the size bound being identical across formats** is enforced by there being one literal rather than by an assertion. `flutter_image_compress` needs a platform channel, so a unit test cannot observe the parameters it was called with.

## Gate

`fvm flutter analyze lib/ test/` clean; `fvm flutter test` 1446 passing.
