### PR TITLE
fix(add-meal): stop telling an empty OpenAI balance to try again later

### DIFF
--- a/lib/features/add_meal/data/openai_meal_items_api.dart
+++ b/lib/features/add_meal/data/openai_meal_items_api.dart
@@ -118,7 +118,7 @@ class OpenAiMealItemsApi implements MealItemsApi {
       _log.warning('Interpreter call failed with ${response.statusCode}');
       throw MealInterpreterException(
         'provider returned ${response.statusCode}',
-        failure: _failureFor(response.statusCode, _errorCode(response.body)),
+        failure: _failureFor(response.statusCode, _errorFields(response.body)),
         statusCode: response.statusCode,
       );
     }
@@ -206,23 +206,33 @@ class OpenAiMealItemsApi implements MealItemsApi {
     );
   }
 
-  /// The provider's machine-readable error code, or null.
+  /// The provider's machine-readable error fields, or nulls.
   ///
-  /// Only the code — never the message. OpenAI's 401 body echoes the key in
+  /// Only the codes — never the message. OpenAI's 401 body echoes the key in
   /// a partially masked form that still carries its real last four
   /// characters, so the message is not a safe thing to keep hold of.
-  static String? _errorCode(String body) {
+  ///
+  /// **Both `code` and `type`**, because they are not the same question and
+  /// billing is where the difference shows. OpenAI's guidance is to *"inspect
+  /// `error.code` to identify the specific cause"* while *"the broader
+  /// `error.type` can still be `insufficient_quota`"* — so `code` may carry
+  /// something narrower than the state the app has to act on, and reading it
+  /// alone would miss exactly the accounts whose cause is spelled out.
+  static ({String? code, String? type}) _errorFields(String body) {
     try {
       final decoded = jsonDecode(body);
       if (decoded is Map && decoded['error'] is Map) {
-        final code = (decoded['error'] as Map)['code'];
-        return code is String ? code : null;
+        final error = decoded['error'] as Map;
+        return (
+          code: error['code'] is String ? error['code'] as String : null,
+          type: error['type'] is String ? error['type'] as String : null,
+        );
       }
     } catch (_) {
       // Not JSON, or not the shape documented. Classification falls back to
       // the status alone, which is the pre-#686 behaviour.
     }
-    return null;
+    return (code: null, type: null);
   }
 
   /// What a status means here — #695 put this in each client precisely so a
@@ -236,17 +246,35 @@ class OpenAiMealItemsApi implements MealItemsApi {
   /// second catalogue entry makes actionable. Classifying it as `rejected`
   /// instead would tell someone whose model was retired to go and retake
   /// their photograph, forever. Measured in #684 and #686.
-  static MealInterpreterFailure _failureFor(int statusCode, String? errorCode) =>
-      switch (statusCode) {
-        401 || 403 => MealInterpreterFailure.auth,
-        400 when errorCode == 'model_not_found' =>
-          MealInterpreterFailure.unsupported,
-        400 || 422 => MealInterpreterFailure.rejected,
-        // `insufficient_quota` arrives as 429 rather than 402 on some
-        // accounts, but 429 is also ordinary rate limiting and retrying is
-        // right for that. Only an explicit 402 is called billing.
-        402 => MealInterpreterFailure.billing,
-        404 => MealInterpreterFailure.unsupported,
-        _ => MealInterpreterFailure.transient,
-      };
+  /// **A 429 is two different failures wearing one status.** Both other
+  /// providers separate an empty balance from going too fast by status alone
+  /// — 402 against 429 — and this one does not: an exhausted prepaid balance
+  /// arrives as 429 on many accounts. The status line is therefore not enough
+  /// here, which is why this client reads the body at all. OpenAI says as
+  /// much itself about retrying: *"Don't retry quota, billing, or other
+  /// errors that require you to take action."*
+  ///
+  /// A bare 429 stays `transient`, because ordinary rate limiting is the
+  /// common case and does clear on its own. A 429 that names
+  /// `insufficient_quota` does not clear, and calling it transient told a
+  /// user with an empty balance to try again later — forever, with the
+  /// interpreter silently falling back on every attempt and nothing on screen
+  /// ever naming the one thing that would fix it.
+  static MealInterpreterFailure _failureFor(
+    int statusCode,
+    ({String? code, String? type}) error,
+  ) => switch (statusCode) {
+    401 || 403 => MealInterpreterFailure.auth,
+    400 when error.code == 'model_not_found' =>
+      MealInterpreterFailure.unsupported,
+    400 || 422 => MealInterpreterFailure.rejected,
+    402 => MealInterpreterFailure.billing,
+    429 when error.code == _quotaCode || error.type == _quotaCode =>
+      MealInterpreterFailure.billing,
+    404 => MealInterpreterFailure.unsupported,
+    _ => MealInterpreterFailure.transient,
+  };
+
+  /// What OpenAI calls an exhausted balance, in either field.
+  static const _quotaCode = 'insufficient_quota';
 }

--- a/test/unit_test/openai_meal_items_api_test.dart
+++ b/test/unit_test/openai_meal_items_api_test.dart
@@ -47,14 +47,23 @@ String _toolReply(List<Map<String, Object?>> items) => jsonEncode({
 });
 
 /// The failure a call classifies as, for a given status and error body.
+///
+/// `type` as well as `code`, because OpenAI does not always put the state the
+/// app must act on in the same field: the code names the specific cause and
+/// the broader type is what stays `insufficient_quota`.
 Future<MealInterpreterException> _failureFrom(
   int status, {
   String? code,
+  String? type,
 }) async {
   final client = MockClient(
     (_) async => http.Response(
       jsonEncode({
-        'error': {'message': 'something went wrong', 'code': ?code},
+        'error': {
+          'message': 'something went wrong',
+          'code': ?code,
+          'type': ?type,
+        },
       }),
       status,
     ),
@@ -328,13 +337,40 @@ void main() {
       );
     });
 
-    test('429 is transient, not billing', () async {
-      // `insufficient_quota` can arrive as 429, but so does ordinary rate
-      // limiting, and retrying is right for that. Only an explicit 402 is
-      // called billing.
+    test('a bare 429 is transient', () async {
+      // Ordinary rate limiting: it clears on its own, and retrying is right.
+      // A 429 that says why is a different matter — see below.
       expect(
         (await _failureFrom(429)).failure,
         MealInterpreterFailure.transient,
+      );
+    });
+
+    test('a 429 that names an exhausted balance is billing', () async {
+      // Both other providers separate this from a rate limit by status alone,
+      // 402 against 429. OpenAI does not, so an empty prepaid balance used to
+      // be told to try again later — forever, with the interpreter falling
+      // back silently every time and nothing on screen ever naming the one
+      // thing that would fix it.
+      expect(
+        (await _failureFrom(429, code: 'insufficient_quota')).failure,
+        MealInterpreterFailure.billing,
+      );
+    });
+
+    test('the broader type carries it when the code is narrower', () async {
+      // OpenAI's own guidance: inspect `error.code` for the specific cause,
+      // while the broader `error.type` can still be `insufficient_quota`. So
+      // the account whose cause *is* spelled out is exactly the one a
+      // code-only read would miss, which would be the same bug with a
+      // smaller blast radius.
+      expect(
+        (await _failureFrom(
+          429,
+          code: 'billing_hard_limit_reached',
+          type: 'insufficient_quota',
+        )).failure,
+        MealInterpreterFailure.billing,
       );
     });
 


### PR DESCRIPTION
Raised by Copilot on #648.

## The failure

Both other providers separate an exhausted balance from a rate limit by status alone — 402 against 429. OpenAI does not: on many accounts an empty prepaid balance arrives as **429**. `_failureFor` called every 429 `transient`, so `ReadMealTextUseCase` fell back to the parser and said nothing — on every attempt, for as long as the balance stayed empty. Nothing on screen ever named the one thing that would fix it. That is the loop the `billing` member was added to prevent.

## This was already researched, and the code went the other way

[`docs/ai-billing-status-codes.md`](docs/ai-billing-status-codes.md) covers Anthropic and OpenRouter, where status alone is enough. [`docs/ai-openai-wire-format.md`](docs/ai-openai-wire-format.md) covers this client and reached the opposite conclusion for it:

> on OpenAI, `isTransient` cannot be decided from the status line alone

and, from OpenAI on retrying:

> Don't retry quota, billing, or other errors that require you to take action.

The comment in `_failureFor` argued that only an explicit 402 should be billing, and it shipped that way.

## The fix

A bare 429 stays `transient` — ordinary rate limiting is the common case and does clear on its own. A 429 that names `insufficient_quota` is `billing`.

**Read from `type` as well as `code`.** This is the half that is easy to get wrong: the guidance is to inspect `error.code` for the specific cause, while *"the broader `error.type` can still be `insufficient_quota`"*. So an account whose cause is spelled out — `billing_hard_limit_reached` — is exactly the one a code-only match would miss. `_errorCode` becomes `_errorFields`, returning both, and still never the message: OpenAI's 401 body echoes the key with its real last four characters.

## Verification

Four mutants, four caught, each by a different test:

| Mutant | Caught by |
|---|---|
| arm removed | both new billing tests |
| match `code` only | the broader type carries it when the code is narrower |
| match `type` only | a 429 that names an exhausted balance is billing |
| every 429 is billing | a bare 429 is transient |

The last one guards what the original comment was right about — ordinary rate limiting still retries.

Bare `fvm flutter analyze` (as CI runs it) clean; full suite 1619 passing.