### PR TITLE
fix(settings): put the provider back when the dialog is dismissed (#848)

### DIFF
--- a/lib/core/utils/ai_credential_storage.dart
+++ b/lib/core/utils/ai_credential_storage.dart
@@ -274,6 +274,28 @@ class AiCredentialStorage {
   Future<void> setActiveProvider(AiProvider provider) =>
       _storage.write(key: _providerTag, value: provider.name);
 
+  /// The stored name **exactly as it is held** — including one this build does
+  /// not know, and including nothing at all.
+  ///
+  /// [activeProvider] answers the question the app asks at runtime, and to do
+  /// that it folds both of those onto values it can act on: nothing stored
+  /// reads as Anthropic, an unrecognised name reads as null (see
+  /// [AiProvider.fromTag]). Neither folded answer can be written back, so a
+  /// caller that means to put the selection back exactly where it found it
+  /// cannot go through the enum. #848.
+  Future<String?> readActiveProviderTag() => _storage.read(key: _providerTag);
+
+  /// Puts back what [readActiveProviderTag] returned.
+  ///
+  /// Null **deletes** rather than writing a default. An install that has never
+  /// chosen a provider is a different state from one that chose Anthropic —
+  /// the first is every install that predates providers existing, and it is
+  /// valid precisely because nothing was ever written to it — and undoing a
+  /// change nobody confirmed must not be what turns the one into the other.
+  Future<void> restoreActiveProviderTag(String? tag) => tag == null
+      ? _storage.delete(key: _providerTag)
+      : _storage.write(key: _providerTag, value: tag);
+
   /// Resolves the active provider **once** and answers everything that hangs
   /// off it, for the callers that want more than one of these values.
   ///

--- a/lib/features/settings/presentation/widgets/ai_assist_dialog.dart
+++ b/lib/features/settings/presentation/widgets/ai_assist_dialog.dart
@@ -62,7 +62,9 @@ class AiAssistDialog extends StatefulWidget {
   /// Not barrier-dismissible: the switch, the provider selector and the
   /// remove button write immediately, so a tap outside would drop the
   /// "something changed" answer on the floor and leave the settings tile
-  /// describing the old state. Leaving is via Cancel, which reports honestly.
+  /// describing the old state. Leaving is via Cancel or the back button, both
+  /// of which report honestly and put the provider back — see
+  /// `_AiAssistDialogState._cancel`.
   static Future<bool> show(
     BuildContext context,
     AiCredentialStorage storage, {
@@ -202,9 +204,26 @@ class _AiAssistDialogState extends State<AiAssistDialog> {
   /// have left: 66 seconds is longer than anyone waits at a settings screen.
   bool _probing = false;
 
+  /// What the store held when the dialog opened, so leaving without
+  /// confirming can put it back. See [_cancel].
+  ///
+  /// **A raw tag rather than an [AiProvider]**, because the two selections
+  /// this dialog cannot itself express — nothing stored, and a name this
+  /// build does not know — are both states Cancel has to restore, and neither
+  /// survives a round trip through the enum.
+  ///
+  /// Kept as the future rather than its answer: the read is started before
+  /// anything is on screen to tap, and awaiting it at the point of use means
+  /// a radio somehow tapped first still reverts to what was there rather than
+  /// to what the tap left behind.
+  late final Future<String?> _providerOnOpen;
+
   @override
   void initState() {
     super.initState();
+    // Started before the first frame, because every write below this point
+    // overwrites the thing being remembered.
+    _providerOnOpen = widget.storage.readActiveProviderTag();
     // **Deliberately only this.** No fetch here, and none in
     // [_selectProvider]: for the three hosted providers opening AI settings
     // sends nothing anywhere, and the README's promise is about what leaves
@@ -378,8 +397,8 @@ class _AiAssistDialogState extends State<AiAssistDialog> {
     // a machine on the user's network at the one moment they cannot see the
     // answer. A route stops being current the moment `pop` is called, which
     // is before it moves focus — so this catches every way out at once:
-    // Cancel, OK, and the system back button, which runs no handler of ours
-    // at all.
+    // Cancel, OK, and the system back button, whose own handler (#848) ends
+    // in the same `pop` and so is covered by the same check.
     //
     // One check rather than a flag set on each exit. A flag was tried first
     // and could not see the back button; adding this made every one of its
@@ -503,6 +522,37 @@ class _AiAssistDialogState extends State<AiAssistDialog> {
     _modelController.text = id;
     _modelError = null;
   });
+
+  /// Leaves, and takes the provider choice back out with it.
+  ///
+  /// **Selecting a provider persists immediately**, and has to: [_load] reads
+  /// the store for whoever is now active, so the write goes first. That made
+  /// Cancel a button that undid nothing — tap OpenAI, tap Cancel, and the
+  /// settings row read *"On — OpenAI"*. #848.
+  ///
+  /// Which matters here more than it would elsewhere, because this dialog is
+  /// the one place that names each destination and states what it does with a
+  /// photo. Reading those is something the app actively invites, so tapping
+  /// down the list to compare them is ordinary use — and it was silently
+  /// repointing where the next meal photo would be sent.
+  ///
+  /// The restore is **awaited before the pop**, not fired off beside it. The
+  /// caller refreshes its subtitle from this dialog's answer, and a row that
+  /// reads the wrong destination for a frame is the same lie in miniature.
+  ///
+  /// Only the provider is put back. A model chosen for a named provider, the
+  /// pause switch, Remove — each is a deliberate act on a thing the user
+  /// pointed at, not a side effect of reading a paragraph; this undoes the one
+  /// change that happened without being asked for.
+  /// The route check is the same idiom [_endpointCommitted] uses, for the
+  /// mirror-image reason: a route stops being current the moment `pop` is
+  /// called, so a second back press arriving during the restore finds this
+  /// already on its way out and does not pop the screen underneath as well.
+  Future<void> _cancel() async {
+    await widget.storage.restoreActiveProviderTag(await _providerOnOpen);
+    if (!mounted || ModalRoute.of(context)?.isCurrent == false) return;
+    Navigator.of(context).pop(_changed);
+  }
 
   Future<void> _save() async {
     final s = S.of(context);
@@ -709,6 +759,24 @@ class _AiAssistDialogState extends State<AiAssistDialog> {
     final s = S.of(context);
     final theme = Theme.of(context);
 
+    return PopScope(
+      // The back button is a dismissal too, and it is the exit that runs no
+      // handler of its own — so it is intercepted here rather than left to pop
+      // straight past the restore, which would make "put the provider back"
+      // a promise that held for one of the two ways out.
+      //
+      // `canPop: false` gates only the pops the *user* initiates. The two this
+      // dialog performs itself call `Navigator.pop` directly and are not
+      // routed through here, which is what keeps a confirmed switch confirmed.
+      canPop: false,
+      onPopInvokedWithResult: (didPop, _) {
+        if (!didPop) unawaited(_cancel());
+      },
+      child: _buildDialog(context, s, theme),
+    );
+  }
+
+  Widget _buildDialog(BuildContext context, S s, ThemeData theme) {
     return AlertDialog(
       // The Experimental marker is deliberately *not* appended here. At a 2x
       // text scale on a 320px phone it makes this title tall enough to squeeze
@@ -941,9 +1009,12 @@ class _AiAssistDialogState extends State<AiAssistDialog> {
               ),
             ),
       actions: [
-        TextButton(
-          onPressed: () => Navigator.of(context).pop(_changed),
-          child: Text(s.dialogCancelLabel),
+        Semantics(
+          identifier: 'ai-assist-cancel',
+          child: TextButton(
+            onPressed: _cancel,
+            child: Text(s.dialogCancelLabel),
+          ),
         ),
         // Offered whenever something on screen can still be typed into. For
         // the hosted three that is exactly "before a key exists", which is

--- a/test/features/settings/presentation/ai_assist_dialog_test.dart
+++ b/test/features/settings/presentation/ai_assist_dialog_test.dart
@@ -2311,6 +2311,172 @@ void main() {
     expect(backing.store, before);
   });
 
+  group('leaving without confirming (#848)', () {
+    /// Taps a provider row the way the adb verifier does — by the identifier
+    /// AGENTS.md asks for rather than by a brand name, which is what a driver
+    /// on a localized device has to use.
+    Future<void> choose(WidgetTester tester, AiProvider provider) async {
+      await tester.tap(
+        find.bySemanticsIdentifier(AiAssistDialog.providerIdentifier(provider)),
+      );
+      await tester.pumpAndSettle();
+    }
+
+    Future<void> cancel(WidgetTester tester) async {
+      await tester.tap(find.bySemanticsIdentifier('ai-assist-cancel'));
+      await tester.pumpAndSettle();
+    }
+
+    testWidgets('Cancel puts the destination back where it found it', (
+      tester,
+    ) async {
+      // Reproduced on a Pixel 6 in the #830 acceptance pass: active provider
+      // OpenRouter, open the dialog, tap OpenAI, tap Cancel, and the settings
+      // row reads "On — OpenAI". The dialog is the one place that names each
+      // destination and says what it does with a photo, so tapping down the
+      // list to read them is ordinary use, and it was quietly repointing
+      // where the next meal photo went.
+      await storage.setActiveProvider(AiProvider.openrouter);
+      await tester.pumpWidget(_app(storage));
+      await tester.pumpAndSettle();
+
+      await choose(tester, AiProvider.openai);
+      expect(
+        await storage.activeProvider(),
+        AiProvider.openai,
+        reason: 'the selection still persists on the way in — the reload '
+            'below the selector reads the store for whoever is now active',
+      );
+
+      await cancel(tester);
+
+      expect(await storage.activeProvider(), AiProvider.openrouter);
+    });
+
+    testWidgets('OK still switches, and still persists', (tester) async {
+      // The other half, and the one that would pass if the revert were
+      // implemented by never writing at all.
+      await storage.setActiveProvider(AiProvider.openrouter);
+      await tester.pumpWidget(_app(storage));
+      await tester.pumpAndSettle();
+
+      await choose(tester, AiProvider.openai);
+      await tester.tap(find.bySemanticsIdentifier('ai-assist-save-key'));
+      await tester.pumpAndSettle();
+
+      expect(await storage.activeProvider(), AiProvider.openai);
+    });
+
+    testWidgets('the system back button puts it back too', (tester) async {
+      // The exit that runs no handler of its own. Driven through the real
+      // `show()` route, because a dialog embedded in a body has nothing to
+      // pop.
+      await storage.setActiveProvider(AiProvider.openrouter);
+      await tester.pumpWidget(
+        MaterialApp(
+          localizationsDelegates: const [
+            S.delegate,
+            GlobalMaterialLocalizations.delegate,
+            GlobalWidgetsLocalizations.delegate,
+            GlobalCupertinoLocalizations.delegate,
+          ],
+          supportedLocales: S.supportedLocales,
+          home: Builder(
+            builder: (context) => Scaffold(
+              body: TextButton(
+                onPressed: () => AiAssistDialog.show(context, storage),
+                child: const Text('open'),
+              ),
+            ),
+          ),
+        ),
+      );
+      await tester.tap(find.text('open'));
+      await tester.pumpAndSettle();
+
+      await choose(tester, AiProvider.openai);
+      // What Android's back gesture delivers. `pageBack` looks for a back
+      // button widget, and a dialog route has none.
+      await tester.binding.handlePopRoute();
+      await tester.pumpAndSettle();
+
+      expect(find.text(l10nEn.settingsAiAssistLabel), findsNothing);
+      expect(await storage.activeProvider(), AiProvider.openrouter);
+    });
+
+    testWidgets('an install that never chose is still one that never chose', (
+      tester,
+    ) async {
+      // Nothing stored reads as Anthropic, and that is what makes every
+      // install predating providers valid without a migration having to run
+      // over it. Restoring by writing "anthropic" would answer the same
+      // question the same way and quietly end that — so the revert puts back
+      // the absence, not the reading of it.
+      await tester.pumpWidget(_app(storage));
+      await tester.pumpAndSettle();
+
+      await choose(tester, AiProvider.openai);
+      await cancel(tester);
+
+      expect(backing.store.containsKey('AiProviderTag'), isFalse);
+    });
+
+    testWidgets('a name this build does not know survives being read past', (
+      tester,
+    ) async {
+      // #753: a newer build wrote a provider this one cannot honour, and the
+      // radios fall back to the first for display only, so that downgrading
+      // and re-upgrading restores what the user picked. That promise is about
+      // *not writing*, and a revert is a write — it has to put the unknown
+      // name back rather than the one the radios were showing.
+      backing.store['AiProviderTag'] = 'someProviderFromALaterBuild';
+      await tester.pumpWidget(_app(storage));
+      await tester.pumpAndSettle();
+      expect(await storage.activeProvider(), isNull);
+
+      await choose(tester, AiProvider.openai);
+      await cancel(tester);
+
+      expect(backing.store['AiProviderTag'], 'someProviderFromALaterBuild');
+      expect(await storage.activeProvider(), isNull);
+    });
+
+    testWidgets('declining the terms and leaving moves nothing', (
+      tester,
+    ) async {
+      // The consent gate (#835, #836) is unchanged by any of this: a switch
+      // that is confirmed with a key still asks before storing it. What this
+      // adds is that saying no leaves the dialog open on a provider the store
+      // has already been pointed at — so it is the exit, not the refusal,
+      // that has to undo the switch.
+      await storage.setTermsAccepted(false);
+      await storage.setActiveProvider(AiProvider.openrouter);
+      await tester.pumpWidget(_app(storage));
+      await tester.pumpAndSettle();
+
+      await choose(tester, AiProvider.openai);
+      await tester.enterText(find.byType(TextField).first, 'sk-x');
+      await tester.pumpAndSettle();
+      await tester.tap(find.bySemanticsIdentifier('ai-assist-save-key'));
+      await tester.pumpAndSettle();
+
+      expect(find.text(l10nEn.aiConsentTitle), findsOneWidget);
+      // OpenAI's disclosure runs past the fold on the test viewport, and the
+      // buttons sit under it — which is the screen doing its job.
+      await tester.drag(find.byType(ListView), const Offset(0, -600));
+      await tester.pumpAndSettle();
+      await tester.tap(find.bySemanticsIdentifier('ai-consent-decline'));
+      await tester.pumpAndSettle();
+
+      expect(await storage.readApiKey(provider: AiProvider.openai), isNull);
+      expect(await storage.hasAcceptedTerms(), isFalse);
+
+      await cancel(tester);
+
+      expect(await storage.activeProvider(), AiProvider.openrouter);
+    });
+  });
+
   testWidgets('a long saved-key label does not overflow its row', (
     tester,
   ) async {


### PR DESCRIPTION
Closes [#848](https://github.com/simonoppowa/OpenNutriTracker/issues/848). Targets `feature/ai-assisted-meal-logging`.

## What was wrong

Selecting a provider in the AI settings dialog persisted it immediately, so **Cancel did not cancel** — the newly-selected provider stayed active. Found on a Pixel 6 during the [#830](https://github.com/simonoppowa/OpenNutriTracker/issues/830) pass: active provider OpenRouter → open dialog → tap OpenAI → tap Cancel → the tile reads *"On — OpenAI"*.

The dialog is the only place that names each destination and says what it does with a photo, so tapping through providers to read those disclosures is exactly what users are invited to do. Doing it silently repointed where the next meal photo would be sent.

## The fix

Cancel — and the system back button — restore the provider that was active when the dialog opened. The snapshot is taken in `initState` and put back through a single `_cancel()` exit path that awaits the restore before popping, so the caller's subtitle refresh cannot read the abandoned choice.

**The snapshot is the raw stored tag, not an `AiProvider`.** The enum folds away the two states a restore has to reach: nothing stored (restoring `anthropic` would end the no-migration property for installs predating providers) and a name this build does not recognise (writing over it would undo what [#753](https://github.com/simonoppowa/OpenNutriTracker/issues/753) protects). So storage gained `readActiveProviderTag()` / `restoreActiveProviderTag(String?)`, where null **deletes** rather than writing a default.

Neither takes `_probeConfigurationLock` — `setActiveProvider` writes the same key lock-free and the cancel path is not inside the lock, so there is no reentrancy hazard.

Selection still persists on the way in, because `_load` reads the store for the newly active provider and needs it there. OK is untouched and still gates on consent exactly as before.

## Scope held deliberately

A model chosen for a named provider, the pause switch, and Remove all still persist through Cancel. Each is a deliberate act on a thing the user pointed at, not a side effect of reading a disclosure. Making Cancel a full transaction is a bigger change and a separate decision.

## Verification

- `flutter analyze` — `No issues found!`
- `flutter test` — **1806 passed**

**Mutation-checked, three ways:**

| Mutation | Result |
|---|---|
| Delete the restore from `_cancel()` | 5 of 6 new tests fail. `OK still switches, and still persists` correctly keeps passing — it is the guard proving the fix did not simply stop writing |
| Flip `PopScope` to `canPop: true` | exactly 1 fails — `the system back button puts it back too`, so that test is load-bearing, not a duplicate |
| Make `restoreActiveProviderTag` write `anthropic` for a null tag | 2 fail, including the pre-existing `cancelling without typing stores nothing` |

Not device-verified. Repro path: Settings → expand → fling to the bottom → AI assist → tap a provider → Cancel → tile should read the original provider.
