### PR TITLE
fix(add-meal): keep the brand on screen when a row is doubted (#847)

### DIFF
--- a/lib/features/add_meal/presentation/screens/bulk_add_screen.dart
+++ b/lib/features/add_meal/presentation/screens/bulk_add_screen.dart
@@ -718,6 +718,17 @@ class _BulkAddScreenState extends State<BulkAddScreen> {
                           : null,
                     ),
                   ),
+                  // The brand names *which* food this is; a warning only
+                  // qualifies it. They were alternatives, and that inverted
+                  // the intent below: the more doubtful a row looked, the
+                  // less identifying detail it showed. #847 found the cost
+                  // on a Pixel 6 — "Spiegeleier" resolved to Haribo's gummy
+                  // sweets, and because the row also carried a unit warning,
+                  // the word "Haribo" never reached the screen. The one
+                  // field that gives the mistake away is the one a warning
+                  // used to hide, so it is now unconditional.
+                  if (meal?.brands != null)
+                    Text(meal!.brands!, style: theme.textTheme.bodySmall),
                   if (!row.isResolved)
                     Text(
                       S.of(context).bulkAddNoMatchLabel,
@@ -741,9 +752,7 @@ class _BulkAddScreenState extends State<BulkAddScreen> {
                       style: theme.textTheme.bodySmall?.copyWith(
                         color: theme.colorScheme.tertiary,
                       ),
-                    )
-                  else if (meal?.brands != null)
-                    Text(meal!.brands!, style: theme.textTheme.bodySmall),
+                    ),
                 ],
               ),
             );

--- a/test/features/add_meal/presentation/bulk_add_screen_test.dart
+++ b/test/features/add_meal/presentation/bulk_add_screen_test.dart
@@ -108,10 +108,16 @@ class _FakeSearch implements SearchProductsUseCase {
   dynamic noSuchMethod(Invocation invocation) => super.noSuchMethod(invocation);
 }
 
