### PR TITLE
fix(core): stop a deleted profile's reminder from outliving it (#764)

### DIFF
--- a/lib/core/domain/usecase/delete_all_user_data_usecase.dart
+++ b/lib/core/domain/usecase/delete_all_user_data_usecase.dart
@@ -1,5 +1,7 @@
 import 'package:logging/logging.dart';
+import 'package:opennutritracker/core/data/repository/config_repository.dart';
 import 'package:opennutritracker/core/utils/hive_db_provider.dart';
+import 'package:opennutritracker/core/utils/notification_service.dart';
 import 'package:sentry_flutter/sentry_flutter.dart';
 
 /// Wipes the **active profile's** data, returning that profile to a
@@ -14,14 +16,25 @@ import 'package:sentry_flutter/sentry_flutter.dart';
 class DeleteAllUserDataUsecase {
   final _log = Logger('DeleteAllUserDataUsecase');
   final HiveDBProvider _hiveDBProvider;
+  final NotificationService _notificationService;
+  final ConfigRepository _configRepository;
 
-  DeleteAllUserDataUsecase(this._hiveDBProvider);
+  DeleteAllUserDataUsecase(
+    this._hiveDBProvider,
+    this._notificationService,
+    this._configRepository,
+  );
 
   Future<void> deleteAll() async {
     _log.info('Clearing the active profile\'s Hive boxes on user request');
 
-    // Closing Sentry first stops any in-flight queue from referencing
-    // boxes mid-clear. The user can re-enable crash reporting later from
+    // Before the boxes, not after, and in two halves — either alone leaves
+    // the reminder alive. #764 watched an 08:00 ping survive a delete-all,
+    // where only uninstalling the app removed it.
+    await _stopScheduledNotifications();
+
+    // Closing Sentry before the clear stops any in-flight queue from
+    // referencing boxes mid-clear. The user can re-enable crash reporting later from
     // Settings; nothing here re-opens the SDK on its own.
     await Sentry.close();
 
@@ -39,5 +52,42 @@ class DeleteAllUserDataUsecase {
       _hiveDBProvider.waterIntakeBox.clear(),
       _hiveDBProvider.fastingBox.clear(),
     ]);
+  }
+
+  /// Stops the reminder in both of the places that keep it alive.
+  ///
+  /// The OS holds the scheduled alarm, and it does not care that the data it
+  /// was scheduled from is gone — so it has to be told. Switching the setting
+  /// off matters just as much and is easier to miss: `notificationsEnabled`
+  /// is a *shared* preference, kept in the app box that this wipe
+  /// deliberately leaves alone so theme, language and units survive. Left
+  /// standing, `main.dart` reschedules the reminder from it on the next cold
+  /// start, and a cancel on its own would hold only until the user next quit
+  /// the app.
+  ///
+  /// Each half is attempted separately and neither can stop the wipe. The
+  /// user asked for their data to be gone, and refusing to delete it because
+  /// a notification plugin was unavailable is the worse of the two failures:
+  /// a surviving alarm can still be uninstalled, while data kept against an
+  /// explicit request is not what they asked for at all.
+  Future<void> _stopScheduledNotifications() async {
+    await _bestEffort(
+      () => _configRepository.setNotificationsEnabled(false),
+      'Could not switch the daily reminder off; the next launch may schedule '
+          'it again from a setting this wipe does not clear',
+    );
+    await _bestEffort(
+      () => _notificationService.cancelAllScheduled(),
+      'Could not cancel scheduled notifications; an alarm may outlive the '
+          'data it was scheduled from',
+    );
+  }
+
+  Future<void> _bestEffort(Future<void> Function() step, String failure) async {
+    try {
+      await step();
+    } catch (error, stackTrace) {
+      _log.severe(failure, error, stackTrace);
+    }
   }
 }

--- a/lib/core/utils/locator.dart
+++ b/lib/core/utils/locator.dart
@@ -140,7 +140,7 @@ Future<void> initLocator() async {
   );
   locator.registerLazySingleton<HiveDBProvider>(() => hiveDBProvider);
   locator.registerLazySingleton<DeleteAllUserDataUsecase>(
-    () => DeleteAllUserDataUsecase(locator()),
+    () => DeleteAllUserDataUsecase(locator(), locator(), locator()),
   );
 
   // Backend

