### PR TITLE
docs: say what happens to a fix that goes straight to main

### DIFF
--- a/docs/RELEASING.md
+++ b/docs/RELEASING.md
@@ -4,6 +4,10 @@ A release is **a merge of `develop` into `main`**. There is no release script an
 by hand: pushing to `main` starts the pipeline, and the pipeline does the packaging, the store
 uploads and the GitHub release itself.
 
+A **hotfix merged straight to `main`** starts the same pipeline, which is why it is a legitimate
+thing to do — and why it needs [its own step afterwards](#hotfixes-and-the-way-back-to-develop),
+because nothing carries it back.
+
 That is worth stating first because most of this page is about the parts the pipeline *cannot* do —
 the ones that are otherwise remembered, or not.
 
@@ -53,6 +57,9 @@ lands on `develop`.
 - [ ] Confirm the checks are **registered**, not just absent. A PR that gets no checks still reports
       mergeable, and silence looks exactly like success.
 - [ ] Merge. From here the pipeline runs; do not tag by hand.
+- [ ] Confirm `develop` is not missing anything `main` already has — see
+      [Hotfixes](#hotfixes-and-the-way-back-to-develop). A hotfix that never came back is invisible
+      at this point, and shipping without it is the whole cost.
 
 ## After the pipeline finishes
 
@@ -65,6 +72,37 @@ lands on `develop`.
       automated.
 - [ ] **Update the store listings** with the "what's new" text, since the pipeline uploads none.
 - [ ] **Merge the release-fingerprint PR** into `develop`.
+
+## Hotfixes, and the way back to `develop`
+
+A fix urgent enough to skip the batch can go straight to `main`. Nothing brings it back down, so
+the next release — cut from `develop` — quietly ships without it.
+
+This has already happened once. [#879](https://github.com/simonoppowa/OpenNutriTracker/pull/879)
+landed on `main` and left `develop` without the setting that keeps the application log, food search
+terms included, out of Sentry breadcrumbs; it was backported in
+[#893](https://github.com/simonoppowa/OpenNutriTracker/pull/893) only because someone went looking.
+The failure mode is silence: no check fails, and the fix simply is not there.
+
+- [ ] **After merging anything directly to `main`, open a backport PR into `develop`** in the same
+      sitting. It is not done until that PR is merged too.
+
+**Cherry-pick the commits. Do not merge `main` into `develop`.** With a squash-merge flow the two
+branches share only an old merge base — the previous release — and `main` carries each release as a
+single squashed commit of everything `develop` had at the time. A merge weighs that against
+`develop`'s individual commits plus everything added since, which conflicts across the whole
+release and can revert newer work where git cannot tell the two apart. `git cherry-pick -x <sha>`
+keeps authorship and records where it came from.
+
+```bash
+git log --oneline origin/develop..origin/main    # what main has that develop does not
+```
+
+**Most of what that command prints is expected and must not be backported.** Release commits are
+absent from `develop` *by construction* under squash merging, so they accumulate there forever.
+Before backporting anything, check whether its content is already present — a file that exists on
+both branches, or a paragraph already corrected — rather than trusting the commit list. Only two of
+the four entries it printed in August 2026 were real gaps.
 
 ## Documentation
 

--- a/test/unit_test/releasing_doc_test.dart
+++ b/test/unit_test/releasing_doc_test.dart
@@ -1,0 +1,75 @@
+import 'dart:io';
+
+import 'package:flutter_test/flutter_test.dart';
+
+/// Keeps [docs/RELEASING.md] pointing at things that exist.
+///
+/// It is a checklist, which is a document read once per release by someone
+/// working through it in order — so a link that goes nowhere is found at the
+/// worst possible moment, by the person least able to stop and investigate.
+/// Nothing else checks it: the architecture page's test guards links *into*
+/// that page, not this file's own.
+///
+/// Paths and anchors only. Whether a step is still the right step is a
+/// judgement no test makes.
+void main() {
+  final doc = File('docs/RELEASING.md');
+  final text = doc.readAsStringSync();
+
+  String slug(String heading) => heading
+      .toLowerCase()
+      .replaceAll(RegExp(r'[^a-z0-9 -]'), '')
+      .trim()
+      .replaceAll(RegExp(r'\s+'), '-');
+
+  final ownAnchors = {
+    for (final m in RegExp(r'^#{1,6}\s+(.+)$', multiLine: true).allMatches(text))
+      slug(m.group(1)!.trim()),
+  };
+
+  // Relative links, resolved from docs/. "../CONTRIBUTING.md" climbs out;
+  // "ai-architecture.md" sits alongside.
+  final relative = RegExp(
+    r'\]\((?!https?:|#)([^)\s#]+)\)',
+  ).allMatches(text).map((m) => m.group(1)!).toSet();
+
+  final internal = RegExp(
+    r'\]\(#([^)\s]+)\)',
+  ).allMatches(text).map((m) => m.group(1)!).toSet();
+
+  group('docs/RELEASING.md', () {
+    test('the checklist is where this test thinks it is', () {
+      expect(doc.existsSync(), isTrue);
+      expect(text, contains('# Releasing'));
+    });
+
+    test('the link scan found something', () {
+      // Without this the two checks below iterate an empty set and pass
+      // while proving nothing — the same canary the architecture page's
+      // test carries, for the same reason.
+      expect(relative, isNotEmpty);
+      expect(internal, isNotEmpty);
+    });
+
+    test('every file it links to exists', () {
+      final missing = [
+        for (final path in relative)
+          if (!File('docs/$path').existsSync() &&
+              !File(path.replaceFirst('../', '')).existsSync())
+            path,
+      ];
+      expect(missing, isEmpty);
+    });
+
+    test('every heading it links to exists', () {
+      // The hotfix section is cross-referenced from two places, so a
+      // reworded heading breaks the step that stops a fix on `main` being
+      // lost — quietly, in a document nobody re-reads between releases.
+      final broken = [
+        for (final anchor in internal)
+          if (!ownAnchors.contains(anchor)) anchor,
+      ];
+      expect(broken, isEmpty);
+    });
+  });
+}


### PR DESCRIPTION
Follow-up to #866, and the process half of #893.

`docs/RELEASING.md` described a release as a `develop → main` merge and said nothing about the
other way code reaches `main`. A hotfix merged directly starts the same pipeline — which is why it
is a reasonable thing to do — and **nothing carries it back**, so the next release, cut from
`develop`, ships without it.

Not hypothetical: [#879](https://github.com/simonoppowa/OpenNutriTracker/pull/879) landed on `main`
and left `develop` without the setting that keeps the application log — food search terms included
— out of Sentry breadcrumbs. Backported in
[#893](https://github.com/simonoppowa/OpenNutriTracker/pull/893) only because someone went looking.
No check failed. The fix simply was not there.

## What the new section says

Three things the next person needs, and would otherwise have to work out under time pressure:

1. **Open the backport in the same sitting**, and treat the hotfix as unfinished until that PR
   merges too.
2. **Cherry-pick; do not merge `main` into `develop`.** The branches share only an old merge base,
   and `main` carries each release as one squashed commit of everything `develop` held at the time.
   A merge weighs that against `develop`'s individual commits plus everything added since —
   conflicting across the whole release, and able to revert newer work where git cannot tell the
   two apart.
3. **Most of what `git log develop..main` prints is expected.** Squash merging leaves every release
   commit permanently absent from `develop`, so they pile up forever. Two of the four entries it
   showed in August 2026 were real gaps. Without this note the list reads as a standing defect and
   gets "fixed" again — which is how the dangerous merge in point 2 gets attempted.

The release-PR section gains one line pointing at all of it, because that is where someone is
reading when it matters.

## New test file

`releasing_doc_test.dart`, not an addition to `ai_architecture_doc_test.dart` — that one guards
links *into* the architecture page, and nothing guarded this file's own. A checklist is read once
per release by someone working through it in order, so a dead link surfaces at the worst moment,
for the person least able to stop and dig.

Four checks: the file exists, the scan matched something, every relative path resolves, every
anchor exists. Same canary as its sibling, since a regex that stops matching turns the other checks
into loops over nothing that pass.

Mutations, all four caught:

| Mutation | |
|---|---|
| Reword the hotfix heading, leave the two links pointing at it | caught |
| Point a file link at something absent | caught |
| Break the architecture-page link | caught |
| Break the scan regex | caught by the canary |

## Checks

- `fvm flutter analyze` — `No issues found!`
- `fvm flutter test` — **1880 passed**, up exactly 4

## Note

This targets `feature/ai-assisted-meal-logging` because `docs/RELEASING.md` lives there — the same
constraint noted in #866. Until that branch reaches `develop`, the checklist and this correction
are not on the branch a release is actually cut from.
