### PR TITLE
fix(core): read a selection as one act, the way it is written as one act

### DIFF
--- a/lib/core/utils/ai_credential_storage.dart
+++ b/lib/core/utils/ai_credential_storage.dart
@@ -311,31 +311,46 @@ class AiCredentialStorage {
         enabled: false,
       );
     }
-    final apiKey = await readApiKey(provider: provider);
-    final endpoint = await readEndpoint(provider: provider);
-    // Read here rather than only in `readSelection`, because usability now
-    // depends on it for one provider. That call gets no more expensive — it
-    // was reading the model separately anyway — and a summary costs one more
-    // round trip than it did, which is the price of the row and the request
-    // agreeing about whether this provider can answer.
-    final modelId = await readModel(provider: provider);
-    // The invariant, stated here once: the flag alone never means "on" — a
-    // provider that is not usable is off whatever the tag says.
-    final enabled =
-        _isUsable(
-          provider,
-          apiKey: apiKey,
-          endpoint: endpoint,
-          modelId: modelId,
-        ) &&
-        await _storage.read(key: _enabledTag) != 'false';
-    return (
-      provider: provider,
-      apiKey: apiKey,
-      endpoint: endpoint,
-      modelId: modelId,
-      enabled: enabled,
-    );
+    final target = provider;
+    // **Read as one act, because it is written as one act.** Each line below
+    // is a platform-channel round trip, and `writeOwnServerConfiguration`
+    // commits an endpoint and a model together under this same lock — so
+    // without it a save landing between two of these reads hands back
+    // `(endpoint A, model B)`, a pair the user never configured and no
+    // machine was ever asked about. That is not a verdict written against the
+    // wrong destination, which the conditional writes already catch; it is a
+    // *request sent* to one, and by then the photograph has left. #813.
+    //
+    // Nothing reachable from in here may take the lock again — it is not
+    // reentrant. These are all plain reads, and `activeProvider` is resolved
+    // above rather than inside.
+    return _probeConfigurationLock.synchronized(() async {
+      final apiKey = await readApiKey(provider: target);
+      final endpoint = await readEndpoint(provider: target);
+      // Read here rather than only in `readSelection`, because usability now
+      // depends on it for one provider. That call gets no more expensive — it
+      // was reading the model separately anyway — and a summary costs one
+      // more round trip than it did, which is the price of the row and the
+      // request agreeing about whether this provider can answer.
+      final modelId = await readModel(provider: target);
+      // The invariant, stated here once: the flag alone never means "on" — a
+      // provider that is not usable is off whatever the tag says.
+      final enabled =
+          _isUsable(
+            target,
+            apiKey: apiKey,
+            endpoint: endpoint,
+            modelId: modelId,
+          ) &&
+          await _storage.read(key: _enabledTag) != 'false';
+      return (
+        provider: target,
+        apiKey: apiKey,
+        endpoint: endpoint,
+        modelId: modelId,
+        enabled: enabled,
+      );
+    });
   }
 
   /// The route every OpenAI-compatible runtime answers on. Fixed by the

