### PR TITLE
feat(core): withdraw the AI agreement with the last credential (#836)

### DIFF
--- a/lib/core/utils/ai_credential_storage.dart
+++ b/lib/core/utils/ai_credential_storage.dart
@@ -935,12 +935,18 @@ class AiCredentialStorage {
       await _storage.delete(key: _probeSlotTag(target));
       await _retireLegacyTagFor(target);
 
-      // Only once nothing is left: with two slots, clearing one key is often
-      // "I am dropping this provider", not "I am done with the feature". The
-      // invariant that matters is narrower — the flag may never be on with no
-      // credential behind it at all.
-      if (!await _hasAnyKey()) {
+      // Only once nothing is left: with four slots, clearing one credential
+      // is often "I am dropping this provider", not "I am done with the
+      // feature". The invariant that matters is narrower — neither flag may
+      // stand with nothing behind it at all.
+      //
+      // The agreement goes with the switch (#836). A recorded yes that
+      // outlives every credential it authorised is a stored answer to a
+      // question nobody is asking any more, and the next credential deserves
+      // to be asked about rather than covered by it.
+      if (!await _hasAnyUsableProvider()) {
         await _storage.delete(key: _enabledTag);
+        await _storage.delete(key: _termsAcceptedTag);
       }
     });
   }
@@ -954,9 +960,28 @@ class AiCredentialStorage {
     await _storage.delete(key: _legacyApiKeyTag);
   }
 
-  Future<bool> _hasAnyKey() async {
+  /// Whether any provider still has something usable behind it.
+  ///
+  /// This asked only about keys until #836, which is the narrower question
+  /// #755 retired everywhere else and [setEnabled] already says it learned:
+  /// a server the user runs is configured by an address and a model, and its
+  /// key is optional. So someone running that server *and* holding a hosted
+  /// key lost the feature by removing the hosted key — switched off while a
+  /// working provider was still configured, with nothing on screen to explain
+  /// it.
+  ///
+  /// Safe inside [clear]'s critical section: every reader below goes straight
+  /// to storage, and none of them take the lock that call already holds.
+  Future<bool> _hasAnyUsableProvider() async {
     for (final provider in AiProvider.values) {
-      if (await readApiKey(provider: provider) != null) return true;
+      if (_isUsable(
+        provider,
+        apiKey: await readApiKey(provider: provider),
+        endpoint: await readEndpoint(provider: provider),
+        modelId: await readModel(provider: provider),
+      )) {
+        return true;
+      }
     }
     return false;
   }

--- a/test/unit_test/ai_credential_storage_test.dart
+++ b/test/unit_test/ai_credential_storage_test.dart
@@ -1464,4 +1464,74 @@ void main() {
       }
     });
   });
