### PR TITLE
fix(settings): stop a refusal outliving the address it judged (#853)

### DIFF
--- a/lib/features/settings/presentation/widgets/ai_assist_dialog.dart
+++ b/lib/features/settings/presentation/widgets/ai_assist_dialog.dart
@@ -379,6 +379,43 @@ class _AiAssistDialogState extends State<AiAssistDialog> {
     });
   }
 
+  /// The address was edited, so everything on screen that judged the old one
+  /// stops being true.
+  ///
+  /// Two things here are verdicts about a *specific* address, rendered either
+  /// side of the field that produced them: the refusal on the field itself,
+  /// and the model-list sentence under the button. Left alone they outlive
+  /// their subject — #853 watched *"that address is public and unencrypted"*
+  /// stay on screen after the address had been edited to a private one the
+  /// app would happily send to. Someone following the notice's own advice
+  /// sees the complaint not go away and reads it as still refused.
+  ///
+  /// The mirror of #758's argument for announcing the refusal at all: silence
+  /// leaves a user never learning that their configuration is one the app
+  /// will not honour, and a stale refusal teaches them the same wrong thing
+  /// about a configuration that is now fine.
+  ///
+  /// **A request already out is superseded rather than left to land**, for
+  /// the reason [_modelsGeneration] exists at all: what it answers about is
+  /// the address that was in the field when it left. The same two moves
+  /// [_load] makes — bump the generation, and turn [_fetchingModels] off by
+  /// hand, because the abandoned request no longer reaches the line that
+  /// would.
+  ///
+  /// Only the address field calls this. A model name, the pause switch and
+  /// the key say nothing about which host was asked, so editing one of those
+  /// leaves a verdict for the address still in the field standing.
+  void _endpointChanged() {
+    setState(() {
+      _endpointError = null;
+      _modelsGeneration++;
+      _fetchingModels = false;
+      _modelIds = null;
+      _modelListFailure = null;
+      _modelListHost = null;
+    });
+  }
+
   /// The user has finished with the address field.
   ///
   /// **A URL change is the second of the two moments a fetch may happen**
@@ -859,11 +896,12 @@ class _AiAssistDialogState extends State<AiAssistDialog> {
                           ),
                           // The disclosure below names this host and derives
                           // its encryption clause from the scheme, so it has
-                          // to follow the field as it is typed. A refusal
-                          // clears with the same keystroke, because it was
-                          // about text that no longer exists.
-                          onChanged: (_) =>
-                              setState(() => _endpointError = null),
+                          // to follow the field as it is typed. So does every
+                          // verdict this dialog has reached about the address
+                          // — a refusal, and the model-list sentence under
+                          // the button — because each was about text that no
+                          // longer exists. See [_endpointChanged].
+                          onChanged: (_) => _endpointChanged(),
                         ),
                       ),
                       const SizedBox(height: 12),

