### PR TITLE
fix(add-meal): stop the entry block squeezing the rows off the screen

### DIFF
--- a/lib/features/add_meal/presentation/screens/bulk_add_screen.dart
+++ b/lib/features/add_meal/presentation/screens/bulk_add_screen.dart
@@ -204,25 +204,49 @@ class _BulkAddScreenState extends State<BulkAddScreen> {
       body: SafeArea(
         child: BlocBuilder<BulkAddBloc, BulkAddState>(
           bloc: _bloc,
-          builder: (context, state) => Column(
-            children: [
-              _buildInput(context),
-              const Divider(height: 1),
-              Expanded(child: _buildBody(context, state)),
-              if (state is BulkAddLoadedState) _buildSubmitBar(context, state),
-            ],
+          builder: (context, state) => LayoutBuilder(
+            builder: (context, constraints) => Column(
+              children: [
+                // The **field** is bounded, not the block. At 2x on a 320dp
+                // screen the entry block measured 388px — a four-line field
+                // plus a full-height button — against about 595px of body,
+                // and with the submit bar's 192 that left the rows nothing
+                // and overflowed by 14px. #820.
+                //
+                // Capping the whole block was tried first and is worse: the
+                // Search button falls below the fold inside the scroll view,
+                // so the primary action of the screen has to be scrolled to.
+                // Bounding the field alone keeps the button where it is.
+                //
+                // A ceiling rather than fewer `maxLines`: shrinking the field
+                // at large text scales would take multi-line entry away from
+                // exactly the users who need the biggest text, on a screen
+                // that exists for typing several items at once.
+                _buildInput(context, maxFieldHeight: constraints.maxHeight * 0.3),
+                const Divider(height: 1),
+                Expanded(child: _buildBody(context, state)),
+                if (state is BulkAddLoadedState)
+                  _buildSubmitBar(context, state),
+              ],
+            ),
           ),
         ),
       ),
     );
   }
 