--- a/lib/features/add_meal/domain/usecase/run_ai_endpoint_probe_usecase.dart
+++ b/lib/features/add_meal/domain/usecase/run_ai_endpoint_probe_usecase.dart
@@ -107,13 +107,15 @@ class AiEndpointProbeRunner {
     String? localeCode,
   }) async {
     try {
-      // A provisional identity, for the case where there turns out to be
-      // nothing to send: it lets a caller joining later tell "tested nothing,
-      // because paused" from "tested a configuration that has since changed".
-      // When there *is* something to send it is replaced below by the
-      // identity of the selection actually probed, which is the only one a
-      // verdict may be validated against.
-      running.testing = await _configurationOf(provider);
+      // Read the configuration **once**, and take the identity from it.
+      //
+      // This used to ask `_configurationOf` first and `selectionFor` after,
+      // which is two reads with a gap between them: a save landing in the gap
+      // probed one machine and validated another. #813 made the selection
+      // read atomic, and asking only it removes the gap as well as the
+      // disagreement. `_configurationOf` is now reached only when there is
+      // nothing to send, where the identity is a hint for a later join rather
+      // than something a verdict is judged against.
       // Named rather than active: this is a probe of *this* provider's stored
       // configuration, not of whoever happens to be selected when it gets
       // around to asking. Reading the active selection instead put a window
@@ -125,15 +127,14 @@ class AiEndpointProbeRunner {
       // is sent, and a probe is a request like any other.
       final selection = await _credentials.selectionFor(provider);
       if (selection == null) {
+        running.testing = await _configurationOf(provider);
         _log.info('Nothing to probe for ${provider.name}');
       } else {
-        // **The identity of what is about to be sent**, taken from the
-        // selection itself rather than from the read above it. Those are two
-        // reads of the same store with a gap between them: a change landing
-        // in that gap probed the new configuration and validated the old, so
-        // a good verdict was thrown away — and if the configuration changed
-        // back before the probe returned, the new machine's verdict was
-        // stored against the old one. Raised by Copilot on #800.
+        // The identity of what is about to be sent, taken from the selection
+        // itself. #800: validating against a separately-read snapshot threw
+        // good verdicts away, and stored the new machine's verdict against
+        // the old one when the configuration changed back before the probe
+        // returned.
         final tested = (
           endpoint: selection.endpoint,
           modelId: selection.modelId,

--- a/test/unit_test/ai_credential_storage_test.dart
+++ b/test/unit_test/ai_credential_storage_test.dart
@@ -557,6 +557,64 @@ void main() {
   });
 
   group('a server the user runs', () {
+    test('a selection is never one save\'s address beside another\'s model', () async {
+      // The read side of the same rule. `writeOwnServerConfiguration` commits
+      // the pair as one act; reading the fields one at a time let a save land
+      // between them and hand back `(endpoint A, model B)` — a pair the user
+      // never configured and no machine was ever asked about.
+      //
+      // Worse than a wasted round trip, because it is a *request* to that
+      // pair: a photo sent to one box asking for another box's model is a
+      // `model_not_found`, which is `unsupported`, which #782 reads as
+      // grounds to take the camera away from a configuration that works.
+      // #813.
+      await storage.setActiveProvider(AiProvider.ownServer);
+      await storage.writeOwnServerConfiguration(
+        endpoint: 'http://192.168.1.5:11434',
+        model: 'model-a',
+        provider: AiProvider.ownServer,
+      );
+
+      // Held after the address has been read and before the model is.
+      const modelKey = 'AiModelTag.ownServer';
+      final held = Completer<void>();
+      backing.readGates[modelKey] = held;
+
+      final reading = storage.selectionFor(AiProvider.ownServer);
+      for (var i = 0; i < 50 && !backing.reads.contains(modelKey); i++) {
+        await Future<void>.delayed(Duration.zero);
+      }
+
+      // Started, not awaited: with the fix the read holds the lock, so this
+      // save waits — and awaiting it here would wait on ourselves.
+      backing.readGates.remove(modelKey);
+      final saved = storage.writeOwnServerConfiguration(
+        endpoint: 'http://192.168.1.9:11434',
+        model: 'model-b',
+        provider: AiProvider.ownServer,
+      );
+      held.complete();
+      final selection = await reading;
+      await saved;
+
+      expect(
+        [selection?.endpoint, selection?.modelId],
+        anyOf(
+          equals([
+            'http://192.168.1.5:11434/v1/chat/completions',
+            'model-a',
+          ]),
+          equals([
+            'http://192.168.1.9:11434/v1/chat/completions',
+            'model-b',
+          ]),
+        ),
+        reason: 'a torn read is not only a crossed pair: writing an address '
+            'clears the model, so the half-read state can also come back as '
+            'not configured at all and the feature go quietly unavailable',
+      );
+    });
+
     test('two overlapping saves cannot cross their endpoint and model', () async {
       // The pair commits as one act or not at all. Taking the lock once per
       // write let two saves interleave — endpoint A, endpoint B, model B,

--- a/test/unit_test/ai_endpoint_probe_runner_test.dart
+++ b/test/unit_test/ai_endpoint_probe_runner_test.dart
@@ -324,18 +324,20 @@ void main() {
     expect(stored.photo, AiCapability.passed);
   });
 
-  test('a verdict is validated against the configuration it probed', () async {
-    // Two reads of the same store with a gap between them: the identity was
-    // taken by `_configurationOf`, and the configuration actually sent came
-    // from `selectionFor` a moment later. A change landing in that gap probed
-    // the new machine and validated the old — so a good verdict was thrown
-    // away, and if the configuration changed *back* before the probe
-    // returned, the new machine's verdict was written against the old one.
-    // Raised by Copilot on #800.
+  test('a save landing as a check starts cannot mislead it', () async {
+    // Two guarantees composed, and neither is enough alone.
+    //
+    // #813 makes the selection read atomic, so a save cannot slip between the
+    // address read and the model read and hand the check a pair that was
+    // never configured — it waits, and the check is sent to the machine that
+    // was configured when it started.
+    //
+    // #800 makes the verdict conditional on that same pair, so the answer
+    // about the old machine is not written against the new one after the save
+    // lands.
     await configure();
-    // Held between the two reads: the key slot is the first thing
-    // `selectionFor` asks for, so the identity is already taken and the
-    // address is not yet.
+    // Held on the first read the selection makes, so the save arrives while
+    // the check is deciding where to go.
     final betweenReads = Completer<void>();
     backing.readGates['AiApiKeyTag.ownServer'] = betweenReads;
     prober.gate = Completer<void>();
@@ -343,36 +345,29 @@ void main() {
     final running = runner.start(own);
     await pumpEventQueue();
 
-    // The user re-points at another box while the check is starting.
-    await storage.writeOwnServerConfiguration(
+    // Started, not awaited: the read holds the lock, so awaiting here would
+    // wait on a save that is waiting on us.
+    backing.readGates.remove('AiApiKeyTag.ownServer');
+    final saved = storage.writeOwnServerConfiguration(
       endpoint: 'http://192.168.1.9:11434',
       model: 'gemma3:4b',
       provider: own,
     );
-    backing.readGates.remove('AiApiKeyTag.ownServer');
     betweenReads.complete();
-    await pumpEventQueue();
-
-    // And back again before the answer lands, which is what made the old
-    // identity match and let the wrong verdict through.
-    await storage.writeOwnServerConfiguration(
-      endpoint: 'http://192.168.1.5:11434',
-      model: 'gemma3:4b',
-      provider: own,
-    );
+    await saved;
 
     prober.gate!.complete();
     await running;
 
     expect(
       prober.lastSelection?.endpoint,
-      contains('192.168.1.9'),
-      reason: 'the probe was sent to the machine configured at the time',
+      contains('192.168.1.5'),
+      reason: 'the save may not tear the pair the check was sent to',
     );
     expect(
       (await storage.readProbe(provider: own)).photo,
       AiCapability.unknown,
-      reason: 'that verdict is about a machine this configuration is not',
+      reason: 'that verdict is about the machine the user has moved off',
     );
   });
 


### PR DESCRIPTION
Closes #813. Raised by Copilot on #800, as a suppressed comment on a review that otherwise reported no findings.

## The failure

`writeOwnServerConfiguration` commits an endpoint and a model together under `_probeConfigurationLock`. `_readState` read the fields one at a time and took no lock, so a save landing between two of those reads handed back a pair the user never configured.

**This is a different class from the four fixed on #800.** Those were about *storing* a verdict against the wrong configuration, and each was closed by validating before the write. This one is about **sending**: by the time anything checks, the request has already gone.

It chains into #782, which merged with #800 — a photo sent to one box asking for another box's model is a `model_not_found`, which is `unsupported`, which now retracts the camera from a configuration that works.

## What the mutation actually showed

I expected a crossed `(endpoint A, model B)`. Removing the lock produces **`null`**: writing an address clears the model, so a read straddling a save sees the new endpoint with no model, `_isUsable` answers false, and the feature reads as *not configured at all*. A working setup goes quietly unavailable. That is in the test's reason, because it is what the next reader will see.

## The change

**`_readState` reads under the same lock the writes take.** Checked before wrapping: none of the six existing lock sites reaches `_readState`, `readSelection`, `selectionFor` or `isEnabled`, and the lock is not reentrant. `activeProvider` stays resolved outside it for the same reason.

**The probe runner now reads once.** It asked `_configurationOf` and then `selectionFor` — two atomic reads with a gap between them, and `_configurationOf` reads its two fields *unlocked*, so it could produce a crossed identity of its own. Taking the identity from the selection removes the gap and the second reader together. `_configurationOf` survives only for the nothing-to-probe case.

## One test had to be rewritten, not kept

The #800 test changed the configuration mid-check by gating the key-slot read. That read is inside the lock now, so the scenario **deadlocks by construction** — the guarantee makes its own premise unreachable. It asserts the composed property instead: a save landing as a check starts neither tears the pair the check is sent to (#813) nor gets the old machine's verdict written against the new one (#800). It starts the save without awaiting it, since the read holds the lock.

## Verification

Mutant — drop the lock from the read — caught by both new tests:

| Test | Level |
|---|---|
| a selection is never one save's address beside another's model | storage |
| a save landing as a check starts cannot mislead it | runner |

Bare `fvm flutter analyze` (as CI runs it) clean; full suite 1768 passing.