+
+  group('the agreement goes with the last credential', () {
+    test('removing the only credential withdraws it', () async {
+      await storage.writeApiKey('sk-test', provider: AiProvider.anthropic);
+      await storage.setTermsAccepted(true);
+
+      await storage.clear(provider: AiProvider.anthropic);
+
+      expect(
+        await storage.hasAcceptedTerms(),
+        isFalse,
+        reason: 'a recorded yes outlived every credential it authorised, and '
+            'the next key would be stored without anyone being asked',
+      );
+    });
+
+    test('removing one of two leaves it standing', () async {
+      await storage.writeApiKey('sk-ant', provider: AiProvider.anthropic);
+      await storage.writeApiKey('sk-oai', provider: AiProvider.openai);
+      await storage.setTermsAccepted(true);
+
+      await storage.clear(provider: AiProvider.openai);
+
+      // Dropping one provider is not being done with the feature, and asking
+      // again while a working credential is still on file would be asking
+      // about a decision the user has not revisited.
+      expect(await storage.hasAcceptedTerms(), isTrue);
+    });
+
+    test('a server the user runs counts as a credential', () async {
+      // The one that is not a key. #755 generalised "has a key" to "is
+      // usable" everywhere else; clear() was still asking the narrow
+      // question, so removing the hosted key switched the feature off and —
+      // once the agreement joined that block — would have withdrawn it too,
+      // while a fully configured server was still there to use.
+      await storage.writeOwnServerConfiguration(
+        endpoint: 'http://192.168.1.5:11434',
+        model: 'qwen3:8b',
+        provider: AiProvider.ownServer,
+      );
+      await storage.writeApiKey('sk-oai', provider: AiProvider.openai);
+      await storage.setTermsAccepted(true);
+
+      await storage.clear(provider: AiProvider.openai);
+
+      expect(
+        await storage.hasAcceptedTerms(),
+        isTrue,
+        reason: 'the agreement was withdrawn while a usable provider remained',
+      );
+      expect(
+        await storage.readEndpoint(provider: AiProvider.ownServer),
+        isNotNull,
+        reason: 'and that provider is still configured',
+      );
+    });
+
+    test('removing the last one withdraws it even without a key', () async {
+      await storage.writeOwnServerConfiguration(
+        endpoint: 'http://192.168.1.5:11434',
+        model: 'qwen3:8b',
+        provider: AiProvider.ownServer,
+      );
+      await storage.setTermsAccepted(true);
+
+      await storage.clear(provider: AiProvider.ownServer);
+
+      expect(await storage.hasAcceptedTerms(), isFalse);
+    });
+  });
 }


### PR DESCRIPTION
> [!WARNING]
> **This PR has no CI, and GitHub still reports it mergeable.**
>
> It is based on `feat/ai-consent-gate` (#838), and the workflow only triggers on `main`, `develop` and `feature/**` — so a PR onto a topic branch gets no checks at all while looking green. Do not read "mergeable" as "verified" here.
>
> Merge order is #837 → #838 → this. GitHub retargets each one as its parent lands, and the checks run for real at that point.

Closes #836. Third and last of the privacy-agreement work, after #837 (#834) and #838 (#835).

## What happens now

Removing the last credential clears the agreement, so adding another asks again. There is no new control for withdrawal: removing a credential is already how the feature gets turned off, and a separate "withdraw" button would be a second way to do one thing.

**On the last credential, not on any of them.** Credentials are stored per provider and the agreement is single, so clearing it whenever one key went away would leave a still-configured provider usable with no agreement recorded — the exact state this work exists to prevent.

## The older bug this uncovered

`clear()` decided whether anything was left by asking whether any **key** remained. That is the narrow question #755 retired everywhere else, and which `setEnabled` already carries a comment about having learned:

> The guard asks `_isUsable` rather than `hasApiKey`, which is the same generalisation #755 made everywhere else and missed here.

`clear()` missed it too. A server the user runs is configured by an address and a model, and its key is optional — so **someone running that server alongside a hosted key lost the feature by removing the hosted key**. Switched off, with a fully configured provider still there and nothing on screen to explain it.

That is a live defect on this branch independent of consent, and it had to be fixed here anyway: joining the agreement to that same decision would have inherited it and broken the rule above for the one provider whose credential is not a key.

It now asks `_isUsable`, the same question `setEnabled` asks.

## A trap worth naming

`clear()` runs inside `_probeConfigurationLock`, which is not reentrant. The new predicate reads three values per provider, so I checked all three readers go straight to storage without taking that lock before calling them from inside the critical section. Had they taken it, this would have deadlocked rather than failed visibly.

## Verification

| | |
|---|---|
| storage suite | **95 pass**, 4 of them new |
| `flutter analyze` (bare, whole project) | **clean** |
| full suite | **1788 pass** |

### Mutation check

| reverted | outcome |
|---|---|
| the agreement survives the last credential | **caught** — *removing the only credential withdraws it*, and the no-key variant |
| back to the narrow key-only question | **caught** — *a server the user runs counts as a credential* |

The second row is the point: it fails only because the own-server case is covered, which is what makes the older bug demonstrated rather than asserted.

