### PR TITLE
feat(add-meal): say the word the food uses, and admit when the amount is ours

### DIFF
--- a/lib/features/add_meal/presentation/bloc/bulk_add_bloc.dart
+++ b/lib/features/add_meal/presentation/bloc/bulk_add_bloc.dart
@@ -110,6 +110,40 @@ class BulkAddRow extends Equatable {
           // unit. A substituted one is just as wrong and less visible.
           : effectiveUnit != unit);
 
+  /// True when the amount on this row is the app's flat fallback — neither
+  /// stated by the user nor carried by the food record.
+  ///
+  /// The gap [amountNeedsCheck] cannot see, and deliberately so: that getter
+  /// requires `resolved.parsed.quantity != null`, so it only ever speaks about
+  /// a number somebody supplied. When nobody supplies one the row falls to
+  /// 100 g (1 oz imperial) and says nothing at all — the case where the app
+  /// guesses hardest is the one case it stayed quiet about. #864.
+  ///
+  /// **Weaker than [amountNeedsCheck], and rendered more quietly.** That flag
+  /// means "this number probably does not mean what you think"; this one only
+  /// means "this number is not yours". 100 g is a defensible neutral — the
+  /// nutriments are published per 100 g, so it is the one figure here nobody
+  /// invented — and a warning that fires on every unquantified row would
+  /// become wallpaper, which is exactly what the model-failure notices were
+  /// shaped to avoid.
+  ///
+  /// Clears once the user types an amount: they have answered it.
+  ///
+  /// Gated on `servingQuantity`, and **not** on `scalableServingQuantity`.
+  /// `_initialAmount` falls back to the flat number exactly when the numeric
+  /// field is absent, so the wider getter would go quiet on rows the fallback
+  /// really did fire on: OFF often leaves `servingQuantity` empty while
+  /// `serving_size` carries "30 g" as text, and `scalableServingQuantity`
+  /// reads the 30 out of it (#629). The row still shows 100.
+  ///
+  /// `hasServingValues` is not consulted either — it is true whenever
+  /// `servingQuantity` is, so pairing them only looks like a stricter test.
+  bool get amountIsProvisional =>
+      !amountEditedByUser &&
+      isResolved &&
+      resolved.parsed.quantity == null &&
+      meal?.servingQuantity == null;
+
   List<String> get allowedUnits => [
     // Only when the serving can actually be scaled. `hasServingValues` is
     // also true for a record carrying nothing but `servingSize` text, and

--- a/lib/features/add_meal/presentation/screens/bulk_add_screen.dart
+++ b/lib/features/add_meal/presentation/screens/bulk_add_screen.dart
@@ -16,6 +16,7 @@ import 'package:opennutritracker/features/add_meal/domain/meal_photo_interpreter
 import 'package:opennutritracker/features/add_meal/domain/usecase/read_meal_text_usecase.dart';
 import 'package:opennutritracker/features/add_meal/presentation/bloc/bulk_add_bloc.dart';
 import 'package:opennutritracker/features/add_meal/util/meal_photo_encoder.dart';
+import 'package:opennutritracker/features/add_meal/util/portion_label.dart';
 import 'package:opennutritracker/features/add_meal/util/meal_text_parser.dart';
 import 'package:opennutritracker/features/add_meal/presentation/widgets/quick_add_bottom_sheet.dart';
 import 'package:opennutritracker/features/diary/presentation/bloc/calendar_day_bloc.dart';
@@ -762,6 +763,17 @@ class _BulkAddScreenState extends State<BulkAddScreen> {
                       style: theme.textTheme.bodySmall?.copyWith(
                         color: theme.colorScheme.tertiary,
                       ),
+                    )
+                  // Last, and the quietest of the four. The others say
+                  // something is probably wrong; this only says the number
+                  // is the app's rather than the user's, so it takes the
+                  // muted surface colour instead of an accent. #864.
+                  else if (row.amountIsProvisional)
+                    Text(
+                      S.of(context).bulkAddDefaultAmountLabel,
+                      style: theme.textTheme.bodySmall?.copyWith(
+                        color: theme.colorScheme.onSurfaceVariant,
+                      ),
                     ),
                 ],
               ),
