### PR TITLE
docs: correct onboarding demo privacy-policy gate in AGENTS.md

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -47,8 +47,12 @@ shipped-in-every-build feature:
   (`lib/features/onboarding/presentation/onboarding_intro_page_body.dart`)
   is a real, shipped feature — a prospective user can seed the same active
   profile with three weeks of always-on-track sample data and jump straight
-  to Home, independent of the privacy-policy checkbox. While the active
-  profile holds sample data, a persistent banner
+  to Home, but only with the privacy-policy checkbox ticked, the same bar as
+  Start — tapping it unchecked just explains itself in a snackbar and seeds
+  nothing, so no path into the app skips policy acceptance. The checkbox
+  that is independent is the data-collection one: crash reporting stays off
+  (and locked) while demo data is active.
+  While the active profile holds sample data, a persistent banner
   (`lib/core/presentation/widgets/demo_mode_banner.dart`) shows on every tab
   of `MainScreen`; tapping "Set up your profile" wipes it and returns to
   onboarding (mirrors `SettingsScreen._confirmDeleteAllData`'s


### PR DESCRIPTION
`AGENTS.md` described the onboarding intro screen's "Try it with sample data"
link as seeding sample data "independent of the privacy-policy checkbox".
That is the opposite of what the code does — it conflated the privacy-policy
checkbox with the data-collection one.

The demo path is privacy-policy-gated, in two places:

- `onboarding_intro_page_body.dart:119` —
  `onPressed: _seedingDemo ? null : (_acceptedPolicy ? _tryDemo : _policyRequired)`.
  Without the checkbox the tap shows the `onboardingBlockedDemoPolicySnack`
  snackbar ("Accept the privacy policy to try the demo") and seeds nothing.
- `_tryDemo` opens with `if (!_acceptedPolicy) return;`, and its doc comment
  says it "Requires the privacy-policy checkbox (same bar as Start) so demo
  entry still records legal acceptance".

The checkbox that *is* independent of the demo path is the data-collection /
anonymous crash reporting one — crash reporting stays off, and locked, while
demo data is active.

This is load-bearing for the privacy review in #875: with the demo behind the
same gate as Start, there is no path into the app that is not
privacy-policy-gated. (`lib/dev/main_dev.dart` skips onboarding, but it throws
in release mode and is never referenced from `lib/main.dart`, as the same
section already notes.)

Docs only — one sentence rewritten in place, no restructuring of the section,
no code or formatting changes.

Refs #875
