### PR TITLE
fix: accept Android document-provider export paths

### DIFF
--- a/lib/core/utils/export_write_verifier.dart
+++ b/lib/core/utils/export_write_verifier.dart
@@ -24,11 +24,16 @@ class ExportWriteVerifier {
   const ExportWriteVerifier._();
 
   /// Throws a [StateError] if [savedPath] can be statted and its length
-  /// differs from [expectedByteLength], or if a non-content:// path cannot
+  /// differs from [expectedByteLength], or if a real filesystem path cannot
   /// be statted at all.
   static void verify(String savedPath, int expectedByteLength) {
-    if (savedPath.startsWith('content://')) {
-      // Not a path dart:io can stat - nothing more we can check.
+    // file_picker 11 returns Uri.path for Android document-provider saves,
+    // rather than the original content:// URI. Uri.path looks like
+    // /document/primary:Download/file.zip, but it is not a dart:io path that
+    // can be statted. The provider has already accepted the bytes by this
+    // point, so treating it as a missing local file creates a false failure.
+    if (savedPath.startsWith('content://') ||
+        savedPath.startsWith('/document/')) {
       return;
     }
 

--- a/test/unit_test/export_write_verifier_test.dart
+++ b/test/unit_test/export_write_verifier_test.dart
@@ -56,6 +56,18 @@ void main() {
       );
     });
 
+    test('does not throw for file_picker Android document-provider paths', () {
+      // file_picker 11 strips the content:// scheme and returns Uri.path,
+      // which looks like this even though it is not a local filesystem path.
+      expect(
+        () => ExportWriteVerifier.verify(
+          '/document/primary:Download/opennutritracker-export (2).zip',
+          4,
+        ),
+        returnsNormally,
+      );
+    });
+
     test('throws when a normal path cannot be statted at all', () {
       // A missing filesystem path means the write never landed — unlike a
       // content:// URI, there is no legitimate unreadable case to excuse.


### PR DESCRIPTION
## What this fixes

Fixes #763.

On Android, `file_picker` 11 writes through the selected Storage Access Framework `content://` URI, then returns `uri.path`. That value looks like `/document/primary:Download/...` but is not a real `dart:io` filesystem path. When Downloads auto-renames an existing export to `(2).zip`, the export verifier tries to stat the provider path and reports a valid export as failed.

This change treats Android document-provider paths the same as `content://` URIs while retaining strict byte-length verification for real filesystem paths.

## Verification

- `dart format lib/core/utils/export_write_verifier.dart test/unit_test/export_write_verifier_test.dart`
- `flutter test test/unit_test/export_write_verifier_test.dart` — 7 tests passed
- `git diff --check` — passed
- `flutter analyze` was attempted, but the checkout is missing the repository's `lib/generated/l10n.dart` localization output and reports broad pre-existing generated-code errors; the focused test suite passes.