### PR TITLE
ci: bound each integration attempt so a hang can be retried (#823)

### DIFF
--- a/.github/workflows/default_workflow.yml
+++ b/.github/workflows/default_workflow.yml
@@ -281,12 +281,15 @@ jobs:
     # simulator's VM service. ios-build / package / deploy stay on macos-26 —
     # they build/sign and never launch a simulator, so they're unaffected.
     runs-on: macos-15
-    # Bound the job so a hung test fails fast rather than drifting toward
-    # GitHub's 6-hour default. A healthy run is the ~11-12 min Xcode build
-    # plus a few minutes of tests, but the "Run integration tests" step
-    # retries the whole build+test once on failure, so a single flake needs
-    # room for a second cold build. 30 was too tight for that and got
-    # cancelled mid-retry; 50 covers the retry while still catching hangs.
+    # The backstop, not the thing that catches hangs. Each attempt below
+    # carries its own 20-minute bound, so a hang is a failed attempt the
+    # retry can act on; this bound only stops a job drifting toward GitHub's
+    # 6-hour default if something escapes both. It has to hold two cold
+    # builds — 30 was too tight and got cancelled mid-retry.
+    #
+    # It used to be the only bound, and a hang cost the whole 50 minutes of
+    # macOS time, reported as a cancelled job rather than a failed test —
+    # which `gh pr checks` renders as `fail` on a PR that is fine (#823).
     timeout-minutes: 50
     permissions:
       contents: read
@@ -349,25 +352,40 @@ jobs:
           xcrun simctl bootstatus "$DEVICE_UDID"
           echo "DEVICE_UDID=$DEVICE_UDID" >> $GITHUB_ENV
 
-      - name: Run integration tests
+      # Two steps rather than a shell loop, matching android-integration-tests
+      # below. The loop this replaces retried on a non-zero exit, and so had
+      # nothing to say about `flutter test` never exiting at all: a hung
+      # attempt blocked until the job's own `timeout-minutes` killed it, and
+      # the retry — the mechanism meant to absorb simulator flakes — was
+      # skipped by the one flake mode that actually happens here. Three of
+      # sixteen runs on 2026-08-24 burned the full 50 minutes that way (#823).
+      #
+      # A step-level `timeout-minutes` turns a hang into a failed attempt, so
+      # the retry fires on it exactly as it does on a failure.
+      #
+      # 20 minutes per attempt: the slowest healthy run of this step in the
+      # last twenty was 15m36s (the range is 8m53s-15m36s, and it includes the
+      # cold Xcode build), and two 20-minute attempts still fit the job's 50
+      # with the ~5m40s of setup and teardown around them.
+      - name: Run integration tests (attempt 1)
+        id: ios-integration
+        continue-on-error: true
+        timeout-minutes: 20
         # --flavor full so the integration-test app matches the production
         # iOS scheme (bundle id + display name) rather than the develop one.
         # The whole integration_test/ directory runs from a single build.
-        # Retry once: integration tests occasionally flake on a slow simulator
-        # (a dropped frame, a transient launch hiccup). A second attempt on the
-        # same booted sim clears those without masking a real failure, since a
-        # genuine break fails both attempts.
+        run: flutter test integration_test/ -d "$DEVICE_UDID" --flavor full --reporter expanded
+
+      # Retry once: integration tests occasionally flake on a slow simulator
+      # (a dropped frame, a transient launch hiccup, a build that never
+      # returns). A second attempt on the same booted sim clears those without
+      # masking a real failure, since a genuine break fails both attempts.
+      - name: Run integration tests (retry once)
+        if: steps.ios-integration.outcome == 'failure'
+        timeout-minutes: 20
         run: |
-          attempt=1
-          max=2
-          until flutter test integration_test/ -d "$DEVICE_UDID" --flavor full --reporter expanded; do
-            if [ "$attempt" -ge "$max" ]; then
-              echo "::error::iOS integration tests failed after $max attempts"
-              exit 1
-            fi
-            attempt=$((attempt + 1))
-            echo "::warning::iOS integration tests flaked; retrying (attempt $attempt of $max)"
-          done
+          echo "::warning::iOS integration tests failed or hung; retrying (attempt 2 of 2)"
+          flutter test integration_test/ -d "$DEVICE_UDID" --flavor full --reporter expanded
 
   android-build:
     runs-on: ubuntu-latest
@@ -437,11 +455,11 @@ jobs:
     # Same as iOS: runs in parallel from the start, gated on neither
     # android-build (it rebuilds the app itself) nor a file-discovery job.
     runs-on: ubuntu-latest
-    # Same bound as iOS so a hung test fails fast rather than running to the
-    # 6-hour default. On a cold cache this job pays an AVD seed boot plus a
-    # test boot, and the "retry once" step adds a third boot + rebuild, so 30
-    # was too tight and got cancelled mid-retry (which also skips the AVD
-    # cache save, keeping the next run cold). 50 covers the retry path.
+    # Same backstop as iOS, and like iOS the per-attempt bounds below are what
+    # actually catch a hang. On a cold cache this job pays an AVD seed boot
+    # plus a test boot, and the "retry once" step adds a third boot + rebuild,
+    # so 30 was too tight and got cancelled mid-retry (which also skips the
+    # AVD cache save, keeping the next run cold). 50 covers the retry path.
     timeout-minutes: 50
     permissions:
       contents: read
@@ -554,6 +572,14 @@ jobs:
       - name: Run integration tests (attempt 1)
         id: android-integration
         continue-on-error: true
+        # Same bound as iOS, for the same reason. No Android run in the last
+        # twenty hung, and the emulator-runner already bounds the boot it is
+        # known to flake on, but `script:` itself is unbounded — so the one
+        # failure mode that skips the retry is available here too, and this
+        # closes it for the price of a line.
+        #
+        # 20 minutes: the slowest healthy attempt in that sample was 12m4s.
+        timeout-minutes: 20
         uses: reactivecircus/android-emulator-runner@v2
         with:
           api-level: 34
@@ -570,6 +596,7 @@ jobs:
 
       - name: Run integration tests (retry once)
         if: steps.android-integration.outcome == 'failure'
+        timeout-minutes: 20
         uses: reactivecircus/android-emulator-runner@v2
         with:
           api-level: 34


### PR DESCRIPTION
Closes #823.

## What was wrong

Three of sixteen `ios-integration-tests` runs on 2026-08-24 burned the whole 50-minute budget and were killed. Not test failures — **hangs**, and the retry built to absorb exactly this could not reach them:

```sh
until flutter test integration_test/ ... ; do
```

The loop retries when `flutter test` **exits non-zero**. It has nothing to say about `flutter test` never exiting at all, so a hung attempt blocked until the job's own `timeout-minutes` killed it and attempt 2 was never reached. The one mechanism meant to absorb simulator flakes was bypassed by the flake mode that actually happens.

## What it does now

Each attempt carries its own bound, so a hang ends as a *failed attempt* rather than a dead job, and the retry fires on it exactly as it does on a failure.

iOS moves from the shell loop to the two-step shape `android-integration-tests` already uses — that is what makes a per-step bound possible, and it also puts each attempt in the Actions UI as its own step. Android gets the same bound on both of its steps: no Android run in the sample hung, and the emulator-runner already bounds the boot it is known to flake on, but `script:` itself is unbounded, so the same gap exists there.

## Why 20 minutes

Measured across the last twenty runs, not picked:

| | slowest healthy attempt | range | hung runs |
|---|---|---|---|
| iOS | **15m36s** | 8m53s – 15m36s | 46m, 45m — killed at the job budget |
| Android | **12m4s** | 6m8s – 12m4s | none in sample |

The iOS step includes its own cold Xcode build, which is most of that time. Setup and teardown around it measure 5m38s, so two 20-minute attempts fit the 50-minute job budget with about four minutes to spare, while leaving 28% headroom over the slowest healthy attempt observed.

## The evidence it works

A hang cannot be reproduced on demand, so the mechanism was proven directly on a throwaway branch — a step that sleeps past its own `timeout-minutes`, with the same `continue-on-error` / `outcome` wiring this change uses ([run 32755907080](https://github.com/simonoppowa/OpenNutriTracker/actions/runs/32755907080)):

| step | conclusion | outcome |
|---|---|---|
| attempt 1 — hung, killed at its bound | `success` | **`failure`** |
| retry — `if: outcome == 'failure'` | ran, warning emitted | — |
| job overall | **green** | |

That also settles a detail worth stating, because getting it wrong would be silent: a step killed by its own timeout reports `conclusion=success` under `continue-on-error`, and only `outcome` is `failure`. A retry gated on `conclusion` would parse, run, and never fire.

## Acceptance criteria

- [x] A hung attempt is bounded and reported as a failed attempt, not a cancelled job
- [x] The retry demonstrably runs after a hang — the warning line appears in the log (run above)
- [x] The per-attempt bound leaves room for two cold builds inside `timeout-minutes`
- [x] The same treatment is applied to `android-integration-tests`
- [x] The job comment stops claiming the timeout "catches hangs" without saying what that costs

## Worth knowing

This makes the retry **fire** after a hang. Whether it then **succeeds** depends on the cause: if a hang leaves the simulator wedged, a second attempt on the same booted sim may hang too, and the job would fail at ~46 minutes instead of being cancelled at 50. That is still an improvement — a failed job with output beats a cancelled one that `gh pr checks` mislabels — but if hangs persist after this, the next move is to shut down and re-boot the simulator between attempts (~90s, measured), which needs the job bound raised to about 55 to stay comfortable. Not done here because I cannot verify it helps without a hang to test against.

## Note

The probe branch `ci/prove-retry-on-hang` could not be deleted — a repository rule rejects the push (`GH013: Cannot delete this branch`). Its workflow file has been removed so the branch is inert and identical to `develop`, but it needs deleting through the UI by someone who can override the rule.
