### PR TITLE
fix(add-meal): tell a model that found nothing from one that answered nothing

### DIFF
--- a/lib/features/add_meal/domain/meal_items_api.dart
+++ b/lib/features/add_meal/domain/meal_items_api.dart
@@ -126,19 +126,42 @@ const mealItemsToolSchema = {
 /// Raises when the array itself is missing or the wrong type, because that
 /// means the provider answered something other than what was asked for and
 /// guessing at it is how silent nonsense gets into a diary.
+///
+/// **And raises when it held entries and none of them survived**, which is
+/// the same sentence one level down. An empty array is a model saying "no
+/// food here", and `ReadMealTextUseCase` honours that by showing no rows —
+/// so a reply of `{"items": [{"name": "egg"}]}`, where every entry is
+/// dropped for carrying no `query`, used to arrive at that use case wearing
+/// the same clothes as a deliberate answer. The user got nothing: not the
+/// model's rows, which never existed, and not the parser's, which were
+/// suppressed by a judgement the model never made.
+///
+/// The distinction can only be drawn here, because this is the only place
+/// that sees both counts. It stays [MealInterpreterFailure.transient], like
+/// the wrong-type case above and for the same reason — nothing about a
+/// malformed reply says the next one will be, and the text path falls back
+/// to the parser in silence rather than blaming a model over one bad batch.
 List<ParsedMealItem> mealItemsFromJson(Object? rawItems) {
   if (rawItems is! List) {
     throw const MealInterpreterException('tool call has no items');
   }
-  return [
+  final items = [
     for (final item in rawItems)
       if (item is Map) _mealItemFrom(item),
   ].nonNulls.toList();
+  if (items.isEmpty && rawItems.isNotEmpty) {
+    throw const MealInterpreterException('every item in the tool call dropped');
+  }
+  return items;
 }
 
 /// One item, or null when it carries no usable query. A malformed entry is
 /// dropped rather than failing the batch — the other items are still worth
 /// showing, and `validateParsedMealItems` reports what it rejects.
+///
+/// "The other items" is load-bearing: [mealItemsFromJson] raises when there
+/// are none, because dropping every entry is not a batch with holes in it,
+/// it is a reply that was not the one asked for.
 ParsedMealItem? _mealItemFrom(Map<dynamic, dynamic> raw) {
   final query = raw['query'];
   if (query is! String) return null;

--- a/test/unit_test/openai_meal_items_api_test.dart
+++ b/test/unit_test/openai_meal_items_api_test.dart
@@ -4,6 +4,7 @@ import 'package:flutter_test/flutter_test.dart';
 import 'package:http/http.dart' as http;
 import 'package:http/testing.dart';
 import 'package:opennutritracker/features/add_meal/data/openai_meal_items_api.dart';
+import 'package:opennutritracker/features/add_meal/domain/meal_interpreter_exception.dart';
 import 'package:opennutritracker/features/add_meal/domain/meal_items_api.dart';
 
 /// What the client sent, so a rule about the request can actually fail.
@@ -271,6 +272,59 @@ void main() {
       );
 
       expect(result.items, isEmpty);
+    });
+
+    test('items that all drop are a failure, not an empty reading', () async {
+      // The pair to the case above, and until now indistinguishable from it.
+      // An entry with no usable `query` is dropped, so a model answering in
+      // the wrong shape produced an empty list — which `ReadMealTextUseCase`
+      // reads as "the model looked, and there is no food here" and shows in
+      // place of the parser's rows. The user got neither: not the model's,
+      // which never existed, and not the parser's, which a judgement the
+      // model never made had suppressed.
+      final s = subject(
+        responseBody: _toolReply([
+          {'name': 'egg', 'quantity': 2},
+          {'quantity': 1, 'unit': 'slice'},
+        ]),
+      );
+
+      await expectLater(
+        () => s.api.requestItems(
+          content: const MealTextContent('2 eggs and a slice of toast'),
+          system: 'rules',
+        ),
+        // Transient, so the text path falls back to the parser without a
+        // notice and the photo path says "try again" — one malformed batch
+        // is not evidence about the next one, and `unsupported` would be:
+        // #782 reads that member as grounds to take a working camera away.
+        throwsA(
+          isA<MealInterpreterException>().having(
+            (e) => e.failure,
+            'failure',
+            MealInterpreterFailure.transient,
+          ),
+        ),
+      );
+    });
+
+    test('one usable item among malformed ones is still a reading', () async {
+      // The drop rule itself is unchanged. A batch with holes in it is worth
+      // showing; only a batch that is entirely holes is a failure.
+      final s = subject(
+        responseBody: _toolReply([
+          {'name': 'egg', 'quantity': 2},
+          {'query': 'toast', 'quantity': 1, 'unit': 'slice'},
+        ]),
+      );
+
+      final result = await s.api.requestItems(
+        content: const MealTextContent('2 eggs and a slice of toast'),
+        system: 'rules',
+      );
+
+      expect(result.items, hasLength(1));
+      expect(result.items.single.query, 'toast');
     });
   });
 

--- a/test/unit_test/openai_meal_items_api_test.dart
+++ b/test/unit_test/openai_meal_items_api_test.dart
@@ -4,7 +4,6 @@ import 'package:flutter_test/flutter_test.dart';
 import 'package:http/http.dart' as http;
 import 'package:http/testing.dart';
 import 'package:opennutritracker/features/add_meal/data/openai_meal_items_api.dart';
-import 'package:opennutritracker/features/add_meal/domain/meal_interpreter_exception.dart';
 import 'package:opennutritracker/features/add_meal/domain/meal_items_api.dart';
 
 /// What the client sent, so a rule about the request can actually fail.


### PR DESCRIPTION
Raised by Copilot on #648.

## The failure

`mealItemsFromJson` drops an entry that carries no usable `query` — right when the other entries are still worth showing. When **every** entry drops it returned an empty list, and an empty list already means something else: `ReadMealTextUseCase` reads it as the model having looked and found no food, and shows it *in place of* the parser's rows deliberately, because the parser will happily turn any sentence into a query.

So a reply of `{"items": [{"name": "egg"}]}` — right shape, wrong key — arrived at that use case wearing the same clothes as a deliberate answer. The user got nothing at all: not the model's rows, which never existed, and not the parser's, which a judgement the model never made had suppressed.

## The fix

One condition in the decoder. Raised there rather than downstream because it is the only place that sees both the raw count and the usable count.

Left at `transient`, matching the wrong-type raise directly above it: one malformed batch says nothing about the next, so the text path falls back to the parser in silence and the photo path offers a retry. Deliberately **not** `unsupported` — #782 reads that member as grounds to take a working camera away, and a model that mislabelled one field has not gone blind.

## Verification

Three cases, driven through the client with real JSON rather than against the decoder directly, because the bug only bites when a reply travels the whole path:

- a genuinely empty list is still a reading
- a batch with holes in it is still a reading
- a batch that is entirely holes is a failure

Mutation-checked, three mutants, all caught:

| Mutant | Caught by |
|---|---|
| `if (false)` — never raise | items that all drop are a failure |
| `if (items.isEmpty)` — raise on a genuine empty too | an empty item list is a reading (plus 20 others) |
| `if (items.length != rawItems.length)` — raise on any drop | one usable item among malformed ones is still a reading |

The middle one matters most: it shows the pre-existing "an empty list is an answer, not a failure" rule is still fully protected, so this does not trade one silent failure for another.

`fvm flutter analyze lib/ test/` clean; full suite 1589 passing.