### PR TITLE
fix(core): bring main's crash-report fix and AGENTS.md correction back to develop

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -47,8 +47,12 @@ shipped-in-every-build feature:
   (`lib/features/onboarding/presentation/onboarding_intro_page_body.dart`)
   is a real, shipped feature — a prospective user can seed the same active
   profile with three weeks of always-on-track sample data and jump straight
-  to Home, independent of the privacy-policy checkbox. While the active
-  profile holds sample data, a persistent banner
+  to Home, but only with the privacy-policy checkbox ticked, the same bar as
+  Start — tapping it unchecked just explains itself in a snackbar and seeds
+  nothing, so no path into the app skips policy acceptance. The checkbox
+  that is independent is the data-collection one: crash reporting stays off
+  (and locked) while demo data is active.
+  While the active profile holds sample data, a persistent banner
   (`lib/core/presentation/widgets/demo_mode_banner.dart`) shows on every tab
   of `MainScreen`; tapping "Set up your profile" wipes it and returns to
   onboarding (mirrors `SettingsScreen._confirmDeleteAllData`'s

--- a/lib/core/utils/sentry_config.dart
+++ b/lib/core/utils/sentry_config.dart
@@ -1,0 +1,26 @@
+import 'package:sentry_flutter/sentry_flutter.dart';
+
+/// The Sentry options a release build runs with, kept out of `main.dart` so
+/// that the one setting which must not drift can be pinned by a test rather
+/// than by a reviewer noticing an absent line.
+///
+/// [SentryOptions.enablePrintBreadcrumbs] defaults to `true`, and Sentry's
+/// `DebugPrintIntegration` is registered unconditionally and bows out only in
+/// debug mode — so it is live in exactly the builds where crash reporting
+/// runs. `LoggerConfig` pipes the whole application log through `debugPrint`
+/// at `Level.ALL`, which means every log line would become a breadcrumb
+/// riding along on the next event of any kind: the food search terms the user
+/// typed, the barcodes they scanned, their water and weight entries, the names
+/// of their custom activities.
+///
+/// The consent they gave says the opposite — "No food log, weight, or personal
+/// data is included" — so the breadcrumbs are turned off at the source.
+/// Sanitising the individual log statements was the alternative and was
+/// rejected: they are spread across data sources, blocs and screens, and
+/// nothing about writing the next `log.fine` would remind its author that the
+/// line can leave the device.
+void configureSentryOptions(SentryOptions options, {required String dsn}) {
+  options.dsn = dsn;
+  options.tracesSampleRate = 1.0;
+  options.enablePrintBreadcrumbs = false;
+}

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -21,6 +21,7 @@ import 'package:opennutritracker/core/utils/env.dart';
 import 'package:opennutritracker/core/utils/hive_storage_integrity_exception.dart';
 import 'package:opennutritracker/core/utils/locator.dart';
 import 'package:opennutritracker/core/utils/logger_config.dart';
+import 'package:opennutritracker/core/utils/sentry_config.dart';
 import 'package:opennutritracker/core/utils/notification_service.dart';
 import 'package:opennutritracker/core/utils/navigation_options.dart';
 import 'package:opennutritracker/core/utils/energy_unit_provider.dart';
@@ -159,10 +160,7 @@ void _runAppWithSentryReporting(
   int? savedAccentColor,
 ) async {
   await SentryFlutter.init(
-    (options) {
-      options.dsn = Env.sentryDns;
-      options.tracesSampleRate = 1.0;
-    },
+    (options) => configureSentryOptions(options, dsn: Env.sentryDns),
     appRunner: () => runAppWithChangeNotifiers(
       isUserInitialized,
       savedAppTheme,

--- a/test/unit_test/sentry_config_test.dart
+++ b/test/unit_test/sentry_config_test.dart
@@ -1,0 +1,28 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:opennutritracker/core/utils/sentry_config.dart';
+import 'package:sentry_flutter/sentry_flutter.dart';
+
+/// Print breadcrumbs are the one Sentry setting this app cannot let drift back
+/// to its default. `LoggerConfig` sends the entire application log through
+/// `debugPrint` at `Level.ALL`, and Sentry replaces `debugPrint` in release
+/// builds, so a `true` here would put diary content — searches, scanned
+/// barcodes, water and weight entries — into crash reports the user was told
+/// contain none of it.
+void main() {
+  SentryOptions configured() {
+    final options = SentryOptions();
+    configureSentryOptions(options, dsn: 'https://key@example.invalid/1');
+    return options;
+  }
+
+  test('release options never send print breadcrumbs', () {
+    expect(configured().enablePrintBreadcrumbs, isFalse);
+  });
+
+  test('release options do not attach default PII', () {
+    // Not set by `configureSentryOptions` — this pins the SDK's own default,
+    // because the README states that `sendDefaultPii` stays false and an SDK
+    // upgrade is the only thing that could quietly change it.
+    expect(configured().sendDefaultPii, isFalse);
+  });
+}


### PR DESCRIPTION
`main` carries two commits whose content never reached `develop`. Both were merged directly to
`main` rather than through the batched release PR, and nothing brings a direct-to-`main` change
back down.

## What was actually missing

| | |
|---|---|
| **#879** | `lib/core/utils/sentry_config.dart` exists **only on `main`**. Verified absent from `develop` *and* from `feature/ai-assisted-meal-logging`. |
| **#880** | `develop`'s AGENTS.md still says demo seeding reaches Home *"independent of the privacy-policy checkbox"* — the exact sentence #880 corrected. |

**#879 is the one that matters.** It pins `enablePrintBreadcrumbs = false` on release Sentry
options, which is what stops the whole application log — food search terms included, i.e. diary
content — riding along as breadcrumbs on the next event of any kind. Without this backport, the
next release cut from `develop` silently reintroduces that.

It matters more on the AI branch than anywhere else: `feature/ai-assisted-meal-logging` adds a
dozen `_log.` call sites in the add-meal use cases alone, and lacks the fix. That branch should
take `develop` after this lands.

## Why cherry-pick rather than merge `main` into `develop`

The merge base is the **2.0.1** release, and `main` carries 2.0.2 as a single squashed commit of
128 files that `develop` already holds as individual commits. Merging would conflict broadly and
could revert newer `develop` work where git cannot tell the two apart. Cherry-picking the two real
commits is surgical and reviewable.

Both applied **cleanly**, with original authorship and `-x` provenance lines preserved.

## Scope

Exactly 4 files, exactly the two upstream commits, nothing rewritten:

```
AGENTS.md                              |  8 ++++++--
lib/core/utils/sentry_config.dart      | 26 ++++++++++++++++++++++++++
lib/main.dart                          |  6 ++----
test/unit_test/sentry_config_test.dart | 28 ++++++++++++++++++++++++++++
```

The other two commits on `main` are **not** backported and should not be: `9ab14fe3` is the 2.0.2
release squash whose content `develop` already has, and `294debe6`'s `CODE_OF_CONDUCT.md` is
already byte-identical on both branches. With a squash-merge release flow, release commits are
permanently absent from `develop` by design — so `git log develop..main` showing them is expected,
not a defect.

## Checks

- `fvm flutter analyze` — `No issues found!`
- `fvm flutter test` — **1098 passed**
- The two backported tests were confirmed to actually execute under the default glob, and
  flipping `enablePrintBreadcrumbs` back to `true` **fails** them

## The structural half, not fixed here

Nothing forces a back-merge, so this will recur the next time a fix goes straight to `main`.
`docs/RELEASING.md` (merged in #866) documents a release as a `develop → main` merge and says
nothing about hotfixes or bringing them back. It lives on `feature/ai-assisted-meal-logging`, so it
cannot be amended from a `develop`-targeted PR — worth a follow-up once that branch lands, or
sooner on its own.
