### PR TITLE
style(onboarding): align a named argument with its siblings

### DIFF
--- a/lib/features/onboarding/presentation/widgets/onboarding_other_options_page_body.dart
+++ b/lib/features/onboarding/presentation/widgets/onboarding_other_options_page_body.dart
@@ -363,7 +363,7 @@ class _OnboardingOtherOptionsPageBodyState
     final subtitle = aiAssistSubtitle(
       s,
       configured: _aiConfigured,
-    endpoint: _aiEndpoint,
+      endpoint: _aiEndpoint,
       enabled: _aiEnabled,
       provider: _aiProvider,
     );


### PR DESCRIPTION
Raised by Copilot on #648.

`endpoint: _aiEndpoint,` sat four spaces in where `configured:`, `enabled:` and `provider:` around it sit at six, which reads as though it belonged to a different call.

## Two corrections to how it was reported

Copilot said the repository's format check would fail on it. It would not, for two separate reasons, and both are worth stating so this is filed under the right heading:

1. **CI does not run the format check.** `just ci` does; the workflow runs `flutter analyze` and `flutter test` only. Nothing automated would ever have caught this.
2. **If it did run, this file would fail anyway.** The pinned SDK's formatter disagrees with it in about a dozen other places — parameter wrapping, a `late final` initialiser, a trailing `)` — all pre-existing and none of them this line. I checked before touching it.

So the value here is legibility, not appeasing a check.

## Why by hand

Running `dart format` on the file would have swept up all of the above and buried a one-line fix in a rewrite of unrelated lines. The repo-wide skew is a known, separate matter.

Bare `fvm flutter analyze` clean; `test/features/onboarding/` and `ai_assist_subtitle_test.dart` — 91 tests — passing. One line changed.