### PR TITLE
fix(diary): give the weekday headings room to grow (#766)

### DIFF
--- a/lib/features/diary/presentation/widgets/diary_table_calendar.dart
+++ b/lib/features/diary/presentation/widgets/diary_table_calendar.dart
@@ -29,6 +29,22 @@ class DiaryTableCalendar extends StatefulWidget {
   State<DiaryTableCalendar> createState() => _DiaryTableCalendarState();
 }
 
+/// What one line of [style] actually needs at the current text scale.
+///
+/// Measured rather than scaled from the package's 16.0: that constant only
+/// equals a heading's height by coincidence — it is `labelSmall`'s line
+/// height today — and scaling it lands fractionally short at some scales
+/// (20.8 against the 21.0 wanted at 1.3x), which clips just as surely.
+double _weekdayRowHeight(BuildContext context, TextStyle style) =>
+    (TextPainter(
+      // Any single line measures the same: the height comes from the font's
+      // metrics, not from which glyphs are in it.
+      text: TextSpan(text: 'Mon', style: style),
+      textDirection: Directionality.of(context),
+      textScaler: MediaQuery.textScalerOf(context),
+    )..layout())
+        .height;
+
 class _DiaryTableCalendarState extends State<DiaryTableCalendar> {
   @override
   Widget build(BuildContext context) {
@@ -36,6 +52,9 @@ class _DiaryTableCalendarState extends State<DiaryTableCalendar> {
     final palette = isDark ? AppPalette.dark : AppPalette.light;
     final accent = Theme.of(context).colorScheme.primary;
     final textTheme = Theme.of(context).textTheme;
+    final weekdayStyle =
+        textTheme.labelSmall?.copyWith(color: palette.textMuted) ??
+            const TextStyle();
 
     return Padding(
       padding: const EdgeInsets.fromLTRB(
@@ -65,9 +84,18 @@ class _DiaryTableCalendarState extends State<DiaryTableCalendar> {
             headerPadding: const EdgeInsets.symmetric(vertical: Dimens.spacing8),
           ),
           daysOfWeekStyle: DaysOfWeekStyle(
-            weekdayStyle: textTheme.labelSmall?.copyWith(color: palette.textMuted) ?? const TextStyle(),
-            weekendStyle: textTheme.labelSmall?.copyWith(color: palette.textMuted) ?? const TextStyle(),
+            weekdayStyle: weekdayStyle,
+            weekendStyle: weekdayStyle,
           ),
+          // The package default is a flat 16.0, and `labelSmall` is 11sp on a
+          // 1.45 line height — exactly 16 logical pixels. So the row has no
+          // slack at all at the default text size, and every step above it
+          // cuts the headings: 21px of text in 16 at 1.3x, 32 in 16 at 2x.
+          //
+          // Nothing throws and no overflow stripes appear, because each
+          // heading sits in a `SizedBox` of this height, and a tight
+          // constraint squeezes its child rather than overflowing (#766).
+          daysOfWeekHeight: _weekdayRowHeight(context, weekdayStyle),
           focusedDay: widget.focusedDate,
           firstDay: widget.currentDate.subtract(widget.calendarDurationDays),
           lastDay: widget.currentDate.add(widget.calendarDurationDays),

--- a/test/features/diary/presentation/widgets/diary_table_calendar_test.dart
+++ b/test/features/diary/presentation/widgets/diary_table_calendar_test.dart
@@ -1,0 +1,68 @@
+import 'package:flutter/material.dart';
+import 'package:flutter/rendering.dart';
+import 'package:flutter_localizations/flutter_localizations.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:opennutritracker/features/diary/presentation/widgets/diary_table_calendar.dart';
+import 'package:opennutritracker/generated/l10n.dart';
+
+Widget _app({required double textScale}) => MediaQuery(
+      data: MediaQueryData(textScaler: TextScaler.linear(textScale)),
+      child: MaterialApp(
+        localizationsDelegates: const [
+          S.delegate,
+          GlobalMaterialLocalizations.delegate,
+          GlobalWidgetsLocalizations.delegate,
+          GlobalCupertinoLocalizations.delegate,
+        ],
+        supportedLocales: S.supportedLocales,
+        home: Scaffold(
+          body: DiaryTableCalendar(
+            onDateSelected: (_, _) {},
+            calendarDurationDays: const Duration(days: 365),
+            focusedDate: DateTime(2026, 8, 24),
+            currentDate: DateTime(2026, 8, 24),
+            selectedDate: DateTime(2026, 8, 24),
+            trackedDaysMap: const {},
+          ),
+        ),
+      ),
+    );
+
+void main() {
+  testWidgets('the weekday headings are not clipped at large font sizes',
+      (tester) async {
+    // #766. `TableCalendar`'s `daysOfWeekHeight` defaults to a flat 16.0,
+    // and the headings are `labelSmall` — 11sp on a 1.45 line height, which
+    // is exactly 16 logical pixels. The row therefore has *no* slack at the
+    // default text size, and every step above it is clipped. Nothing throws
+    // and no overflow stripes appear, because a fixed-height box clipping
+    // its child is not a RenderFlex overflowing.
+    for (final scale in const [1.0, 1.3, 1.5, 2.0]) {
+      await tester.pumpWidget(_app(textScale: scale));
+      await tester.pumpAndSettle();
+
+      // The painted size cannot show this. Each heading sits in a
+      // `SizedBox(height: daysOfWeekHeight)`, which is a *tight* constraint,
+      // so the paragraph is squeezed to whatever the box allows and reports
+      // that as its size however much it actually needs. Ask what it wants.
+      final heading = tester.renderObject<RenderParagraph>(
+        find.text('Mon').first,
+      );
+      final wanted = heading.getMaxIntrinsicHeight(heading.size.width);
+      final given = tester
+          .getSize(
+            find
+                .ancestor(of: find.text('Mon'), matching: find.byType(SizedBox))
+                .first,
+          )
+          .height;
+
+      expect(
+        given,
+        greaterThanOrEqualTo(wanted),
+        reason: 'at ${scale}x a heading needs ${wanted}px and its row gives '
+            '${given}px, so the top and bottom of the label are cut off',
+      );
+    }
+  });
+}


### PR DESCRIPTION
Closes #766.

## What was wrong

`DiaryTableCalendar` never set `daysOfWeekHeight`, so it took the package default:

```dart
this.daysOfWeekHeight = 16.0,   // table_calendar 3.2.0
```

The headings are `labelSmall` — 11sp on a 1.45 line height, which is **exactly 16 logical pixels**. So the row had no slack at all at the default text size, and every step above it cut the labels. Measured through the widget's own render objects:

| text scale | row gives | heading wants | shortfall |
|---:|---:|---:|---:|
| 1.0x | 16.0 | 16.0 | none, and none to spare |
| 1.3x | 16.0 | 21.0 | 5px |
| 1.5x | 16.0 | 24.0 | 8px |
| 2.0x | 16.0 | 32.0 | 16px — half the label |

The reporter saw it at 1.5x; it starts at about 1.1x.

## Why nothing complained

The issue notes there were no yellow overflow stripes, and that is worth explaining because it also shaped the test. Each heading sits in a `SizedBox` of this height, and `SizedBox` imposes a **tight** constraint — the paragraph is squeezed rather than overflowing a flex, so nothing throws.

It also means the painted size cannot detect this: a `RenderParagraph` squeezed into 16px *reports 16px as its own size* at every text scale, including 2.0x. My first attempt at the test measured exactly that and passed against the unfixed widget. The test asks `getMaxIntrinsicHeight` instead — what the heading actually wants — and compares it against the box it is given.

## The fix

The row height is measured from the heading's own style rather than scaled from the 16.

Scaling is the obvious alternative and it is subtly wrong. The 16 only equals a heading's height by coincidence — it is `labelSmall`'s line height today — and `textScaler.scale(16)` lands fractionally short at some sizes: **20.8 against the 21.0 wanted at 1.3x**, which clips just as surely. That is not a theoretical objection; it is the second mutation below.

## Mutation check

| reverted | outcome |
|---|---|
| back to the package's flat `16.0` | **caught** — *needs 21.0px and its row gives 16.0px* |
| `textScaler.scale(16)` instead of measuring | **caught** — *needs 21.0px and its row gives 20.8px* |

## Test

New `test/features/diary/presentation/widgets/diary_table_calendar_test.dart`, which pumps the real calendar at 1.0x, 1.3x, 1.5x and 2.0x and asserts each heading's row is at least as tall as the heading wants.
