### PR TITLE
style(settings): bring the disclosure line back under 120 (#648 review)

### DIFF
--- a/lib/features/add_meal/presentation/add_meal_screen.dart
+++ b/lib/features/add_meal/presentation/add_meal_screen.dart
@@ -104,10 +104,13 @@ class _AddMealScreenState extends State<AddMealScreen> {
                         tooltip: S.of(context).bulkAddTitle,
                       ),
                     ),
-                    IconButton(
-                      onPressed: () =>
-                          _onCustomAddButtonPressed(state.usesImperialUnits),
-                      icon: const Icon(Icons.add_circle_outline),
+                    Semantics(
+                      identifier: 'add-meal-custom-add',
+                      child: IconButton(
+                        onPressed: () =>
+                            _onCustomAddButtonPressed(state.usesImperialUnits),
+                        icon: const Icon(Icons.add_circle_outline),
+                      ),
                     ),
                   ],
                 );

--- a/lib/features/settings/presentation/widgets/ai_assist_dialog.dart
+++ b/lib/features/settings/presentation/widgets/ai_assist_dialog.dart
@@ -1027,7 +1027,8 @@ class _AiAssistDialogState extends State<AiAssistDialog> {
                     // which is the fact that changes — then the sentences that
                     // are true whichever provider is chosen.
                     Text(
-                      '${aiDisclosureFor(s, provider: _provider, typedEndpoint: _endpointController.text)}\n\n${s.aiAssistDisclosureCommon}',
+                      '${aiDisclosureFor(s, provider: _provider, typedEndpoint: _endpointController.text)}'
+                      '\n\n${s.aiAssistDisclosureCommon}',
                       style: theme.textTheme.bodySmall,
                     ),
                     const SizedBox(height: 12),


### PR DESCRIPTION
Both documented-standard findings from the review of [#648](https://github.com/simonoppowa/OpenNutriTracker/pull/648). Targets `feature/ai-assisted-meal-logging`.

## 1 — a 141-character line

`ai_assist_dialog.dart` interpolated the disclosure on one line running to 141 characters, against the **120-character width** AGENTS.md records at line 156 and `analysis_options.yaml` configures. It was the **only** line over the limit across all changed Dart files — verified by scanning every one of them, not just the file named.

Split at the string boundary rather than reflowed, so the provider paragraph and the common paragraph stay two separate things.

## 2 — an unlabelled sibling on the add-meal appbar

The custom-add `IconButton` had no `Semantics(identifier:)`. It is pre-existing code, so this is arguably not new — but **this branch moved it into a new `Row` beside the bulk-add button it did label**, which left two adjacent icon buttons where one is drivable by handle and the other only by coordinate.

AGENTS.md:160 asks for an identifier on every interactive widget for exactly this reason, and it is not academic here: the [#830](https://github.com/simonoppowa/OpenNutriTracker/issues/830) device pass drives this screen over ADB. Now `add-meal-custom-add`, matching its siblings `add-meal-quick-add` and `add-meal-bulk-add`.

## Verification

- `flutter analyze` — `No issues found!`
- `flutter test` — **1849 passed**
- No repo-wide `dart format`; only the two lines involved were touched

## What else the review raised, handled elsewhere

- **The stale ARB figures** were in #648's description, not the code. Corrected there — and the review's own number was off too. Counted as parsed JSON rather than by line, **all nine locales hold exactly 1022 real keys** and this branch adds **+86 to each**. The "counts differ per locale" claim in an earlier revision of that description was my error: a line-based count also matches keys nested inside `@`-metadata blocks.
- **The scope-creep finding was correct and is the most important thing in the review.** Four of [#599](https://github.com/simonoppowa/OpenNutriTracker/issues/599)'s eight decisions had been superseded without the record being updated — including #5, which still asserted a model *may* emit full macros when the settled position since 2026-08-14 is that it never may. #599 now carries a **Decisions since revised** section; the original table is struck through rather than rewritten, so the route actually walked stays visible.
