### PR TITLE
fix(core): keep the diary out of crash reports

### DIFF
--- a/lib/core/utils/sentry_config.dart
+++ b/lib/core/utils/sentry_config.dart
@@ -1,0 +1,26 @@
+import 'package:sentry_flutter/sentry_flutter.dart';
+
+/// The Sentry options a release build runs with, kept out of `main.dart` so
+/// that the one setting which must not drift can be pinned by a test rather
+/// than by a reviewer noticing an absent line.
+///
+/// [SentryOptions.enablePrintBreadcrumbs] defaults to `true`, and Sentry's
+/// `DebugPrintIntegration` is registered unconditionally and bows out only in
+/// debug mode — so it is live in exactly the builds where crash reporting
+/// runs. `LoggerConfig` pipes the whole application log through `debugPrint`
+/// at `Level.ALL`, which means every log line would become a breadcrumb
+/// riding along on the next event of any kind: the food search terms the user
+/// typed, the barcodes they scanned, their water and weight entries, the names
+/// of their custom activities.
+///
+/// The consent they gave says the opposite — "No food log, weight, or personal
+/// data is included" — so the breadcrumbs are turned off at the source.
+/// Sanitising the individual log statements was the alternative and was
+/// rejected: they are spread across data sources, blocs and screens, and
+/// nothing about writing the next `log.fine` would remind its author that the
+/// line can leave the device.
+void configureSentryOptions(SentryOptions options, {required String dsn}) {
+  options.dsn = dsn;
+  options.tracesSampleRate = 1.0;
+  options.enablePrintBreadcrumbs = false;
+}

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -19,6 +19,7 @@ import 'package:opennutritracker/core/utils/env.dart';
 import 'package:opennutritracker/core/utils/hive_storage_integrity_exception.dart';
 import 'package:opennutritracker/core/utils/locator.dart';
 import 'package:opennutritracker/core/utils/logger_config.dart';
+import 'package:opennutritracker/core/utils/sentry_config.dart';
 import 'package:opennutritracker/core/utils/notification_service.dart';
 import 'package:opennutritracker/core/utils/navigation_options.dart';
 import 'package:opennutritracker/core/utils/energy_unit_provider.dart';
@@ -148,10 +149,7 @@ void _runAppWithSentryReporting(
   int? savedAccentColor,
 ) async {
   await SentryFlutter.init(
-    (options) {
-      options.dsn = Env.sentryDns;
-      options.tracesSampleRate = 1.0;
-    },
+    (options) => configureSentryOptions(options, dsn: Env.sentryDns),
     appRunner: () => runAppWithChangeNotifiers(
       isUserInitialized,
       savedAppTheme,

--- a/test/unit_test/sentry_config_test.dart
+++ b/test/unit_test/sentry_config_test.dart
@@ -1,0 +1,28 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:opennutritracker/core/utils/sentry_config.dart';
+import 'package:sentry_flutter/sentry_flutter.dart';
+
+/// Print breadcrumbs are the one Sentry setting this app cannot let drift back
+/// to its default. `LoggerConfig` sends the entire application log through
+/// `debugPrint` at `Level.ALL`, and Sentry replaces `debugPrint` in release
+/// builds, so a `true` here would put diary content — searches, scanned
+/// barcodes, water and weight entries — into crash reports the user was told
+/// contain none of it.
+void main() {
+  SentryOptions configured() {
+    final options = SentryOptions();
+    configureSentryOptions(options, dsn: 'https://key@example.invalid/1');
+    return options;
+  }
+
+  test('release options never send print breadcrumbs', () {
+    expect(configured().enablePrintBreadcrumbs, isFalse);
+  });
+
+  test('release options do not attach default PII', () {
+    // Not set by `configureSentryOptions` — this pins the SDK's own default,
+    // because the README states that `sendDefaultPii` stays false and an SDK
+    // upgrade is the only thing that could quietly change it.
+    expect(configured().sendDefaultPii, isFalse);
+  });
+}


### PR DESCRIPTION
Crash reports were carrying the user's diary. Anyone who opted in was sending more than they agreed to.

## What was happening

Two independently reasonable settings met badly.

Sentry's `DebugPrintIntegration` is registered unconditionally by `SentryFlutter.init` and bows out only in debug mode — so it is live in exactly the builds where crash reporting runs at all. `enablePrintBreadcrumbs` defaults to `true`, and the app overrode nothing: it set `dsn` and `tracesSampleRate`, and that was the whole configuration. The integration replaces `debugPrint` and turns whatever passes through it into breadcrumbs, which attach to every subsequent event.

`LoggerConfig` sends the entire application log through `debugPrint` at `Level.ALL`.

So every log line rode along on the next event of any kind:

| Where | What it logged |
| :-- | :-- |
| `water_intake_data_source.dart:19` | amount in ml, with timestamp |
| `weight_log_data_source.dart:20`, `:51` | weight-log entries by date |
| `edit_meal_screen.dart:942`, `:948`, `:1199`, `:1212` | scanned barcodes |
| `scanner_screen.dart:233`, `:313` | scanned and manually entered barcodes |
| `custom_activity_template_data_source.dart:23`, `:48` | custom activity names the user typed |
| `activity_detail_screen.dart:253` | a typed quantity, on the parse-failure path |
| `off_data_source.dart:94`, `:115` | food search URLs, query string included |

The consent this is collected under says the opposite — `dataCollectionLabel`: *"Send anonymous crash reports to help fix bugs. No food log, weight, or personal data is included."* Water and weight entries are two of the categories that sentence names outright.

Only release builds, and only for users who opted in — but for those users it had been true since crash reporting shipped.

## The fix

`enablePrintBreadcrumbs = false`.

Sanitising the log statements was the alternative and it loses. They are spread across data sources, blocs and screens, and nothing about writing the next `log.fine` would remind its author that the line can leave the device. One setting makes the claim structurally true rather than dependent on everyone remembering it forever.

The options move out of `main.dart` into `configureSentryOptions` so a test can pin them. That test also pins `sendDefaultPii`, which the README asserts and which only an SDK upgrade could quietly change.

Nothing else about the reporting changes: stack traces, contexts, app and OS version and device model still arrive, which is exactly what the README already claims Sentry receives. **No policy or README wording needs to change as a result of this** — the documents were right and the code was wrong.

## Why this branches off `main`

The defect is in the shipped app (`v2.0.2`), so the fix should be releasable without the unreleased AI work. `main.dart`, `logger_config.dart` and `off_data_source.dart` are identical on `main` and on the feature branches, so it merges forward cleanly.

## Checks

`fvm flutter analyze` clean; `fvm flutter test` 824 passing.

Found while auditing the published Data policy against the source (#867); resolves #877.