-  Widget _buildInput(BuildContext context) => Padding(
+  Widget _buildInput(BuildContext context, {required double maxFieldHeight}) =>
+      Padding(
     padding: const EdgeInsets.all(16),
     child: Column(
       crossAxisAlignment: CrossAxisAlignment.stretch,
       children: [
-        Semantics(
+        // Scrolls past its ceiling rather than being clipped: what is typed
+        // must stay reachable, and at ordinary text sizes four lines are far
+        // below this so nothing changes.
+        ConstrainedBox(
+          constraints: BoxConstraints(maxHeight: maxFieldHeight),
+          child: Semantics(
           identifier: 'bulk-add-input',
           child: TextField(
             controller: _textController,
@@ -235,6 +259,7 @@ class _BulkAddScreenState extends State<BulkAddScreen> {
               border: const OutlineInputBorder(),
             ),
           ),
+        ),
         ),
         const SizedBox(height: 12),
         Semantics(

--- a/test/features/add_meal/presentation/bulk_add_screen_test.dart
+++ b/test/features/add_meal/presentation/bulk_add_screen_test.dart
@@ -464,14 +464,82 @@ void main() {
     // The cap being gone is the fix, not an implementation detail: any
     // maxLines put back here truncates German at this size.
     expect(notice.maxLines, isNull);
-    // **Not `takeException()` here.** This viewport also produces a 14px
-    // RenderFlex overflow that has nothing to do with the notice — halving
-    // the notice's own ceiling leaves it at exactly 14px — so asserting a
-    // clean frame would fail this test for someone else's defect and hide
-    // this one behind it. Filed separately; the assertion above is what #777
-    // is about.
+    // Still not `takeException()`: #820 removed the vertical overflow, and
+    // doing so uncovered horizontal ones in the row layout that had been
+    // masked by it. Those are #824; the assertion above is what #777 is
+    // about.
     tester.takeException();
   });
+
+  testWidgets('the screen fits at 2x on a narrow phone, in German', (
+    tester,
+  ) async {
+    // #820. Only the row list could give ground: the entry block and the
+    // submit bar were both fixed, and at 2x they measured 388 and 192 against
+    // about 595 of body — so the rows got nothing and the column overflowed
+    // by 14px. German, because the buttons carry the longest labels.
+    tester.view.physicalSize = const Size(320 * 3, 640 * 3);
+    tester.view.devicePixelRatio = 3.0;
+    addTearDown(tester.view.reset);
+
+    await _registerWithFailingReader({
+      'toast': [_meal('Toast')],
+    }, const MealInterpreterException(
+      'request timed out',
+      failure: MealInterpreterFailure.timeout,
+    ));
+
+    // Collected rather than asserted away. Fixing the vertical overflow
+    // uncovered horizontal ones in the row layout — 65 and 244 pixels —
+    // which had been masked while layout aborted before the rows were
+    // reached. Those are #824, so this test
+    // says precisely what it guarantees: nothing overflows *downwards* any
+    // more. A blanket `takeException` would pass while the column overflowed
+    // again, and a clean-frame assertion would fail for the rows.
+    final errors = <String>[];
+    final previous = FlutterError.onError;
+    FlutterError.onError = (details) => errors.add(details.toString());
+    addTearDown(() => FlutterError.onError = previous);
+
+    await tester.pumpWidget(
+      MediaQuery(
+        data: const MediaQueryData(textScaler: TextScaler.linear(2.0)),
+        child: _app(locale: const Locale('de')),
+      ),
+    );
+    await tester.pumpAndSettle();
+    await _parse(tester, '100g toast');
+
+    expect(
+      errors.where((e) => e.contains('overflowed') && e.contains('bottom')),
+      isEmpty,
+      reason: 'the column still does not fit the screen it is given',
+    );
+
+    final input = tester
+        .getSize(find.bySemanticsIdentifier('bulk-add-input'))
+        .height;
+    final submit = tester
+        .getSize(find.bySemanticsIdentifier('bulk-add-submit'))
+        .height;
+    final parse = tester
+        .getSize(find.bySemanticsIdentifier('bulk-add-parse'))
+        .height;
+
+    expect(
+      input,
+      lessThanOrEqualTo(640 * 0.3),
+      reason: 'the field is what gives ground, so the rows do not have to',
+    );
+    // The rows are what was being squeezed to nothing. 32 of padding above
+    // and 32 below the two buttons, and a 1px divider.
+    expect(
+      input + parse + submit + 65,
+      lessThan(640),
+      reason: 'the fixed children have to leave the list some height',
+    );
+  });
+
 
   testWidgets('the advice is a control, so nothing can truncate it', (
     tester,


### PR DESCRIPTION
Closes #820.

## The arithmetic

At 2x text scale on a 320dp screen, measured through the widgets:

| part | height |
| :-- | --: |
| entry block (four-line field + button + padding) | **388** |
| divider | 1 |
| submit bar | **192** |
| **fixed total** | **581** |
| available body | ~595 |

Only the row list was `Expanded`, so it was the only child that could give ground — and there was none left. Hence the 14px.

## The fix, and the one I tried first

The **field** is bounded at 30% of available height and scrolls past it. At ordinary text sizes four lines are far below that, and a `ConstrainedBox` only caps, so nothing changes for most users.

**Bounding the whole entry block was my first attempt and is worse.** It puts the Search button below the fold inside the scroll view — the primary action of the screen would have to be scrolled to. The tests caught it: `_parse` could no longer reach the button. Bounding the field alone keeps the button where it is.

**A ceiling rather than fewer `maxLines` at large scales.** Shrinking the field would take multi-line entry away from exactly the users who need the biggest text, on a screen that exists for typing several items at once.

## What it uncovered

Two **horizontal** overflows in the row layout — 65px and 244px — which had been masked because layout aborted vertically before the rows were reached. Not a regression from this change; the rows were always like that. Filed as #824, with the likely cause (`_buildAmountRow`'s fixed `SizedBox(width: 110)` against a scaling field and dropdown).

## Why the test does not assert a clean frame

It collects `FlutterError`s and requires none of them to be a **downward** overflow.

- A clean-frame assertion would fail for #824 and hide this fix behind someone else's defect.
- A blanket `takeException()` would pass while the column overflowed again — the exact regression this exists to catch.

So it says the true narrower thing. #777's test keeps its narrower assertion for the same reason, with its comment now pointing at #824 rather than "filed separately".

## Verification

Mutant — remove the field's ceiling — fails `the screen fits at 2x on a narrow phone, in German`.

Bare `fvm flutter analyze` clean; full suite **1772** passing.