-MealEntity _meal(String name, {double? servingQuantity, String? mealUnit}) =>
+MealEntity _meal(
+  String name, {
+  double? servingQuantity,
+  String? mealUnit,
+  String? brands,
+}) =>
     MealEntity(
       code: name,
       name: name,
+      brands: brands,
       url: null,
       mealQuantity: null,
       mealUnit: mealUnit,
@@ -994,6 +1000,70 @@ void main() {
     await _parse(tester, '2 eggs');
 
     expect(find.text(l10nEn.bulkAddCheckAmountLabel), findsNothing);
+  });
+
+  testWidgets('a brand stays visible behind a unit warning', (tester) async {
+    // #847. Found on a Pixel 6: "Spiegeleier" resolved to Haribo's gummy
+    // sweets — 340 kcal/100 g of sugar where the user meant fried eggs. The
+    // row also carried the bare-count warning, and because the brand was an
+    // *alternative* to that warning rather than a companion, the word
+    // "Haribo" never reached the screen. The warning is about the amount;
+    // the brand is the thing that tells you the food itself is wrong, so a
+    // doubtful row is exactly when it must not disappear.
+    await _register({
+      'spiegeleier': [_meal('Spiegeleier', brands: 'Haribo')],
+    });
+    await tester.pumpWidget(_app());
+    await _parse(tester, '2 spiegeleier');
+
+    expect(find.text(l10nEn.bulkAddCheckAmountLabel), findsOneWidget);
+    expect(find.text('Haribo'), findsOneWidget);
+  });
+
+  testWidgets('a brand still shows on a row with no warning', (tester) async {
+    await _register({
+      'butter': [_meal('Butter', brands: 'Gut Bio', servingQuantity: 10)],
+    });
+    await tester.pumpWidget(_app());
+    await _parse(tester, '2 butter');
+
+    expect(find.text(l10nEn.bulkAddCheckAmountLabel), findsNothing);
+    expect(find.text('Gut Bio'), findsOneWidget);
+  });
+
+  testWidgets('a brand and a warning together still fit at 2x', (tester) async {
+    // The brand is a new *third* line on a row that already carried a title
+    // and a warning, and this screen has run out of room twice before (#820
+    // vertically, #824 horizontally). German at 2x is the worst case the
+    // suite has: every glyph is one em wide in the test font, so
+    // "Einheit fuer diese Menge pruefen" is far wider here than on a device.
+    await _register({
+      'spiegeleier': [_meal('Spiegeleier', brands: 'Haribo')],
+    });
+
+    final errors = <String>[];
+    final previous = FlutterError.onError;
+    FlutterError.onError = (details) => errors.add(details.toString());
+    addTearDown(() => FlutterError.onError = previous);
+
+    await tester.pumpWidget(
+      MediaQuery(
+        data: const MediaQueryData(textScaler: TextScaler.linear(2.0)),
+        child: _app(locale: const Locale('de')),
+      ),
+    );
+    await tester.pumpAndSettle();
+    await _parse(tester, '2 spiegeleier');
+
+    // Restored before asserting: a failed `expect` while this is installed is
+    // an error the framework cannot reconcile, and the test hangs instead.
+    FlutterError.onError = previous;
+    expect(
+      errors.where((e) => e.contains('overflowed')),
+      isEmpty,
+      reason: 'the brand line does not fit beside the warning it accompanies',
+    );
+    expect(find.text('Haribo'), findsOneWidget);
   });
 
   testWidgets('parse errors are shown alongside the rows that parsed', (


### PR DESCRIPTION
Closes [#847](https://github.com/simonoppowa/OpenNutriTracker/issues/847). Targets `feature/ai-assisted-meal-logging`.

## What was wrong

The review row has one subtitle slot and four claimants, resolved by an exclusive `if / else if` chain with the brand last. Any warning therefore suppressed the brand — so **the more doubtful a row looked, the less identifying detail it showed**.

Found on a Pixel 6 during the [#830](https://github.com/simonoppowa/OpenNutriTracker/issues/830) acceptance pass. `zwei Spiegeleier und eine Scheibe Vollkornbrot mit Butter` resolved *Spiegeleier* to **Haribo Spiegeleier — the gummy sweets**: 340 kcal/100 g, 79 g sugar, where the user meant fried eggs.

Nothing about that broke the provenance guarantee. The numbers are real values from a real Open Food Facts record and no model emitted a macro — which is exactly what made it dangerous: every promise the app makes was kept and the entry was still wrong. The row also carried a bare count, so `bulkAddCheckAmountLabel` took the slot and the word **Haribo never reached the screen**. Butter and Milch displayed their brands in the same list purely because they had nothing to warn about.

## Why not a confidence heuristic

That was the obvious fix and the measurement rejected it. Open Food Facts returns four candidates for `Spiegeleier`:

| Product | Brand | kcal/100 g | carb | fat |
|---|---|---|---|---|
| Spiegeleier | Haribo | 340 | 79 | 0.5 |
| Spiegeleier | Haribo | 339 | 79 | 0.5 |
| Spiegeleier | Haribo | 339 | 79 | 0.5 |
| Spiegeleier Baagel | Billa | 239 | 18 | 13 |

Three of four are the same product, and **no fried-egg record exists under that name** — the right answer is not in the pool. So a confidence floor would not fire (the name match is exact, ~1.0, far above the 0.45 floor), a runner-up gap would not fire (the runner-up is a duplicate of the same wrong item), and candidate-set dispersion would not fire either. `MealEntity` carries no category or tag, so there is no local signal separating this from a legitimate branded match.

The app genuinely cannot decide this one. What it can do is show the user the field that gives it away.

## The change

The brand becomes unconditional; the warnings keep their existing precedence among themselves. 15 lines in the screen.

## Verification

- `flutter analyze` — `No issues found!`
- `flutter test` — **1800 passed**
- New coverage: the brand surviving a unit warning, the brand on an unwarned row, and both together in **German at 2× text**. That last one is not ceremony — the brand is a third line on a row that already had a title and a warning, and this screen has run out of room twice before ([#820](https://github.com/simonoppowa/OpenNutriTracker/issues/820) vertically, [#824](https://github.com/simonoppowa/OpenNutriTracker/issues/824) horizontally).

**Mutation-checked:**

| Mutation | Caught by |
|---|---|
| Restore the brand as an exclusive `else if` (pre-#847 behaviour) | `a brand stays visible behind a unit warning`, `a brand and a warning together still fit at 2x` |
| Delete the brand line entirely | those two, plus `a brand still shows on a row with no warning` |

## What this does not fix

A wrong match with **no** brand still shows nothing extra, and an unbranded generic record that is simply the wrong food remains undetectable locally. This closes the case where the evidence existed and was being hidden; it does not give the resolver judgement it has no data for.
