### PR TITLE
fix(settings): stop a model list outliving the address it was asked for

### DIFF
--- a/lib/features/settings/presentation/widgets/ai_assist_dialog.dart
+++ b/lib/features/settings/presentation/widgets/ai_assist_dialog.dart
@@ -166,6 +166,14 @@ class _AiAssistDialogState extends State<AiAssistDialog> {
 
   bool _fetchingModels = false;
 
+  /// Which model-list request is the current one.
+  ///
+  /// The same job [_loadGeneration] does for the keystore reads, for the same
+  /// reason one level out: a request to a machine on someone's network can
+  /// take as long as it likes, and what it answers about is the address that
+  /// was in the field when it left — not whatever is there when it lands.
+  int _modelsGeneration = 0;
+
   /// The address the model on screen belongs to: what was stored when the
   /// dialog opened, then whatever was last asked.
   ///
@@ -282,6 +290,15 @@ class _AiAssistDialogState extends State<AiAssistDialog> {
       _modelIds = null;
       _modelListFailure = null;
       _modelListHost = null;
+      // Part of the same block, and easy to leave out of it. Bumping the
+      // generation is what makes a request that was in flight across the
+      // reload drop its own answer — including one started before a switch
+      // away and back, where the provider it belongs to is selected again by
+      // the time it lands. Clearing the flag is the other half: nothing is
+      // left to turn it off, and left set it disables the button for the
+      // rest of the dialog's life over a request nobody wants any more.
+      _modelsGeneration++;
+      _fetchingModels = false;
       _probe = probe;
       _probing = running != null;
       _loading = false;
@@ -386,12 +403,6 @@ class _AiAssistDialogState extends State<AiAssistDialog> {
   /// that it works for this app. Whether it works is #735's probe, which
   /// finds out by sending a real request.
   Future<void> _loadModels() async {
-    // The button disables itself while one is in flight; this covers the
-    // other caller. Finishing with the address field and pressing the button
-    // can land in the same gesture — tapping a control moves focus off the
-    // field — and two requests to somebody's server for one act is one too
-    // many.
-    if (_fetchingModels) return;
     final s = S.of(context);
     final typed = _endpointController.text.trim();
     final url = AiCredentialStorage.resolveModelsEndpoint(typed);
@@ -400,13 +411,31 @@ class _AiAssistDialogState extends State<AiAssistDialog> {
       setState(() => _endpointError = s.aiAssistEndpointInvalidLabel);
       return;
     }
+    final asking = AiCredentialStorage.resolveEndpoint(typed);
+
+    // **One request per address, not one at a time.** Finishing with the
+    // address field and pressing the button can land in the same gesture —
+    // tapping a control moves focus off the field — and two requests to
+    // somebody's server for one act is one too many. That is a statement
+    // about *this* address, though, and reading it as "busy" swallowed the
+    // next one: typing a second address while the first was still out
+    // cleared the model field, sent nothing, and then filled the picker with
+    // the first server's models under the second server's address.
+    if (_fetchingModels && asking == _lastEndpoint) return;
+
+    final generation = ++_modelsGeneration;
+    // Captured for the read below rather than for the guard: a key belongs to
+    // the provider that was selected when the request was built, and
+    // re-reading `_provider` after an await is how one provider's credential
+    // reaches another's endpoint.
+    final provider = _provider;
 
     setState(() {
       _fetchingModels = true;
       _modelIds = null;
       _modelListFailure = null;
       _modelListHost = AiCredentialStorage.displayHost(typed);
-      _lastEndpoint = AiCredentialStorage.resolveEndpoint(typed);
+      _lastEndpoint = asking;
     });
 
     // None of the four runtimes wants one by default; a reverse proxy in
@@ -417,10 +446,12 @@ class _AiAssistDialogState extends State<AiAssistDialog> {
       url,
       apiKey: typedKey.isNotEmpty
           ? typedKey
-          : await widget.storage.readApiKey(provider: _provider),
+          : await widget.storage.readApiKey(provider: provider),
     );
 
-    if (!mounted) return;
+    // Dropping this one loses nothing: a newer request writes every field it
+    // would have, and a provider switch has already cleared them.
+    if (!mounted || generation != _modelsGeneration) return;
     setState(() {
       _fetchingModels = false;
       _modelIds = result.failure == null ? result.ids : null;

--- a/test/features/settings/presentation/ai_assist_dialog_test.dart
+++ b/test/features/settings/presentation/ai_assist_dialog_test.dart
@@ -122,7 +122,34 @@ class _Server {
   final requests = <Uri>[];
   final http.Response Function(Uri url) _respond;
 
+  /// Answers held open, per host, until the test releases them.
+  ///
+  /// A machine on someone's LAN answers when it answers, and everything this
+  /// dialog gets wrong about model lists happens in that window. A fixture
+  /// that replies in a microtask closes it before a test can reach it.
+  ///
+  /// **Per host, so they can be released out of order.** Two requests that
+  /// always land in the order they were sent let a guard that drops a stale
+  /// answer pass for the wrong reason — the newest answer would have been
+  /// written last regardless.
+  final gates = <String, Completer<void>>{};
+
   _Server(this._respond);
+
+  /// A different list per host, so one server's answer can be told apart
+  /// from the answer of the server asked before it.
+  factory _Server.perHost(Map<String, List<String>> byHost) => _Server(
+    (url) => http.Response(
+      jsonEncode({
+        'object': 'list',
+        'data': [
+          for (final id in byHost[url.host] ?? const <String>[])
+            {'id': id, 'object': 'model'},
+        ],
+      }),
+      200,
+    ),
+  );
 
   /// Answers with a `/v1/models` body in the shape all four runtimes serve.
   factory _Server.listing(List<String> ids) => _Server(
@@ -142,6 +169,8 @@ class _Server {
   late final AiModelListApi api = AiModelListApi(
     client: MockClient((request) async {
       requests.add(request.url);
+      final held = gates[request.url.host];
+      if (held != null) await held.future;
       return _respond(request.url);
     }),
   );
@@ -1067,6 +1096,24 @@ void main() {
         await tester.pumpAndSettle();
       }
 
+      /// Commits an address **without letting the clock run**.
+      ///
+      /// `pumpAndSettle` advances the fake clock until nothing is scheduled,
+      /// and `AiModelListApi` carries a 15-second timeout — so a request held
+      /// open by [_Server.gate] times out instead of staying in flight, and
+      /// the window these cases are about never exists. Two sequential
+      /// fetches look exactly like the bug being tested for, which is how the
+      /// first version of this passed against the unfixed code.
+      Future<void> commitEndpoint(WidgetTester tester, String endpoint) async {
+        await tester.enterText(
+          find.bySemanticsIdentifier('ai-assist-endpoint-field'),
+          endpoint,
+        );
+        await tester.pump();
+        await tester.testTextInput.receiveAction(TextInputAction.done);
+        await tester.pump();
+      }
+
       Future<void> pressLoad(WidgetTester tester) async {
         final button = find.bySemanticsIdentifier('ai-assist-load-models');
         // The dialog is taller than a phone by design, so the control may
@@ -1345,6 +1392,142 @@ void main() {
               ?.text,
           isEmpty,
           reason: 'the model belonged to the address that just changed',
+        );
+      });
+
+      testWidgets('a second address committed while the first is still out '
+          'is asked too', (tester) async {
+        // #796. The one-request-per-act rule was read as "one at a time", so
+        // committing a second address while the first was still out cleared
+        // the model field and then sent nothing. The user is left looking at
+        // an address nothing was ever asked about.
+        final server = _Server.perHost({
+          '192.168.1.9': ['qwen3:8b'],
+          '192.168.1.7': ['llama3.2:3b'],
+        });
+        server.gates['192.168.1.9'] = Completer<void>();
+        server.gates['192.168.1.7'] = Completer<void>();
+        await storage.writeOwnServerConfiguration(
+          endpoint: 'http://192.168.1.5:11434',
+          model: 'gemma3:4b',
+          provider: AiProvider.ownServer,
+        );
+        await tester.pumpWidget(_app(storage, modelList: server.api));
+        await tester.pumpAndSettle();
+
+        await commitEndpoint(tester, 'http://192.168.1.9:11434');
+        await commitEndpoint(tester, 'http://192.168.1.7:11434');
+
+        expect(server.requests, [
+          Uri.parse('http://192.168.1.9:11434/v1/models'),
+          Uri.parse('http://192.168.1.7:11434/v1/models'),
+        ]);
+
+        for (final gate in server.gates.values) {
+          gate.complete();
+        }
+        await tester.pumpAndSettle();
+      });
+
+      testWidgets('the first server\'s list is not shown under the second '
+          'server\'s address', (tester) async {
+        // The visible half of the same bug, and the one that costs something:
+        // `_pickModel` writes the chosen id into the model field, so a list
+        // belonging to another machine is a model that does not exist on the
+        // one being configured — stored, and left for the setup check to fail
+        // on for a reason the dialog has already said is fine.
+        final server = _Server.perHost({
+          '192.168.1.9': ['qwen3:8b'],
+          '192.168.1.7': ['llama3.2:3b'],
+        });
+        server.gates['192.168.1.9'] = Completer<void>();
+        server.gates['192.168.1.7'] = Completer<void>();
+        await storage.writeOwnServerConfiguration(
+          endpoint: 'http://192.168.1.5:11434',
+          model: 'gemma3:4b',
+          provider: AiProvider.ownServer,
+        );
+        await tester.pumpWidget(_app(storage, modelList: server.api));
+        await tester.pumpAndSettle();
+
+        await commitEndpoint(tester, 'http://192.168.1.9:11434');
+        await commitEndpoint(tester, 'http://192.168.1.7:11434');
+
+        // **The newer answer first, then the older one.** Released in the
+        // order they were sent, the right list would be written last by
+        // accident and a missing guard would pass.
+        server.gates['192.168.1.7']!.complete();
+        await tester.pump();
+        await tester.pump();
+        server.gates['192.168.1.9']!.complete();
+        await tester.pumpAndSettle();
+
+        // The picker is closed, so it renders its hint rather than its items
+        // — `find.text` on an id would pass whatever the list held. Read the
+        // items off the widget instead.
+        final picker = tester.widget<DropdownButton<String>>(
+          find.descendant(
+            of: find.bySemanticsIdentifier('ai-assist-model-picker'),
+            matching: find.byType(DropdownButton<String>),
+          ),
+        );
+        expect(
+          picker.items?.map((item) => item.value),
+          ['llama3.2:3b'],
+          reason: 'the list on screen must belong to the address on screen',
+        );
+      });
+
+      testWidgets('a list that lands after a provider switch changes '
+          'nothing', (tester) async {
+        // Every other await in this dialog drops a write that no longer
+        // belongs (#788); this one arrived with #757 and did not. Contained
+        // today only because the picker renders for this provider alone —
+        // which is a fact about the current layout, not about the invariant.
+        final server = _Server.perHost({
+          '192.168.1.9': ['qwen3:8b'],
+        });
+        server.gates['192.168.1.9'] = Completer<void>();
+        await storage.writeOwnServerConfiguration(
+          endpoint: 'http://192.168.1.5:11434',
+          model: 'gemma3:4b',
+          provider: AiProvider.ownServer,
+        );
+        await tester.pumpWidget(_app(storage, modelList: server.api));
+        await tester.pumpAndSettle();
+
+        await commitEndpoint(tester, 'http://192.168.1.9:11434');
+
+        // **Away and back before the answer lands**, which is the case a
+        // provider check alone cannot see: by the time this request returns,
+        // the provider it was started for is selected again. What makes it
+        // stale is the reload in between, not who is on screen.
+        await tester.tap(find.text('Anthropic'));
+        await tester.pump();
+        await tester.pump();
+        await tester.tap(find.text(l10nEn.aiAssistProviderOwnServerLabel));
+        await tester.pump();
+        await tester.pump();
+
+        server.gates['192.168.1.9']!.complete();
+        await tester.pumpAndSettle();
+
+        // No picker at all rather than an empty one: `_load` clears the list
+        // on a switch, and nothing may put it back.
+        expect(
+          find.bySemanticsIdentifier('ai-assist-model-picker'),
+          findsNothing,
+        );
+        final button = find.bySemanticsIdentifier('ai-assist-load-models');
+        await tester.ensureVisible(button);
+        await tester.pumpAndSettle();
+        expect(
+          tester.widget<TextButton>(
+            find.descendant(of: button, matching: find.byType(TextButton)),
+          ).onPressed,
+          isNotNull,
+          reason: 'a request nobody wants any more must not disable the '
+              'button for the rest of the dialog',
         );
       });
 


### PR DESCRIPTION
Closes #796.

Every await in this dialog drops a write that no longer belongs ([#788](https://github.com/simonoppowa/OpenNutriTracker/pull/788)). The model-list fetch arrived with [#757](https://github.com/simonoppowa/OpenNutriTracker/issues/757) and did not.

## A committed address was swallowed

The one-request-per-act rule exists because a single gesture can produce two requests — tapping the button also unfocuses the field. It was written as *one at a time*. So typing a second address while the first was still out cleared the model field, **sent nothing**, and then filled the picker with the first server's models under the second server's address.

That is not cosmetic: `_pickModel` writes the chosen id into the model field, so OK stores a model that exists only on the machine the user moved off, and the setup check ([#780](https://github.com/simonoppowa/OpenNutriTracker/issues/780)) fails on it for a reason the dialog has already called fine.

The rule is now about the address. The same address twice still costs one request; a different one is asked.

## An answer could outlive the state it belonged to

The completion carries a generation, and `_load` bumps it as part of the block where it clears the list.

**A provider check would not have been enough**, which is the part worth flagging: switch away and back before the answer lands and the provider it was started for is selected again, so the check passes and the stale list is written. What makes it stale is the reload in between, not who is on screen.

`_load` also clears the in-flight flag. The guard makes that load-bearing — a request abandoned across a reload no longer turns it off, and left set it disables the button for the rest of the dialog's life. That would have been a new bug introduced by the fix.

## On the tests, because two of them were wrong first

**They passed against the unfixed code.** `AiModelListApi` has a 15-second timeout and `pumpAndSettle` advances the fake clock until nothing is scheduled — so a request held open by a completer timed out and completed before the second address was committed. What I had written was two *sequential* fetches, which is exactly what the bug looks like when it is not happening. Only the mutation run surfaced it. Commits now go through a helper that pumps frames without advancing time, and the trap is documented there.

**Answers are held per host so they can be released out of order.** Released in the order they were sent, the newest answer is written last by accident and a missing guard passes for the wrong reason.

| Mutant | Caught by |
|---|---|
| dedupe back to "one at a time" | a second address committed while the first is still out is asked too |
| no generation guard on the answer | the first server's list is not shown under the second server's address |
| reload does not supersede a request | a list that lands after a provider switch changes nothing |
| reload leaves the in-flight flag set | (same test, button-enabled assertion) |

Bare `fvm flutter analyze` (as CI runs it) clean; full suite 1629 passing.