### PR TITLE
test(core): pin the probe's verdicts and make one survive a restart (#854)

### DIFF
--- a/test/unit_test/ai_credential_storage_test.dart
+++ b/test/unit_test/ai_credential_storage_test.dart
@@ -1386,6 +1386,51 @@ void main() {
       );
     });
 
+    test('a verdict outlives the process that learned it (#854)', () async {
+      // "Remember the answer" is half of what #784 built, and the existing
+      // round-trip test writes and reads through **one** storage object — so
+      // it pins the encoder, not persistence. A probe costs up to four
+      // minutes; if its result did not survive a restart the user would pay
+      // that again every launch, and nothing in the suite would have noticed.
+      //
+      // A second `AiCredentialStorage` over the same backing store is what a
+      // relaunch actually is: the keystore persists, the object does not.
+      await configure();
+      await storage.writeProbe(
+        const AiEndpointProbe(
+          text: AiCapability.passed,
+          photo: AiCapability.failed,
+          checked: true,
+        ),
+        provider: own,
+      );
+
+      final afterRestart = AiCredentialStorage(backing);
+      final probe = await afterRestart.readProbe(provider: own);
+
+      expect(probe.text, AiCapability.passed);
+      expect(probe.photo, AiCapability.failed);
+      expect(probe.checked, isTrue);
+    });
+
+    test('and so does a check that learned nothing (#854)', () async {
+      // The #850 state specifically. This is the one a naive encoding drops,
+      // because "nothing conclusive" and "never asked" look identical unless
+      // the record keeps them apart — and it is also the state a user is
+      // most likely to be in when they put the phone down and come back.
+      await configure();
+      await storage.writeProbe(
+        AiEndpointProbe.nothingLearned,
+        provider: own,
+      );
+
+      final probe = await AiCredentialStorage(backing).readProbe(provider: own);
+
+      expect(probe.text, AiCapability.unknown);
+      expect(probe.photo, AiCapability.unknown);
+      expect(probe.checked, isTrue);
+    });
+
     test('a check that established nothing is still remembered (#850)', () async {
       // The measured bug: both legs of a probe ran to their timeout, both
       // verdicts stayed `unknown` — correctly — and the record was deleted,

--- a/test/unit_test/ai_endpoint_prober_test.dart
+++ b/test/unit_test/ai_endpoint_prober_test.dart
@@ -174,6 +174,82 @@ void main() {
     });
   });
 
