### PR TITLE
docs: correct what the README claims about the wire

### DIFF
--- a/README.md
+++ b/README.md
@@ -138,7 +138,7 @@ No account, no sign-in, no analytics, no ads. Your profile, diary, activities, w
 
 [USDA FoodData Central](https://fdc.nal.usda.gov/), the German [BLS](https://www.blsdb.de), INDB and TBCA are where the food *data* comes from, not places your device talks to. Those datasets are ingested into the Supabase backend ahead of time ([self-hosting guide](docs/supabase-fdc-self-hosting.md)), so a search reaches that backend and stops there. Settings → Food databases chooses which datasets a search covers. Five are selectable today, with INDB and TBCA in the schema but not yet carrying data ([`sp_const.dart`](lib/features/add_meal/data/dto/sp/sp_const.dart)).
 
-Requests carry a User-Agent naming the app, platform, and version, with no user or device identifier. Search results are cached locally and pruned after 90 days.
+Requests to Open Food Facts carry a User-Agent naming the app, platform, and version; requests to the Supabase backend carry the Supabase SDK's own client headers instead. **The app generates no user or device identifier and sends none** — but a request still arrives from somewhere, and the Supabase gateway logs the address it came from along with a coarse location and a fingerprint of the TLS connection, kept for 24 hours. Search results are cached locally and pruned after 90 days.
 
 **Crash reporting** is off until you enable it, and initializes only in release builds ([`main.dart:119`](lib/main.dart:119)). `sendDefaultPii` stays `false`, so no username, email, or IP-derived identity is attached. Disabling it, or deleting your data, closes the SDK immediately.
 


### PR DESCRIPTION
Two sentences in the README's Privacy section were wrong, and both were wrong in the same direction: they described what we meant to send rather than what a request actually carries.

Everything else in that section held up. The three-destination table is accurate — a separate audit confirmed the USDA FoodData Central client is wired but unreachable, so a search really does reach the Supabase backend and stop there. The errors are all in the paragraph about the wire.

## What was wrong

**"Requests carry a User-Agent naming the app, platform, and version"** — true only of Open Food Facts. `ONTHttpClient` sets that header and its only callers are in [`off_data_source.dart`](lib/features/add_meal/data/data_sources/off_data_source.dart). The Supabase client builds its own requests; the gateway records them as `Dart/3.12 (dart:io)` with an `x_client_info` naming the SDK version.

**"with no user or device identifier"** — true of what the app generates, false as a description of what the recipient ends up holding. The Supabase API gateway log pairs each search with the connecting IP, a city, region and postal code, the ISP name, and a JA3/JA4 fingerprint of the TLS handshake. Retained one day on the current plan.

Neither is something the app *sends*. Both are things the sentence implied nobody has.

## The fix

Split the claim so it says both halves — what the app transmits, and what any server necessarily records:

> Requests to Open Food Facts carry a User-Agent naming the app, platform, and version; requests to the Supabase backend carry the Supabase SDK's own client headers instead. **The app generates no user or device identifier and sends none** — but a request still arrives from somewhere, and the Supabase gateway logs the address it came from along with a coarse location and a fingerprint of the TLS connection, kept for 24 hours.

Stating the second half **is** the correction rather than an addition to it. Withholding it is precisely how the original sentence came to mislead a reader who was trusting the table above it.

## Notes

The feature branches carry the same sentence in their expanded Privacy section and will need the same edit when they merge.

Found while auditing the published Data policy against the source (#867); resolves #883, which also retired the rule that made this README the canonical document the privacy policy defers to — deferring to it would have carried these two sentences into a document with legal weight.