@@ -934,7 +946,7 @@ class _BulkAddScreenState extends State<BulkAddScreen> {
     for (final unit in row.allowedUnits) {
       widest = math.max(
         widest,
-        _textWidth(context, _unitLabel(context, unit), style),
+        _textWidth(context, _unitLabel(context, unit, row), style),
       );
     }
     return widest + _dropdownArrowWidth;
@@ -960,21 +972,26 @@ class _BulkAddScreenState extends State<BulkAddScreen> {
       DropdownMenuItem(
         value: unit,
         child: Text(
-          _unitLabel(context, unit),
+          _unitLabel(context, unit, row),
           maxLines: 1,
           overflow: TextOverflow.ellipsis,
         ),
       ),
   ];
 
-  String _unitLabel(BuildContext context, String unit) =>
+  /// Takes the row because one of the six units is not a fixed word: the
+  /// food names its own portion, and "3 slice" says what "3 serving" only
+  /// implies. Display only — the value behind it stays `serving` (#864).
+  String _unitLabel(BuildContext context, String unit, BulkAddRow row) =>
       switch (UnitDropdownItem.g.fromString(unit)) {
         UnitDropdownItem.g => S.of(context).gramUnit,
         UnitDropdownItem.ml => S.of(context).milliliterUnit,
         UnitDropdownItem.gml => S.of(context).gramMilliliterUnit,
         UnitDropdownItem.oz => S.of(context).ozUnit,
         UnitDropdownItem.flOz => S.of(context).flOzUnit,
-        UnitDropdownItem.serving => S.of(context).servingLabel,
+        UnitDropdownItem.serving =>
+          householdPortionLabel(row.meal?.servingSize) ??
+              S.of(context).servingLabel,
       };
 
   Widget _buildSubmitBar(BuildContext context, BulkAddLoadedState state) {

--- a/lib/features/add_meal/util/portion_label.dart
+++ b/lib/features/add_meal/util/portion_label.dart
@@ -1,0 +1,66 @@
+/// The household word a food names its own portion with — "slice", "cup,
+/// sliced", "egg" — pulled out of the serving description for **display
+/// only**.
+///
+/// The app's unit vocabulary is six fixed values and `serving` is the only
+/// one a count can land on, so a row that correctly logs three slices of
+/// bread says "3 serving". The word the user actually said is already in
+/// the data: the backend's `food_summary` builds `serving_size` from FDC's
+/// `portion_description`/`modifier`, and `MealEntity._spServingLabel`
+/// renders it as "1 slice (38 g)". Nothing read it back out.
+///
+/// **Display only, and that is a decision rather than an omission (#864).**
+/// The stored unit stays inside the closed six-value set, because
+/// `IntakeEntity.unit` is published in `docs/export-format.md` and rides in
+/// a *positional* QR share array parsed by other builds on other phones.
+/// Feeding dataset prose — which carries commas, per the backend's own
+/// schema comment for "cup, sliced" — into a CSV column and a positional
+/// array would be a compatibility change wearing a label change's clothes.
+library;
+
+/// A leading count: "1 slice", "0.5 cup", "1,5 l".
+final _leadingCount = RegExp(r'^\s*\d+(?:[.,]\d+)?\s*');
+
+/// A trailing parenthetical carrying the weight: "1 slice (38 g)".
+final _trailingWeight = RegExp(r'\s*\([^)]*\)\s*$');
+
+/// What is left when a description names no household measure at all — a
+/// bare weight or volume. Matched whole, so "cup" survives and "g" does
+/// not.
+final _bareUnit = RegExp(
+  r'^(?:g|kg|ml|l|lb|oz|fl\.?\s?oz|g/ml|portion|serving)$',
+  caseSensitive: false,
+);
+
+/// Anything with a letter in it. A description reduced to punctuation or
+/// digits names nothing.
+final _hasLetter = RegExp(r'\p{L}', unicode: true);
+
+/// Long enough for "cup, sliced" and short enough not to reopen #824, where
+/// this row overflowed by 65px because one field took the width it wanted.
+/// The dropdown sizes itself to its widest item, so this bound is a layout
+/// constraint rather than a stylistic one — a label that would blow the row
+/// out is worth losing, since "Serving" is still correct underneath it.
+const maxHouseholdPortionLabel = 16;
+
+/// The household measure in [servingSize], or null when it names none and
+/// the caller should keep saying "serving".
+///
+/// Deliberately conservative: every rejection falls back to today's wording,
+/// so a miss costs nothing and a false positive would cost a wrong-looking
+/// unit on a correct number.
+String? householdPortionLabel(String? servingSize) {
+  if (servingSize == null) return null;
+
+  final withoutWeight = servingSize.replaceFirst(_trailingWeight, '');
+  final label = withoutWeight.replaceFirst(_leadingCount, '').trim();
+
+  if (label.isEmpty) return null;
+  // "30 g" reduces to "g", and OFF's "1 portion" to "portion". Neither says
+  // more than the word already on the dropdown.
+  if (_bareUnit.hasMatch(label)) return null;
+  if (!_hasLetter.hasMatch(label)) return null;
+  if (label.length > maxHouseholdPortionLabel) return null;
+
+  return label;
+}

--- a/lib/l10n/intl_cs.arb
+++ b/lib/l10n/intl_cs.arb
@@ -1116,6 +1116,7 @@
   "bulkAddNothingToLogLabel": "Zatím není co zaznamenat",
   "bulkAddSearchFailedLabel": "Vyhledávání potravin selhalo",
   "bulkAddCheckAmountLabel": "Zkontrolujte jednotku množství",
+  "bulkAddDefaultAmountLabel": "Množství neuvedeno",
   "bulkAddErrorInvalidName": "Položka {number}: neplatný název potraviny",
   "bulkAddErrorQuantityTooSmall": "Položka {number}: množství musí být větší než 0",
   "bulkAddErrorQuantityTooLarge": "Položka {number}: množství smí být nejvýše {bound}",

--- a/lib/l10n/intl_de.arb
+++ b/lib/l10n/intl_de.arb
@@ -1147,6 +1147,7 @@
   "bulkAddNothingToLogLabel": "Noch nichts zu speichern",
   "bulkAddSearchFailedLabel": "Suche nach diesen Lebensmitteln fehlgeschlagen",
   "bulkAddCheckAmountLabel": "Einheit für diese Menge prüfen",
+  "bulkAddDefaultAmountLabel": "Menge nicht angegeben",
   "bulkAddErrorInvalidName": "Eintrag {number}: kein gültiger Lebensmittelname",
   "bulkAddErrorQuantityTooSmall": "Eintrag {number}: Menge muss größer als 0 sein",
   "bulkAddErrorQuantityTooLarge": "Eintrag {number}: Menge darf höchstens {bound} betragen",

--- a/lib/l10n/intl_en.arb
+++ b/lib/l10n/intl_en.arb
@@ -1201,6 +1201,7 @@
   "bulkAddSearchFailedLabel": "Couldn't search for these foods",
   "@bulkAddSubmitLabel": {"placeholders": {"count": {"type": "int"}}},
   "bulkAddCheckAmountLabel": "Check the unit for this amount",
+  "bulkAddDefaultAmountLabel": "Amount not stated",
   "bulkAddErrorInvalidName": "Item {number}: not a valid food name",
   "@bulkAddErrorInvalidName": {
       "placeholders": {

--- a/lib/l10n/intl_it.arb
+++ b/lib/l10n/intl_it.arb
@@ -1116,6 +1116,7 @@
   "bulkAddNothingToLogLabel": "Niente da registrare",
   "bulkAddSearchFailedLabel": "Ricerca degli alimenti non riuscita",
   "bulkAddCheckAmountLabel": "Controlla l'unità di questa quantità",
+  "bulkAddDefaultAmountLabel": "Quantità non indicata",
   "bulkAddErrorInvalidName": "Voce {number}: nome dell'alimento non valido",
   "bulkAddErrorQuantityTooSmall": "Voce {number}: la quantità deve essere maggiore di 0",
   "bulkAddErrorQuantityTooLarge": "Voce {number}: la quantità non può superare {bound}",

--- a/lib/l10n/intl_pl.arb
+++ b/lib/l10n/intl_pl.arb
@@ -1116,6 +1116,7 @@
   "bulkAddNothingToLogLabel": "Nie ma jeszcze nic do zapisania",
   "bulkAddSearchFailedLabel": "Nie udało się wyszukać produktów",
   "bulkAddCheckAmountLabel": "Sprawdź jednostkę tej ilości",
+  "bulkAddDefaultAmountLabel": "Nie podano ilości",
   "bulkAddErrorInvalidName": "Pozycja {number}: nieprawidłowa nazwa produktu",
   "bulkAddErrorQuantityTooSmall": "Pozycja {number}: ilość musi być większa niż 0",
   "bulkAddErrorQuantityTooLarge": "Pozycja {number}: ilość nie może przekraczać {bound}",

--- a/lib/l10n/intl_sk.arb
+++ b/lib/l10n/intl_sk.arb
@@ -1147,6 +1147,7 @@
   "bulkAddNothingToLogLabel": "Zatiaľ nie je čo zaznamenať",
   "bulkAddSearchFailedLabel": "Vyhľadávanie potravín zlyhalo",
   "bulkAddCheckAmountLabel": "Skontrolujte jednotku množstva",
+  "bulkAddDefaultAmountLabel": "Množstvo neuvedené",
   "bulkAddErrorInvalidName": "Položka {number}: neplatný názov potraviny",
   "bulkAddErrorQuantityTooSmall": "Položka {number}: množstvo musí byť väčšie ako 0",
   "bulkAddErrorQuantityTooLarge": "Položka {number}: množstvo smie byť najviac {bound}",

--- a/lib/l10n/intl_tr.arb
+++ b/lib/l10n/intl_tr.arb
@@ -1147,6 +1147,7 @@
   "bulkAddNothingToLogLabel": "Henüz kaydedilecek bir şey yok",
   "bulkAddSearchFailedLabel": "Bu yiyecekler aranamadı",
   "bulkAddCheckAmountLabel": "Bu miktarın birimini kontrol edin",
+  "bulkAddDefaultAmountLabel": "Miktar belirtilmedi",
   "bulkAddErrorInvalidName": "{number}. öğe: geçerli bir besin adı değil",
   "bulkAddErrorQuantityTooSmall": "{number}. öğe: miktar 0'dan büyük olmalı",
   "bulkAddErrorQuantityTooLarge": "{number}. öğe: miktar en fazla {bound} olabilir",

--- a/lib/l10n/intl_uk.arb
+++ b/lib/l10n/intl_uk.arb
@@ -1116,6 +1116,7 @@
   "bulkAddNothingToLogLabel": "Поки що нічого записувати",
   "bulkAddSearchFailedLabel": "Не вдалося виконати пошук продуктів",
   "bulkAddCheckAmountLabel": "Перевірте одиницю для цієї кількості",
+  "bulkAddDefaultAmountLabel": "Кількість не вказано",
   "bulkAddErrorInvalidName": "Пункт {number}: некоректна назва продукту",
   "bulkAddErrorQuantityTooSmall": "Пункт {number}: кількість має бути більшою за 0",
   "bulkAddErrorQuantityTooLarge": "Пункт {number}: кількість не може перевищувати {bound}",

--- a/lib/l10n/intl_zh.arb
+++ b/lib/l10n/intl_zh.arb
@@ -1117,6 +1117,7 @@
   "bulkAddNothingToLogLabel": "暂无可记录的内容",
   "bulkAddSearchFailedLabel": "无法搜索这些食物",
   "bulkAddCheckAmountLabel": "请核对此数量的单位",
+  "bulkAddDefaultAmountLabel": "未说明数量",
   "bulkAddErrorInvalidName": "第 {number} 项：食物名称无效",
   "bulkAddErrorQuantityTooSmall": "第 {number} 项：数量必须大于 0",
   "bulkAddErrorQuantityTooLarge": "第 {number} 项：数量不能超过 {bound}",

--- a/test/features/add_meal/presentation/bulk_add_screen_test.dart
+++ b/test/features/add_meal/presentation/bulk_add_screen_test.dart
@@ -112,6 +112,7 @@ class _FakeSearch implements SearchProductsUseCase {
 MealEntity _meal(
   String name, {
   double? servingQuantity,
+  String? servingSize,
   String? mealUnit,
   String? brands,
 }) =>
@@ -124,7 +125,7 @@ MealEntity _meal(
       mealUnit: mealUnit,
       servingQuantity: servingQuantity,
       servingUnit: null,
-      servingSize: null,
+      servingSize: servingSize,
       source: MealSourceEntity.off,
       nutriments: const MealNutrimentsEntity(
         energyKcal100: 100,
@@ -579,6 +580,88 @@ void main() {
       greaterThanOrEqualTo(needed),
       reason: 'the unit dropdown is narrower than the unit it has to show, '
           'and a clipped unit reads as a different one',
+    );
+  });
+
+  testWidgets('a row says the word the food uses, not "serving"', (
+    tester,
+  ) async {
+    // #864. Three slices of bread already logs 3 x 38 g correctly; the row
+    // just called it "3 serving". The word is in the record and was never
+    // read back out.
+    await _register({
+      'bread': [
+        _meal('Bread', servingQuantity: 38, servingSize: '1 slice (38 g)'),
+      ],
+    });
+
+    await tester.pumpWidget(_app());
+    await tester.pumpAndSettle();
+    await _parse(tester, '3 bread');
+
+    expect(find.text('slice'), findsOneWidget);
+    expect(find.text(lookupS(const Locale('en')).servingLabel), findsNothing);
+  });
+
+  testWidgets('and keeps "serving" when the record names no measure', (
+    tester,
+  ) async {
+    // OFF's ordinary shape: a weight in the text and no household word in
+    // it. Reducing "30 g" to "g" would put a wrong unit on a right number,
+    // so the fallback has to hold.
+    await _register({
+      'yoghurt': [
+        _meal('Yoghurt', servingQuantity: 125, servingSize: '30 g'),
+      ],
+    });
+
+    await tester.pumpWidget(_app());
+    await tester.pumpAndSettle();
+    await _parse(tester, '2 yoghurt');
+
+    expect(find.text(lookupS(const Locale('en')).servingLabel), findsOneWidget);
+  });
+
+  testWidgets('a defaulted amount is marked, quietly', (tester) async {
+    // #864. Nobody stated an amount and the record carries none, so the row
+    // shows 100 g that came from the app. `amountNeedsCheck` cannot speak
+    // about this case at all, so before this the row said nothing.
+    await _register({
+      'toast': [_meal('Toast')],
+    });
+
+    await tester.pumpWidget(_app());
+    await tester.pumpAndSettle();
+    await _parse(tester, 'toast');
+
+    final en = lookupS(const Locale('en'));
+    expect(find.text(en.bulkAddDefaultAmountLabel), findsOneWidget);
+    // Quieter than its siblings: the muted surface colour, not an accent.
+    final marker = tester.widget<Text>(
+      find.text(en.bulkAddDefaultAmountLabel),
+    );
+    final scheme = Theme.of(
+      tester.element(find.text(en.bulkAddDefaultAmountLabel)),
+    ).colorScheme;
+    expect(marker.style?.color, scheme.onSurfaceVariant);
+    expect(marker.style?.color, isNot(scheme.tertiary));
+    expect(marker.style?.color, isNot(scheme.error));
+  });
+
+  testWidgets('and stays quiet when the amount came from the record', (
+    tester,
+  ) async {
+    await _register({
+      'bread': [_meal('Bread', servingQuantity: 38)],
+    });
+
+    await tester.pumpWidget(_app());
+    await tester.pumpAndSettle();
+    await _parse(tester, 'bread');
+
+    expect(
+      find.text(lookupS(const Locale('en')).bulkAddDefaultAmountLabel),
+      findsNothing,
     );
   });
 

--- a/test/unit_test/bulk_add_bloc_test.dart
+++ b/test/unit_test/bulk_add_bloc_test.dart
@@ -768,6 +768,103 @@ void main() {
       );
     });
   });
+
+  group('a defaulted amount says so (#864)', () {
+    BulkAddRow rowFor(
+      MealEntity food, {
+      double? statedQuantity,
+      bool amountEdited = false,
+    }) => BulkAddRow(
+      resolved: ResolvedMealItem(
+        parsed: ParsedMealItem(query: food.name!, quantity: statedQuantity),
+        candidates: [food],
+        selectedIndex: 0,
+        confidence: 0.9,
+      ),
+      selectedIndex: 0,
+      amountText: '100',
+      unit: 'g',
+      amountEditedByUser: amountEdited,
+    );
+
+    test('nobody stated an amount and the record carries none', () {
+      // The flat 100 g. `amountNeedsCheck` cannot see this case at all,
+      // because it requires a stated quantity — so before this getter the
+      // row where the app guesses hardest was the one row saying nothing.
+      final row = rowFor(meal('toast'));
+      expect(row.amountIsProvisional, isTrue);
+      expect(row.amountNeedsCheck, isFalse);
+    });
+
+    test('the record supplied the amount, so it is not the app guessing', () {
+      final row = rowFor(meal('bread', servingQuantity: 38));
+      expect(row.amountIsProvisional, isFalse);
+    });
+
+    test('serving *text* alone is still the flat fallback', () {
+      // OFF's real shape: no numeric field, a weight only in the text.
+      // `scalableServingQuantity` reads the 30 out of it (#629) but
+      // `_initialAmount` does not — it gates on `servingQuantity` — so the
+      // row shows 100 and this must say so.
+      //
+      // The example matters. An earlier version used "1 egg", where
+      // `scalableServingQuantity` is *also* null, so the test passed against
+      // either gate and pinned nothing.
+      final row = rowFor(meal('yoghurt', servingSize: '30 g'));
+      expect(row.meal!.hasServingValues, isTrue);
+      expect(row.meal!.scalableServingQuantity, 30);
+      expect(row.meal!.servingQuantity, isNull);
+      expect(row.amountIsProvisional, isTrue);
+    });
+
+    test('a stated amount is never provisional', () {
+      // That number is the user's or the model's. Whether it means what
+      // they think is `amountNeedsCheck`'s question, not this one.
+      final row = rowFor(meal('toast'), statedQuantity: 2);
+      expect(row.amountIsProvisional, isFalse);
+    });
+
+    test('typing an amount answers it', () {
+      final row = rowFor(meal('toast'), amountEdited: true);
+      expect(row.amountIsProvisional, isFalse);
+    });
+
+    test('an unresolved row has nothing to be provisional about', () {
+      final row = BulkAddRow(
+        resolved: const ResolvedMealItem(
+          parsed: ParsedMealItem(query: 'zzzz'),
+          candidates: [],
+          selectedIndex: 0,
+          confidence: 0,
+        ),
+        selectedIndex: 0,
+        amountText: '100',
+        unit: 'g',
+      );
+      expect(row.isResolved, isFalse);
+      expect(row.amountIsProvisional, isFalse);
+    });
+
+    test('the two flags never fire together', () {
+      // The screen renders them in one exclusive chain, so an overlap would
+      // silently hide the louder of the two rather than show both.
+      for (final food in [
+        meal('toast'),
+        meal('bread', servingQuantity: 38),
+        meal('egg', servingSize: '1 egg'),
+      ]) {
+        for (final stated in [null, 2.0]) {
+          final row = rowFor(food, statedQuantity: stated);
+          expect(
+            row.amountIsProvisional && row.amountNeedsCheck,
+            isFalse,
+            reason: '${food.name} stated=$stated',
+          );
+        }
+      }
+    });
+  });
+
 }
 
 final _photo = MealPhoto(

--- a/test/unit_test/portion_label_test.dart
+++ b/test/unit_test/portion_label_test.dart
@@ -1,0 +1,67 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:opennutritracker/features/add_meal/util/portion_label.dart';
+
+void main() {
+  group('householdPortionLabel', () {
+    test('pulls the measure out of an FDC-style label', () {
+      // What `MealEntity._spServingLabel` renders for a backend food.
+      expect(householdPortionLabel('1 slice (38 g)'), 'slice');
+    });
+
+    test('keeps a qualified measure whole, comma and all', () {
+      // The backend's own schema comment names this exact shape, and the
+      // comma is why the word may never reach the *stored* unit (#864).
+      expect(householdPortionLabel('1 cup, sliced (240 g)'), 'cup, sliced');
+    });
+
+    test('handles a description with no weight appended', () {
+      expect(householdPortionLabel('1 egg'), 'egg');
+    });
+
+    test('a bare weight names no household measure', () {
+      // OFF's common shape. Reducing "30 g" to "g" and showing it as a unit
+      // would replace a correct word with a wrong one.
+      expect(householdPortionLabel('30 g'), isNull);
+      expect(householdPortionLabel('240ml'), isNull);
+      expect(householdPortionLabel('1.5 l'), isNull);
+    });
+
+    test('a decimal or comma count is stripped like any other', () {
+      expect(householdPortionLabel('0.5 cup (120 g)'), 'cup');
+      expect(householdPortionLabel('1,5 slices'), 'slices');
+    });
+
+    test('"portion" is the backend saying it has no household measure', () {
+      // `food_summary` maps FDC's measure_unit 9999 ('undetermined') to the
+      // word "portion". It says nothing the dropdown does not already say.
+      expect(householdPortionLabel('1 portion'), isNull);
+      expect(householdPortionLabel('serving'), isNull);
+    });
+
+    test('nothing usable gives null rather than an empty label', () {
+      expect(householdPortionLabel(null), isNull);
+      expect(householdPortionLabel(''), isNull);
+      expect(householdPortionLabel('   '), isNull);
+      expect(householdPortionLabel('1'), isNull);
+      expect(householdPortionLabel('1 (38 g)'), isNull);
+      expect(householdPortionLabel('---'), isNull);
+    });
+
+    test('a label too long for the row is refused, not truncated', () {
+      // The dropdown sizes itself to its widest item and this row has
+      // already overflowed once (#824). "Serving" underneath is still
+      // correct, so losing the word is the cheaper failure.
+      final long = 'a' * (maxHouseholdPortionLabel + 1);
+      expect(householdPortionLabel('1 $long'), isNull);
+      final atLimit = 'a' * maxHouseholdPortionLabel;
+      expect(householdPortionLabel('1 $atLimit'), atLimit);
+    });
+
+    test('a non-Latin measure survives', () {
+      // The backend translates portion descriptions per locale, so this
+      // function must not assume the Latin script it was written against.
+      expect(householdPortionLabel('1 片 (38 g)'), '片');
+      expect(householdPortionLabel('1 Scheibe (38 g)'), 'Scheibe');
+    });
+  });
+}


### PR DESCRIPTION
Phase 1 of #864 — the half that needs no backend change and no new data.

Both halves address the same defect: **a correct row and an incorrect one currently look
identical.**

## "3 serving" becomes "3 slice"

Three slices of bread already logs 3 × 38 g correctly. The row just called it a *serving*, because
`serving` is the only one of six units a count can land on.

The word was already in the record. The backend builds `serving_size` from FDC's
`portion_description`/`modifier`, and `MealEntity._spServingLabel` already renders it as
`"1 slice (38 g)"`. Nothing read it back out. `householdPortionLabel` does.

**Display only — a decision, not a shortcut.** `IntakeEntity.unit` is published in
[docs/export-format.md](https://github.com/simonoppowa/OpenNutriTracker/blob/main/docs/export-format.md)
as *"e.g. `g`, `ml`, `serving`"*, and it rides in a **positional** QR share array parsed by other
builds on other phones. FDC portion prose carries commas — the backend's own schema comment gives
`"cup, sliced"` — so letting it reach the stored unit would be a compatibility change wearing a
label change's clothes. The value behind the dropdown stays `serving`. Nothing about the export,
the share payload, or the stored intake moves.

**The extraction is deliberately timid.** A bare weight (`"30 g"`), the backend's `"portion"`
placeholder, anything with no letter in it, and anything too long for the row all fall back to
"Serving". A miss costs nothing; a false positive would put a wrong-looking unit on a right number.
The length cap is a layout constraint, not a stylistic one — this row overflowed by 65px in #824,
and the dropdown sizes itself to its widest item.

## A defaulted amount now says so

```dart
bool get amountNeedsCheck =>
    !unitChosenByUser && isResolved &&
    resolved.parsed.quantity != null && (...)
```

That flag requires a **stated** quantity. So the one case where the app guesses hardest — nobody
said an amount, the record carries none, the row shows 100 g — was the one case it stayed quiet
about.

`amountIsProvisional` covers it, in `onSurfaceVariant` rather than an accent. The other three
markers mean *"this is probably wrong"*; this one only means *"this number is not yours"*. 100 g is
not a guess worth replacing — the nutriments are published per 100 g, making it the one figure in
this area nobody invented — and a warning on every unquantified row would become wallpaper, which
is exactly what the model-failure notices were shaped to avoid.

## The near-miss worth reading

`amountIsProvisional` gates on `servingQuantity`, **not** `scalableServingQuantity`, because
`_initialAmount` does. That distinction is the whole point of the getter, and **the first test of
it did not prove it**: the example was `servingSize: '1 egg'`, which has neither field, so the test
passed against either gate. Mutation testing caught it; nothing else would have.

Rewritten around `'30 g'` — OFF's real shape, where `scalableServingQuantity` reads the 30 out of
the text (#629), the numeric field is empty, and the row still shows 100. Also removed a redundant
`hasServingValues` clause that never did anything, since it is true whenever `servingQuantity` is.

## Checks

- `fvm flutter analyze` (whole project) — `No issues found!`
- `fvm flutter test` — **1869 passed**, up exactly 20 from the 1849 baseline
- **9 mutations, 9 caught** — label always null · bare-unit guard dropped · length cap dropped ·
  gate widened to `scalableServingQuantity` · user-typed amount ignored · stated quantity ignored ·
  label reverted to plain `servingLabel` · provisional line removed · provisional given the accent
  colour
- ARB discipline: **+1/−0 in each of nine files**, no reformatting, **1023 keys each**, parity held

## Not in this PR

Phase 2 of #864 — reading the backend's `food_portion` table so a food can offer *all* its cited
portions, and matching a household word the user or the model supplies against them. That needs a
backend read path. This PR deliberately changes nothing about which portion is used or what any row
computes.

## Wants a human

The eight non-English strings for `bulkAddDefaultAmountLabel` are mine. Same standing concern as
the cs/de/sk/uk disclosures — they want a native read, not a reviewer's glance.
