### PR TITLE
fix(l10n): stop re-pushing a per-app language override the user cleared

### DIFF
--- a/lib/core/data/data_source/config_data_source.dart
+++ b/lib/core/data/data_source/config_data_source.dart
@@ -218,6 +218,14 @@ class ConfigDataSource {
     await _update((c) => c.selectedLocale = locale);
   }
 
+  Future<bool> getLocaleSyncSeeded() async {
+    return _readMerged().localeSyncSeeded ?? false;
+  }
+
+  Future<void> setLocaleSyncSeeded() async {
+    await _update((c) => c.localeSyncSeeded = true);
+  }
+
   Future<void> setConfigShowMicronutrients(bool show) async {
     await _update((c) => c.showMicronutrients = show);
   }

--- a/lib/core/data/dbo/config_dbo.dart
+++ b/lib/core/data/dbo/config_dbo.dart
@@ -152,6 +152,14 @@ class ConfigDBO extends HiveObject {
   // nothing has been deleted.
   @HiveField(36)
   List<String>? healthDeletedExternalIds;
+  // One-shot marker for [reconcileAppLocale]'s migration push: set once the
+  // saved language has been offered to Android's per-app language picker (or
+  // the picker was seen holding a value). Null means the push has not
+  // happened yet. Without it, an override the user cleared in the OS picker
+  // is indistinguishable from one that was never seeded, and gets silently
+  // pushed back on the next launch.
+  @HiveField(37)
+  bool? localeSyncSeeded;
 
   ConfigDBO(
     this.hasAcceptedDisclaimer,
@@ -188,6 +196,7 @@ class ConfigDBO extends HiveObject {
     this.healthWorkoutKcalMultiplier,
     this.healthLastImportAt,
     this.healthDeletedExternalIds,
+    this.localeSyncSeeded,
   });
 
   factory ConfigDBO.empty() =>

--- a/lib/core/data/dbo/config_dbo.g.dart
+++ b/lib/core/data/dbo/config_dbo.g.dart
@@ -51,6 +51,7 @@ class ConfigDBOAdapter extends TypeAdapter<ConfigDBO> {
         healthWorkoutKcalMultiplier: (fields[34] as num?)?.toDouble(),
         healthLastImportAt: fields[35] as DateTime?,
         healthDeletedExternalIds: (fields[36] as List?)?.cast<String>(),
+        localeSyncSeeded: fields[37] as bool?,
       )
       ..userCarbGoalPct = (fields[6] as num?)?.toDouble()
       ..userProteinGoalPct = (fields[7] as num?)?.toDouble()
@@ -60,7 +61,7 @@ class ConfigDBOAdapter extends TypeAdapter<ConfigDBO> {
   @override
   void write(BinaryWriter writer, ConfigDBO obj) {
     writer
-      ..writeByte(37)
+      ..writeByte(38)
       ..writeByte(0)
       ..write(obj.hasAcceptedDisclaimer)
       ..writeByte(1)
@@ -134,7 +135,9 @@ class ConfigDBOAdapter extends TypeAdapter<ConfigDBO> {
       ..writeByte(35)
       ..write(obj.healthLastImportAt)
       ..writeByte(36)
-      ..write(obj.healthDeletedExternalIds);
+      ..write(obj.healthDeletedExternalIds)
+      ..writeByte(37)
+      ..write(obj.localeSyncSeeded);
   }
 
   @override
@@ -202,6 +205,7 @@ ConfigDBO _$ConfigDBOFromJson(Map<String, dynamic> json) =>
             (json['healthDeletedExternalIds'] as List<dynamic>?)
                 ?.map((e) => e as String)
                 .toList(),
+        localeSyncSeeded: json['localeSyncSeeded'] as bool?,
       )
       ..userCarbGoalPct = (json['userCarbGoalPct'] as num?)?.toDouble()
       ..userProteinGoalPct = (json['userProteinGoalPct'] as num?)?.toDouble()
@@ -245,6 +249,7 @@ Map<String, dynamic> _$ConfigDBOToJson(ConfigDBO instance) => <String, dynamic>{
   'healthWorkoutKcalMultiplier': instance.healthWorkoutKcalMultiplier,
   'healthLastImportAt': instance.healthLastImportAt?.toIso8601String(),
   'healthDeletedExternalIds': instance.healthDeletedExternalIds,
+  'localeSyncSeeded': instance.localeSyncSeeded,
 };
 
 const _$AppThemeDBOEnumMap = {

--- a/lib/core/data/repository/config_repository.dart
+++ b/lib/core/data/repository/config_repository.dart
@@ -110,6 +110,14 @@ class ConfigRepository {
     await _configDataSource.setSelectedLocale(locale);
   }
 
+  Future<bool> getLocaleSyncSeeded() async {
+    return await _configDataSource.getLocaleSyncSeeded();
+  }
+
+  Future<void> setLocaleSyncSeeded() async {
+    await _configDataSource.setLocaleSyncSeeded();
+  }
+
   Future<void> setConfigShowMicronutrients(bool show) async {
     await _configDataSource.setConfigShowMicronutrients(show);
   }

--- a/lib/core/utils/app_locale_service.dart
+++ b/lib/core/utils/app_locale_service.dart
@@ -19,15 +19,25 @@ import 'package:flutter/services.dart';
 class AppLocaleService {
   static const _channel = MethodChannel('com.opennutritracker/locale');
 
-  /// The language tag the user chose in Android's Settings, or null when they
-  /// have not overridden it and the app should follow its own saved choice.
-  static Future<String?> getApplicationLocale() async {
+  /// The language tag the user chose in Android's Settings, or a null tag
+  /// when they have not overridden it and the app should follow its own saved
+  /// choice.
+  ///
+  /// `readFailed` separates "the platform says there is no override" from
+  /// "the platform could not be asked". [reconcileAppLocale] treats a missing
+  /// override as the user having cleared it, so a transient channel failure
+  /// reported as a plain null would destroy their saved language.
+  /// [MissingPluginException] is not a failure: no registered handler means a
+  /// platform with no per-app language setting at all, where "no override" is
+  /// the honest answer.
+  static Future<({String? tag, bool readFailed})> getApplicationLocale() async {
     try {
-      return await _channel.invokeMethod<String?>('getApplicationLocale');
+      final tag = await _channel.invokeMethod<String?>('getApplicationLocale');
+      return (tag: tag, readFailed: false);
     } on PlatformException {
-      return null;
+      return (tag: null, readFailed: true);
     } on MissingPluginException {
-      return null;
+      return (tag: null, readFailed: false);
     }
   }
 

--- a/lib/core/utils/app_locale_sync.dart
+++ b/lib/core/utils/app_locale_sync.dart
@@ -7,40 +7,52 @@ import 'dart:ui';
 /// and Settings -> Apps -> OpenNutriTracker -> Language. Whichever one someone
 /// reaches for, they should get the same answer afterwards.
 ///
-/// Four cases, decided on the raw [systemLocaleTag] rather than on the
+/// The cases are decided on the raw [systemLocaleTag] rather than on the
 /// language it resolves to, because "no override at all" and "an override we
-/// cannot render" mean opposite things:
+/// cannot render" mean opposite things. [localeSyncSeeded] records one fact
+/// and only that fact: **the OS has been seen holding an override** -- it is
+/// what makes a later absence readable as the user having cleared it. It is
+/// never set on a platform that reports no override, because there the
+/// absence is permanent and means nothing.
 ///
 /// - **A supported override.** The system wins -- it is the side the user can
-///   see from outside the app -- and is saved if it differs. Both sides now
-///   agree, so the migration below must never fire again: seeded is recorded.
+///   see from outside the app -- and is saved if it differs. The OS holds a
+///   value, so seeded is recorded.
 /// - **A tag we do not ship** (`ja`, say). Neither side is followed: the app
 ///   cannot render that language, and the saved choice is not pushed over it
-///   either. The user picked that language in the OS for a reason, and
-///   overwriting their choice is a louder wrong answer than ignoring it.
-/// - **No override, never seeded.** The upgrade path: an install that predates
-///   this wiring, or one where only the in-app picker has been used. The saved
-///   choice is pushed out so both sides start from the same place. This is a
-///   one-time migration, so it is recorded as seeded either way.
-/// - **No override, already seeded.** The OS once held a value and no longer
-///   does, which only happens when the user picked "System default" in
-///   Android's picker. That is a deliberate choice, so the in-app override is
-///   cleared to follow it -- without [localeSyncSeeded] this case is
-///   indistinguishable from the one above and the cleared value gets silently
-///   pushed back on the next cold start.
-///
-/// Off Android and below API 33 there is no system override to read and none
-/// can ever be set, so the first launch seeds nothing, records seeded, and
-/// every launch after that returns the saved choice untouched.
+///   either -- overwriting an explicit OS-level choice is a louder wrong
+///   answer than ignoring it. The OS still demonstrably holds a value, so
+///   seeded is recorded; switching it to System default later reads as the
+///   clear it is.
+/// - **The read failed.** Nothing is decided on a failed read: the saved
+///   choice is returned untouched. Treating it as "no override" would clear
+///   a language the user never cleared.
+/// - **No override, never seeded.** The upgrade path: an install that
+///   predates this wiring, or one where only the in-app picker has been
+///   used. The saved choice is pushed out so both sides start from the same
+///   place. Deliberately not recorded as seeded here -- the record comes
+///   from *observing* the pushed value on a later read. On Android 13+ that
+///   is the next launch; on platforms with no per-app override the push
+///   no-ops, the observation never comes, and this branch harmlessly repeats
+///   instead of ever mistaking the platform for a user who cleared it.
+/// - **No override, seeded.** The OS held a value and no longer does, which
+///   only happens when the user picked "System default" in Android's picker.
+///   That is a deliberate choice, so the in-app override is cleared to
+///   follow it -- without the seeded record this case is indistinguishable
+///   from the one above and the cleared value got silently pushed back on
+///   the next cold start.
 Future<String?> reconcileAppLocale({
   required String? savedLocaleCode,
   required String? systemLocaleTag,
+  required bool systemTagReadFailed,
   required bool localeSyncSeeded,
   required Iterable<Locale> supportedLocales,
   required Future<void> Function(String? localeCode) persistSelectedLocale,
   required Future<void> Function(String? languageTag) pushToSystem,
   required Future<void> Function() markLocaleSyncSeeded,
 }) async {
+  if (systemTagReadFailed) return savedLocaleCode;
+
   final systemCode = supportedLanguageCode(systemLocaleTag, supportedLocales);
 
   if (systemCode != null) {
@@ -50,11 +62,13 @@ Future<String?> reconcileAppLocale({
   }
 
   final hasSystemTag = systemLocaleTag != null && systemLocaleTag.isNotEmpty;
-  if (hasSystemTag) return savedLocaleCode;
+  if (hasSystemTag) {
+    if (!localeSyncSeeded) await markLocaleSyncSeeded();
+    return savedLocaleCode;
+  }
 
   if (!localeSyncSeeded) {
     if (savedLocaleCode != null) await pushToSystem(savedLocaleCode);
-    await markLocaleSyncSeeded();
     return savedLocaleCode;
   }
 

--- a/lib/core/utils/app_locale_sync.dart
+++ b/lib/core/utils/app_locale_sync.dart
@@ -30,11 +30,13 @@ import 'dart:ui';
 /// - **No override, never seeded.** The upgrade path: an install that
 ///   predates this wiring, or one where only the in-app picker has been
 ///   used. The saved choice is pushed out so both sides start from the same
-///   place. Deliberately not recorded as seeded here -- the record comes
-///   from *observing* the pushed value on a later read. On Android 13+ that
-///   is the next launch; on platforms with no per-app override the push
-///   no-ops, the observation never comes, and this branch harmlessly repeats
-///   instead of ever mistaking the platform for a user who cleared it.
+///   place. Seeded is recorded only by *observing* the pushed value, read
+///   back in this same call -- never by the attempt alone. On Android 13+
+///   the read-back sees the value immediately, so the record lands before
+///   this call returns and a clear arriving any time after it is honoured;
+///   on platforms with no per-app override the push no-ops, the read-back
+///   stays empty, and this branch harmlessly repeats instead of ever
+///   mistaking the platform for a user who cleared it.
 /// - **No override, seeded.** The OS held a value and no longer does, which
 ///   only happens when the user picked "System default" in Android's picker.
 ///   That is a deliberate choice, so the in-app override is cleared to
@@ -49,6 +51,7 @@ Future<String?> reconcileAppLocale({
   required Iterable<Locale> supportedLocales,
   required Future<void> Function(String? localeCode) persistSelectedLocale,
   required Future<void> Function(String? languageTag) pushToSystem,
+  required Future<({String? tag, bool readFailed})> Function() readSystemTag,
   required Future<void> Function() markLocaleSyncSeeded,
 }) async {
   if (systemTagReadFailed) return savedLocaleCode;
@@ -68,7 +71,13 @@ Future<String?> reconcileAppLocale({
   }
 
   if (!localeSyncSeeded) {
-    if (savedLocaleCode != null) await pushToSystem(savedLocaleCode);
+    if (savedLocaleCode != null) {
+      await pushToSystem(savedLocaleCode);
+      final verify = await readSystemTag();
+      if (!verify.readFailed && verify.tag != null && verify.tag!.isNotEmpty) {
+        await markLocaleSyncSeeded();
+      }
+    }
     return savedLocaleCode;
   }
 

--- a/lib/core/utils/app_locale_sync.dart
+++ b/lib/core/utils/app_locale_sync.dart
@@ -7,30 +7,59 @@ import 'dart:ui';
 /// and Settings -> Apps -> OpenNutriTracker -> Language. Whichever one someone
 /// reaches for, they should get the same answer afterwards.
 ///
-/// The system override wins when it exists, because it is the one the user can
-/// see from outside the app. When it does not exist but we have a saved choice
-/// -- an install that predates this wiring, or a fresh one where only the
-/// in-app picker has been used -- the saved choice is pushed out to the system
-/// so both sides start from the same place.
+/// Four cases, decided on the raw [systemLocaleTag] rather than on the
+/// language it resolves to, because "no override at all" and "an override we
+/// cannot render" mean opposite things:
 ///
-/// Off Android and below API 33 there is no system override at all, and this
-/// collapses to returning the saved choice untouched.
+/// - **A supported override.** The system wins -- it is the side the user can
+///   see from outside the app -- and is saved if it differs. Both sides now
+///   agree, so the migration below must never fire again: seeded is recorded.
+/// - **A tag we do not ship** (`ja`, say). Neither side is followed: the app
+///   cannot render that language, and the saved choice is not pushed over it
+///   either. The user picked that language in the OS for a reason, and
+///   overwriting their choice is a louder wrong answer than ignoring it.
+/// - **No override, never seeded.** The upgrade path: an install that predates
+///   this wiring, or one where only the in-app picker has been used. The saved
+///   choice is pushed out so both sides start from the same place. This is a
+///   one-time migration, so it is recorded as seeded either way.
+/// - **No override, already seeded.** The OS once held a value and no longer
+///   does, which only happens when the user picked "System default" in
+///   Android's picker. That is a deliberate choice, so the in-app override is
+///   cleared to follow it -- without [localeSyncSeeded] this case is
+///   indistinguishable from the one above and the cleared value gets silently
+///   pushed back on the next cold start.
+///
+/// Off Android and below API 33 there is no system override to read and none
+/// can ever be set, so the first launch seeds nothing, records seeded, and
+/// every launch after that returns the saved choice untouched.
 Future<String?> reconcileAppLocale({
   required String? savedLocaleCode,
   required String? systemLocaleTag,
+  required bool localeSyncSeeded,
   required Iterable<Locale> supportedLocales,
   required Future<void> Function(String? localeCode) persistSelectedLocale,
   required Future<void> Function(String? languageTag) pushToSystem,
+  required Future<void> Function() markLocaleSyncSeeded,
 }) async {
   final systemCode = supportedLanguageCode(systemLocaleTag, supportedLocales);
 
   if (systemCode != null) {
     if (systemCode != savedLocaleCode) await persistSelectedLocale(systemCode);
+    if (!localeSyncSeeded) await markLocaleSyncSeeded();
     return systemCode;
   }
 
-  if (savedLocaleCode != null) await pushToSystem(savedLocaleCode);
-  return savedLocaleCode;
+  final hasSystemTag = systemLocaleTag != null && systemLocaleTag.isNotEmpty;
+  if (hasSystemTag) return savedLocaleCode;
+
+  if (!localeSyncSeeded) {
+    if (savedLocaleCode != null) await pushToSystem(savedLocaleCode);
+    await markLocaleSyncSeeded();
+    return savedLocaleCode;
+  }
+
+  if (savedLocaleCode != null) await persistSelectedLocale(null);
+  return null;
 }
 
 /// The supported language code behind a platform language tag, or null when
@@ -47,7 +76,8 @@ String? supportedLanguageCode(
   if (languageTag == null || languageTag.isEmpty) return null;
   final code = languageTag.split(RegExp(r'[-_]')).first.toLowerCase();
   if (code.isEmpty) return null;
-  final isSupported =
-      supportedLocales.any((locale) => locale.languageCode == code);
+  final isSupported = supportedLocales.any(
+    (locale) => locale.languageCode == code,
+  );
   return isSupported ? code : null;
 }

--- a/lib/dev/main_dev.dart
+++ b/lib/dev/main_dev.dart
@@ -34,9 +34,11 @@ Future<void> main() async {
   final config = await configRepo.getConfig();
   // Mirrors the reconciliation in main.dart so a dev build behaves the same
   // way when the OS holds a per-app language.
+  final systemLocale = await AppLocaleService.getApplicationLocale();
   final localeCode = await reconcileAppLocale(
     savedLocaleCode: await configRepo.getSelectedLocale(),
-    systemLocaleTag: await AppLocaleService.getApplicationLocale(),
+    systemLocaleTag: systemLocale.tag,
+    systemTagReadFailed: systemLocale.readFailed,
     localeSyncSeeded: await configRepo.getLocaleSyncSeeded(),
     supportedLocales: S.supportedLocales,
     persistSelectedLocale: configRepo.setSelectedLocale,

--- a/lib/dev/main_dev.dart
+++ b/lib/dev/main_dev.dart
@@ -43,6 +43,7 @@ Future<void> main() async {
     supportedLocales: S.supportedLocales,
     persistSelectedLocale: configRepo.setSelectedLocale,
     pushToSystem: AppLocaleService.setApplicationLocale,
+    readSystemTag: AppLocaleService.getApplicationLocale,
     markLocaleSyncSeeded: configRepo.setLocaleSyncSeeded,
   );
   final savedLocale = localeCode != null ? Locale(localeCode) : null;

--- a/lib/dev/main_dev.dart
+++ b/lib/dev/main_dev.dart
@@ -37,9 +37,11 @@ Future<void> main() async {
   final localeCode = await reconcileAppLocale(
     savedLocaleCode: await configRepo.getSelectedLocale(),
     systemLocaleTag: await AppLocaleService.getApplicationLocale(),
+    localeSyncSeeded: await configRepo.getLocaleSyncSeeded(),
     supportedLocales: S.supportedLocales,
     persistSelectedLocale: configRepo.setSelectedLocale,
     pushToSystem: AppLocaleService.setApplicationLocale,
+    markLocaleSyncSeeded: configRepo.setLocaleSyncSeeded,
   );
   final savedLocale = localeCode != null ? Locale(localeCode) : null;
   final savedAppTheme = await configRepo.getConfigAppTheme();

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -94,6 +94,7 @@ Future<void> _bootstrapApp() async {
     supportedLocales: S.supportedLocales,
     persistSelectedLocale: configRepo.setSelectedLocale,
     pushToSystem: AppLocaleService.setApplicationLocale,
+    readSystemTag: AppLocaleService.getApplicationLocale,
     markLocaleSyncSeeded: configRepo.setLocaleSyncSeeded,
   );
   final savedLocale = localeCode != null ? Locale(localeCode) : null;
@@ -239,13 +240,41 @@ class _OpenNutriTrackerAppState extends State<OpenNutriTrackerApp>
     unawaited(_adoptSystemLocale());
   }
 
+  /// True while [_adoptSystemLocale] is between its awaits; a second entry
+  /// then only queues a re-run instead of racing the first.
+  bool _adoptingSystemLocale = false;
+  bool _adoptSystemLocaleQueued = false;
+
   /// The same [reconcileAppLocale] the launch path runs, deliberately: this
   /// fires for any locale change — the per-app picker, but also a plain
   /// system-language change on platforms with no per-app override — and a
   /// second hand-rolled copy of the decision table here could disagree with
   /// the launch one about the same OS state within one session. Only the
   /// screen update is local; every persistence decision stays in one place.
+  ///
+  /// Serialized against itself: reconciling can change the locale (the
+  /// migration push), which re-fires [didChangeLocales] while the first run
+  /// is still mid-flight. Overlapping runs would read the same pre-write
+  /// config snapshot and double-apply it, so a run arriving early is queued
+  /// and replayed once the current one finishes — dropped instead of
+  /// queued, it could miss a clear that arrived mid-run.
   Future<void> _adoptSystemLocale() async {
+    if (_adoptingSystemLocale) {
+      _adoptSystemLocaleQueued = true;
+      return;
+    }
+    _adoptingSystemLocale = true;
+    try {
+      do {
+        _adoptSystemLocaleQueued = false;
+        await _reconcileAndAdoptLocale();
+      } while (_adoptSystemLocaleQueued);
+    } finally {
+      _adoptingSystemLocale = false;
+    }
+  }
+
+  Future<void> _reconcileAndAdoptLocale() async {
     final configRepo = locator<ConfigRepository>();
     final systemLocale = await AppLocaleService.getApplicationLocale();
     final localeCode = await reconcileAppLocale(
@@ -256,8 +285,12 @@ class _OpenNutriTrackerAppState extends State<OpenNutriTrackerApp>
       supportedLocales: S.supportedLocales,
       persistSelectedLocale: configRepo.setSelectedLocale,
       pushToSystem: AppLocaleService.setApplicationLocale,
+      readSystemTag: AppLocaleService.getApplicationLocale,
       markLocaleSyncSeeded: configRepo.setLocaleSyncSeeded,
     );
+    // Persistence above deliberately ran to completion regardless of widget
+    // lifetime — what is saved must not depend on whether this State is
+    // still mounted. Only the on-screen update needs the live context.
     if (!mounted) return;
 
     final localeProvider = Provider.of<LocaleProvider>(context, listen: false);

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -85,9 +85,11 @@ Future<void> _bootstrapApp() async {
   // Android's own per-app language picker and ours are two doors into the
   // same setting, so ask the system what it holds before trusting what we
   // saved. See [reconcileAppLocale] for which side wins and why.
+  final systemLocale = await AppLocaleService.getApplicationLocale();
   final localeCode = await reconcileAppLocale(
     savedLocaleCode: await configRepo.getSelectedLocale(),
-    systemLocaleTag: await AppLocaleService.getApplicationLocale(),
+    systemLocaleTag: systemLocale.tag,
+    systemTagReadFailed: systemLocale.readFailed,
     localeSyncSeeded: await configRepo.getLocaleSyncSeeded(),
     supportedLocales: S.supportedLocales,
     persistSelectedLocale: configRepo.setSelectedLocale,
@@ -237,29 +239,31 @@ class _OpenNutriTrackerAppState extends State<OpenNutriTrackerApp>
     unawaited(_adoptSystemLocale());
   }
 
+  /// The same [reconcileAppLocale] the launch path runs, deliberately: this
+  /// fires for any locale change — the per-app picker, but also a plain
+  /// system-language change on platforms with no per-app override — and a
+  /// second hand-rolled copy of the decision table here could disagree with
+  /// the launch one about the same OS state within one session. Only the
+  /// screen update is local; every persistence decision stays in one place.
   Future<void> _adoptSystemLocale() async {
-    final systemTag = await AppLocaleService.getApplicationLocale();
-    final systemCode = supportedLanguageCode(systemTag, S.supportedLocales);
+    final configRepo = locator<ConfigRepository>();
+    final systemLocale = await AppLocaleService.getApplicationLocale();
+    final localeCode = await reconcileAppLocale(
+      savedLocaleCode: await configRepo.getSelectedLocale(),
+      systemLocaleTag: systemLocale.tag,
+      systemTagReadFailed: systemLocale.readFailed,
+      localeSyncSeeded: await configRepo.getLocaleSyncSeeded(),
+      supportedLocales: S.supportedLocales,
+      persistSelectedLocale: configRepo.setSelectedLocale,
+      pushToSystem: AppLocaleService.setApplicationLocale,
+      markLocaleSyncSeeded: configRepo.setLocaleSyncSeeded,
+    );
     if (!mounted) return;
 
     final localeProvider = Provider.of<LocaleProvider>(context, listen: false);
+    if (localeProvider.locale?.languageCode == localeCode) return;
 
-    if (systemCode == null) {
-      // A tag we do not ship is ignored, same as at launch. No tag at all
-      // means the user picked "System default" in Android's picker — follow
-      // it, or that picker appears to do nothing in the clearing direction.
-      if (systemTag != null && systemTag.isNotEmpty) return;
-      if (localeProvider.locale == null) return;
-
-      localeProvider.updateLocale(null);
-      await locator<ConfigRepository>().setSelectedLocale(null);
-      return;
-    }
-
-    if (localeProvider.locale?.languageCode == systemCode) return;
-
-    localeProvider.updateLocale(Locale(systemCode));
-    await locator<ConfigRepository>().setSelectedLocale(systemCode);
+    localeProvider.updateLocale(localeCode != null ? Locale(localeCode) : null);
   }
 
   @override

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -88,9 +88,11 @@ Future<void> _bootstrapApp() async {
   final localeCode = await reconcileAppLocale(
     savedLocaleCode: await configRepo.getSelectedLocale(),
     systemLocaleTag: await AppLocaleService.getApplicationLocale(),
+    localeSyncSeeded: await configRepo.getLocaleSyncSeeded(),
     supportedLocales: S.supportedLocales,
     persistSelectedLocale: configRepo.setSelectedLocale,
     pushToSystem: AppLocaleService.setApplicationLocale,
+    markLocaleSyncSeeded: configRepo.setLocaleSyncSeeded,
   );
   final savedLocale = localeCode != null ? Locale(localeCode) : null;
 
@@ -236,13 +238,24 @@ class _OpenNutriTrackerAppState extends State<OpenNutriTrackerApp>
   }
 
   Future<void> _adoptSystemLocale() async {
-    final systemCode = supportedLanguageCode(
-      await AppLocaleService.getApplicationLocale(),
-      S.supportedLocales,
-    );
-    if (systemCode == null || !mounted) return;
+    final systemTag = await AppLocaleService.getApplicationLocale();
+    final systemCode = supportedLanguageCode(systemTag, S.supportedLocales);
+    if (!mounted) return;
 
     final localeProvider = Provider.of<LocaleProvider>(context, listen: false);
+
+    if (systemCode == null) {
+      // A tag we do not ship is ignored, same as at launch. No tag at all
+      // means the user picked "System default" in Android's picker — follow
+      // it, or that picker appears to do nothing in the clearing direction.
+      if (systemTag != null && systemTag.isNotEmpty) return;
+      if (localeProvider.locale == null) return;
+
+      localeProvider.updateLocale(null);
+      await locator<ConfigRepository>().setSelectedLocale(null);
+      return;
+    }
+
     if (localeProvider.locale?.languageCode == systemCode) return;
 
     localeProvider.updateLocale(Locale(systemCode));

--- a/test/unit_test/app_locale_service_test.dart
+++ b/test/unit_test/app_locale_service_test.dart
@@ -30,7 +30,10 @@ void main() {
     test('reads the language the OS holds', () async {
       handleWith((_) async => 'pl');
 
-      expect(await AppLocaleService.getApplicationLocale(), 'pl');
+      expect(await AppLocaleService.getApplicationLocale(), (
+        tag: 'pl',
+        readFailed: false,
+      ));
       expect(calls.single.method, 'getApplicationLocale');
     });
 
@@ -53,10 +56,16 @@ void main() {
       expect(calls.single.arguments, {'tag': null});
     });
 
-    test('a platform failure does not escape', () async {
+    // The read must say it failed, not answer "no override": downstream, a
+    // missing override from a working read means the user cleared their
+    // language, and a transient failure must never read as that.
+    test('a platform failure does not escape, and says it failed', () async {
       handleWith((_) => throw PlatformException(code: 'unavailable'));
 
-      await expectLater(AppLocaleService.getApplicationLocale(), completion(isNull));
+      expect(await AppLocaleService.getApplicationLocale(), (
+        tag: null,
+        readFailed: true,
+      ));
       await expectLater(AppLocaleService.setApplicationLocale('de'), completes);
     });
   });
@@ -64,8 +73,14 @@ void main() {
   // Nothing on the other side of the channel is the normal case on iOS, on
   // desktop, and in any widget test that pumps the settings screen. Failing
   // there would break a screen someone opened to fix their language.
+  // Reported as a clean "no override", not as a failure: on these platforms
+  // the absence is permanent and true, and marking it failed would freeze
+  // locale handling there forever.
   test('a missing native side is not an error', () async {
-    expect(await AppLocaleService.getApplicationLocale(), isNull);
+    expect(await AppLocaleService.getApplicationLocale(), (
+      tag: null,
+      readFailed: false,
+    ));
     await expectLater(AppLocaleService.setApplicationLocale('de'), completes);
   });
 }

--- a/test/unit_test/app_locale_sync_test.dart
+++ b/test/unit_test/app_locale_sync_test.dart
@@ -21,12 +21,20 @@ const _supported = [
 ];
 
 class _Recorder {
+  /// What a read-back of the OS tag answers after a push. By default it
+  /// echoes the pushed value — a platform that holds per-app overrides.
+  /// Pass false for one that cannot hold them, where a push no-ops.
+  _Recorder({this.readBackFollowsPush = true});
+
+  final bool readBackFollowsPush;
   final persisted = <String?>[];
   final pushed = <String?>[];
   int seededMarks = 0;
 
   Future<void> persist(String? code) async => persisted.add(code);
   Future<void> push(String? tag) async => pushed.add(tag);
+  Future<({String? tag, bool readFailed})> readBack() async =>
+      (tag: readBackFollowsPush ? pushed.lastOrNull : null, readFailed: false);
   Future<void> markSeeded() async => seededMarks++;
 }
 
@@ -44,6 +52,7 @@ Future<String?> _reconcile(
   supportedLocales: _supported,
   persistSelectedLocale: recorder.persist,
   pushToSystem: recorder.push,
+  readSystemTag: recorder.readBack,
   markLocaleSyncSeeded: recorder.markSeeded,
 );
 
@@ -94,8 +103,11 @@ void main() {
 
     // The upgrade path: someone chose a language in the app long before this
     // wiring existed, so the OS has no override yet. Their choice is what
-    // they meant, and it seeds the system rather than being overwritten by it.
-    test('with no override, a saved choice seeds the system', () async {
+    // they meant, and it seeds the system rather than being overwritten by
+    // it. The read-back sees the pushed value, so seeded is recorded in the
+    // same call — a clear arriving any time afterwards is honoured, with no
+    // window in which it would read as never-seeded and be re-pushed.
+    test('a saved choice seeds the system and the echo records it', () async {
       final recorder = _Recorder();
 
       final result = await _reconcile(recorder, saved: 'uk', system: null);
@@ -105,20 +117,19 @@ void main() {
       expect(recorder.persisted, isEmpty);
       expect(
         recorder.seededMarks,
-        0,
+        1,
         reason:
-            'seeded means the OS was SEEN holding a value; recording it on '
-            'the attempt would turn a platform that cannot hold one — where '
-            'this branch repeats forever — into a user who cleared it',
+            'seeded means the OS was SEEN holding a value — here via the '
+            'read-back of the push, not the attempt itself',
       );
     });
 
-    // The observation that completes the migration: the pushed value comes
-    // back on the next read, which is when seeded may be recorded. On a
-    // platform with no per-app override the push no-ops, this never fires,
-    // and the saved choice survives every launch.
+    // On a platform with no per-app override the push no-ops and the
+    // read-back stays empty, so seeded is never recorded and the migration
+    // branch repeats — harmlessly — instead of the platform ever being
+    // mistaken for a user who cleared their override.
     test('a saved choice on an override-less platform survives', () async {
-      final recorder = _Recorder();
+      final recorder = _Recorder(readBackFollowsPush: false);
 
       await _reconcile(recorder, saved: 'uk', system: null);
       final result = await _reconcile(recorder, saved: 'uk', system: null);
@@ -128,6 +139,11 @@ void main() {
         recorder.persisted,
         isEmpty,
         reason: 'nothing may clear a choice the user never cleared',
+      );
+      expect(
+        recorder.pushed,
+        ['uk', 'uk'],
+        reason: 'the repeat is the design: pushes that never take are no-ops',
       );
       expect(recorder.seededMarks, 0);
     });
@@ -227,7 +243,7 @@ void main() {
 
       expect(result, 'it');
       expect(recorder.pushed, ['it']);
-      expect(recorder.seededMarks, 0);
+      expect(recorder.seededMarks, 1);
     });
 
     // A channel failure is not an answer. Deciding anything on it — most of

--- a/test/unit_test/app_locale_sync_test.dart
+++ b/test/unit_test/app_locale_sync_test.dart
@@ -35,9 +35,11 @@ Future<String?> _reconcile(
   String? saved,
   String? system,
   bool seeded = false,
+  bool readFailed = false,
 }) => reconcileAppLocale(
   savedLocaleCode: saved,
   systemLocaleTag: system,
+  systemTagReadFailed: readFailed,
   localeSyncSeeded: seeded,
   supportedLocales: _supported,
   persistSelectedLocale: recorder.persist,
@@ -93,7 +95,7 @@ void main() {
     // The upgrade path: someone chose a language in the app long before this
     // wiring existed, so the OS has no override yet. Their choice is what
     // they meant, and it seeds the system rather than being overwritten by it.
-    test('with no override, a saved choice seeds the system once', () async {
+    test('with no override, a saved choice seeds the system', () async {
       final recorder = _Recorder();
 
       final result = await _reconcile(recorder, saved: 'uk', system: null);
@@ -103,11 +105,31 @@ void main() {
       expect(recorder.persisted, isEmpty);
       expect(
         recorder.seededMarks,
-        1,
+        0,
         reason:
-            'unrecorded, this push would repeat on every launch and '
-            'silently reinstate an override the user cleared',
+            'seeded means the OS was SEEN holding a value; recording it on '
+            'the attempt would turn a platform that cannot hold one — where '
+            'this branch repeats forever — into a user who cleared it',
       );
+    });
+
+    // The observation that completes the migration: the pushed value comes
+    // back on the next read, which is when seeded may be recorded. On a
+    // platform with no per-app override the push no-ops, this never fires,
+    // and the saved choice survives every launch.
+    test('a saved choice on an override-less platform survives', () async {
+      final recorder = _Recorder();
+
+      await _reconcile(recorder, saved: 'uk', system: null);
+      final result = await _reconcile(recorder, saved: 'uk', system: null);
+
+      expect(result, 'uk');
+      expect(
+        recorder.persisted,
+        isEmpty,
+        reason: 'nothing may clear a choice the user never cleared',
+      );
+      expect(recorder.seededMarks, 0);
     });
 
     // The other reading of "no override": it was seeded before, so its
@@ -146,11 +168,7 @@ void main() {
       expect(result, isNull);
       expect(recorder.pushed, isEmpty);
       expect(recorder.persisted, isEmpty);
-      expect(
-        recorder.seededMarks,
-        1,
-        reason: 'there is nothing to migrate, so the migration is done',
-      );
+      expect(recorder.seededMarks, 0);
     });
 
     test('a region-qualified tag resolves to the language we ship', () async {
@@ -194,8 +212,11 @@ void main() {
       );
       expect(
         recorder.seededMarks,
-        0,
-        reason: 'nothing was reconciled; the migration question stays open',
+        1,
+        reason:
+            'the OS demonstrably holds an override, so its later absence '
+            'must read as the user clearing it — not as never-seeded, which '
+            'would re-push the saved code over their System default',
       );
     });
 
@@ -206,7 +227,27 @@ void main() {
 
       expect(result, 'it');
       expect(recorder.pushed, ['it']);
-      expect(recorder.seededMarks, 1);
+      expect(recorder.seededMarks, 0);
+    });
+
+    // A channel failure is not an answer. Deciding anything on it — most of
+    // all the seeded+absent clear below — would destroy a language the user
+    // never touched.
+    test('a failed read changes nothing, even when seeded', () async {
+      final recorder = _Recorder();
+
+      final result = await _reconcile(
+        recorder,
+        saved: 'de',
+        system: null,
+        seeded: true,
+        readFailed: true,
+      );
+
+      expect(result, 'de');
+      expect(recorder.pushed, isEmpty);
+      expect(recorder.persisted, isEmpty);
+      expect(recorder.seededMarks, 0);
     });
   });
 

--- a/test/unit_test/app_locale_sync_test.dart
+++ b/test/unit_test/app_locale_sync_test.dart
@@ -23,54 +23,77 @@ const _supported = [
 class _Recorder {
   final persisted = <String?>[];
   final pushed = <String?>[];
+  int seededMarks = 0;
 
   Future<void> persist(String? code) async => persisted.add(code);
   Future<void> push(String? tag) async => pushed.add(tag);
+  Future<void> markSeeded() async => seededMarks++;
 }
 
 Future<String?> _reconcile(
   _Recorder recorder, {
   String? saved,
   String? system,
-}) =>
-    reconcileAppLocale(
-      savedLocaleCode: saved,
-      systemLocaleTag: system,
-      supportedLocales: _supported,
-      persistSelectedLocale: recorder.persist,
-      pushToSystem: recorder.push,
-    );
+  bool seeded = false,
+}) => reconcileAppLocale(
+  savedLocaleCode: saved,
+  systemLocaleTag: system,
+  localeSyncSeeded: seeded,
+  supportedLocales: _supported,
+  persistSelectedLocale: recorder.persist,
+  pushToSystem: recorder.push,
+  markLocaleSyncSeeded: recorder.markSeeded,
+);
 
 void main() {
   group('reconcileAppLocale', () {
     test('the system override wins and is saved', () async {
       final recorder = _Recorder();
 
-      final result =
-          await _reconcile(recorder, saved: 'de', system: 'pl');
+      final result = await _reconcile(recorder, saved: 'de', system: 'pl');
 
       expect(result, 'pl');
-      expect(recorder.persisted, ['pl'],
-          reason: 'Settings should show what the OS picker holds');
-      expect(recorder.pushed, isEmpty,
-          reason: 'the OS already has this value; writing it back is noise');
+      expect(
+        recorder.persisted,
+        ['pl'],
+        reason: 'Settings should show what the OS picker holds',
+      );
+      expect(
+        recorder.pushed,
+        isEmpty,
+        reason: 'the OS already has this value; writing it back is noise',
+      );
+      expect(
+        recorder.seededMarks,
+        1,
+        reason: 'an OS value existing means both sides are already met',
+      );
     });
 
     test('an override that already matches is not written again', () async {
       final recorder = _Recorder();
 
-      final result =
-          await _reconcile(recorder, saved: 'de', system: 'de');
+      final result = await _reconcile(
+        recorder,
+        saved: 'de',
+        system: 'de',
+        seeded: true,
+      );
 
       expect(result, 'de');
       expect(recorder.persisted, isEmpty);
       expect(recorder.pushed, isEmpty);
+      expect(
+        recorder.seededMarks,
+        0,
+        reason: 'already recorded; another config write is noise',
+      );
     });
 
     // The upgrade path: someone chose a language in the app long before this
     // wiring existed, so the OS has no override yet. Their choice is what
     // they meant, and it seeds the system rather than being overwritten by it.
-    test('with no override, a saved choice seeds the system', () async {
+    test('with no override, a saved choice seeds the system once', () async {
       final recorder = _Recorder();
 
       final result = await _reconcile(recorder, saved: 'uk', system: null);
@@ -78,6 +101,41 @@ void main() {
       expect(result, 'uk');
       expect(recorder.pushed, ['uk']);
       expect(recorder.persisted, isEmpty);
+      expect(
+        recorder.seededMarks,
+        1,
+        reason:
+            'unrecorded, this push would repeat on every launch and '
+            'silently reinstate an override the user cleared',
+      );
+    });
+
+    // The other reading of "no override": it was seeded before, so its
+    // absence now is the user having picked System default in Android's
+    // picker. Re-pushing the saved choice would undo their action; instead
+    // the saved choice follows the OS and is cleared.
+    test('once seeded, a cleared override clears the saved choice', () async {
+      final recorder = _Recorder();
+
+      final result = await _reconcile(
+        recorder,
+        saved: 'uk',
+        system: null,
+        seeded: true,
+      );
+
+      expect(result, isNull);
+      expect(
+        recorder.pushed,
+        isEmpty,
+        reason: 'pushing the old choice back is the bug this exists for',
+      );
+      expect(
+        recorder.persisted,
+        [null],
+        reason: 'System default means follow the system in both pickers',
+      );
+      expect(recorder.seededMarks, 0);
     });
 
     test('with nothing on either side, nothing happens', () async {
@@ -88,6 +146,11 @@ void main() {
       expect(result, isNull);
       expect(recorder.pushed, isEmpty);
       expect(recorder.persisted, isEmpty);
+      expect(
+        recorder.seededMarks,
+        1,
+        reason: 'there is nothing to migrate, so the migration is done',
+      );
     });
 
     test('a region-qualified tag resolves to the language we ship', () async {
@@ -102,23 +165,38 @@ void main() {
     test('a script-and-region tag resolves the same way', () async {
       final recorder = _Recorder();
 
-      final result =
-          await _reconcile(recorder, saved: null, system: 'zh-Hans-CN');
+      final result = await _reconcile(
+        recorder,
+        saved: null,
+        system: 'zh-Hans-CN',
+      );
 
       expect(result, 'zh');
       expect(recorder.persisted, ['zh']);
     });
 
-    // A tag we do not ship must not strand anyone in a half-translated app.
-    test('an unshipped language is treated as no override', () async {
+    // A tag we do not ship must not strand anyone in a half-translated app —
+    // but it is still the user's explicit OS-level choice, so it is ignored,
+    // not overwritten. The app keeps its saved language and the OS keeps its.
+    test('an unshipped language is ignored, not corrected', () async {
       final recorder = _Recorder();
 
       final result = await _reconcile(recorder, saved: 'de', system: 'ja');
 
       expect(result, 'de');
       expect(recorder.persisted, isEmpty);
-      expect(recorder.pushed, ['de'],
-          reason: 'the OS holds a language we cannot render; correct it');
+      expect(
+        recorder.pushed,
+        isEmpty,
+        reason:
+            'overwriting an OS-level choice we merely cannot render '
+            'is a stronger action than ignoring it',
+      );
+      expect(
+        recorder.seededMarks,
+        0,
+        reason: 'nothing was reconciled; the migration question stays open',
+      );
     });
 
     test('an empty tag is treated as no override', () async {
@@ -128,6 +206,7 @@ void main() {
 
       expect(result, 'it');
       expect(recorder.pushed, ['it']);
+      expect(recorder.seededMarks, 1);
     });
   });
 


### PR DESCRIPTION
Follow-up to #672. The launch-time reconciliation pushes the saved in-app language to the OS whenever the OS reports no override. That push was meant as a one-time migration for installs that predate the wiring, but nothing records that it happened — and "no override" is also exactly what the OS reports after the user picks **System default** in Android's per-app picker. Their clear is silently re-pushed on the next cold start, so the only way off the override is the in-app picker, with nothing suggesting so. Two neighbouring cases share the flaw:

- An OS override the app does not ship (say `ja`) folds to the same null, so the saved code was pushed **over** the user's OS-level choice — overwriting it rather than ignoring it.
- Clearing the override while the app is alive did nothing on screen: `_adoptSystemLocale` early-returned on null, the inert-picker failure in the clearing direction.

### The fix

Config gains `localeSyncSeeded` (Hive index 37), recording exactly one fact: **the OS has been seen holding an override.** `reconcileAppLocale` decides the ambiguous cases on the raw system tag instead of the folded language code:

- Supported override → system wins, saved if different, seeded recorded.
- Unshipped override → ignored on both sides (the OS demonstrably holds a value, so seeded is still recorded — switching it to System default later reads as the clear it is).
- Failed channel read → nothing is decided; a transient failure must never read as a deliberate clear. `AppLocaleService.getApplicationLocale` now reports `readFailed` distinctly instead of folding `PlatformException` into "no override" (`MissingPluginException` stays a clean "no override": on iOS/desktop the absence is permanent and true).
- No override, not seeded → the one-time migration push, **verified by reading the tag straight back**: on Android 13+ the value echoes back and seeded is recorded before the call returns, so a clear arriving any time later is honoured; on platforms with no per-app override the read-back stays empty and the branch repeats as a harmless no-op instead of ever mistaking the platform for a user who cleared their override.
- No override, seeded → the user picked System default: the in-app override is cleared to follow it.

`_adoptSystemLocale` now runs the same `reconcileAppLocale` instead of hand-rolling a second copy of the decision table, which gives the runtime path the seeded guard and the failed-read guard for free — and fixes the clearing direction while the app is alive. It is also serialized against itself: the migration push re-fires `didChangeLocales` mid-run, and two interleaved runs would double-apply one config snapshot; an early arrival queues a replay rather than being dropped.

### Verification

- Unit tests cover the full decision table: push-echo seeding, the cleared-override clear, the unshipped-tag ignore, the override-less-platform repeat (pushes asserted), the failed-read guard, and the existing supported-override cases.
- `flutter analyze` clean; full suite green (1093 tests).