--- a/lib/core/utils/notification_service.dart
+++ b/lib/core/utils/notification_service.dart
@@ -168,6 +168,20 @@ class NotificationService {
     _log.fine('Fasting-complete notification cancelled');
   }
 
+  /// Cancels every notification this app has scheduled.
+  ///
+  /// For the delete-all path, which must not leave an alarm behind that
+  /// outlives the record of it. Deliberately not a list of the ids above: a
+  /// notification added later would not be on such a list, and the omission
+  /// would surface as a ping on a stranger's phone weeks afterwards rather
+  /// than as anything a test or a reviewer would catch. `cancelAll` reaches
+  /// only this app's own notifications.
+  Future<void> cancelAllScheduled() async {
+    await _ensureInitialized();
+    await _plugin.cancelAll();
+    _log.fine('All scheduled notifications cancelled');
+  }
+
   Future<void> _ensureInitialized() async {
     if (!_initialized) await initialize();
   }

--- a/test/unit_test/delete_all_user_data_cancels_notifications_test.dart
+++ b/test/unit_test/delete_all_user_data_cancels_notifications_test.dart
@@ -1,0 +1,190 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:hive_ce/hive.dart';
+import 'package:opennutritracker/core/data/data_source/config_data_source.dart';
+import 'package:opennutritracker/core/data/data_source/user_activity_dbo.dart';
+import 'package:opennutritracker/core/data/dbo/app_theme_dbo.dart';
+import 'package:opennutritracker/core/data/dbo/config_dbo.dart';
+import 'package:opennutritracker/core/data/dbo/fasting_session_dbo.dart';
+import 'package:opennutritracker/core/data/dbo/intake_dbo.dart';
+import 'package:opennutritracker/core/data/dbo/tracked_day_dbo.dart';
+import 'package:opennutritracker/core/data/dbo/user_dbo.dart';
+import 'package:opennutritracker/core/data/dbo/user_gender_dbo.dart';
+import 'package:opennutritracker/core/data/dbo/user_pal_dbo.dart';
+import 'package:opennutritracker/core/data/dbo/user_weight_goal_dbo.dart';
+import 'package:opennutritracker/core/data/dbo/water_intake_dbo.dart';
+import 'package:opennutritracker/core/data/dbo/weight_log_dbo.dart';
+import 'package:opennutritracker/core/data/repository/config_repository.dart';
+import 'package:opennutritracker/core/domain/usecase/delete_all_user_data_usecase.dart';
+import 'package:opennutritracker/core/utils/notification_service.dart';
+
+import '../helpers/fake_hive_db_provider.dart';
+import '../helpers/hive_test_setup.dart';
+
+/// Stands in for the OS. Records whether the user's data was still on file
+/// when it was told to drop the alarm — which, rather than call order for its
+/// own sake, is the property #764 turns on.
+///
+/// It watches the *user* box rather than the config box on purpose. Config is
+/// written through a read-modify-write, so a cancel step that runs after the
+/// wipe puts a config row straight back into the box it was just cleared
+/// from; a probe pointed at config would read that rewrite as "still on file"
+/// and pass in exactly the arrangement it exists to reject. Nothing
+/// repopulates the user box.
+class _RecordingNotificationService extends NotificationService {
+  _RecordingNotificationService(this._userBox, {this.throws = false});
+
+  final Box<UserDBO> _userBox;
+  final bool throws;
+
+  int cancels = 0;
+  bool? userDataStillOnFileWhenCancelled;
+
+  @override
+  Future<void> cancelAllScheduled() async {
+    cancels++;
+    userDataStillOnFileWhenCancelled = _userBox.isNotEmpty;
+    if (throws) throw StateError('notification plugin unavailable');
+  }
+}
+
+void main() {
+  group('delete-all and the alarm the OS is holding', () {
+    late Box<ConfigDBO> appConfigBox;
+    late Box<ConfigDBO> configBox;
+    late Box<UserDBO> userBox;
+    late FakeHiveDBProvider provider;
+    late ConfigRepository configRepository;
+
+    setUp(() async {
+      TestWidgetsFlutterBinding.ensureInitialized();
+      Hive.init('.');
+      registerHiveAdaptersOnce();
+
+      appConfigBox = await Hive.openBox<ConfigDBO>('delete_all_app_config');
+      configBox = await Hive.openBox<ConfigDBO>('delete_all_config');
+      provider = FakeHiveDBProvider(
+        appConfigBox: appConfigBox,
+        configBox: configBox,
+        intakeBox: await Hive.openBox<IntakeDBO>('delete_all_intake'),
+        userActivityBox: await Hive.openBox<UserActivityDBO>('delete_all_act'),
+        userBox: userBox = await Hive.openBox<UserDBO>('delete_all_user'),
+        trackedDayBox: await Hive.openBox<TrackedDayDBO>('delete_all_days'),
+        weightLogBox: await Hive.openBox<WeightLogDBO>('delete_all_weight'),
+        waterIntakeBox: await Hive.openBox<WaterIntakeDBO>('delete_all_water'),
+        fastingBox: await Hive.openBox<FastingSessionDBO>('delete_all_fast'),
+      );
+      final configDataSource = ConfigDataSource(provider);
+      configRepository = ConfigRepository(configDataSource);
+
+      // The state #764 was reported from: the 08:00 reminder switched on,
+      // alongside the device-wide preferences a wipe is meant to leave alone.
+      await configDataSource.addConfig(
+        ConfigDBO(
+          true,
+          true,
+          false,
+          AppThemeDBO.dark,
+          usesImperialUnits: true,
+          notificationsEnabled: true,
+          notificationHour: 8,
+          notificationMinute: 0,
+        ),
+      );
+      // The probe above reads this box, so it has to hold something: an empty
+      // box is indistinguishable from a wiped one, and the ordering assertion
+      // would pass for the wrong reason.
+      await userBox.put(
+        'user',
+        UserDBO(
+          birthday: DateTime(1990, 6, 15),
+          heightCM: 165,
+          weightKG: 70,
+          gender: UserGenderDBO.female,
+          goal: UserWeightGoalDBO.loseWeight,
+          pal: UserPALDBO.sedentary,
+        ),
+      );
+    });
+
+    tearDown(() async => Hive.deleteFromDisk());
+
+    DeleteAllUserDataUsecase subject(NotificationService notifications) =>
+        DeleteAllUserDataUsecase(provider, notifications, configRepository);
+
+    test('the alarm the OS holds is cancelled, not merely forgotten', () async {
+      final notifications = _RecordingNotificationService(userBox);
+
+      await subject(notifications).deleteAll();
+
+      expect(
+        notifications.cancels,
+        1,
+        reason: 'nothing told the OS to drop the alarm, so it still fires at '
+            '08:00 for a profile that no longer exists',
+      );
+      expect(configBox.isEmpty, isTrue, reason: 'the wipe must still happen');
+    });
+
+    test('cancelled before the data it belongs to is wiped', () async {
+      final notifications = _RecordingNotificationService(userBox);
+
+      await subject(notifications).deleteAll();
+
+      // Order is half the defect. Cancel after the clear and the cancel runs
+      // with nothing left to say an alarm was ever set.
+      expect(
+        notifications.userDataStillOnFileWhenCancelled,
+        isTrue,
+        reason: 'the alarm was cancelled after the data it belonged to was '
+            'already gone',
+      );
+    });
+
+    test('the next launch cannot schedule it again', () async {
+      await subject(_RecordingNotificationService(userBox)).deleteAll();
+
+      // The other half, and the easier one to miss. `notificationsEnabled` is
+      // a *shared* preference living in the app box, which this wipe
+      // deliberately leaves alone — so cancelling without switching it off
+      // holds only until the user next quits the app, and `main.dart` puts
+      // the reminder straight back on the following cold start.
+      final afterWipe = await configRepository.getConfig();
+      expect(
+        afterWipe.notificationsEnabled,
+        isFalse,
+        reason: 'a cold start would read this and reschedule the reminder the '
+            'user just deleted everything to be rid of',
+      );
+    });
+
+    test('the device-wide preferences a wipe keeps are untouched', () async {
+      await subject(_RecordingNotificationService(userBox)).deleteAll();
+
+      // The counterweight to the test above: switching the reminder off must
+      // not turn into wiping the shared app box, which is where theme,
+      // language and units live for every profile on the device.
+      final afterWipe = await configRepository.getConfig();
+      expect(afterWipe.usesImperialUnits, isTrue);
+      expect(afterWipe.appTheme.name, 'dark');
+    });
+
+    test('a notification failure does not block the wipe', () async {
+      final notifications = _RecordingNotificationService(
+        userBox,
+        throws: true,
+      );
+
+      await subject(notifications).deleteAll();
+
+      // The user asked for their data to be gone. Keeping it because a plugin
+      // was unavailable is the worse of the two failures: a surviving alarm
+      // can still be uninstalled, data kept against an explicit request
+      // cannot be un-kept.
+      expect(
+        configBox.isEmpty,
+        isTrue,
+        reason: 'the data survived because cancelling an alarm failed',
+      );
+    });
+  });
+}


