### PR TITLE
test(settings): point the doc reference at the field that exists

### DIFF
--- a/test/features/settings/presentation/ai_assist_dialog_test.dart
+++ b/test/features/settings/presentation/ai_assist_dialog_test.dart
@@ -1100,7 +1100,7 @@ void main() {
       ///
       /// `pumpAndSettle` advances the fake clock until nothing is scheduled,
       /// and `AiModelListApi` carries a 15-second timeout — so a request held
-      /// open by [_Server.gate] times out instead of staying in flight, and
+      /// open by [_Server.gates] times out instead of staying in flight, and
       /// the window these cases are about never exists. Two sequential
       /// fetches look exactly like the bug being tested for, which is how the
       /// first version of this passed against the unfixed code.


### PR DESCRIPTION
Raised by Copilot on #798, and missed the merge — #798 was merged at `1903b2f6` while this was being pushed, so the fix landed on the branch but not in the integration branch.

The gate became per-host while the comment was being written, so `[_Server.gate]` resolves to nothing.

Worth its own commit for where it sits: that comment is what explains why these cases pump frames instead of calling `pumpAndSettle` — the trap that made the first version of them pass against the unfixed code. A reader who follows the link and finds nothing has reason to doubt the rest of it.

One word. Bare `fvm flutter analyze` clean; the 81 tests in that file pass.