### PR TITLE
fix(settings): read a pasted model-list URL as the base it names

### DIFF
--- a/lib/core/utils/ai_credential_storage.dart
+++ b/lib/core/utils/ai_credential_storage.dart
@@ -362,15 +362,31 @@ class AiCredentialStorage {
   /// itself — so this is the protocol rather than a guess about it, which is
   /// what separates it from the scheme above. The field's own hint is a base
   /// address, and it has to work. A path the user typed is kept as typed.
+  ///
+  /// **The model-list route names a base too.** `…/v1/models` is the URL these
+  /// runtimes print in their own docs and the one a user checking their server
+  /// is alive has in the clipboard, so it is an easy thing to paste into a
+  /// field asking for an address — and it is not a chat route. Left as typed
+  /// it was stored as the destination every meal request would be POSTed to,
+  /// and #757's Load models then appended a second `/models` to it and asked
+  /// `…/v1/models/models`. Both halves of that come from the same wrong
+  /// premise, and both are fixed by reading the segment for what it is: the
+  /// list route, sitting on the base this address really names.
   static Uri? resolveEndpoint(String endpoint) {
     final uri = Uri.tryParse(endpoint.trim());
     if (uri == null) return null;
     if (uri.scheme != 'http' && uri.scheme != 'https') return null;
     if (uri.host.isEmpty) return null;
 
-    final path = uri.path.endsWith('/')
+    final typed = uri.path.endsWith('/')
         ? uri.path.substring(0, uri.path.length - 1)
         : uri.path;
+    // Safe to strip before anything else looks at the path: `/models` is
+    // fixed by the protocol as the list route, so no OpenAI-compatible server
+    // serves chat on a path ending in it.
+    final path = typed.endsWith(_modelsSuffix)
+        ? typed.substring(0, typed.length - _modelsSuffix.length)
+        : typed;
     if (path.isEmpty) return uri.replace(path: _chatCompletionsPath);
     // `http://host:11434/v1` is what LM Studio prints and what the OpenAI
     // SDKs call the base URL, so it is a base rather than a route.
@@ -382,6 +398,10 @@ class AiCredentialStorage {
 
   /// The suffix [resolveEndpoint] completes a base address to.
   static const _chatCompletionsSuffix = '/chat/completions';
+
+  /// The other half of the OpenAI-compatible pair, and the segment
+  /// [resolveEndpoint] reads as naming a base rather than a route.
+  static const _modelsSuffix = '/models';
 
   /// Where to ask [endpoint] what models it serves, or null when what was
   /// typed cannot be requested at all.
@@ -407,8 +427,8 @@ class AiCredentialStorage {
     return chat.replace(
       path: path.endsWith(_chatCompletionsSuffix)
           ? '${path.substring(0, path.length - _chatCompletionsSuffix.length)}'
-                '/models'
-          : '$path/models',
+                '$_modelsSuffix'
+          : '$path$_modelsSuffix',
     );
   }
 

--- a/test/unit_test/ai_model_list_api_test.dart
+++ b/test/unit_test/ai_model_list_api_test.dart
@@ -47,6 +47,80 @@ void main() {
       );
     });
 
+    test('the models URL names the base it sits on, not a route', () {
+      // The URL these runtimes print in their own docs, and the one in the
+      // clipboard of anyone who has just checked their server is alive — so
+      // it is an easy thing to paste into a field asking for an address.
+      //
+      // Two failures came out of taking it literally, and the second is the
+      // quiet one: Load models asked `/v1/models/models` and reported that
+      // the server answered with something else, *and* the address was
+      // stored as the chat route, so every meal request would have been
+      // POSTed to `/v1/models` for as long as it stayed configured.
+      expect(
+        AiCredentialStorage.resolveModelsEndpoint(
+          'http://192.168.1.5:11434/v1/models',
+        ),
+        Uri.parse('http://192.168.1.5:11434/v1/models'),
+      );
+      expect(
+        AiCredentialStorage.resolveEndpoint(
+          'http://192.168.1.5:11434/v1/models',
+        ),
+        Uri.parse('http://192.168.1.5:11434/v1/chat/completions'),
+        reason: 'the half that would have been wrong in silence',
+      );
+    });
+
+    test('a trailing slash on the models URL changes nothing', () {
+      expect(
+        AiCredentialStorage.resolveModelsEndpoint(
+          'http://127.0.0.1:1234/v1/models/',
+        ),
+        Uri.parse('http://127.0.0.1:1234/v1/models'),
+      );
+    });
+
+    test('a reverse-proxied models URL keeps its prefix', () {
+      // The prefix is the user's, and stripping the last segment must not
+      // take the rest of their routing with it.
+      expect(
+        AiCredentialStorage.resolveModelsEndpoint(
+          'https://ollama.example.com/api/v1/models',
+        ),
+        Uri.parse('https://ollama.example.com/api/v1/models'),
+      );
+      expect(
+        AiCredentialStorage.resolveEndpoint(
+          'https://ollama.example.com/api/v1/models',
+        ),
+        Uri.parse('https://ollama.example.com/api/v1/chat/completions'),
+      );
+    });
+
+    test('a path that merely ends in models is still not doubled', () {
+      // Nothing here claims the remainder is a `/v1` base — it is not, so it
+      // is kept as typed, which is what an unrecognised path has always got.
+      expect(
+        AiCredentialStorage.resolveModelsEndpoint(
+          'https://ollama.example.com/proxy/models',
+        ),
+        Uri.parse('https://ollama.example.com/proxy/models'),
+      );
+    });
+
+    test('a segment that merely ends in the word is left alone', () {
+      // The suffix is `/models`, not `models`. Without the slash this would
+      // eat the tail of any segment ending in those six letters and quietly
+      // send meals to a path the user never typed.
+      expect(
+        AiCredentialStorage.resolveEndpoint(
+          'https://ollama.example.com/v1/supermodels',
+        ),
+        Uri.parse('https://ollama.example.com/v1/supermodels'),
+      );
+    });
+
     test('what cannot be requested at all has nowhere to ask', () {
       // The form Ollama's own documentation shows, and not a URL.
       expect(AiCredentialStorage.resolveModelsEndpoint('192.168.1.5:11434'),


### PR DESCRIPTION
Raised by Copilot on #787.

## The failure

`…/v1/models` is the URL these runtimes print in their own docs, and the one in the clipboard of anyone who has just checked their server is alive — so it is an easy thing to paste into a field asking for an address. It was taken literally, and **two** things went wrong from the one wrong premise.

**The visible one**, which is what Copilot reported: `resolveModelsEndpoint` appends `/models` to anything that is not the chat route, so Load models asked `…/v1/models/models` and reported that the server had answered with something else.

**The quiet one, and the worse of the two:** the same text is stored as the *chat* endpoint. Every meal request would have been POSTed to `…/v1/models` for as long as that address stayed configured — failing into the parser fallback with nothing on screen to say why.

## The fix

One premise, so one place: `resolveEndpoint`, where both routes are decided. `resolveModelsEndpoint` needed **no change** — once the base resolves to the chat route, swapping the last segment already lands on `/v1/models`.

Stripping before anything else looks at the path is safe because `/models` is fixed by the protocol as the list route: no OpenAI-compatible server serves chat on a path ending in it. The suffix is `/models`, not `models`, so a segment merely ending in those six letters keeps them.

## Verification

Five new cases: the models URL itself, a trailing slash, a reverse-proxied `/api/v1/models` keeping its prefix, an unrecognised `/proxy/models` still not doubled, and `/v1/supermodels` left intact.

Three mutants, all caught:

| Mutant | Caught by |
|---|---|
| no strip (revert) | the models URL names the base it sits on |
| strip unconditionally | the three pre-existing base/chat-route tests |
| `'models'` without the leading slash | a segment that merely ends in the word is left alone |

The third is worth a note. It is also caught by four other tests, so I re-ran it alone to check the new `supermodels` case fails on its own merits rather than riding along — it does. Without the slash, `/v1/supermodels` silently becomes `/v1/super`, which is the same class of bug as the one being fixed.

Bare `fvm flutter analyze` (as CI runs it) clean; full suite 1622 passing.