--- a/test/features/settings/presentation/ai_assist_dialog_test.dart
+++ b/test/features/settings/presentation/ai_assist_dialog_test.dart
@@ -1793,7 +1793,12 @@ void main() {
         /// lookup**. `PlaintextDestinationGuard` answers a literal from its
         /// bytes; a name would send the test host to a real resolver and make
         /// the result depend on the network the suite runs on.
-        const publicAddress = 'http://93.184.216.34:11434';
+        ///
+        /// TEST-NET-3 (RFC 5737), which exists to be written down: reserved
+        /// for documentation, guaranteed never routed, and owned by nobody.
+        /// A real host's address would read as public to the guard just the
+        /// same, but it would also be someone's.
+        const publicAddress = 'http://203.0.113.1:11434';
         const privateAddress = 'http://192.168.99.99:11434';
 
         /// Types **without letting the clock run**, for the same reason
@@ -2252,7 +2257,7 @@ void main() {
 
         await tester.enterText(
           find.bySemanticsIdentifier('ai-assist-endpoint-field'),
-          'http://93.184.216.34:11434',
+          'http://203.0.113.1:11434',
         );
         await tester.enterText(
           find.bySemanticsIdentifier('ai-assist-model-field'),

--- a/test/features/settings/presentation/ai_assist_dialog_test.dart
+++ b/test/features/settings/presentation/ai_assist_dialog_test.dart
@@ -1787,6 +1787,219 @@ void main() {
 
         expect(tester.takeException(), isNull);
       });
+
+      group('a verdict does not outlive the address it judged (#853)', () {
+        /// A public literal, so the refusal is reached **without a DNS
+        /// lookup**. `PlaintextDestinationGuard` answers a literal from its
+        /// bytes; a name would send the test host to a real resolver and make
+        /// the result depend on the network the suite runs on.
+        const publicAddress = 'http://93.184.216.34:11434';
+        const privateAddress = 'http://192.168.99.99:11434';
+
+        /// Types **without letting the clock run**, for the same reason
+        /// [commitEndpoint] does: `pumpAndSettle` ages a request held open by
+        /// [_Server.gates] past `AiModelListApi`'s fifteen-second timeout, and
+        /// the window where an answer is still out is the whole of what the
+        /// last case here is about.
+        Future<void> typeEndpointNow(
+          WidgetTester tester,
+          String endpoint,
+        ) async {
+          await tester.enterText(
+            find.bySemanticsIdentifier('ai-assist-endpoint-field'),
+            endpoint,
+          );
+          await tester.pump();
+        }
+
+        /// Presses the button and returns while the request is still out.
+        Future<void> pressLoadNow(WidgetTester tester) async {
+          final button = find.bySemanticsIdentifier('ai-assist-load-models');
+          // Nothing is in flight yet, so settling here costs nothing.
+          await tester.ensureVisible(button);
+          await tester.pumpAndSettle();
+          await tester.tap(button);
+          await tester.pump();
+        }
+
+        testWidgets('editing the address clears the refusal it produced', (
+          tester,
+        ) async {
+          // The reported defect, in the order it was found on a Pixel 6: the
+          // app refuses a public plaintext address, the user does exactly what
+          // the sentence tells them to and moves to a private one, and the
+          // complaint stays on screen still calling the address public. It
+          // reads as *still refused* over a configuration the app would now
+          // happily send to.
+          final server = _Server.listing(['gemma3:4b']);
+          await tester.pumpWidget(_app(storage, modelList: server.api));
+          await tester.pumpAndSettle();
+
+          await typeEndpoint(tester, publicAddress);
+          await pressLoad(tester);
+
+          expect(
+            find.text(l10nEn.aiAssistModelsInsecureLabel),
+            findsOneWidget,
+            reason: 'the refusal has to be announced at all, or #758 is '
+                'undone',
+          );
+          expect(server.requests, isEmpty, reason: 'nothing was sent');
+
+          await typeEndpoint(tester, privateAddress);
+
+          expect(
+            find.text(l10nEn.aiAssistModelsInsecureLabel),
+            findsNothing,
+            reason: 'the sentence was about an address that is no longer in '
+                'the field',
+          );
+        });
+
+        testWidgets('editing the address clears the list fetched for the old '
+            'one', (tester) async {
+          // The other statement about a particular host, immediately below the
+          // first. A picker offering one machine's models under another
+          // machine's address is the same lie with a cost attached: picking a
+          // row writes that id into the model field.
+          final server = _Server.listing(['qwen3:8b']);
+          await tester.pumpWidget(_app(storage, modelList: server.api));
+          await tester.pumpAndSettle();
+
+          await typeEndpoint(tester, 'http://192.168.1.5:11434');
+          await pressLoad(tester);
+
+          expect(
+            find.bySemanticsIdentifier('ai-assist-model-picker'),
+            findsOneWidget,
+          );
+
+          await typeEndpoint(tester, 'http://192.168.1.9:11434');
+
+          expect(
+            find.bySemanticsIdentifier('ai-assist-model-picker'),
+            findsNothing,
+            reason: 'the list belonged to the address that was just edited '
+                'away',
+          );
+        });
+
+        testWidgets('an edit elsewhere in the dialog leaves the verdict '
+            'standing', (tester) async {
+          // The half that stops this being "clear it whenever anything
+          // happens". A model name, the pause switch and the key say nothing
+          // about which host was asked, so a list fetched for the address
+          // still in the field is still that address's list — and throwing it
+          // away on every keystroke would make the picker unusable, since
+          // picking from it is what fills the model field.
+          final server = _Server.listing(['qwen3:8b']);
+          await storage.writeOwnServerConfiguration(
+            endpoint: 'http://192.168.1.5:11434',
+            model: 'gemma3:4b',
+            provider: AiProvider.ownServer,
+          );
+          await tester.pumpWidget(_app(storage, modelList: server.api));
+          await tester.pumpAndSettle();
+
+          await pressLoad(tester);
+          expect(
+            find.bySemanticsIdentifier('ai-assist-model-picker'),
+            findsOneWidget,
+          );
+
+          await tester.enterText(
+            find.bySemanticsIdentifier('ai-assist-model-field'),
+            'llama3.2:3b',
+          );
+          await tester.pumpAndSettle();
+
+          final toggle = find.bySemanticsIdentifier('ai-assist-enabled');
+          await tester.ensureVisible(toggle);
+          await tester.pumpAndSettle();
+          await tester.tap(toggle);
+          await tester.pumpAndSettle();
+
+          final key = find.bySemanticsIdentifier('ai-assist-key-field');
+          await tester.ensureVisible(key);
+          await tester.pumpAndSettle();
+          await tester.enterText(key, 'sk-behind-a-reverse-proxy');
+          await tester.pumpAndSettle();
+
+          expect(
+            find.bySemanticsIdentifier('ai-assist-model-picker'),
+            findsOneWidget,
+            reason: 'the address that list belongs to never changed',
+          );
+        });
+
+        testWidgets('asking again after the edit answers about the new '
+            'address', (tester) async {
+          // Clearing the sentence is only half of what the user was told to
+          // do. The button beside it has to work against what they typed
+          // instead, or the fix is a dialog that goes quiet and stays quiet.
+          final server = _Server.listing(['gemma3:4b']);
+          await tester.pumpWidget(_app(storage, modelList: server.api));
+          await tester.pumpAndSettle();
+
+          await typeEndpoint(tester, publicAddress);
+          await pressLoad(tester);
+          await typeEndpoint(tester, privateAddress);
+          await pressLoad(tester);
+
+          expect(server.requests, [
+            Uri.parse('http://192.168.99.99:11434/v1/models'),
+          ]);
+          expect(
+            find.bySemanticsIdentifier('ai-assist-model-picker'),
+            findsOneWidget,
+          );
+          for (final message in messagesFor('192.168.99.99:11434')) {
+            expect(find.text(message), findsNothing);
+          }
+        });
+
+        testWidgets('an answer for the old address does not land under the '
+            'new one', (tester) async {
+          // A verdict that arrives *after* the edit is as stale as one that
+          // was already there — a machine on someone's LAN answers when it
+          // answers, and what it answers about is the address that was in the
+          // field when the request left. So the edit supersedes the request
+          // rather than only wiping what is currently painted.
+          final server = _Server.perHost({
+            '192.168.1.9': ['qwen3:8b'],
+          });
+          server.gates['192.168.1.9'] = Completer<void>();
+          await tester.pumpWidget(_app(storage, modelList: server.api));
+          await tester.pumpAndSettle();
+
+          await typeEndpointNow(tester, 'http://192.168.1.9:11434');
+          await pressLoadNow(tester);
+          await typeEndpointNow(tester, 'http://192.168.1.7:11434');
+
+          server.gates['192.168.1.9']!.complete();
+          await tester.pumpAndSettle();
+
+          expect(
+            find.bySemanticsIdentifier('ai-assist-model-picker'),
+            findsNothing,
+            reason: 'nothing has been asked about the address on screen',
+          );
+          for (final message in messagesFor('192.168.1.9:11434')) {
+            expect(find.text(message), findsNothing);
+          }
+          final button = find.bySemanticsIdentifier('ai-assist-load-models');
+          await tester.ensureVisible(button);
+          await tester.pumpAndSettle();
+          expect(
+            tester.widget<TextButton>(
+              find.descendant(of: button, matching: find.byType(TextButton)),
+            ).onPressed,
+            isNotNull,
+            reason: 'the button has to be pressable against the address that '
+                'replaced the one being fetched for',
+          );
+        });
+      });
     });
 
     group('the setup check (#780)', () {


### PR DESCRIPTION
Closes [#853](https://github.com/simonoppowa/OpenNutriTracker/issues/853). Targets `feature/ai-assisted-meal-logging`.

## The ticket's diagnosis was slightly wrong, and that matters

I wrote #853 assuming the stale sentence was `_endpointError`. It is not — **that one was already cleared on keystroke.** The sentence seen on the Pixel 6 is the *model-list* result: `AiModelListFailure.insecureDestination` rendered under **Load models**, together with `_modelIds` and `_modelListHost`. Nothing cleared that trio when the address changed.

So the bug is real and the repro is real, but it lives one block lower than the ticket said. Worth recording, because a fix aimed at the ticket's wording would have changed code that was already correct and left the actual defect in place.

## What was wrong

1. Enter `http://example.com/v1`, tap **Load models**
2. The app correctly refuses — *"Nothing was sent: this address is public and unencrypted"*
3. Edit the address to a private one, which the plaintext policy permits
4. The refusal is still there, still calling the address public

A verdict about a *specific* address, rendered beside an editable field, outliving its subject. A user following its own advice watches the complaint not go away.

## The fix

`_endpointChanged()` replaces the old inline clear on the address field's `onChanged`, and clears the whole address-derived set: `_endpointError`, `_modelIds`, `_modelListFailure`, `_modelListHost`.

It also **supersedes any in-flight fetch** — bumping `_modelsGeneration` and clearing `_fetchingModels` by hand, the same two moves `_load()` already makes on a provider switch. An answer that lands *after* the edit is exactly as stale as one already painted, and without this the abandoned request never reaches the line that re-enables the button.

Only the address field calls it, so a verdict for the address currently in the field survives edits to the model name, the pause switch and the key.

## Verification

- `flutter analyze` — `No issues found!`
- `flutter test` — **1823 passed**

**Mutation-checked three ways**, including two that exist to stop the tests being tautologies:

| Mutation | Caught by |
|---|---|
| Full revert of the production change | 3 of 5 |
| Keep the fix, delete only the two supersede lines | exactly 1 — `an answer for the old address does not land under the new one`, pinning the async half specifically rather than leaving it untested |
| Keep the fix, but *also* wire the clear into the model field | exactly 1 — `an edit elsewhere in the dialog leaves the verdict standing`, so the control test has teeth |

## One test-design note

The tests reach the refusal with a literal `http://93.184.216.34:11434` rather than a hostname. `PlaintextDestinationGuard.approve` answers a literal from its bytes with no DNS lookup; a name would send the suite to a real resolver and make the result depend on the network CI happens to run on.