### PR DESCRIPTION
Closes #764.

## What was wrong

Deleting all data returned the app to onboarding and left the daily reminder scheduled with the OS. Android still listed the alarm, and the 08:00 ping kept arriving for a profile that no longer existed — only uninstalling the app removed it.

`DeleteAllUserDataUsecase.deleteAll()` cleared eight Hive boxes and never told anything to stop:

```dart
await Future.wait([
  _hiveDBProvider.configBox.clear(),   // ← the reminder's per-profile copy
  _hiveDBProvider.intakeBox.clear(),
  ...
]);
```

## Two things kept it alive

The issue describes the first. The second is the one that would have made a naive fix silently regress.

**The OS holds the alarm** and does not care that the data it was scheduled from is gone. Nothing was telling it to drop it.

**`notificationsEnabled` is a shared preference**, not a per-profile one. It lives in the app box alongside theme, language and units — which this wipe deliberately leaves alone, since they belong to every profile on the device. So the setting survives the wipe, and on the next cold start `main.dart` reads it and schedules the reminder again:

```dart
if (config.notificationsEnabled) {          // ← still true after a delete-all
  await notificationService.scheduleDailyReminder(...);
}
```

Cancelling alone would therefore have held only until the user next quit the app, and the bug would have come back looking fixed.