+  group('every failure kind is ruled on, not inherited (#854)', () {
+    // The mapping in `_verdictForFailure` is the whole of #850's argument in
+    // code: some failures say something durable about the destination and
+    // some say nothing at all. Until now it was reached only sideways, via
+    // an unreachable host and a 500 — so six of the seven members were
+    // pinned by nothing. Flipping `auth` to `failed` is the plausible
+    // mistake (a rejected key *feels* like a failure) and it would have
+    // turned the camera off for a server that can see perfectly well.
+    //
+    // Driven through real status codes rather than by calling the mapper, so
+    // these also pin `_failureFor`'s half of the journey.
+    Future<AiCapability> textVerdictFor(int status) async {
+      final client = _ScriptedClient([_reply('{}', status: status)]);
+      final result = await _prober(client).probe(_selection);
+      return result.text;
+    }
+
+    test('401 says nothing about what the model can do', () async {
+      // A key problem is the user's to fix, and it is not a capability.
+      // A server the user runs should not be answering this at all.
+      expect(await textVerdictFor(401), AiCapability.unknown);
+    });
+
+    test('403 is NOT the same answer as 401 on this client', () async {
+      // The trap this test exists for. On the direct OpenAI client 403 is
+      // `permission_error` and pairs with 401 as auth — but a server the
+      // user runs goes through `OpenAiCompatibleMealItemsApi`, where 403 is
+      // documented as a guardrail block or moderation flag. Treating it as a
+      // credential problem would send someone whose photo tripped a filter
+      // off to check a key that works fine.
+      //
+      // So it is `rejected`, which is a real verdict: the request was
+      // refused and will be refused again tomorrow.
+      expect(await textVerdictFor(403), AiCapability.failed);
+    });
+
+    test('402 is a bill, not an ability', () async {
+      expect(await textVerdictFor(402), AiCapability.unknown);
+    });
+
+    test('404 means nothing here serves this, and will not tomorrow', () async {
+      // On Ollama, which has no `tool_choice` at all, this is the expected
+      // way a weak model fails rather than a rare one (#733).
+      expect(await textVerdictFor(404), AiCapability.failed);
+    });
+
+    test('400 is the request itself being refused', () async {
+      expect(await textVerdictFor(400), AiCapability.failed);
+    });
+
+    test('422 is the same answer as 400', () async {
+      expect(await textVerdictFor(422), AiCapability.failed);
+    });
+
+    test('an unrecognised status is not a verdict', () async {
+      // Anything unclassified folds to transient, which is the whole reason
+      // `unknown` exists — asleep, loading, or rate limited.
+      expect(await textVerdictFor(418), AiCapability.unknown);
+    });
+
+    test('every one of them still records that a check ran', () async {
+      // The #850 property, across the whole mapping rather than one case of
+      // it: a verdict is a claim about knowledge, `checked` is a claim about
+      // history, and no failure kind may quietly cost the second one.
+      for (final status in [400, 401, 402, 403, 404, 422, 418, 500]) {
+        final client = _ScriptedClient([_reply('{}', status: status)]);
+        final result = await _prober(client).probe(_selection);
+        expect(
+          result.checked,
+          isTrue,
+          reason: 'a $status left the run looking like it never happened',
+        );
+      }
+    });
+  });
+
   test('the two verdicts are independent', () async {
     // The common case for a small local model: it handles a meal line and
     // cannot see. One combined verdict could not express it, and the text


### PR DESCRIPTION
Closes [#854](https://github.com/simonoppowa/OpenNutriTracker/issues/854). Targets `feature/ai-assisted-meal-logging`. **Test-only — no production code changed.**

## I audited before writing anything

[#859](https://github.com/simonoppowa/OpenNutriTracker/pull/859) closed most of this ticket on its way past: pass/fail/unknown at the prober level, `the two verdicts are independent`, and `and the distinction survives reopening the dialog`. Writing those again would have been worse than useless.

**Two gaps survived that audit**, and both are ones the existing suite could not have caught.

## Gap 1 — not one failure kind was pinned

`_verdictForFailure` rules on seven `MealInterpreterFailure` members, and the tests reached it only sideways: an unreachable host and a 500. Six of the seven rested on nothing.

The plausible mistake is `auth => failed` — a rejected key *feels* like a failure — and it would turn the camera off for a server that sees perfectly well. That is precisely the class of error [#850](https://github.com/simonoppowa/OpenNutriTracker/issues/850) was about: a verdict the probe never earned.

These drive each kind through a **real status code** rather than calling the mapper, so they also pin the classifier's half of the journey.

| Status | Failure | Verdict |
|---|---|---|
| 401 | auth | `unknown` |
| **403** | **rejected** | **`failed`** |
| 402 | billing | `unknown` |
| 400, 422 | rejected | `failed` |
| 404 | unsupported | `failed` |
| 418, 500 | transient | `unknown` |

### Writing them found that 403 is not what it looks like

My first version asserted 403 → `unknown`, pairing it with 401. That is correct on the **direct** OpenAI client, where 403 is `permission_error`. A server the user runs goes through `OpenAiCompatibleMealItemsApi`, where 403 is documented as a guardrail block or moderation flag — so it is `rejected`, and treating it as a credential problem would send someone whose photo tripped a filter off to check a key that works fine.

The code says all this in a comment. **Nothing tested it.** The mutation that folds 403 back in with 401 is caught by exactly one test — the new one.

## Gap 2 — the persistence test did not test persistence

`a verdict survives a round trip` writes and reads through **one** storage object, so it pins the encoder, not persistence.

"Remember the answer" is half of what [#784](https://github.com/simonoppowa/OpenNutriTracker/issues/784) built, and a probe costs up to four minutes. If its result did not outlive the process, the user would pay that again on every launch and nothing in the suite would have noticed. A second `AiCredentialStorage` over the same backing store is what a relaunch actually is.

Two tests: a genuine mixed verdict, and the #850 "checked but learned nothing" state — the one a naive encoding drops, because *nothing conclusive* and *never asked* look identical unless the record keeps them apart.

## What I deliberately did not add

A mixed text-passed/photo-failed **rendering** test. #859's `a genuine verdict is untouched by all of that` already covers it.

## Verification

- `flutter analyze` — `No issues found!`
- `flutter test` — **1849 passed**
- Diff is test-only: 121 insertions, zero production lines

**Mutation-checked:**

| Mutation | Caught by |
|---|---|
| `unsupported => unknown` | 3, including the new 404 test |
| 403 folded back in with 401 as auth | **exactly 1 — the new 403 test** |
| `encode()` drops the `checked` flag | both new restart tests, plus 3 of #859's |

## Still open, and not closable here

[#830](https://github.com/simonoppowa/OpenNutriTracker/issues/830) cases **21–23** — a real verdict, a mixed verdict, and persistence — are now written down but need an actual OpenAI-compatible server reachable from the device. That was the setup burden that got this skipped originally, and it is the maintainer's to schedule, not something a test file can discharge.
