### PR TITLE
fix(add-meal): land the model-failure notice on the AI settings (#852)

### DIFF
--- a/lib/features/add_meal/presentation/screens/bulk_add_screen.dart
+++ b/lib/features/add_meal/presentation/screens/bulk_add_screen.dart
@@ -23,6 +23,7 @@ import 'package:opennutritracker/features/diary/presentation/bloc/diary_bloc.dar
 import 'package:opennutritracker/features/home/presentation/bloc/home_bloc.dart';
 import 'package:opennutritracker/features/meal_detail/presentation/bloc/meal_detail_bloc.dart';
 import 'package:opennutritracker/features/meal_detail/util/meal_quantity_converter.dart';
+import 'package:opennutritracker/features/settings/settings_screen.dart';
 import 'package:opennutritracker/generated/l10n.dart';
 
 class BulkAddScreenArguments {
@@ -490,9 +491,18 @@ class _BulkAddScreenState extends State<BulkAddScreen> {
         // is what a three-line cap ate. It is a control now, so it cannot be
         // truncated at any text scale — and every one of these failures is
         // answered in the same place.
-        action: () => Navigator.of(
-          context,
-        ).pushNamed(NavigationOptions.settingsRoute),
+        //
+        // #852: which is why it asks for that place by name. Plain Settings
+        // opens on Units & Energy and the AI row is four category groups
+        // below it, so the recovery from "your server did not answer in
+        // time" used to end in a hunt through a long list. The failure kind
+        // does not appear here on purpose: the auth, unsupported, billing,
+        // timeout and insecure-destination cases are all fixed in this one
+        // dialog, so they all ask for the same thing.
+        action: () => Navigator.of(context).pushNamed(
+          NavigationOptions.settingsRoute,
+          arguments: const SettingsScreenArguments(openAiAssist: true),
+        ),
       );
     }
 

--- a/lib/features/settings/settings_screen.dart
+++ b/lib/features/settings/settings_screen.dart
@@ -48,6 +48,24 @@ import 'package:opennutritracker/features/settings/presentation/widgets/macro_sp
 import 'package:opennutritracker/features/settings/presentation/widgets/nutrient_goals_screen.dart';
 import 'package:opennutritracker/features/settings/presentation/widgets/per_meal_kcal_share_dialog.dart';
 
+/// What the settings route was opened *for*.
+///
+/// This screen is long enough that "go to Settings" is not an answer on its
+/// own: pushed plain it lands on Units & Energy, four category groups above
+/// the AI row, and a Pixel 6 pass (#830) took several attempts to scroll to
+/// that row while deliberately looking for it. A caller that already knows
+/// which control the user came to change says so here, and the screen opens
+/// that control itself rather than leaving them to hunt for it. #852.
+///
+/// Arguments are optional — every other way in pushes the route without
+/// them, and a null or foreign `arguments` is simply the plain screen.
+class SettingsScreenArguments {
+  /// Open the AI assistance dialog as soon as the screen is up.
+  final bool openAiAssist;
+
+  const SettingsScreenArguments({this.openAiAssist = false});
+}
+
 class SettingsScreen extends StatefulWidget {
   /// When true, renders the settings list inline (no Scaffold/AppBar, the list
   /// shrink-wraps) so it can be hosted inside the You tab's scroll. The pushed
@@ -78,6 +96,14 @@ class _SettingsScreenState extends State<SettingsScreen> {
   /// Null when the stored name is unrecognised — see #753.
   AiProvider? _aiProvider;
 
+  /// Whether the route's arguments have been acted on.
+  ///
+  /// `didChangeDependencies` runs again for anything this screen depends on —
+  /// a theme change, a locale change, the keyboard, and the dialog's own
+  /// route going up — so an unguarded read reopens a dialog that is already
+  /// open, and closing it leaves a second behind.
+  bool _routeRequestHandled = false;
+
   @override
   void initState() {
     _aiCredentials = locator<AiCredentialStorage>();
@@ -98,6 +124,28 @@ class _SettingsScreenState extends State<SettingsScreen> {
     // leaves stale values on the screen for the rest of the session.
     // Refresh on every entry instead.
     _settingsBloc.add(LoadSettingsEvent());
+  }
+
+  /// Acts on what the caller asked the settings route for — see
+  /// [SettingsScreenArguments].
+  ///
+  /// The embedded form is skipped: it has no route of its own, so what it
+  /// would read is the host route's arguments, which are not addressed to it.
+  @override
+  void didChangeDependencies() {
+    super.didChangeDependencies();
+    if (_routeRequestHandled || widget.embedded) return;
+    _routeRequestHandled = true;
+    final arguments = ModalRoute.of(context)?.settings.arguments;
+    if (arguments is! SettingsScreenArguments || !arguments.openAiAssist) {
+      return;
+    }
+    // After the frame, not during it: this runs inside a build, and
+    // `showDialog` pushes a route.
+    WidgetsBinding.instance.addPostFrameCallback((_) {
+      if (!mounted) return;
+      unawaited(_openAiAssistDialog(context));
+    });
   }
 
   @override

--- a/test/features/add_meal/presentation/bulk_add_screen_test.dart
+++ b/test/features/add_meal/presentation/bulk_add_screen_test.dart
@@ -26,6 +26,7 @@ import 'package:opennutritracker/features/diary/presentation/bloc/calendar_day_b
 import 'package:opennutritracker/features/diary/presentation/bloc/diary_bloc.dart';
 import 'package:opennutritracker/features/home/presentation/bloc/home_bloc.dart';
 import 'package:opennutritracker/features/meal_detail/presentation/bloc/meal_detail_bloc.dart';
+import 'package:opennutritracker/features/settings/settings_screen.dart';
 import 'package:opennutritracker/generated/l10n.dart';
 
 import '../../../helpers/test_l10n.dart';
@@ -224,6 +225,21 @@ Future<BulkAddBloc> _registerWithFailingReader(
   return bloc;
 }
 
+/// What an interpreter has to throw for the screen to draw [kind]'s notice.
+///
+/// A switch over the notice's own enum rather than a lookup by name: a sixth
+/// failure that offers the Settings action cannot then be added without this
+/// answering for it, which is how the "every failure kind behaves the same"
+/// promise of #852 stays true rather than staying written down.
+MealInterpreterFailure _throwsFor(MealTextModelFailure kind) => switch (kind) {
+  MealTextModelFailure.auth => MealInterpreterFailure.auth,
+  MealTextModelFailure.unsupported => MealInterpreterFailure.unsupported,
+  MealTextModelFailure.billing => MealInterpreterFailure.billing,
+  MealTextModelFailure.timeout => MealInterpreterFailure.timeout,
+  MealTextModelFailure.insecureDestination =>
+    MealInterpreterFailure.insecureDestination,
+};
+
 class _AlwaysFailsInterpreter implements MealTextInterpreter {
   final MealInterpreterException failure;
 
@@ -265,20 +281,28 @@ class _MapStorage implements FlutterSecureStorage {
 /// The screen reads its arguments off the route and pops back to
 /// `mainRoute`, so it needs a real navigator with that route named. The
 /// rows render kcal through `EnergyDisplay`, which reads the provider.
-/// Records the names of routes pushed, so "the button goes somewhere" is an
-/// assertion rather than a hope.
+/// Records the routes pushed, so "the button goes somewhere" is an assertion
+/// rather than a hope.
+///
+/// Settings rather than names: #852 made *where inside* Settings the action
+/// lands the point of it, and that travels as the route's arguments. A
+/// recorder that kept only names would pass just as happily on the bug.
 class _PushRecorder extends NavigatorObserver {
-  _PushRecorder(this.names);
-  final List<String?> names;
+  _PushRecorder(this.routes);
+  final List<RouteSettings> routes;
 
   @override
   void didPush(Route<dynamic> route, Route<dynamic>? previousRoute) {
-    names.add(route.settings.name);
+    routes.add(route.settings);
     super.didPush(route, previousRoute);
   }
 }
 
-Widget _app({bool imperial = false, Locale? locale, List<String?>? pushed}) =>
+Widget _app({
+  bool imperial = false,
+  Locale? locale,
+  List<RouteSettings>? pushed,
+}) =>
     ChangeNotifierProvider<EnergyUnitProvider>(
       create: (_) => EnergyUnitProvider(usesKilojoules: false),
       child: MaterialApp(
@@ -297,6 +321,20 @@ Widget _app({bool imperial = false, Locale? locale, List<String?>? pushed}) =>
             return MaterialPageRoute<void>(
               settings: settings,
               builder: (_) => const Scaffold(body: SizedBox()),
+            );
+          }
+          // A stand-in for the settings screen, which needs a locator graph
+          // of its own. It keeps the arguments the caller passed — those are
+          // what carries the request to open the AI dialog (#852), and
+          // rewriting them here, as the branch below has to for the screen
+          // under test, would hide the thing being asserted.
+          if (settings.name == NavigationOptions.settingsRoute) {
+            return MaterialPageRoute<void>(
+              settings: settings,
+              builder: (_) => const Scaffold(
+                key: Key('settings-stub'),
+                body: SizedBox(),
+              ),
             );
           }
           return MaterialPageRoute<void>(
@@ -677,7 +715,7 @@ void main() {
       failure: MealInterpreterFailure.billing,
     ));
 
-    final pushed = <String?>[];
+    final pushed = <RouteSettings>[];
     await tester.pumpWidget(_app(pushed: pushed));
     await tester.pumpAndSettle();
     await _parse(tester, '100g toast');
@@ -689,11 +727,107 @@ void main() {
     await tester.pumpAndSettle();
 
     expect(
-      pushed,
+      pushed.map((route) => route.name),
       contains(NavigationOptions.settingsRoute),
       reason: 'the advice has to go somewhere the user can act',
     );
     expect(tester.takeException(), isNull);
+  });
+
+  // #852. Somewhere the user can act was not enough: the route landed on
+  // Units & Energy, and the AI row is four category groups below it — far
+  // enough down that the #830 device pass took several attempts to reach it
+  // while looking for it. The action now names the control it is talking
+  // about, and it does so identically for every failure that offers it,
+  // because all five are fixed in that one dialog.
+  for (final kind in MealTextModelFailure.values) {
+    testWidgets('the ${kind.name} notice asks for the AI settings by name', (
+      tester,
+    ) async {
+      tester.view.physicalSize = const Size(1080, 2400);
+      tester.view.devicePixelRatio = 2.625;
+      addTearDown(tester.view.reset);
+
+      await _registerWithFailingReader({
+        'toast': [_meal('Toast')],
+      }, MealInterpreterException('failed', failure: _throwsFor(kind)));
+
+      final pushed = <RouteSettings>[];
+      await tester.pumpWidget(_app(pushed: pushed));
+      await tester.pumpAndSettle();
+      await _parse(tester, '100g toast');
+
+      final action = find.bySemanticsIdentifier('bulk-add-notice-action');
+      expect(action, findsOneWidget, reason: '${kind.name} offers the action');
+
+      await tester.tap(action);
+      await tester.pumpAndSettle();
+
+      final settings = pushed
+          .where((route) => route.name == NavigationOptions.settingsRoute)
+          .toList();
+      expect(settings, hasLength(1));
+      expect(
+        settings.single.arguments,
+        isA<SettingsScreenArguments>().having(
+          (arguments) => arguments.openAiAssist,
+          'openAiAssist',
+          isTrue,
+        ),
+        reason:
+            'a notice about the model that drops the user at the top of '
+            'Settings has sent them hunting for the fix',
+      );
+      expect(tester.takeException(), isNull);
+    });
+  }
+
+  testWidgets('and coming back from it, the rows are still there', (
+    tester,
+  ) async {
+    // The parser rows survive a failed model read — they are the reason the
+    // user is still on this screen at all. Sending them to Settings and
+    // handing back an empty screen would be a worse bug than the one #852
+    // fixes, so the route is pushed over this screen rather than replacing
+    // it.
+    tester.view.physicalSize = const Size(1080, 2400);
+    tester.view.devicePixelRatio = 2.625;
+    addTearDown(tester.view.reset);
+
+    await _registerWithFailingReader({
+      'toast': [_meal('Toast')],
+    }, const MealInterpreterException(
+      'request timed out',
+      failure: MealInterpreterFailure.timeout,
+    ));
+
+    await tester.pumpWidget(_app());
+    await tester.pumpAndSettle();
+    await _parse(tester, '100g toast');
+    expect(find.textContaining('Toast'), findsWidgets);
+
+    await tester.tap(find.bySemanticsIdentifier('bulk-add-notice-action'));
+    await tester.pumpAndSettle();
+
+    // Actually left: the rows are behind the pushed route, not still in
+    // front of the user.
+    expect(find.byKey(const Key('settings-stub')), findsOneWidget);
+    expect(find.textContaining('Toast'), findsNothing);
+
+    tester.state<NavigatorState>(find.byType(Navigator)).pop();
+    await tester.pumpAndSettle();
+
+    expect(
+      find.textContaining('Toast'),
+      findsWidgets,
+      reason: 'the rows are what the user came back to finish',
+    );
+    expect(
+      find.bySemanticsIdentifier('bulk-add-notice-action'),
+      findsOneWidget,
+      reason: 'and the notice is still there if the fix did not take',
+    );
+    expect(find.bySemanticsIdentifier('bulk-add-submit'), findsOneWidget);
   });
 
 

--- a/test/features/settings/settings_screen_test.dart
+++ b/test/features/settings/settings_screen_test.dart
@@ -1,0 +1,190 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_localizations/flutter_localizations.dart';
+import 'package:flutter_secure_storage/flutter_secure_storage.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:get_it/get_it.dart';
+import 'package:opennutritracker/core/domain/entity/app_theme_entity.dart';
+import 'package:opennutritracker/core/utils/ai_credential_storage.dart';
+import 'package:opennutritracker/core/utils/locator.dart';
+import 'package:opennutritracker/core/utils/navigation_options.dart';
+import 'package:opennutritracker/features/add_meal/domain/usecase/probe_ai_endpoint_usecase.dart';
+import 'package:opennutritracker/features/add_meal/domain/usecase/run_ai_endpoint_probe_usecase.dart';
+import 'package:opennutritracker/features/diary/presentation/bloc/calendar_day_bloc.dart';
+import 'package:opennutritracker/features/diary/presentation/bloc/diary_bloc.dart';
+import 'package:opennutritracker/features/home/presentation/bloc/home_bloc.dart';
+import 'package:opennutritracker/features/profile/presentation/bloc/profile_bloc.dart';
+import 'package:opennutritracker/features/settings/presentation/bloc/settings_bloc.dart';
+import 'package:opennutritracker/features/settings/presentation/widgets/ai_assist_dialog.dart';
+import 'package:opennutritracker/features/settings/settings_screen.dart';
+import 'package:opennutritracker/features/trends/presentation/bloc/trends_bloc.dart';
+import 'package:opennutritracker/generated/l10n.dart';
+
+import '../../helpers/test_l10n.dart';
+
+/// A loaded settings screen without the config box behind it.
+///
+/// The screen only ever reads the state and posts `LoadSettingsEvent`, so a
+/// bloc that answers with one fixed loaded state renders exactly what the
+/// real one renders — and skips Hive, `package_info`, and the cache size
+/// read, none of which are what these tests are about.
+class _FakeSettingsBloc extends Fake implements SettingsBloc {
+  @override
+  SettingsState get state =>
+      const SettingsLoadedState('1.0.0', false, AppThemeEntity.system, false);
+
+  @override
+  Stream<SettingsState> get stream => const Stream<SettingsState>.empty();
+
+  @override
+  void add(SettingsEvent event) {}
+}
+
+/// The screen resolves these in `initState` and only calls them from
+/// controls no test here touches.
+class _FakeProfileBloc extends Fake implements ProfileBloc {}
+
+class _FakeHomeBloc extends Fake implements HomeBloc {}
+
+class _FakeDiaryBloc extends Fake implements DiaryBloc {}
+
+class _FakeCalendarDayBloc extends Fake implements CalendarDayBloc {}
+
+class _FakeTrendsBloc extends Fake implements TrendsBloc {}
+
+/// Nothing is configured, which is the state a user arrives in from a
+/// rejected key or a refused destination.
+class _EmptyStorage implements FlutterSecureStorage {
+  @override
+  Future<String?> read({
+    required String key,
+    AppleOptions? iOptions,
+    AndroidOptions? aOptions,
+    LinuxOptions? lOptions,
+    WebOptions? webOptions,
+    AppleOptions? mOptions,
+    WindowsOptions? wOptions,
+  }) async => null;
+
+  @override
+  dynamic noSuchMethod(Invocation invocation) => super.noSuchMethod(invocation);
+}
+
+/// The runner is real; only the thing that would talk to a server is not.
+/// Nothing here presses the check, so it is never asked anything.
+class _FakeProber extends Fake implements AiEndpointProber {}
+
+void _register() {
+  final getIt = GetIt.instance;
+  getIt.registerSingleton<SettingsBloc>(_FakeSettingsBloc());
+  getIt.registerSingleton<ProfileBloc>(_FakeProfileBloc());
+  getIt.registerSingleton<HomeBloc>(_FakeHomeBloc());
+  getIt.registerSingleton<DiaryBloc>(_FakeDiaryBloc());
+  getIt.registerSingleton<CalendarDayBloc>(_FakeCalendarDayBloc());
+  getIt.registerSingleton<TrendsBloc>(_FakeTrendsBloc());
+  final credentials = AiCredentialStorage(_EmptyStorage());
+  getIt.registerSingleton<AiCredentialStorage>(credentials);
+  getIt.registerSingleton<AiEndpointProbeRunner>(
+    AiEndpointProbeRunner(credentials, _FakeProber()),
+  );
+}
+
+/// Pushes the settings route the way the app does, so the screen reads its
+/// arguments off a real `ModalRoute` rather than a constructor.
+Widget _app({Object? arguments}) => MaterialApp(
+  localizationsDelegates: const [
+    S.delegate,
+    GlobalMaterialLocalizations.delegate,
+    GlobalWidgetsLocalizations.delegate,
+    GlobalCupertinoLocalizations.delegate,
+  ],
+  supportedLocales: S.supportedLocales,
+  initialRoute: NavigationOptions.settingsRoute,
+  onGenerateRoute: (settings) => MaterialPageRoute<void>(
+    settings: RouteSettings(name: settings.name, arguments: arguments),
+    builder: (_) => const SettingsScreen(),
+  ),
+);
+
+void main() {
+  // A handset, because the point of #852 is where the AI row sits on one.
+  setUp(() => _register());
+  tearDown(() async => locator.reset());
+
+  testWidgets('the AI row is nowhere near the top of a plain Settings', (
+    tester,
+  ) async {
+    // The premise of #852, pinned so the fix cannot be read as cosmetic: on
+    // a Pixel-sized screen the Data group is far enough down that the tile
+    // is not even built, let alone visible. A user sent here by the notice
+    // has to scroll past four category groups to find the one control that
+    // answers their failure.
+    tester.view.physicalSize = const Size(1080, 2400);
+    tester.view.devicePixelRatio = 2.625;
+    addTearDown(tester.view.reset);
+
+    await tester.pumpWidget(_app());
+    await tester.pumpAndSettle();
+
+    expect(find.text(l10nEn.settingsAiAssistLabel), findsNothing);
+    expect(find.byType(AiAssistDialog), findsNothing);
+  });
+
+  testWidgets('asked for the AI settings, it opens the AI dialog', (
+    tester,
+  ) async {
+    tester.view.physicalSize = const Size(1080, 2400);
+    tester.view.devicePixelRatio = 2.625;
+    addTearDown(tester.view.reset);
+
+    await tester.pumpWidget(
+      _app(arguments: const SettingsScreenArguments(openAiAssist: true)),
+    );
+    await tester.pumpAndSettle();
+
+    expect(
+      find.byType(AiAssistDialog),
+      findsOneWidget,
+      reason: 'the caller named the control the user came to change',
+    );
+  });
+
+  testWidgets('the dialog is opened once, not on every rebuild', (
+    tester,
+  ) async {
+    // `didChangeDependencies` runs again for a theme change, a locale
+    // change, a keyboard. Reading the arguments each time would reopen a
+    // dialog over the one already up, and closing it would leave a second
+    // behind.
+    tester.view.physicalSize = const Size(1080, 2400);
+    tester.view.devicePixelRatio = 2.625;
+    addTearDown(tester.view.reset);
+
+    await tester.pumpWidget(
+      _app(arguments: const SettingsScreenArguments(openAiAssist: true)),
+    );
+    await tester.pumpAndSettle();
+
+    // Anything that makes the screen's dependencies change: a new
+    // MediaQuery is the cheapest.
+    tester.view.physicalSize = const Size(1080, 2000);
+    await tester.pumpAndSettle();
+
+    expect(find.byType(AiAssistDialog), findsOneWidget);
+  });
+
+  testWidgets('arguments that ask for nothing leave the screen alone', (
+    tester,
+  ) async {
+    // Every other way into Settings pushes the route plain. A screen that
+    // opened the AI dialog for them would be a worse bug than the one #852
+    // fixes.
+    tester.view.physicalSize = const Size(1080, 2400);
+    tester.view.devicePixelRatio = 2.625;
+    addTearDown(tester.view.reset);
+
+    await tester.pumpWidget(_app(arguments: const SettingsScreenArguments()));
+    await tester.pumpAndSettle();
+
+    expect(find.byType(AiAssistDialog), findsNothing);
+  });
+}


### PR DESCRIPTION
Closes [#852](https://github.com/simonoppowa/OpenNutriTracker/issues/852). Targets `feature/ai-assisted-meal-logging`.

## What was wrong

When a model read failed, the notice's **Settings** action navigated — but landed at the top of Settings, on Units & Energy. The AI row sits in the Data group four category groups below, and during the [#830](https://github.com/simonoppowa/OpenNutriTracker/issues/830) device pass it took several attempts to scroll to while deliberately looking for it.

So the recovery path from *"your server did not answer in time"* ended in a hunt through a long list for the one control that could fix it.

## The fix

The caller now says what it opened the route **for**: a `SettingsScreenArguments(openAiAssist: true)`, and the settings screen opens the AI dialog itself.

The failure kind deliberately does not appear at the call site — auth, unsupported, billing, timeout and insecure-destination are all fixed in that same dialog, so they all ask for the same thing. Each is covered by its own test anyway, so a future failure kind that needs somewhere else to go will not silently inherit this.

Three details worth a reviewer's eye:

- **The dialog opens after the frame, not during it.** `didChangeDependencies` runs inside a build and `showDialog` pushes a route.
- **It is guarded against reopening.** `didChangeDependencies` fires again for a theme change, a locale change, the keyboard, and the dialog's own route going up — unguarded, closing the dialog leaves a second one behind. There is a test named `the dialog is opened once, not on every rebuild`.
- **The embedded form is skipped.** It has no route of its own, so what it would read is the host route's arguments, which are not addressed to it.

Arguments are optional: every other way into Settings pushes the route without them, and a null or foreign `arguments` is simply the plain screen.

## Verification

- `flutter analyze` — `No issues found!`
- `flutter test` — **1810 passed**
- 10 new tests, including one per failure kind, `and coming back from it, the rows are still there` (the rows survive the failure and are why the user is still on that screen — losing them would be worse than the bug being fixed), and `the AI row is nowhere near the top of a plain Settings`, which is what makes the other tests mean anything.