## Ordering is part of the fix

Both steps run **before** the boxes are cleared, and each for its own reason.

Cancelling afterwards is a cancel with nothing left to say an alarm was ever set. Switching the setting off afterwards is worse than useless: config is written through a read-modify-write, so running it after the clear puts a config row **straight back into the box it was just cleared from** — the wipe partially undoes itself. That is not hypothetical; it is what the ordering mutant below actually did.

## Neither step can stop the wipe

Both are best-effort and logged on failure. The user asked for their data to be gone, and keeping it because a notification plugin was unavailable is the worse of the two failures: a surviving alarm can still be uninstalled, where data kept against an explicit request cannot be un-kept.

## Tests

New `test/unit_test/delete_all_user_data_cancels_notifications_test.dart`:

| test | what it pins |
|---|---|
| the alarm the OS holds is cancelled, not merely forgotten | something tells the OS to drop it |
| cancelled before the data it belongs to is wiped | the ordering above |
| the next launch cannot schedule it again | the shared setting is off, so `main.dart` cannot resurrect it |
| the device-wide preferences a wipe keeps are untouched | the counterweight — switching the reminder off must not become wiping the shared app box |
| a notification failure does not block the wipe | the deletion still happens |

## Mutation check

| reverted | outcome |
|---|---|
| the cancel removed | **caught** — *the alarm the OS holds is cancelled*, *cancelled before the data it belongs to is wiped* |
| the cancel moved after the wipe | **caught** — those two, plus *a notification failure does not block the wipe* |
| the setting left switched on | **caught** — *the next launch cannot schedule it again* |
| a notification failure allowed to propagate | **caught** — *a notification failure does not block the wipe* |

The second row is worth a note. My ordering probe originally watched the config box, and it **passed** under that mutant — because the misordered step rewrote config into the cleared box, and the probe read that rewrite as "still on file". It was a test that would have passed in exactly the arrangement it existed to reject. It now watches the user box, which nothing repopulates, and catches the mutant on its own.

## Worth knowing

`NotificationService.cancelAllScheduled()` cancels **all** of this app's notifications rather than a list of known ids. A list would silently miss any notification added later, and the omission would surface as a ping on a stranger's phone rather than as anything a reviewer or a test would catch. It reaches only this app's own notifications.

Two consequences worth stating plainly:

- **Multi-profile:** the reminder switch is device-wide and the OS holds a single alarm, so a delete-all turns the reminder off for the device, not just for the profile being deleted. That follows from it being a shared setting; the alternative is the alarm surviving, which is the bug.
- **Demo mode** exits through the same usecase, so leaving demo mode also switches the reminder off. In practice a demo user has not set one — they have not onboarded.

The fasting-complete ping is cancelled by the same call. It has no resurrection path: nothing reschedules it at launch, only starting a session does.
