### PR TITLE
fix(add-meal): give a row's controls a line of their own (#824)

### DIFF
--- a/lib/features/add_meal/presentation/screens/bulk_add_screen.dart
+++ b/lib/features/add_meal/presentation/screens/bulk_add_screen.dart
@@ -1,3 +1,5 @@
+import 'dart:math' as math;
+
 import 'package:auto_size_text/auto_size_text.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter/services.dart';
@@ -554,93 +556,166 @@ class _BulkAddScreenState extends State<BulkAddScreen> {
     final title = meal?.name ?? row.resolved.parsed.query;
     final faded = row.skipped || !row.isResolved;
 
+    // Both rows below decide between one line and two, so they need the width
+    // they were actually given rather than the screen's.
     return Opacity(
       opacity: row.skipped ? 0.5 : 1.0,
       child: Padding(
         padding: const EdgeInsets.symmetric(horizontal: 16, vertical: 10),
-        child: Column(
-          crossAxisAlignment: CrossAxisAlignment.start,
-          children: [
-            Row(
-              children: [
-                Expanded(
-                  child: InkWell(
-                    onTap: row.isResolved
-                        ? () => _showCandidatePicker(index, row)
-                        : null,
-                    child: Column(
-                      crossAxisAlignment: CrossAxisAlignment.start,
-                      children: [
-                        // User content inside a Row: shrink to fit before
-                        // ellipsizing, never wrap (AGENTS.md).
-                        AutoSizeText(
-                          title,
-                          maxLines: 1,
-                          minFontSize: 12,
-                          overflow: TextOverflow.ellipsis,
-                          style: theme.textTheme.titleSmall?.copyWith(
-                            decoration: row.skipped
-                                ? TextDecoration.lineThrough
-                                : null,
-                          ),
-                        ),
-                        if (!row.isResolved)
-                          Text(
-                            S.of(context).bulkAddNoMatchLabel,
-                            style: theme.textTheme.bodySmall?.copyWith(
-                              color: theme.colorScheme.error,
-                            ),
-                          )
-                        else if (row.isLowConfidence)
-                          Text(
-                            S.of(context).bulkAddUncertainLabel,
-                            style: theme.textTheme.bodySmall?.copyWith(
-                              color: theme.colorScheme.tertiary,
-                            ),
-                          )
-                        // A bare count the app could not interpret. Shown
-                        // below a doubtful match, because a wrong food
-                        // matters more than a wrong unit on the right one.
-                        else if (row.amountNeedsCheck)
-                          Text(
-                            S.of(context).bulkAddCheckAmountLabel,
-                            style: theme.textTheme.bodySmall?.copyWith(
-                              color: theme.colorScheme.tertiary,
-                            ),
-                          )
-                        else if (meal?.brands != null)
-                          Text(meal!.brands!, style: theme.textTheme.bodySmall),
-                      ],
+        child: LayoutBuilder(
+          builder: (context, constraints) {
+            final available = constraints.maxWidth;
+            final actions = _rowActions(context, index, row);
+            // A `TextButton` is its label plus Material's padding, floored at
+            // its minimum size. At 2x on a 320dp screen the German "skip"
+            // alone measures 353px of the 288 this row gets, and a `Row`
+            // answers that by squeezing the name to nothing and overflowing
+            // by 65 anyway. #824.
+            final actionsWidth = actions.fold<double>(
+              0,
+              (sum, action) => sum + _actionWidth(context, action.label),
+            );
+            // Below this the name has no share of the line worth reading, so
+            // the controls take a line of their own and leave it the width.
+            final stacked =
+                available - actionsWidth <
+                MediaQuery.textScalerOf(context).scale(72);
+
+            final buttons = [
+              for (final action in actions)
+                TextButton(
+                  onPressed: action.onPressed,
+                  child: Text(action.label),
+                ),
+            ];
+
+            final titleBlock = InkWell(
+              onTap: row.isResolved
+                  ? () => _showCandidatePicker(index, row)
+                  : null,
+              child: Column(
+                crossAxisAlignment: CrossAxisAlignment.start,
+                children: [
+                  // User content inside a Row: shrink to fit before
+                  // ellipsizing, never wrap (AGENTS.md).
+                  AutoSizeText(
+                    title,
+                    maxLines: 1,
+                    minFontSize: 12,
+                    overflow: TextOverflow.ellipsis,
+                    style: theme.textTheme.titleSmall?.copyWith(
+                      decoration: row.skipped
+                          ? TextDecoration.lineThrough
+                          : null,
                     ),
                   ),
-                ),
-                if (!row.isResolved)
-                  TextButton(
-                    onPressed: _showQuickAdd,
-                    child: Text(S.of(context).quickAddCardLabel),
+                  if (!row.isResolved)
+                    Text(
+                      S.of(context).bulkAddNoMatchLabel,
+                      style: theme.textTheme.bodySmall?.copyWith(
+                        color: theme.colorScheme.error,
+                      ),
+                    )
+                  else if (row.isLowConfidence)
+                    Text(
+                      S.of(context).bulkAddUncertainLabel,
+                      style: theme.textTheme.bodySmall?.copyWith(
+                        color: theme.colorScheme.tertiary,
+                      ),
+                    )
+                  // A bare count the app could not interpret. Shown
+                  // below a doubtful match, because a wrong food
+                  // matters more than a wrong unit on the right one.
+                  else if (row.amountNeedsCheck)
+                    Text(
+                      S.of(context).bulkAddCheckAmountLabel,
+                      style: theme.textTheme.bodySmall?.copyWith(
+                        color: theme.colorScheme.tertiary,
+                      ),
+                    )
+                  else if (meal?.brands != null)
+                    Text(meal!.brands!, style: theme.textTheme.bodySmall),
+                ],
+              ),
+            );
+
+            return Column(
+              crossAxisAlignment: CrossAxisAlignment.start,
+              children: [
+                if (stacked)
+                  // Stretched, so each label is bounded by the line rather
+                  // than by whatever is left of it.
+                  Column(
+                    crossAxisAlignment: CrossAxisAlignment.stretch,
+                    children: [titleBlock, ...buttons],
+                  )
+                else
+                  // Unchanged wherever they fit, which is every ordinary
+                  // text size: name on the left, controls on the right.
+                  Row(
+                    children: [
+                      Expanded(child: titleBlock),
+                      ...buttons,
+                    ],
                   ),
-                TextButton(
-                  onPressed: () => _bloc.add(ToggleRowSkippedEvent(index)),
-                  child: Text(
-                    row.skipped
-                        ? S.of(context).bulkAddIncludeLabel
-                        : S.of(context).bulkAddSkipLabel,
-                  ),
-                ),
+                if (!faded)
+                  _buildAmountRow(context, state, index, row, available),
               ],
-            ),
-            if (!faded) _buildAmountRow(context, state, index, row),
-          ],
+            );
+          },
         ),
       ),
     );
   }
+
+  /// The controls on a row, as label and action rather than as widgets, so
+  /// that what is measured cannot drift from what is drawn.
+  List<({String label, VoidCallback onPressed})> _rowActions(
+    BuildContext context,
+    int index,
+    BulkAddRow row,
+  ) => [
+    if (!row.isResolved)
+      (label: S.of(context).quickAddCardLabel, onPressed: _showQuickAdd),
+    (
+      label: row.skipped
+          ? S.of(context).bulkAddIncludeLabel
+          : S.of(context).bulkAddSkipLabel,
+      onPressed: () => _bloc.add(ToggleRowSkippedEvent(index)),
+    ),
+  ];
+
+  /// The width a text button needs for [label]: the label itself, Material's
+  /// horizontal padding at its widest, and never less than the narrowest a
+  /// button is allowed to be.
+  double _actionWidth(BuildContext context, String label) => math.max(
+    _minButtonWidth,
+    _textWidth(context, label, Theme.of(context).textTheme.labelLarge) +
+        _buttonPadding,
+  );
+
+  static const _buttonPadding = 24.0;
+  static const _minButtonWidth = 64.0;
+
+  /// The width [text] needs at the current text scale.
+  ///
+  /// Measured rather than estimated. These rows have to choose between one
+  /// line and two, and an estimate wide enough to be safe for the widest
+  /// possible glyphs is about twice too wide for a real font — it would
+  /// stack the controls on screens where they comfortably fit.
+  double _textWidth(BuildContext context, String text, TextStyle? style) =>
+      (TextPainter(
+        text: TextSpan(text: text, style: style),
+        textDirection: Directionality.of(context),
+        textScaler: MediaQuery.textScalerOf(context),
+      )..layout()).width;
 
   Widget _buildAmountRow(
     BuildContext context,
     BulkAddLoadedState state,
     int index,
     BulkAddRow row,
+    double available,
   ) {
     final controller = _amountControllers.putIfAbsent(
       index,
@@ -650,48 +725,94 @@ class _BulkAddScreenState extends State<BulkAddScreen> {
       controller.text = row.amountText;
     }
 
+    final theme = Theme.of(context);
+    // The quantity box was a flat 110px while every label beside it grew with
+    // the text scale, so at 2x on a 320dp screen this row wanted 532px of a
+    // 288px slot and overflowed by 244. It scales now, like the other fixed
+    // widths in the app. #824.
+    final fieldWidth = MediaQuery.textScalerOf(context).scale(110);
+    final unitWidth = _unitDropdownWidth(context, row);
+    final energyText = _energyLabel(context, row);
+    final energyWidth = _textWidth(
+      context,
+      energyText,
+      theme.textTheme.titleSmall,
+    );
+    // Nothing flexes 532px into 288px. Where the three do not fit, they take
+    // a line each rather than share one: the unit is a whole word in some
+    // locales, and a clipped unit is not a narrower reading of the amount,
+    // it is a wrong one.
+    final stacked = available < fieldWidth + 12 + unitWidth + 8 + energyWidth;
+
+    final field = TextField(
+      controller: controller,
+      keyboardType: const TextInputType.numberWithOptions(decimal: true),
+      // Same shape the manual-entry field enforces, so the two paths accept
+      // exactly the same input.
+      inputFormatters: [FilteringTextInputFormatter.allow(_quantityPattern)],
+      decoration: InputDecoration(
+        labelText: S.of(context).quantityLabel,
+        isDense: true,
+        border: const OutlineInputBorder(),
+      ),
+      onChanged: (value) => _bloc.add(ChangeRowAmountEvent(index, value)),
+    );
+
+    final unit = DropdownButton<String>(
+      value: row.effectiveUnit,
+      items: _unitItems(context, row),
+      // Only when it has a line to fill; on a shared line it takes the width
+      // its longest unit needs, which is what `stacked` was measured against.
+      isExpanded: stacked,
+      onChanged: (value) {
+        if (value != null) _bloc.add(ChangeRowUnitEvent(index, value));
+      },
+    );
+
+    final energy = Text(energyText, style: theme.textTheme.titleSmall);
+
     return Padding(
       padding: const EdgeInsets.only(top: 8),
-      child: Row(
-        children: [
-          SizedBox(
-            width: 110,
-            child: TextField(
-              controller: controller,
-              keyboardType: const TextInputType.numberWithOptions(
-                decimal: true,
-              ),
-              // Same shape the manual-entry field enforces, so the two
-              // paths accept exactly the same input.
-              inputFormatters: [
-                FilteringTextInputFormatter.allow(_quantityPattern),
+      child: stacked
+          ? Column(
+              crossAxisAlignment: CrossAxisAlignment.stretch,
+              children: [
+                field,
+                const SizedBox(height: 8),
+                unit,
+                const SizedBox(height: 4),
+                Align(alignment: AlignmentDirectional.centerEnd, child: energy),
               ],
-              decoration: InputDecoration(
-                labelText: S.of(context).quantityLabel,
-                isDense: true,
-                border: const OutlineInputBorder(),
-              ),
-              onChanged: (value) =>
-                  _bloc.add(ChangeRowAmountEvent(index, value)),
+            )
+          // Unchanged wherever it fits, which is every ordinary text size:
+          // the figure stays on the same line, pushed to the trailing edge.
+          : Row(
+              children: [
+                SizedBox(width: fieldWidth, child: field),
+                const SizedBox(width: 12),
+                unit,
+                const Spacer(),
+                energy,
+              ],
             ),
-          ),
-          const SizedBox(width: 12),
-          DropdownButton<String>(
-            value: row.effectiveUnit,
-            items: _unitItems(context, row),
-            onChanged: (value) {
-              if (value != null) _bloc.add(ChangeRowUnitEvent(index, value));
-            },
-          ),
-          const Spacer(),
-          Text(
-            _energyLabel(context, row),
-            style: Theme.of(context).textTheme.titleSmall,
-          ),
-        ],
-      ),
     );
   }
+
+  /// What the unit dropdown needs to show its longest unit without clipping
+  /// it: the dropdown sizes itself to its widest item, plus its arrow.
+  double _unitDropdownWidth(BuildContext context, BulkAddRow row) {
+    final style = Theme.of(context).textTheme.titleMedium;
+    var widest = 0.0;
+    for (final unit in row.allowedUnits) {
+      widest = math.max(
+        widest,
+        _textWidth(context, _unitLabel(context, unit), style),
+      );
+    }
+    return widest + _dropdownArrowWidth;
+  }
+
+  static const _dropdownArrowWidth = 24.0;
 
   /// Empty when the amount is not yet usable or the food has no energy value.
   String _energyLabel(BuildContext context, BulkAddRow row) {
@@ -711,19 +832,22 @@ class _BulkAddScreenState extends State<BulkAddScreen> {
       DropdownMenuItem(
         value: unit,
         child: Text(
-          switch (UnitDropdownItem.g.fromString(unit)) {
-            UnitDropdownItem.g => S.of(context).gramUnit,
-            UnitDropdownItem.ml => S.of(context).milliliterUnit,
-            UnitDropdownItem.gml => S.of(context).gramMilliliterUnit,
-            UnitDropdownItem.oz => S.of(context).ozUnit,
-            UnitDropdownItem.flOz => S.of(context).flOzUnit,
-            UnitDropdownItem.serving => S.of(context).servingLabel,
-          },
+          _unitLabel(context, unit),
           maxLines: 1,
           overflow: TextOverflow.ellipsis,
         ),
       ),
   ];
+
+  String _unitLabel(BuildContext context, String unit) =>
+      switch (UnitDropdownItem.g.fromString(unit)) {
+        UnitDropdownItem.g => S.of(context).gramUnit,
+        UnitDropdownItem.ml => S.of(context).milliliterUnit,
+        UnitDropdownItem.gml => S.of(context).gramMilliliterUnit,
+        UnitDropdownItem.oz => S.of(context).ozUnit,
+        UnitDropdownItem.flOz => S.of(context).flOzUnit,
+        UnitDropdownItem.serving => S.of(context).servingLabel,
+      };
 
   Widget _buildSubmitBar(BuildContext context, BulkAddLoadedState state) {
     final count = state.loggableCount;

--- a/test/features/add_meal/presentation/bulk_add_screen_test.dart
+++ b/test/features/add_meal/presentation/bulk_add_screen_test.dart
@@ -464,11 +464,112 @@ void main() {
     // The cap being gone is the fix, not an implementation detail: any
     // maxLines put back here truncates German at this size.
     expect(notice.maxLines, isNull);
-    // Still not `takeException()`: #820 removed the vertical overflow, and
-    // doing so uncovered horizontal ones in the row layout that had been
-    // masked by it. Those are #824; the assertion above is what #777 is
-    // about.
-    tester.takeException();
+    // Clean now: #820 removed the vertical overflow, #824 the horizontal ones
+    // in the rows that it uncovered.
+    expect(tester.takeException(), isNull);
+  });
+
+  testWidgets('a row fits at 2x on an ordinary phone, unit and all', (
+    tester,
+  ) async {
+    // #824. 320dp is the bound; 411dp at 2x is the combination people
+    // actually meet, being a Pixel at the accessibility size they actually
+    // choose. The food carries a serving, so the unit dropdown has to hold a
+    // word rather than "g" — and a unit clipped to "Por" is not a narrower
+    // reading of the amount, it is a different one.
+    tester.view.physicalSize = const Size(411 * 3, 891 * 3);
+    tester.view.devicePixelRatio = 3.0;
+    addTearDown(tester.view.reset);
+
+    await _register({
+      'toast': [_meal('Toast', servingQuantity: 30)],
+    });
+
+    final errors = <String>[];
+    final previous = FlutterError.onError;
+    FlutterError.onError = (details) => errors.add(details.toString());
+    addTearDown(() => FlutterError.onError = previous);
+
+    await tester.pumpWidget(
+      MediaQuery(
+        data: const MediaQueryData(textScaler: TextScaler.linear(2.0)),
+        child: _app(locale: const Locale('de')),
+      ),
+    );
+    await tester.pumpAndSettle();
+    await _parse(tester, '100g toast');
+
+    // Put the handler back before asserting. While it is still installed a
+    // failed `expect` is an error the framework cannot reconcile, so the test
+    // hangs to its ten-minute timeout instead of failing.
+    FlutterError.onError = previous;
+    expect(
+      errors.where((e) => e.contains('overflowed')),
+      isEmpty,
+      reason: 'something on this row does not fit the space it is given',
+    );
+
+    // The dropdown shows one unit but sizes itself to its widest, so this is
+    // the width the row has to find even while "g" is the one on screen. Its
+    // other items are not in the tree to be found, only measured against.
+    final de = lookupS(const Locale('de'));
+    final dropdown = find.byType(DropdownButton<String>);
+    final needed = (TextPainter(
+      text: TextSpan(
+        text: de.servingLabel,
+        style: Theme.of(tester.element(dropdown)).textTheme.titleMedium,
+      ),
+      textDirection: TextDirection.ltr,
+      textScaler: const TextScaler.linear(2.0),
+    )..layout()).width;
+    expect(
+      tester.getSize(dropdown).width,
+      greaterThanOrEqualTo(needed),
+      reason: 'the unit dropdown is narrower than the unit it has to show, '
+          'and a clipped unit reads as a different one',
+    );
+  });
+
+  testWidgets('the quantity box holds the largest amount at 2x', (
+    tester,
+  ) async {
+    // #824. Where the screen is wide enough to keep the controls on one line
+    // the box is a fixed width, and the fixed width was the original bug: at
+    // 2x, 10000 — the largest amount this screen accepts — no longer fits the
+    // 110px the box used to get, so the number the user typed scrolled out of
+    // its own field.
+    tester.view.physicalSize = const Size(800 * 3, 900 * 3);
+    tester.view.devicePixelRatio = 3.0;
+    addTearDown(tester.view.reset);
+
+    await _register({
+      'toast': [_meal('Toast')],
+    });
+
+    await tester.pumpWidget(
+      MediaQuery(
+        data: const MediaQueryData(textScaler: TextScaler.linear(2.0)),
+        child: _app(locale: const Locale('de')),
+      ),
+    );
+    await tester.pumpAndSettle();
+    await _parse(tester, '10000g toast');
+
+    final field = find.byType(TextField).last;
+    final needed = (TextPainter(
+      text: TextSpan(
+        text: '10000',
+        style: Theme.of(tester.element(field)).textTheme.bodyLarge,
+      ),
+      textDirection: TextDirection.ltr,
+      textScaler: const TextScaler.linear(2.0),
+    )..layout()).width;
+
+    expect(
+      tester.getSize(field).width,
+      greaterThan(needed),
+      reason: 'the amount box cannot show the largest amount it accepts',
+    );
   });
 
   testWidgets('the screen fits at 2x on a narrow phone, in German', (
@@ -489,13 +590,13 @@ void main() {
       failure: MealInterpreterFailure.timeout,
     ));
 
-    // Collected rather than asserted away. Fixing the vertical overflow
-    // uncovered horizontal ones in the row layout — 65 and 244 pixels —
-    // which had been masked while layout aborted before the rows were
-    // reached. Those are #824, so this test
-    // says precisely what it guarantees: nothing overflows *downwards* any
-    // more. A blanket `takeException` would pass while the column overflowed
-    // again, and a clean-frame assertion would fail for the rows.
+    // Collected rather than asserted away, so the assertion can name what it
+    // covers. It began downwards-only: fixing the vertical overflow (#820)
+    // uncovered horizontal ones in the rows — 65 and 244 pixels — masked
+    // until then because layout aborted before reaching them. #824 fixed
+    // those, so it now covers both directions. A blanket `takeException`
+    // would pass while the screen overflowed again, which is the regression
+    // this exists to catch.
     final errors = <String>[];
     final previous = FlutterError.onError;
     FlutterError.onError = (details) => errors.add(details.toString());
@@ -510,10 +611,14 @@ void main() {
     await tester.pumpAndSettle();
     await _parse(tester, '100g toast');
 
+    // Put the handler back before asserting. While it is still installed a
+    // failed `expect` is an error the framework cannot reconcile, so the test
+    // hangs to its ten-minute timeout instead of failing.
+    FlutterError.onError = previous;
     expect(
-      errors.where((e) => e.contains('overflowed') && e.contains('bottom')),
+      errors.where((e) => e.contains('overflowed')),
       isEmpty,
-      reason: 'the column still does not fit the screen it is given',
+      reason: 'something on this screen does not fit the space it is given',
     );
 
     final input = tester


### PR DESCRIPTION
Closes #824.

## What was wrong

At 2x text on a 320dp screen, two `RenderFlex`es inside a meal row overflowed — by 65px and by 244px. Both had the same cause: a `Row` of controls whose labels grow with the text scale, laid out as though they could not.

Measured on the failing frame:

| | wants | has |
|---|---|---|
| the "Überspringen" button | 353px | 288px |
| the food's name beside it | — | **0px** |
| amount field + unit + energy | 532px | 288px |

The 65 is the worse of the pair: it squeezed the food's name to nothing and overflowed anyway, and the name is the part the user opened this screen to check.

## What it does now

A row measures what its controls actually need — the buttons' labels, the widest unit the dropdown can show, the energy figure — and where they do not fit on one line, gives them a line each. Wherever they fit, which is every ordinary text size, nothing changes.

Measured rather than estimated. An estimate wide enough to be safe for the widest possible glyphs is about twice too wide for a real font, so estimating would stack the controls on screens where they sit side by side comfortably.

Two smaller things follow from it:

- **The quantity box scales with the text**, as the app's other fixed widths already do (`macro_split_dialog`, `nutrient_goals_screen`, `kcal_adjustment_dialog`). At 2x it was a flat 110px holding a five-digit number.
- **The unit dropdown gets the width its longest unit needs.** "Portion" clipped to "Por" is not a narrower reading of an amount, it is a different one.

## What it costs

The measuring happens in `build`, which is worth being explicit about: a row lays out at most nine short strings through a `TextPainter` — one or two button labels, up to six unit labels, the energy figure. A `SliverList` rebuilds an item when the state changes, not on every scroll frame, so this is a few dozen short layouts per keystroke rather than per frame, and only for rows on screen.

A `Wrap` would get the same result with no measuring at all, and I tried it first. It costs the layout the row has today: `Wrap` has no `Spacer`, so the energy figure stops sitting at the trailing edge, and a long food name starts pushing the buttons onto a second line for everyone rather than only where they do not fit.

## Acceptance criteria

- [x] Rows render at 320dp / 2x with no horizontal overflow, in German as well as English
- [x] The amount field stays usable — nothing clips the number or the unit
- [x] 411dp at 2x checked too
- [x] #820's test tightens: the error filter widens from downward-only to any overflow, and its comment pointing here goes
- [x] Mutation-checked

## Tests

| test | what it pins |
|---|---|
| `the screen fits at 2x on a narrow phone, in German` | filter widened from downward-only to **any** overflow; #777's test goes back to a clean-frame assertion |
| `a row fits at 2x on an ordinary phone, unit and all` | new — 411dp, and a food carrying a serving so the dropdown has to hold a word |
| `the quantity box holds the largest amount at 2x` | new — a screen wide enough to keep the row on one line, which is exactly where a fixed width was the bug |

Both capture-based tests now restore `FlutterError.onError` **before** asserting. While the handler is still installed a failed `expect` is an error the framework cannot reconcile, so the test used to hang to its ten-minute timeout instead of failing — a real regression would have cost CI ten minutes to report.

## Mutation check

| reverted | outcome |
|---|---|
| title row never stacks | **caught** — *the whole notice is readable at 2x on a narrow screen*, *the screen fits at 2x on a narrow phone, in German* |
| amount row never stacks | **caught** — *the whole notice is readable at 2x on a narrow screen*, *a row fits at 2x on an ordinary phone, unit and all*, *the screen fits at 2x on a narrow phone, in German* |
| quantity box unscaled | **caught** — *the quantity box holds the largest amount at 2x* |
