### PR TITLE
docs: the research behind the privacy-policy spec

### DIFF
--- a/docs/privacy-fdc-reachability.md
+++ b/docs/privacy-fdc-reachability.md
@@ -1,0 +1,165 @@
+# Is the USDA FoodData Central path reachable at runtime?
+
+Research for [#868](https://github.com/simonoppowa/OpenNutriTracker/issues/868), on map [#867](https://github.com/simonoppowa/OpenNutriTracker/issues/867). Written 2026-08-27. Baseline: tag `v2.0.2` (commit `9ab14fe3`), which is what `main` is at. All line numbers below are `v2.0.2` unless stated otherwise.
+
+## Short answer
+
+**Not reachable. `api.nal.usda.gov` receives nothing from the released app under any condition — no setting, no flag, no fallback, no hidden screen.** The direct FDC client is instantiated on every launch and injected into `ProductsRepository`, but the one repository method that would use it, `getFDCFoodsByString`, has **zero callers anywhere in the tree** — not in `lib/`, not in tests, not in tooling. The trail breaks at exactly one line: the use case named `searchFDCFoodByString` calls `getSupabaseFoodsByString`, not `getFDCFoodsByString`. The "FDC" naming throughout the search stack is a label for *which corpus the results came from*, not for *which host was contacted*.
+
+The README's claim that a search "reaches that backend and stops there" is **accurate as written**. USDA FoodData Central is **not** a live recipient and does not belong on the recipients list.
+
+## What the direct client would send, if it were reached
+
+Establishing the payload first, because it is what would have to be disclosed if any hop connected.
+
+`FDCDataSource.fetchSearchWordResults` ([`fdc_data_source.dart:15-36`](../lib/features/add_meal/data/data_sources/fdc_data_source.dart)) builds its URL via `FDCConst.getFDCWordSearchUrl(searchString, Env.fdcApiKey)` (`fdc_data_source.dart:17-20`) and issues a plain `http.get` with a 10-second timeout (`fdc_data_source.dart:23`).
+
+`FDCConst.getFDCWordSearchUrl` ([`fdc_const.dart:168-178`](../lib/features/add_meal/data/dto/fdc/fdc_const.dart)) returns `Uri.https(_fdcBaseUrl, _fdcFoodSearchPath, queryParameters)`, which resolves to:
+
+```
+GET https://api.nal.usda.gov/fdc/v1/foods/search
+      ?query=<the user's raw search term>
+      &pageSize=20
+      &dataType=Foundation,SR%20Legacy
+      &sortOrder=asc
+      &api_key=<FDC_API_KEY>
+```
+
+Host `api.nal.usda.gov` is `fdc_const.dart:8`; path `/fdc/v1/foods/search` is `fdc_const.dart:9`; the five query parameters are `fdc_const.dart:11-25` and `fdc_const.dart:169-175`. The user's search term is passed through verbatim as `query`.
+
+The API key **is a single shared project key that identifies this app to USDA**, not a per-user credential. `Env.fdcApiKey` ([`env.dart:7-8`](../lib/core/utils/env.dart)) is an `envied` compile-time field read from `.env` (`FDC_API_KEY`, see `.env.example:2`), and release builds get it from a repository secret: `.github/workflows/default_workflow.yml:653` and `:807` pass `secrets.FDC_API_KEY` into `.github/actions/write-env-file/action.yml:22-33`. So every install of an official build would carry the same key, and USDA would see all traffic as one identified API consumer — the project's. Obfuscation (`obfuscate: true`) hides it from casual strings-dumping, not from the wire.
+
+Note the transport: `Uri.https` forces TLS, so this would not be a cleartext transfer. That is the only mitigating detail, and it is moot given the path is dead.
+
+## The trace, hop by hop
+
+### Hop 1 — the client is constructed and injected (this is real, and it is why the code *looks* live)
+
+- [`locator.dart:527`](../lib/core/utils/locator.dart) — `locator.registerLazySingleton<FDCDataSource>(() => FDCDataSource());`
+- [`locator.dart:479`](../lib/core/utils/locator.dart) — `() => ProductsRepository(locator(), locator(), locator())`, the second `locator()` resolving to the `FDCDataSource` above.
+- [`products_repository.dart:32`](../lib/features/add_meal/data/repository/products_repository.dart) — held as `final FDCDataSource _fdcDataSource;`, assigned in the constructor at `products_repository.dart:35-39`.
+
+Being a lazy singleton, the instance is not even built until first resolution — and since nothing resolves it beyond the `ProductsRepository` factory, construction is all that ever happens to it. `FDCDataSource`'s constructor performs no I/O ([`fdc_data_source.dart:11-14`](../lib/features/add_meal/data/data_sources/fdc_data_source.dart) is a logger field and a timeout constant).
+
+### Hop 2 — the only method that touches the client
+
+`ProductsRepository` has exactly one method referencing `_fdcDataSource`:
+
+- [`products_repository.dart:105-114`](../lib/features/add_meal/data/repository/products_repository.dart) — `getFDCFoodsByString(String searchString)`, calling `_fdcDataSource.fetchSearchWordResults(searchString)` at `products_repository.dart:106`, mapping via `MealEntity.fromFDCFood` at `:110`.
+
+The repository's other network methods do not touch it:
+
+- `getOFFProductsByString` (`products_repository.dart:41-66`) → `_offDataSource`
+- `getSupabaseFoodsByString` (`products_repository.dart:116-127`) → `_spBackendDataSource`
+- `getOFFProductByBarcode` (`products_repository.dart:129-133`) → `_offDataSource`
+
+### Hop 3 — the break. Nothing calls `getFDCFoodsByString`
+
+A full-tree search over the `v2.0.2` blob (`git grep -n "getFDCFoodsByString" v2.0.2 -- .`) returns exactly one line: the declaration itself at `products_repository.dart:105`. No caller in `lib/`, none in `test/`, none in `integration_test/`, none in `tool/`, none in any script.
+
+Callers of `ProductsRepository` methods across the whole of `lib/`, exhaustively:
+
+| Call site | Method called | Reaches |
+| :-- | :-- | :-- |
+| [`search_products_usecase.dart:60`](../lib/features/add_meal/domain/usecase/search_products_usecase.dart) | `getOFFProductsByString` | Open Food Facts |
+| [`search_products_usecase.dart:82`](../lib/features/add_meal/domain/usecase/search_products_usecase.dart) | `getSupabaseFoodsByString` | Supabase |
+| [`meal_detail_bloc.dart:140`](../lib/features/meal_detail/presentation/bloc/meal_detail_bloc.dart) | `getOFFProductByBarcode` | Open Food Facts |
+| [`meal_detail_bloc.dart:199`](../lib/features/meal_detail/presentation/bloc/meal_detail_bloc.dart) | `getOFFProductByBarcode` | Open Food Facts |
+| [`search_product_by_barcode_usecase.dart:50`](../lib/features/scanner/domain/usecase/search_product_by_barcode_usecase.dart) | `getOFFProductByBarcode` | Open Food Facts |
+
+`getFDCFoodsByString` appears in no row. That is the whole finding.
+
+### Hop 4 — the decisive line: the "FDC" use case searches Supabase
+
+This is the single line that makes the name misleading and the path dead, and it is where anyone grepping for "FDC" would go wrong:
+
+[`search_products_usecase.dart:72-87`](../lib/features/add_meal/domain/usecase/search_products_usecase.dart)
+
+```dart
+Future<SearchProductsResult> searchFDCFoodByString(
+  String searchString, {
+  bool skipRemote = false,
+}) async {
+  if (skipRemote) {
+    return _buildResult(searchString, const [],
+        remoteSkipped: true, cacheSource: MealSourceEntity.fdc);
+  }
+  final remote = await _safeRemoteCall(
+    'FDC',
+    () => _productsRepository.getSupabaseFoodsByString(searchString),   // <- line 82
+  );
+  ...
+}
+```
+
+The method is called `searchFDCFoodByString`, the log label passed to `_safeRemoteCall` is the string `'FDC'` (`:81`), and the cache tag is `MealSourceEntity.fdc` (`:78`, `:86`) — but the closure at `search_products_usecase.dart:82` calls `getSupabaseFoodsByString`. Every user-visible "FDC" search in the released app is a Supabase query.
+
+`MealEntity.fromSpFood` documents the same aliasing from the other end ([`meal_entity.dart:219-223`](../lib/features/add_meal/domain/entity/meal_entity.dart)): *"All Supabase backend foods keep the fdc source tag ... `fdc` here means 'reference food database' as opposed to OFF/custom"*, because `MealSourceDBO` is persisted in Hive and a per-source enum value would need a data migration. The real origin travels in `backendSource`.
+
+### Hop 5 — bloc and UI, for completeness (they end at Supabase)
+
+- [`food_bloc.dart:43`](../lib/features/add_meal/presentation/bloc/food_bloc.dart) — `RefreshFoodEvent` handler → `searchFDCFoodByString`
+- [`food_bloc.dart:86`](../lib/features/add_meal/presentation/bloc/food_bloc.dart) — `_loadFood` (shared by `LoadFoodEvent` and the debounced `SearchFoodInputChangedEvent`, `food_bloc.dart:28-34`) → `searchFDCFoodByString`
+- [`locator.dart:285`](../lib/core/utils/locator.dart) — `FoodBloc` factory
+- [`add_meal_screen.dart:51`](../lib/features/add_meal/presentation/add_meal_screen.dart) — Add Meal screen resolves `FoodBloc`; the search box is `MealSearchBar` at `add_meal_screen.dart:112-117`, results rendered at `:298-330`, manual refresh at `:142-144`
+- [`food_search_tab_view.dart:55`](../lib/features/recipes/presentation/widgets/food_search_tab_view.dart) — the recipe-builder food search resolves the same bloc
+
+Both user-reachable search surfaces therefore terminate at Supabase via hop 4. They never re-enter `ProductsRepository` by any other route.
+
+### Hop 6 — the other candidate paths, checked individually
+
+- **Barcode scan.** [`search_product_by_barcode_usecase.dart:50`](../lib/features/scanner/domain/usecase/search_product_by_barcode_usecase.dart) → `getOFFProductByBarcode` → Open Food Facts only. There is no FDC barcode lookup in the codebase (the `fdc_branded` corpus that carries barcodes lives in Supabase, and its barcode column is `SPConst.foodBarcode`, [`sp_const.dart:27`](../lib/features/add_meal/data/dto/sp/sp_const.dart)).
+- **Settings → Food databases.** The toggles filter the Supabase query server-side — [`sp_food_data_source.dart:80-88`](../lib/features/add_meal/data/data_sources/sp_food_data_source.dart) reads them and `:102` / `:176` apply them as `inFilter(SPConst.foodSource, enabledSources)`. Enabling `fdc_foundation` or `fdc_branded` selects **rows in Supabase**, it does not switch on a USDA call. Disabling every source short-circuits to an empty list without any request (`sp_food_data_source.dart:36-39`).
+- **Fallback on failure.** `_safeRemoteCall` ([`search_products_usecase.dart:104-118`](../lib/features/add_meal/domain/usecase/search_products_usecase.dart)) catches a failed remote search and returns `const []` — it falls back to *local* results (custom meals, recipes, intake history, the 90-day cache, `search_products_usecase.dart:155-198`). There is no secondary remote source and no retry against a different host. A Supabase outage produces fewer results, never a USDA request.
+- **Meal detail / logging an intake.** `HydrateMealEvent` returns immediately unless `meal.source == MealSourceEntity.off` ([`meal_detail_bloc.dart:126-131`](../lib/features/meal_detail/presentation/bloc/meal_detail_bloc.dart)). `_refreshCacheForSelectedMeal` explicitly routes non-OFF meals to a local cache-timestamp touch with no network at all (`meal_detail_bloc.dart:190-197`, and the comment at `:185-189` names FDC as one of the "everything else" cases).
+- **Custom food import / QR meal share.** `import_meal_scanner_screen.dart` and `edit_meal_screen.dart` reference `fdc` only as the persisted `MealSourceEntity` enum value; neither holds a `ProductsRepository`.
+- **Tests.** [`products_repository_ranking_test.dart:82`](../test/features/add_meal/data/repository/products_repository_ranking_test.dart) constructs a real `FDCDataSource()` to satisfy the constructor's positional argument, then only ever exercises `getOFFProductsByString`. Even the test suite never calls the method.
+
+## The `fdc.nal.usda.gov` URLs are attribution links, not API calls
+
+Easy to conflate with the above; they are a different question and a different (much smaller) disclosure.
+
+There are two distinct USDA hosts in the codebase:
+
+| Constant | Value | Nature |
+| :-- | :-- | :-- |
+| `FDCConst._fdcBaseUrl` ([`fdc_const.dart:8`](../lib/features/add_meal/data/dto/fdc/fdc_const.dart)) | `api.nal.usda.gov` | The **API**. Unreachable, per the trace above. |
+| `FDCConst.fdcWebsiteUrl` ([`fdc_const.dart:5`](../lib/features/add_meal/data/dto/fdc/fdc_const.dart)) | `https://fdc.nal.usda.gov/fdc-app.html#` | A **public website**, opened in the user's browser. |
+| `SPConst.foodSourceWebsites` ([`sp_const.dart:105-113`](../lib/features/add_meal/data/dto/sp/sp_const.dart)) | `https://fdc.nal.usda.gov` for the four `fdc_*` sources | Source **attribution**, opened in the user's browser. |
+
+The `sp_const.dart` map is the one flagged in the ticket. It is provenance metadata for rows that were **ingested into Supabase ahead of time** (see [`docs/supabase-self-hosting.md:17-18`](supabase-self-hosting.md)) — it records where a row *came from*, and it is used to build a "learn more" link. It never becomes a request the app makes. `SPConst.fdcSourcePrefix` (`sp_const.dart:57`) exists for the same reason: to decide whether a food has a public detail page worth linking to.
+
+Where those links surface, both via `url_launcher` with `LaunchMode.externalApplication`, i.e. handing the URL to the system browser:
+
+- [`meal_info_button.dart:55-61`](../lib/features/meal_detail/presentation/widgets/meal_info_button.dart) — the info button on a meal detail. For a Supabase FDC food the URL is `MealEntity.url`, built at [`meal_entity.dart:210-212`](../lib/features/add_meal/domain/entity/meal_entity.dart) from `FDCConst.getFoodDetailUrlString(foodItem.sourceCode)` — a `fdc.nal.usda.gov` detail page for the ingested row's original id. Launch at `meal_info_button.dart:94-99`.
+- [`food_sources_screen.dart:85-87`](../lib/features/settings/presentation/widgets/food_sources_screen.dart) — the info icon beside each toggle in Settings → Food databases, using `SPConst.foodSourceWebsites`. Launch helper at `food_sources_screen.dart:54-57`.
+
+So: a user who taps an info button causes **their browser** to visit `fdc.nal.usda.gov`. The app itself sends nothing, sends no search term, and sends no key. That is a user-initiated navigation to a public page, of the same kind as the existing Open Food Facts and Sentry-policy links, not a transfer by the app.
+
+(`MealEntity.fromFDCFood` at [`meal_entity.dart:184-200`](../lib/features/add_meal/domain/entity/meal_entity.dart) also builds a `fdc.nal.usda.gov` URL at `:191`, but that factory is only called from `products_repository.dart:110` — inside the dead method — so it never runs either.)
+
+## Feature branch vs. v2.0.2
+
+**No difference.** Diffing `v2.0.2..HEAD` (`6cc0efe8`, `feat/own-server-settings` with the AI-meal-logging feature branch merged in) across `fdc_data_source.dart`, `lib/features/add_meal/data/dto/fdc/`, `products_repository.dart`, `search_products_usecase.dart` and `locator.dart` returns an empty diff — those five files are byte-identical. A fresh grep for `getFDCFoodsByString` on the working tree still finds only the declaration at `products_repository.dart:105`. The unreleased AI work adds providers, but it did not wire up FDC and did not disturb the break at `search_products_usecase.dart:82`.
+
+## What keeps it unreachable — and how fragile that is
+
+Nothing structural. It is unreachable for exactly one reason: **no line of code calls the method.** There is no compile-time guard, no feature flag, no build variant, no `assert`, no dead-code elimination that would complain. Specifically:
+
+- The data source is registered unconditionally at `locator.dart:527`, so it is always available to anything that asks.
+- The `FDC_API_KEY` secret is still injected into every official release build (`default_workflow.yml:653`, `:807`), so a live key ships in the binary today.
+- Dart's analyzer will not flag `getFDCFoodsByString` as unused: it is a public method on a public class.
+- The name collision is actively misleading. A future contributor asked to "make the FDC search work offline-first" would reasonably find `searchFDCFoodByString` and `getFDCFoodsByString` and assume they belong together. Swapping `getSupabaseFoodsByString` for `getFDCFoodsByString` at `search_products_usecase.dart:82` is a one-token edit that would silently make USDA a live recipient on the app's primary search path.
+
+The repo's own docs already record the state — [`AGENTS.md:389`](../AGENTS.md) lists the direct FDC source as *"not actively surfaced in the UI"* and `AGENTS.md:110` says the key is *"not actively used in UI"* — but a note in a contributor guide is not a mechanism.
+
+## What this means for the policy
+
+**USDA FoodData Central is not a live recipient and must not be added to the recipients list.** On `v2.0.2`, and on the current feature-branch HEAD, no user action of any kind causes the app to contact `api.nal.usda.gov`. Adding USDA to the iubenda documents would state a transfer that does not occur — which the map identifies as its own kind of untruth. The live network recipients for search remain Open Food Facts and the Supabase backend, plus Sentry on opt-in.
+
+**The README's claim is accurate as written.** *"Those datasets are ingested into the Supabase backend ahead of time ... so a search reaches that backend and stops there"* ([`README.md:139`](../README.md)) is exactly what the trace shows: the "FDC" search path terminates at Supabase at `search_products_usecase.dart:82`. The "Three destinations, nothing else" table at `README.md:131-137` is complete for the released app. The apparent contradiction that opened this ticket — live-looking wiring at `locator.dart:527` and `products_repository.dart:32` versus the README's claim — resolves in the README's favour: the wiring is real, the call is not.
+
+Two things that are *not* settled by this finding, and belong to the adjudication and rendering tickets rather than here:
+
+1. **The attribution links are a separate, minor question.** Tapping the info button on a meal detail or in Settings → Food databases opens `fdc.nal.usda.gov` in the user's browser (`meal_info_button.dart:94-99`, `food_sources_screen.dart:54-57`). Whether outbound links to third-party websites warrant a mention is a policy-drafting judgement, not a transfer by the app; the same question applies equally to the existing Open Food Facts, BLS, and iubenda links, so it should be decided once for all of them rather than for USDA specially.
+2. **A shipped-but-unused key is a code-hygiene finding, not a policy one.** `FDC_API_KEY` is still injected into release builds. Removing the dead method, the data source, its locator registration and the CI secret would close the one-refactor-away gap described above, and would let the "FDC" naming be renamed to something honest (`searchBackendFoodByString`). That is a PR, and per this map's scope it belongs to a ticket of its own.

--- a/docs/privacy-iubenda-expressiveness.md
+++ b/docs/privacy-iubenda-expressiveness.md
@@ -1,0 +1,464 @@
+# What can iubenda be made to express, and are EN and DE one config or two?
+
+Research for [#871](https://github.com/simonoppowa/OpenNutriTracker/issues/871), on
+map [#867](https://github.com/simonoppowa/OpenNutriTracker/issues/867). Researched
+2026-08-27 against iubenda's own help centre and changelog, the documented public
+read API, and the two live policy documents (`53501884` EN, `53922100` DE) plus one
+unrelated live iubenda policy used as a worked example.
+
+**The short answer: the generator can say almost anything, but only in the wrong
+shape.** Two of the missing recipients are already in the catalogue as first-class
+services (`OpenAI API`, and `Supabase` / `Supabase (self-hosted)`); the rest have to
+go through the *custom service* mechanism, which is a service name plus one free-text
+box. Free text buys unlimited wording — including conditionality, which the structured
+catalogue cannot express at all — but it is paid for by leaving the machine-readable
+spine of the document: a custom service renders as prose with **no** *"Personal Data
+processed:"* line and **no** *"Place of processing:"* line. And the two document IDs
+are, unavoidably, two records — iubenda gives every language its own policy ID — but
+they may or may not be *linked* translations that propagate edits to each other, and
+that distinction is invisible from outside the dashboard.
+
+---
+
+## 1. Does the catalogue carry Open Food Facts, a self-hosted Supabase, or the AI providers?
+
+**Two yes, three not found.** iubenda does not publish a complete browsable catalogue,
+so this had to be answered from the generator's own legal changelog, which announces
+each service as it is added.
+
+**OpenAI is in, and has been since 2023.** From the *Privacy and Cookie Policy
+Generator – Legal Changelog*, week of 12–16 June 2023:
+
+> We've added a new hosting and backend infrastructure service to our Privacy and
+> Cookie Policy Generator: OpenAI API
+
+**Supabase is in, in both flavours, including the self-hosted one.** Week of
+23–27 June 2025:
+
+> We've added the following new hosting and backend services: Supabase, Supabase
+> (self-hosted)
+
+and, in the same entry:
+
+> We've added the following new registration and authentication services: Supabase
+> Auth, Supabase Auth (self-hosted)
+
+That is directly load-bearing: the *"(self-hosted)"* suffix is an established house
+convention in the catalogue, not a one-off — the same changelog carries `n8n
+(self-hosted)`, `WordPress (self-hosted)`, `RudderStack (self-hosted)`, `GrowthBook
+(self-hosted)`, `Piwik PRO Analytics Suite (self-hosted)`, `Piwik PRO Customer Data
+Platform (self-hosted)` and `vtenext Business (self-hosted)`. So the backend this
+project operates is not a service iubenda has never heard of. It has a catalogue entry
+built for exactly the case where the developer runs the instance.
+
+**Anthropic, OpenRouter and Open Food Facts: not found, but "not found" is weaker than
+it looks.** The changelog contains no occurrence of *Anthropic*, *Claude*,
+*OpenRouter*, *Hugging Face*, *Mistral*, *Vertex*, *Cohere*, *Groq*, *Replicate*,
+*Ollama*, *Azure OpenAI*, or *Food*. Two caveats make this evidence rather than proof:
+
+- The changelog's oldest entry is *Week January 10-14, 2022* and its newest is
+  *Week 21 July – 25 July 2025*. It is 241 weekly entries covering roughly three and a
+  half years, and it has not been added to for about thirteen months as of today.
+  Anything added since July 2025 would not appear.
+- The [alphabetical service guide](https://www.iubenda.com/en/help/20713-individual-services/)
+  is explicitly partial and cannot be used as a catalogue index either:
+  > The list is not yet complete (as creating posts for each of the 1700+ posts takes
+  > quite some time), but we will continue to update as we go along.
+
+**What would settle it: typing each name into the generator's own service search in
+the dashboard.** That is a thirty-second check for whoever holds the account and it is
+the only authoritative answer; no public surface exposes the catalogue for querying.
+Note also that the catalogue is claimed at *"over 1700"* on one page and *"over
+2,000"* on another, so even iubenda's own marketing copy is not a stable index of it.
+
+## 2. What is the mechanism for a service iubenda has never heard of?
+
+**A "custom service": a name, one free-text box, and an optional purpose tag.** That is
+the whole of it. From
+[*How to Add a Custom Service and Customize to Your Needs*](https://www.iubenda.com/en/help/386-how-to-add-a-custom-service-and-customize-to-your-needs/):
+
+> The "custom service" is simply a clause that contains details of an additional data
+> collection activity that you participate in, written in your own words
+
+The **mandatory** fields are exactly two:
+
+> **Service name.** Here you enter the title of your custom service. Try to make it
+> precise but brief.
+
+> **Privacy Policy.** This is where you'll describe the types of data you are
+> collecting, who this data is being shared with and if it's a third party service (if
+> there is a third party involved, you'll need to include their headquarters – e.g.
+> Germany – and privacy policy).
+
+**Read that second quote carefully — it is the finding.** iubenda instructs you to put
+the data types, the recipient, and the recipient's *headquarters* into **prose**. There
+is no structured field for either. For a catalogue service, iubenda holds those as
+data and renders them as fixed lines; for a custom service, they are whatever sentence
+you typed.
+
+**The optional *Purpose* field controls placement, not structure:**
+
+> This field allows you to assign a purpose to your custom service with a simple
+> click. [...] It includes a drop-down list of over 40 purposes
+
+> Another great benefit of applying this option is that it allows the custom services
+> it's applied to, to be displayed alongside all other services in your policy (instead
+> of being positioned in a separate section).
+
+> The default value of "No specific purpose" will apply if a purpose is not assigned.
+> If you did not assign a purpose to your custom service, you'll find the data
+> collection practices outlined in a highlighted area of the privacy policy called
+> "Further Information about Personal Data".
+
+So an untagged custom service is quarantined into a trailing section; a tagged one sits
+under a real purpose heading among the catalogue services.
+
+### Does a custom entry render into the personal-data-categories list and the place-of-processing list?
+
+**No — and this is confirmed against a live document, not inferred.** The help centre
+never states it, so it was checked against a real iubenda policy that uses both
+mechanisms side by side:
+[TruTech Tools, LTD.](https://www.iubenda.com/app/privacy-policy/62541747/legal?from_cookie_policy=true).
+
+A catalogue service immediately above renders with the structured spine intact:
+
+> **HubSpot Chat (HubSpot Germany GmbH)**
+> HubSpot Chat is a service for interacting with the HubSpot live chat platform
+> provided by HubSpot Germany GmbH.
+> Personal Data processed: Data communicated while using the service; Trackers; Usage
+> Data. Place of processing: Germany – Privacy Policy.
+
+The custom service immediately below it, under the same purpose heading, renders with
+neither line:
+
+> **AI Chat Data (App and Website)**
+> This application and website include AI‑powered chat features that allow users to
+> submit free‑text questions. User inputs are processed by third‑party service
+> providers to generate responses and support customer interactions.
+> For the mobile application, chat data is transmitted to Anthropic, which processes
+> the data as a data processor for the purpose of generating AI responses.
+
+No *"Personal Data processed:"*. No *"Place of processing:"*. Multi-paragraph free text
+is clearly supported. The same document's *Further information about the processing of
+Personal Data* section carries four more custom clauses (`AirCall`, `Barcode
+Scanning`, `SearchSpring`, `User Account (Creation and Deletion)`), one of which runs
+to seven numbered headings of the owner's own prose — so the box takes a great deal of
+text, unstructured.
+
+**Consequence for this app's documents.** The top-of-policy summary — on
+[53501884](https://www.iubenda.com/privacy-policy/53501884) it reads
+
+> Among the types of Personal Data that this Application collects, by itself or through
+> third parties, there are: Usage Data; Storage permission; Reminders permission;
+> Camera permission, without saving or recording; diagnostics; email address; app
+> information; device logs; device information; Data communicated while using the
+> service.
+
+— is assembled from the structured fields of catalogue services. A custom service has
+no structured fields, so **anything declared only as a custom service will not appear
+in that list**, however carefully its prose is written. That is not stated in
+iubenda's documentation; it follows from the form having no such field and is
+consistent with every live rendering examined. **If a build ticket depends on a data
+category reaching the summary list, that is worth a written question to iubenda
+support before the work is scheduled.**
+
+**Cost:** custom services require a paid tier.
+
+> All pre-built clauses are available on every tier. Custom clauses are available on
+> Advanced and Ultimate plans.
+
+> If you have a Pro or Ultra license, you have full access to all services (unlimited
+> clauses) for the duration of your license.
+
+The account is at least Pro-equivalent: the read API returns `403` with *"To access
+this privacy policy via API, convert it to Pro"* for non-Pro documents, and
+`53501884` returns `200`. (The two help pages disagree slightly — *"With a PRO
+license you can add as many custom services as you need"* on one, *"Advanced and
+Ultimate"* on the other — which is legacy-vs-current pricing, not a contradiction that
+affects this account.)
+
+**One translation caveat, which matters here specifically:** custom services are the
+one thing that does *not* propagate between languages. See §4.
+
+## 3. Can a recipient be declared conditional?
+
+**Not by the catalogue. Only by free text — which means only as a custom service.**
+
+This is the load-bearing question and the documentation answers it by omission, so it
+needs stating precisely.
+
+**What a catalogue service can express is fixed and unconditional.** Every rendering
+examined, in both languages, is the same three-part template: a name and provider, a
+one-sentence description iubenda wrote, then *"Personal Data processed: …"* and
+*"Place of processing: …"*. There is no toggle, no qualifier, no "if enabled" slot.
+The help centre documents no per-service conditionality option anywhere, and the
+per-policy options that do exist —
+[*Picking the right privacy policy options*](https://www.iubenda.com/en/help/5858-switch-privacy-policy-options/)
+— are about *whether a practice occurs at all* (profiling, automated decision-making,
+the legal basis for transfers abroad), not about whether a given user triggers it. The
+closest thing the catalogue has to conditionality is the transfer clause
+*"Data Transfer abroad based on consent"*, and that qualifies the **legal basis**, not
+the **occurrence**.
+
+**What free text can express is anything, and the worked example above proves it in
+practice.** The TruTech clause is already a conditional description of an AI
+recipient — *"AI‑powered chat features that allow users to submit free‑text
+questions"*, then Anthropic named as the recipient of what those users submit. Nothing
+in the mechanism stops a clause reading, in the owner's own words, that a provider
+receives data only where the user has enabled the feature and supplied their own
+credential, and receives nothing otherwise.
+
+**So the honest formulation is: the AI providers can be described truthfully, but only
+by giving up the structured listing for them.** A custom clause can carry the
+conditionality, the user-supplied-key detail, and the fact that the endpoint address is
+never known to the project. What it cannot do is put those providers in the same
+machine-readable shape as TestFlight and Sentry, because that shape has no room for the
+qualifier. There is no third option in the generator.
+
+**What the documentation does not answer, and what would:** whether iubenda's legal
+team considers a conditional custom clause an acceptable substitute for a service
+entry under GDPR Art. 13/14, and whether a recipient the *user* chooses and
+authenticates is a recipient of the *owner's* processing at all. Both are legal
+questions about the drafting, not questions about the tool, and both want a written
+answer from iubenda support (or the project's own reading recorded as a decision) —
+they cannot be resolved by reading the help centre.
+
+## 4. Are two IDs necessarily two independent configurations?
+
+**Two IDs are unavoidable; two independent *configurations* are not — but which of the
+two situations these documents are in cannot be determined from outside.**
+
+**iubenda has no single-ID multilingual policy.** The creation API's documented output
+is a list, one entry per language, each with its own `id` and its own `policy_url`:
+
+> `"privacy_policies" => [ // hashing array, one for each privacy policy that was
+> added, each hash has the following structure: { "id" => … "lang" => … "policy_url"
+> => … } ]`
+
+and its own example returns exactly that shape for a policy with `"lang" => "it"`. So
+`53501884` and `53922100` being separate numbers proves nothing either way — a *linked*
+German translation of the English policy would also have its own number.
+
+**iubenda does support one policy source rendered in several languages, and edits
+propagate.** From
+[*How to Add Another Language to Your Documents*](https://www.iubenda.com/en/help/137-add-language/):
+
+> Any change made in any language of the privacy policy/terms and conditions will be
+> automatically added to the other languages (except, as anticipated a little earlier,
+> any custom services).
+
+and the dedicated FAQ,
+[*Must I Repeat the Process of Adding Services for Every Language…*](https://www.iubenda.com/en/help/3803-must-i-repeat-the-process-of-adding-services-for-every-language-in-which-i-generate-the-policy),
+answers its own title:
+
+> If you own a multilingual site or app **it is not necessary** to do so.
+
+> the same data controller and the same list of services of the "original" version,
+> except for any custom services that you may have written, which, as it was written by
+> you, will have to be recreated by you for the new language.
+
+Available languages are:
+
+> Czech, Danish, Dutch, US English, UK English, French, German, Greek, Italian, Polish,
+> Portuguese, Brazilian Portuguese, Russian, Spanish, or Swedish
+
+German is among them. Adding a language is a button —
+*"Add language" in the "Manage languages" box on the edit page"* — so if the two
+documents are **not** currently linked, there is a supported destination to migrate
+toward, though the docs describe adding a language to an existing document, not
+merging two existing documents. **Whether an already-separate German document can be
+folded into the English one's language set, as opposed to being deleted and re-added
+as a translation (which would change its public ID and break every link to
+`53922100`), is not documented. That is a question for iubenda support in writing, and
+it should be asked before anyone plans the migration.**
+
+**What the live URLs show.** Both were fetched and compared:
+
+- No `hreflang`, no alternate-language `<link>`, no language switcher in either
+  document. Each `<link rel="canonical">` points at itself:
+  `…/privacy-policy/53501884` and `…/privacy-policy/53922100`. The only cross-document
+  links are to *iubenda's own* policy, localised (`65675001` from EN, `45483222` from
+  DE) — nothing to do with this project.
+- `/privacy-policy/53501884/legal` and `/…/full-legal` both return `200`, but they are
+  **rendering variants of the same document in the same language** — `/legal` serves
+  `<html lang="en">` with the same `<h1>`. There is no language variant at a path.
+- The two documents are currently **in perfect sync**: identical section structure,
+  the same five services (TestFlight, Google Play Beta Testing, Sentry, Google Play
+  Store, App Store Connect), the same three device permissions, and the same stamp —
+  *"Latest update: June 10, 2026"* / *"Letzte Aktualisierung: 10. Juni 2026"*. Only the
+  ordering of purpose headings differs, and that is alphabetisation per language
+  (EN puts *Infrastructure monitoring* before *Platform services and hosting*; DE puts
+  *Plattform-Dienste und Hosting* before *Überwachung der Infrastruktur*).
+
+**That sync is consistent with linked translations and equally consistent with
+disciplined manual duplication, so it settles nothing.** The distinction is visible in
+one place only: the *Manage languages* box on the document's edit page in the
+dashboard. **Whoever holds the account can answer this in one look, and the map should
+treat it as an open fact rather than assume either way.**
+
+**The one thing that is certain either way:** even under a linked multilingual setup,
+*custom services do not propagate*. Every clause written for Open Food Facts, for a
+user-run endpoint, or for an AI provider will have to be written **twice**, once in
+English and once in German, and will drift independently thereafter. iubenda offers
+only a *"Specify service translations"* checkbox on the custom-service form —
+> By checking the "Specify service translations" box, you can localize the custom
+> service and use a different name and description based on the languages in which you
+> are generating your policy.
+
+— which is a manual second text box, not a translation. Its own advice is to use DeepL
+or Google Translate and then *"consult with a native to make sure that the
+translations are ok"*.
+
+## 5. The last-updated date, and version history
+
+**The date is automatic on edit, with a manual override; there is no version history.**
+
+From
+[*How to Force Update & Change the "Last updated" Date Information*](https://www.iubenda.com/en/help/4158-force-update-and-changing-the-last-updated-date-information):
+
+> Whenever you change your privacy policy and terms & conditions in our generator, this
+> is not needed. In those cases (in 99.9% of cases), the generator takes care of this
+> for you.
+
+There are exactly two ways to move it:
+
+> (1) You can change your privacy policy/terms and conditions by adding something new
+> or by removing something from your existing document
+
+> (2) We've made a dedicated button for this exact use case
+
+which
+
+> will flush the cache and update the date on your privacy policy/terms and conditions
+> to now/today.
+
+and lives at *Dashboard > [your website] > Edit > Advanced Settings*.
+
+**Version history: absent from the documentation entirely.** Neither the force-update
+page nor [*How to Edit a Privacy Policy*](https://www.iubenda.com/en/help/2739-edit-privacy-policy/)
+mentions retained versions, an archive, diffs, or a citable previous revision;
+2739 says only that
+
+> Changes are often required and can be done anytime
+
+**This is a genuine gap, not an inference.** No iubenda help page examined states
+either that history is kept or that it is discarded. What the generated policy itself
+promises the user is a *date*, not a history — from `53501884`:
+
+> It is strongly recommended to check this page often, referring to the date of the
+> last modification listed at the bottom.
+
+**What would answer it: a question to iubenda support in writing.** Until then, the
+only linkable record of what the policy said on a given day is a third-party archive
+(e.g. the Wayback Machine), which is outside iubenda and outside the project's control.
+If the map wants users to be able to see *what changed* — as opposed to *that
+something changed* — that capability has to be built somewhere other than iubenda, for
+example a changelog in this repository that the policy links to.
+
+## 6. Export or API for reviewing the configuration as text
+
+**There is a public read API, and it returns the rendered document — not the
+configuration.** From
+[*Adding iubenda's Privacy Policy to Your Site: Direct Text Embedding and API*](https://www.iubenda.com/en/help/78-privacy-policy-direct-text-embedding-api/),
+three endpoints:
+
+- `https://www.iubenda.com/api/privacy-policy/:public_id`
+- `https://www.iubenda.com/api/privacy-policy/:public_id/only-legal`
+- `https://www.iubenda.com/api/privacy-policy/:public_id/no-markup`
+
+with the response shape
+
+> `{ :success => true, :content => "… privacy policy content …" }`
+
+and, for documents below the required tier,
+
+> `{ :success => false, :error => "To access this privacy policy via API, convert it to
+> Pro" }`
+
+**Verified live on 2026-08-27.** `GET https://www.iubenda.com/api/privacy-policy/53501884`
+returns `{"success":true,"content":"…"}` with the policy's HTML, and the `/no-markup`
+variant returns the same text in a lighter wrapper. So both documents *can* be diffed
+and reviewed as text without touching the dashboard, and both can be pulled by CI.
+
+**But `content` is HTML, not structure.** It is the rendered output, so a review
+against it reads the same sentences a user reads. That is the right artefact for
+checking *what the policy says*; it is not an export of *which services are ticked,
+with which purposes and data categories*. Nothing in the public documentation exposes
+the latter:
+
+- The [creation API](https://www.iubenda.com/en/help/61591-api-docs-create-and-recall-a-privacy-policy/)
+  is titled *"create and recall"* but documents only `POST api/transactions` with
+  `type => create_privacy_policy`. There is no documented `GET` for a policy's
+  configuration.
+- iubenda ships an MCP connector for Claude and ChatGPT with
+  > 28 tools your assistant can use, from setting up a site to running scans
+
+  advertising *"Check what's already set up on my site"* and *"Add Google Analytics to
+  my policy"*. **Whether any of those 28 tools returns a configuration as structured
+  data is not stated on the public page, and the tool list is not published.** That is
+  the one plausible route to a JSON view of the configuration, and it would take either
+  reading iubenda's connector documentation once connected, or a question to support,
+  to know.
+
+The generated pages also carry a *"Download PDF"* control, which is an export for a
+human reader and not a reviewable diff.
+
+---
+
+## What this constrains
+
+**#867's downstream questions that are now bounded:**
+
+- **"Add the missing processors" is two different jobs, not one.** The self-hosted
+  Supabase backend can be a proper catalogue service with a structured
+  *Personal Data processed* / *Place of processing* line, because
+  `Supabase (self-hosted)` exists. Anything not in the catalogue cannot, and drops to
+  prose. Confirm each name in the dashboard's service search before scoping the work —
+  that check costs seconds and changes what the ticket is.
+- **The AI providers cannot be described truthfully *and* structurally.** Any spec that
+  assumes a "conditional recipient" checkbox is specifying something the generator does
+  not have. The choice is a free-text custom clause that says the true, conditional
+  thing but sits outside the structured lists, or a catalogue entry that lists the
+  provider unconditionally and is therefore false for the ~all users who never enable
+  the feature. That is a decision for the map, and it should be taken explicitly rather
+  than discovered during implementation.
+- **Whatever is added as a custom service is added twice and drifts.** Any correction
+  plan must carry an EN and a DE version of every custom clause, and must expect them
+  to diverge over time. Catalogue services do not have this problem — those propagate.
+- **"Migrate to one multilingual source" is not yet a scopeable ticket.** It rests on
+  two unknowns: whether `53501884` and `53922100` are already linked (one look at the
+  dashboard), and whether two separate documents can be merged without re-issuing the
+  German public ID (a question to iubenda support). The second one has a real cost
+  attached — a changed ID breaks every existing link to the German policy, including
+  any already shipped in the app or on the store listings.
+- **"Point users at what changed" cannot be satisfied by iubenda.** The generator
+  offers a date and, undocumented, possibly nothing else. If the map wants a citable
+  history, it has to live in this repository.
+- **Review-as-text is solved, review-as-configuration is not.** Both documents are
+  fetchable as text over a public API today, so a corrected policy can be diffed in
+  CI. Verifying the *configuration* behind it still means clicking through the form,
+  unless the MCP connector turns out to expose it.
+
+---
+
+## Sources
+
+- [How to Add a Custom Service and Customize to Your Needs — iubenda help](https://www.iubenda.com/en/help/386-how-to-add-a-custom-service-and-customize-to-your-needs/)
+- [How to Add Services to Your Privacy Policy — iubenda help](https://www.iubenda.com/en/help/20-services-privacy-policy/)
+- [Privacy and Cookie Policy Generator – Legal Changelog — iubenda help](https://www.iubenda.com/en/help/30061-pcp-legal-changelog/)
+- [Compliance for Individual Services — iubenda help](https://www.iubenda.com/en/help/20713-individual-services/)
+- [How to Add Another Language to Your Documents — iubenda help](https://www.iubenda.com/en/help/137-add-language/)
+- [Must I Repeat the Process of Adding Services for Every Language…? — iubenda help](https://www.iubenda.com/en/help/3803-must-i-repeat-the-process-of-adding-services-for-every-language-in-which-i-generate-the-policy)
+- [How to Force Update & Change the "Last updated" Date Information — iubenda help](https://www.iubenda.com/en/help/4158-force-update-and-changing-the-last-updated-date-information)
+- [How to Edit a Privacy Policy — iubenda help](https://www.iubenda.com/en/help/2739-edit-privacy-policy/)
+- [Picking the right privacy policy options — iubenda help](https://www.iubenda.com/en/help/5858-switch-privacy-policy-options/)
+- [Adding iubenda's Privacy Policy to Your Site: Direct Text Embedding and API — iubenda help](https://www.iubenda.com/en/help/78-privacy-policy-direct-text-embedding-api/)
+- [API docs: create and recall a privacy policy — iubenda help](https://www.iubenda.com/en/help/61591-api-docs-create-and-recall-a-privacy-policy/)
+- [iubenda for Claude and ChatGPT](https://www.iubenda.com/en/iubenda-for-claude-and-chatgpt/)
+- [OpenNutriTracker privacy policy, English (53501884)](https://www.iubenda.com/privacy-policy/53501884)
+- [OpenNutriTracker privacy policy, German (53922100)](https://www.iubenda.com/privacy-policy/53922100)
+- [Privacy Policy of TruTech Tools, LTD. — live example of custom vs. catalogue rendering](https://www.iubenda.com/app/privacy-policy/62541747/legal?from_cookie_policy=true)
+
+**Not usable as sources:** `support.iubenda.com` forum threads (including the public
+requests to add Supabase and other services) redirect to an OAuth login and cannot be
+read without an account.

--- a/docs/privacy-permission-audit.md
+++ b/docs/privacy-permission-audit.md
@@ -1,0 +1,97 @@
+# Privacy permission audit — what the released build actually requests
+
+Research for [#872](https://github.com/simonoppowa/OpenNutriTracker/issues/872) on map [#867](https://github.com/simonoppowa/OpenNutriTracker/issues/867). Audited 2026-08-27 against tag `v2.0.2` (`9ab14fe3`), the released build.
+
+**Short answer: the policy overclaims on both entries. There is no storage permission of any kind — not in the app manifest, not injected by any plugin, not requested at runtime — and export/import goes through the Storage Access Framework, which by design needs none; "Storage permission" is false in every sense and should go. "Reminders permission" is a misnaming, not a fabrication: the app's own UI calls the feature "Daily Reminder", it is delivered by `flutter_local_notifications` over `POST_NOTIFICATIONS`, and no Reminders/EventKit API is touched on either platform. The transitive permissions the merged manifest does add — `CAMERA`, `VIBRATE`, `ACCESS_NETWORK_STATE` — appear in neither policy, so the same audit that removes an overclaim also uncovers three underclaims.**
+
+## Method
+
+Route taken: **a real merged manifest**, produced by the Android manifest merger in this checkout.
+
+`fvm flutter build apk --flavor full --debug` fails in this environment for an unrelated reason — `lib/core/utils/env.g.dart` is an `envied` codegen artifact that needs a `.env` the repo does not carry, so `:app:compileFlutterBuildFullDebug` dies before Gradle reaches the merge. The manifest merger does not depend on the Dart compile, so it was run directly instead:
+
+```
+./gradlew :app:processFullDebugMainManifest
+./gradlew :app:processFullReleaseMainManifest
+```
+
+Both succeeded. The `full` flavor is the public artifact (`develop` is the sideload flavor; there is no `production` flavor — see `android/app/build.gradle`). **The release and debug merges produce an identical permission set**, so nothing below is a debug-only artefact. Outputs read:
+
+- `build/app/intermediates/merged_manifest/fullRelease/processFullReleaseMainManifest/AndroidManifest.xml`
+- `build/app/intermediates/merged_manifest/fullDebug/processFullDebugMainManifest/AndroidManifest.xml`
+- `build/app/outputs/logs/manifest-merger-full-debug-report.txt` (per-permission attribution)
+
+Plugin manifests in `~/.pub-cache` and the `:app:dependencies` tree were used only to corroborate attribution, not as a substitute.
+
+## Android — the merged permission set at `v2.0.2`
+
+Eight `uses-permission` entries survive the merge (six real, one signature-level plumbing counted twice under a placeholder and a resolved application id).
+
+| Permission | Source | What needs it |
+| --- | --- | --- |
+| `android.permission.INTERNET` | app manifest, line 4 (also merged from `io.sentry:sentry-android-core:8.39.1` and `transport-backend-cct:2.3.3`) | food search, barcode lookup, Supabase/FDC, Sentry upload |
+| `android.permission.RECEIVE_BOOT_COMPLETED` | app manifest, line 6 | re-arming the scheduled daily reminder after a reboot (`ScheduledNotificationBootReceiver`) |
+| `android.permission.POST_NOTIFICATIONS` | app manifest, line 7 (also merged from `flutter_local_notifications`) | the daily reminder and the fasting-timer notification |
+| `android.permission.VIBRATE` | **injected** by `flutter_local_notifications` 19.5.0 (`android/src/main/AndroidManifest.xml:3`) | notification vibration; never requested by app code |
+| `android.permission.CAMERA` | **injected** by `mobile_scanner` 7.2.0 (`android/src/main/AndroidManifest.xml:3`) | barcode scanning; also gates `image_picker`'s `ImageSource.camera` path for meal/recipe/profile photos |
+| `android.permission.ACCESS_NETWORK_STATE` | **injected** transitively: `mobile_scanner` → `com.google.mlkit:barcode-scanning:17.3.0` → `play-services-mlkit-barcode-scanning:18.3.1` → `transport-backend-cct:2.3.3` | nothing the app calls; ML Kit's telemetry transport declares it |
+| `<applicationId>.DYNAMIC_RECEIVER_NOT_EXPORTED_PERMISSION` | **injected** by `androidx.core:core:1.18.0` | signature-level internal guard; not user-visible, not a privacy-relevant capability |
+
+Also merged, for completeness: `uses-feature android.hardware.camera` with `android:required="false"` (from `mobile_scanner`) — a Play-filtering hint, not a permission.
+
+**Not present anywhere in the merged manifest:** `READ_EXTERNAL_STORAGE`, `WRITE_EXTERNAL_STORAGE`, `MANAGE_EXTERNAL_STORAGE`, `READ_MEDIA_IMAGES`, `READ_MEDIA_VISUAL_USER_SELECTED`, `SCHEDULE_EXACT_ALARM`, `USE_EXACT_ALARM`, `READ_CALENDAR`/`WRITE_CALENDAR`. Grepping the merger report for `STORAGE`, `READ_MEDIA`, `ALARM`, `maxSdkVersion`, `REMINDER` and `CALENDAR` returns no permission hits — the only `STORAGE` matches are the plugin *name* `flutter_secure_storage`, and the only `ALARM` match is a datatransport `AlarmManagerSchedulerBroadcastReceiver` class name. There is no `maxSdkVersion`-gated legacy storage permission hiding in the merge either.
+
+`permission_handler` is not a dependency, and `grep -rn "permission_handler\|Permission\."` over `lib/` returns nothing. The only runtime permission request in the app is `NotificationService.requestPermission()` (`lib/core/utils/notification_service.dart:48`).
+
+## iOS — usage-description keys at `v2.0.2`
+
+`ios/Runner/Info.plist` declares exactly two, and a `grep` for `NS[A-Za-z]*UsageDescription` across `ios/` and `macos/` finds no others:
+
+| Key | Line | Declared purpose | Which plugin requires it |
+| --- | --- | --- | --- |
+| `NSCameraUsageDescription` | `ios/Runner/Info.plist:62` | "scan barcodes and to attach a photo to a custom meal…" | `mobile_scanner`, `image_picker_ios` (camera source) |
+| `NSPhotoLibraryUsageDescription` | `ios/Runner/Info.plist:64` | "attach a photo to a custom meal… and for exporting data" | `image_picker_ios` (gallery source) |
+
+**`NSRemindersUsageDescription` is absent, and nothing asks for it.** Grepping the iOS sources of `flutter_local_notifications` 19.5.0, `image_picker_ios`, `mobile_scanner`, `share_plus` and `file_picker` for `EKEventStore`, `EKReminder`, `EventKit` and `RemindersUsage` returns nothing. No plugin in the tree links EventKit, so no plugin can demand the key. This is expected: iOS local notifications go through `UNUserNotificationCenter`, whose authorization is a runtime prompt with no Info.plist usage-description key at all — `notification_service.dart:60` calls `ios.requestPermissions(alert: true, badge: true, sound: true)`.
+
+`ios/Runner/PrivacyInfo.xcprivacy` is consistent with this: it declares only `UserDefaults`, `FileTimestamp` and `DiskSpace` API categories and crash/performance data types. It says nothing about storage or reminders access, and nothing there contradicts the merged manifest.
+
+## Adjudicating the two suspect entries
+
+### "Storage permission"
+
+False in three independent ways.
+
+1. **No storage permission is declared.** Not by the app, not by any plugin, in either build variant. See the merged-manifest section above.
+2. **The export/import path uses the Storage Access Framework, which needs no permission.** Export builds a zip in memory and hands the bytes to a document picker: `lib/features/settings/domain/usecase/export_data_usecase.dart:189` calls `FilePicker.saveFile(fileName: …, type: FileType.custom, allowedExtensions: ['zip'], bytes: …)`, which on Android is `ACTION_CREATE_DOCUMENT`. Import is the mirror image — `FilePicker.pickFiles(...)` at `import_data_usecase.dart:53` and `:193`, i.e. `ACTION_OPEN_DOCUMENT`. `file_picker` 11.0.2's own manifest (`~/.pub-cache/hosted/pub.dev/file_picker-11.0.2/android/src/main/AndroidManifest.xml`) declares **no** `uses-permission` — only a `<queries>` block for `GET_CONTENT` intent visibility. The user picks the destination in the system document UI; the app never gets, and never needs, broad filesystem access.
+3. **Nothing else in the app takes storage either.** Photos come from `image_picker` (`ImageSource.gallery` / `ImageSource.camera` at `edit_meal_screen.dart:359-360`, `recipe_builder_screen.dart:167,171`, `profile_editor_screen.dart:76-77`), which on modern Android uses the Photo Picker and declares no storage permission of its own (`image_picker_android` contributes only an `ImagePickerFileProvider`). App data lives in `path_provider`'s app-private directories, which need no permission. `share_plus` is used only for the QR-code share sheet (`share_qr_dialog.dart:121`) and adds no permission.
+
+Note the iOS text is a *little* better founded than the Android side: `NSPhotoLibraryUsageDescription`'s own wording says "and for exporting data", so on iOS there is at least a photo-library key in play. But a photo-library key is not a storage permission, and it is declared for the picker, not for the export.
+
+### "Reminders permission"
+
+A misnaming of the local-notification permission, not a false claim about the iOS Reminders app. Three pieces of evidence:
+
+1. **The app calls the feature "Reminder" in its own UI.** `lib/l10n/intl_en.arb:997` — `"settingsNotificationsLabel": "Daily Reminder"`; `:998` — `"settingsNotificationsTimeLabel": "Reminder time: {time}"`; `:548` — `"notificationsDailyReminderChannelName": "Daily Reminders"`. A policy author reading the settings screen would naturally write "Reminders permission".
+2. **The mechanism is notifications.** `flutter_local_notifications` 19.5.0, wrapped by `lib/core/utils/notification_service.dart`, with `POST_NOTIFICATIONS` declared in the app manifest under a `#312: Notification reminders` comment. Callers: onboarding (`onboarding_screen.dart:456`), settings (`settings_screen.dart:501`) and the fasting timer (`fasting_screen.dart:424`).
+3. **No Reminders API is touched.** No `NSRemindersUsageDescription`, no EventKit in any plugin, no calendar permission in the merged manifest.
+
+So the *capability* the entry gestures at is real and is genuinely user-consented; only the name is wrong. It is worth being precise about what the capability is, though: `POST_NOTIFICATIONS` lets the app *show* the user something. It is not a collection of personal data from the user, which is the list the entry currently sits in. The naming defect and the categorisation defect are separate problems.
+
+## Does the answer differ on the feature branch?
+
+**No.** `git diff --stat v2.0.2 6cc0efe8 -- android ios pubspec.yaml pubspec.lock` is empty: the AI-assisted-meal-logging work on `feat/own-server-settings` changes no native manifest, adds no plugin, and locks no new dependency. The camera/photo path the AI feature uses is the one that already exists at `v2.0.2` for barcode scanning and custom-meal photos, so it reuses `mobile_scanner`'s `CAMERA` and `image_picker`'s pickers rather than adding anything. The permission set above holds for both `v2.0.2` and the current feature-branch HEAD.
+
+That is a finding in its own right for the map: the AI feature changes *where data goes*, not *what the OS lets the app take*. Nothing in this audit needs revisiting when it ships.
+
+## What this means for the policy
+
+**"Storage permission" — remove.** The evidence settles it. There is no declared storage permission in the merged manifest at either variant, no plugin injects one, `permission_handler` is not in the tree, and the export/import path deliberately uses SAF document pickers precisely so that none is needed. There is no reading under which the app holds a storage permission. Leaving the entry in tells users the app can read their files, which it cannot.
+
+If the underlying intent was "the app writes an export file to a location you choose", that is a true statement about a user-initiated action and belongs in a purpose or user-rights clause (data portability), not in a list of personal data collected — and it should not be phrased as a permission.
+
+**"Reminders permission" — rename, do not remove.** The capability is real; the label is wrong. The honest description is the notification permission (`POST_NOTIFICATIONS` on Android 13+, `UNUserNotificationCenter` authorization on iOS), used for the daily meal-logging reminder and the fasting timer. Deleting the entry outright would swing from overclaiming to underclaiming a permission the app does prompt for at onboarding.
+
+One thing this audit does **not** settle: whether a notification permission belongs in the "personal data collected" list at all, versus a separate disclosure. `POST_NOTIFICATIONS` is an outbound capability — the app shows the user a message — and no personal data flows to the controller through it. Whether iubenda can express it as anything other than a collected-data category is a question for the expressiveness research, and whether Art.13 owes a disclosure for it at all is for the rendering pass. This ticket's finding is narrower and firm: **whatever the entry becomes, it must not be called "Reminders", because that names an OS API the app does not use.**
+
+**Three underclaims found in passing.** `CAMERA`, `VIBRATE` and `ACCESS_NETWORK_STATE` are all in the released build's merged manifest and appear in neither policy. `CAMERA` is the significant one — it is a user-prompted, privacy-relevant permission backing barcode scanning and photo capture, and both iOS usage-description strings describe it, so the policy is silent about a capability the App Store listing already discloses. `VIBRATE` and `ACCESS_NETWORK_STATE` are normal-protection-level and arguably below the threshold of an Art.13 disclosure, but the rendering pass should decide that deliberately rather than by omission. Whether these belong in the policy is out of scope here; that they are missing is recorded as a finding.

--- a/docs/privacy-sentry-ios-ip.md
+++ b/docs/privacy-sentry-ios-ip.md
@@ -1,0 +1,552 @@
+# Does an iOS build send the user's IP to Sentry despite `sendDefaultPii`?
+
+Research for [#889](https://github.com/simonoppowa/OpenNutriTracker/issues/889), on
+map [#867](https://github.com/simonoppowa/OpenNutriTracker/issues/867). Researched
+2026-08-27 against the pinned SDK sources on disk, the sentry-cocoa and Relay
+sources at the versions this app actually meets, and Sentry's own SDK
+documentation.
+
+**The short answer: no. Neither iOS event path attaches the IP, and the Apple
+documentation that raised the alarm is stale.** `sendDefaultPii` does propagate
+across the method channel into sentry-cocoa; sentry-cocoa 8.58.1 turns it into an
+explicit `sdk.settings.infer_ip: "never"` on natively-originated events; and
+Dart-originated events escape the server-side legacy backfill for a different
+reason — their `platform` is `"other"`, and Relay's legacy rule fires only for
+`javascript`, `cocoa` and `objc`. Android was never at risk. **But two things the
+ticket did not ask are true and matter more than the answer:** Relay derives
+`user.geo` from the connection IP *even when `user.ip_address` is absent*, which
+contradicts what #870 recorded; and the org-level "Prevent Storing of IP Addresses"
+toggle does **not** stop that geo lookup. See §3 and §4.
+
+Versions this rests on, both pinned in the repo:
+
+- [`pubspec.lock:1262`](pubspec.lock:1262) — `sentry_flutter` `9.19.0`
+- [`ios/Podfile.lock:86`](ios/Podfile.lock:86) — `Sentry/HybridSDK (8.58.1)`
+
+and the app's own options, which set three things and never `sendDefaultPii`
+([`lib/core/utils/sentry_config.dart:22`](lib/core/utils/sentry_config.dart:22)):
+
+```dart
+void configureSentryOptions(SentryOptions options, {required String dsn}) {
+  options.dsn = dsn;
+  options.tracesSampleRate = 1.0;
+  options.enablePrintBreadcrumbs = false;
+}
+```
+
+---
+
+## 1. Does the Flutter SDK initialise the native Cocoa SDK, and does `sendDefaultPii` reach it?
+
+**Yes to both.** The native SDK is initialised by default, and `sendDefaultPii` is
+one of the keys carried across the method channel.
+
+`autoInitializeNativeSdk` defaults to `true`, and the app never touches it:
+
+> `bool autoInitializeNativeSdk = true;`
+> — `~/.pub-cache/hosted/pub.dev/sentry_flutter-9.19.0/lib/src/sentry_flutter_options.dart:33`
+
+`NativeSdkIntegration` is the only gate, and it is open:
+
+> ```dart
+> if (!options.autoInitializeNativeSdk) {
+>   return;
+> }
+> try {
+>   await _native.init(hub);
+> ```
+> — `~/.pub-cache/hosted/pub.dev/sentry_flutter-9.19.0/lib/src/integrations/native_sdk_integration.dart:24`
+
+The options map sent over the channel to `initNativeSdk` includes the flag
+verbatim:
+
+> `'sendDefaultPii': options.sendDefaultPii,`
+> — `~/.pub-cache/hosted/pub.dev/sentry_flutter-9.19.0/lib/src/native/sentry_native_channel.dart:60`
+
+and the Swift side reads it straight onto the native options object:
+
+> ```swift
+> if let sendDefaultPii = data["sendDefaultPii"] as? Bool {
+>     options.sendDefaultPii = sendDefaultPii
+> }
+> ```
+> — `~/.pub-cache/hosted/pub.dev/sentry_flutter-9.19.0/ios/sentry_flutter/Sources/sentry_flutter/SentryFlutter.swift:46`
+
+So the premise the ticket was worried about — that the Dart-side flag might not
+reach the native layer — is false. It reaches it.
+
+## 2. What does sentry-cocoa do with `ip_address`, and do the two event paths differ?
+
+**sentry-cocoa 8.58.1 never sets `ip_address` at all. It sends a server-side
+instruction instead, and `sendDefaultPii` gates it.** The two paths differ in
+*mechanism* but arrive at the same result.
+
+### 2a. The native path (a hard crash, an ANR, a watchdog termination)
+
+`grep` for `{{auto}}` across `Sources/` in the sentry-cocoa 8.58.1 tarball returns
+**nothing**. The IP is no longer expressed as a magic user value. It is expressed
+as an SDK setting:
+
+> ```swift
+> @objc public init(options: Options?) {
+>     autoInferIP = options?.sendDefaultPii ?? false
+> }
+> ...
+> @objc public func serialize() -> NSDictionary {
+>     [
+>         "infer_ip": autoInferIP ? "auto" : "never"
+>     ]
+> }
+> ```
+> — `getsentry/sentry-cocoa@8.58.1`, `Sources/Swift/Protocol/SentrySDKSettings.swift:11-28`
+
+That object is part of the SDK metadata block…
+
+> `"settings": self.settings.serialize()`
+> — `Sources/Swift/Helper/SentrySdkInfo.swift:154`
+
+…which the client stamps onto every event it prepares:
+
+> ```objc
+> - (void)setSdk:(SentryEvent *)event
+> {
+>     if (event.sdk) {
+>         return;
+>     }
+>     event.sdk = [[[SentrySdkInfo alloc] initWithOptions:self.options] serialize];
+> ```
+> — `Sources/Sentry/SentryClient.m:955-961`
+
+With `sendDefaultPii = NO`, that serialises to `"sdk": { …, "settings": {
+"infer_ip": "never" } }`.
+
+The Flutter plugin's `beforeSend` hook runs afterwards and *merges into* that
+dictionary — it appends `packages`, `integrations` and `features` and reassigns
+`event.sdk = sdk` — so the `settings` key survives
+(`sentry_flutter-9.19.0/ios/sentry_flutter/Sources/sentry_flutter/SentryFlutterPlugin.swift:323-347`).
+The plugin also renames the SDK to `"sentry.cocoa.flutter"`
+(`SentryFlutterPlugin.swift:23`), which changes the name but not the settings.
+
+The change is dated. sentry-cocoa's changelog for **8.56.0** records:
+
+> `- Ensure IP address is only inferred by Relay if sendDefaultPii is true (#5877)`
+> — `getsentry/sentry-cocoa@8.58.1`, `CHANGELOG.md:127` (under the `## 8.56.0` heading at `:106`)
+
+and the PR that landed it is titled
+["feat: Replace `user.ipAddress = {{auto}}` with a new settings.infer_ip property in the sdk metadata"](https://github.com/getsentry/sentry-cocoa/pull/5877)
+(merged 2025-08-15). The pin is 8.58.1, so this app has it.
+
+**The doc comment inside sentry-cocoa itself still describes the old behaviour**,
+which is presumably where the Apple docs got it:
+
+> ```
+> Due to backward compatibility concerns, Sentry sets
+> sdk.settings.infer_ip  to @c auto out of the box for Cocoa. If you want to stop Sentry from
+> using the connections IP address, you have to enable Prevent Storing of IP Addresses in your
+> project settings in Sentry.
+> ```
+> — `Sources/Sentry/Public/SentryOptions.h:274-277`
+
+That paragraph is contradicted by the code twelve directories away in the same
+release. **Recorded here because it is the plausible-sounding wrong answer**, and
+because Sentry's public Apple documentation still repeats it today:
+
+> "Due to backward compatibility concerns, Sentry sets the IP address to `"{{auto}}"`
+> out of the box for Apple. Therefore setting `send-default-pii` to `false` won't stop
+> Sentry from collecting users' IP addresses via the client connection."
+> — [`docs/platforms/apple/common/enriching-events/identify-user/index.mdx`](https://github.com/getsentry/sentry-docs/blob/master/docs/platforms/apple/common/enriching-events/identify-user/index.mdx),
+> read 2026-08-27
+
+The equivalent Flutter page carries no such warning.
+
+### 2b. The Dart path (a caught or uncaught Dart exception, a transaction)
+
+This path never touches `SentryClient.m`. The Dart SDK builds the whole envelope
+and hands the *bytes* to the native layer, which parses and posts them without
+running the client pipeline:
+
+> ```swift
+> guard let envelope = PrivateSentrySDKOnly.envelope(with: data) else { … }
+> PrivateSentrySDKOnly.capture(envelope)
+> ```
+> — `sentry_flutter-9.19.0/ios/sentry_flutter/Sources/sentry_flutter/SentryFlutterPlugin.swift:448-453`
+
+The plugin's own comment says as much: *"for now, in sentry-cocoa, beforeSend is
+not called before captureEnvelope"* (`SentryFlutterPlugin.swift:319`). So on this
+path the native SDK contributes the transport and nothing else — no `setSdk`, no
+`infer_ip`, no `{{auto}}`.
+
+What the Dart SDK puts in the payload is what #870 already established:
+
+> `user?.ipAddress ?? (_options.sendDefaultPii ? _defaultIpAddress : null);`
+> — `~/.pub-cache/hosted/pub.dev/sentry-9.19.0/lib/src/sentry_client.dart:348`
+
+with `sendDefaultPii` false, so no `ip_address` key. Two further facts about this
+payload turn out to be decisive in §3, and neither was established before:
+
+- The Dart SDK's SDK-metadata serialiser emits **no `settings` key at all** —
+  `name`, `version`, `packages`, `integrations`, `features`, and nothing else
+  (`sentry-9.19.0/lib/src/protocol/sdk_version.dart:98-108`). So a Dart event
+  carries no `infer_ip` instruction in either direction.
+- The Dart event's `platform` is **`"other"`**:
+  > `..platform = event.platform ?? sdkPlatform(_options.platform.isWeb);`
+  > — `sentry-9.19.0/lib/src/sentry_client.dart:241`
+  > `const String _ioSdkPlatform = 'other';`
+  > — `sentry-9.19.0/lib/src/version.dart:30`
+
+  `sentry_flutter` never overrides it — `grep` for an assignment to `event.platform`
+  across `sentry_flutter-9.19.0/lib/` finds none. A natively-originated event, by
+  contrast, is `"cocoa"`
+  (`sentry-cocoa Sources/Sentry/include/SentryInternalDefines.h:5`, applied at
+  `Sources/Sentry/SentryEvent.m:50`).
+
+So the two paths look like this on the wire:
+
+| | Dart exception / transaction | Native crash |
+|---|---|---|
+| Built by | sentry-dart 9.19.0 | sentry-cocoa 8.58.1 |
+| Sent by | sentry-cocoa (envelope passthrough) | sentry-cocoa |
+| `platform` | `other` | `cocoa` |
+| `sdk.name` | `sentry.dart.flutter` | `sentry.cocoa.flutter` |
+| `user.ip_address` | absent | absent |
+| `sdk.settings.infer_ip` | **absent** | `never` |
+
+The interesting row is the last one: the two paths hand Relay *different*
+instructions, and only one of them is explicit.
+
+## 3. What does Relay do when `ip_address` is absent entirely?
+
+**This is the crux, and it very nearly went the other way.** Relay does not treat
+an absent `ip_address` uniformly — its default is a legacy mode that backfills the
+connection IP for three specific platforms.
+
+Sentry's SDK spec documents the three settings:
+
+> - `auto`: infer the IP address based on available request information. […]
+> - `never`: Do not infer the IP address from the request. This is the default if an invalid value for `infer_ip` was sent.
+> - `legacy`: Infer the IP address only if the value is `{{auto}}`. For Javascript and Cocoa it will also infer if `ip_address` is empty. **This is the default if no value was sent.**
+>
+> — [`develop-docs/sdk/foundations/envelopes/event-payloads/sdk.mdx`](https://github.com/getsentry/sentry-docs/blob/master/develop-docs/sdk/foundations/envelopes/event-payloads/sdk.mdx)
+
+The implementation keys on the **event's `platform` field**, not on the SDK name:
+
+> ```rust
+> // Legacy behaviour:
+> // * Backfill if there is a REMOTE_ADDR and the user.ip_address was not backfilled until now
+> // * Empty means {{auto}} for some SDKs
+> if infer_ip == AutoInferSetting::Legacy {
+>     …
+>             // In an ideal world all SDKs would set {{auto}} explicitly.
+>             if let Some("javascript") | Some("cocoa") | Some("objc") = platform {
+>                 user.ip_address = Annotated::new(client_ip.to_owned());
+>             }
+> ```
+> — [`getsentry/relay@26.8.0`, `relay-event-normalization/src/event.rs:482-503`](https://github.com/getsentry/relay/blob/26.8.0/relay-event-normalization/src/event.rs)
+
+and `never` short-circuits before any of that:
+
+> ```rust
+> // If infer_ip is set to Never then we just remove auto and don't continue
+> if let AutoInferSetting::Never = infer_ip {
+>     // No user means there is also no IP so we can stop here
+>     let Some(user) = user.value_mut() else {
+>         return;
+>     };
+>     // If there is no IP we can also stop
+>     let Some(ip) = user.ip_address.value() else {
+>         return;
+>     };
+> ```
+> — same file, `:439-448` — the `Never` arm
+
+Applying that to the two rows of the table:
+
+- **Native crash** — `infer_ip: "never"` → the first `return` fires (the event has a
+  `user` with an id but no ip). **No IP stored.**
+- **Dart exception** — no `infer_ip` → defaults to `Legacy` → `platform` is
+  `"other"`, which is not `javascript`/`cocoa`/`objc`. **No IP stored.**
+
+**The margin here is thin and worth stating plainly.** The Dart path is protected
+by the string `"other"` rather than by anything anyone chose for privacy reasons.
+If a future `sentry_flutter` set `event.platform = "cocoa"` on Apple targets — a
+perfectly reasonable thing to do for symbolication or issue grouping — the IP
+would start being stored on that path, silently, with no option change on our
+side. The native path is protected by an explicit instruction and is robust.
+
+### The finding the ticket did not ask for: `user.geo` is inferred anyway
+
+#870 recorded that "Relay only infers `geo` when `ip_address` is present". **On
+Relay 26.8.0 that is not true.** The geo lookup falls back to the connection IP:
+
+> ```rust
+> pub fn normalize_user_geoinfo(
+>     geoip_lookup: &GeoIpLookup,
+>     user: &mut Annotated<User>,
+>     ip_addr: Option<&IpAddr>,
+> ) {
+>     …
+>     if let Some(ip_address) = user
+>         .ip_address
+>         .value()
+>         .filter(|ip| !ip.is_auto())
+>         .or(ip_addr)
+> ```
+> — [`relay-event-normalization/src/event.rs:511-526`](https://github.com/getsentry/relay/blob/26.8.0/relay-event-normalization/src/event.rs)
+
+`.or(ip_addr)` is the fallback, and the caller passes the **unfiltered**
+connection IP:
+
+> ```rust
+> let client_ip = config.client_ip.filter(|_| config.infer_ip_address);
+> …
+> normalize_ip_addresses(…, client_ip, event.client_sdk.value());
+>
+> if let Some(geoip_lookup) = config.geoip_lookup {
+>     normalize_user_geoinfo(geoip_lookup, &mut event.user, config.client_ip);
+> }
+> ```
+> — same file, `:282-298`
+
+Note the asymmetry: `normalize_ip_addresses` gets the filtered `client_ip`,
+`normalize_user_geoinfo` gets `config.client_ip`. So on **both** iOS paths — and on
+Android, and on every event this app has ever sent — Relay may store
+`user.geo` (country code, region, city) derived from the connection IP, while
+storing no IP.
+
+**One link in that chain is not established from source.** `geoip_lookup` is
+`Option`, populated from a `processing.geoip_path` config value
+(`getsentry/relay@26.8.0`, `relay-config/src/config.rs:1139`), and whether
+Sentry's SaaS processing Relays supply that database is a deployment fact I cannot
+read out of any repository. It is one lookup to settle — see §5.
+
+## 4. Is there a server-side control, and would it settle this?
+
+**There are three, they live in different places, and — this is the useful part —
+none of them is needed for the IP, and none of them fixes the geo.**
+
+**(a) "Prevent Storing of IP Addresses", organisation-wide.** It exists, at
+`/settings/:orgId/security-and-privacy/`:
+
+> ```ts
+> 'organization-security-and-privacy.scrubIPAddresses': {
+>   name: 'scrubIPAddresses',
+>   formId: 'organization-security-and-privacy',
+>   route: '/settings/:orgId/security-and-privacy/',
+>   label: t('Prevent Storing of IP Addresses'),
+>   hintText: t('Preventing IP addresses from being stored for new events on all projects'),
+> },
+> ```
+> — [`getsentry/sentry`, `static/app/views/settings/fieldRegistry.generated.ts:675-683`](https://github.com/getsentry/sentry/blob/master/static/app/views/settings/fieldRegistry.generated.ts)
+
+**(b) The same toggle per project**, at
+`/settings/:orgId/projects/:projectId/security-and-privacy/`, same label, hint
+*"Preventing IP addresses from being stored for new events"* (same file, `:425-431`).
+The Apple docs point at this one; the org-level one is strictly broader.
+
+Either flips two switches in Relay. It disables inference at the source:
+
+> ```rust
+> // if the setting is enabled we do not want to infer the ip address
+> infer_ip_address: !project_info
+>     .config
+>     .datascrubbing_settings
+>     .scrub_ip_addresses,
+> ```
+> — [`relay-server/src/processing/utils/event.rs:259-263`](https://github.com/getsentry/relay/blob/26.8.0/relay-server/src/processing/utils/event.rs)
+
+and adds a scrubbing rule that removes the known IP-bearing fields outright:
+
+> ```rust
+> if datascrubbing_config.scrub_ip_addresses {
+>     // legacy(?) scrubs all fields that are known to have IPs regardless of actual content
+>     applications.insert(KNOWN_IP_FIELDS.clone(), vec!["@anything:remove".to_owned()]);
+>     // checks actual contents of all fields and scrubs where there is an IP address
+>     applied_rules.push("@ip:replace".to_owned());
+> }
+> ```
+> — [`relay-pii/src/convert.rs:148-154`](https://github.com/getsentry/relay/blob/26.8.0/relay-pii/src/convert.rs), with
+
+> `"($request.env.REMOTE_ADDR | $user.ip_address | $sdk.client_ip | $span.sentry_tags.'user.ip' | attributes.'client.address')"`
+> — `relay-pii/src/convert.rs:24`
+
+**(c) `beforeSend` and advanced data scrubbing.** `beforeSend` is a client-side
+hook and is the wrong instrument here: on iOS it is *not invoked* for the Dart
+path at all (`SentryFlutterPlugin.swift:319`, quoted in §2b), and the IP is not in
+the payload it would see anyway — it is added downstream by Relay. Server-side
+advanced scrubbing (`[Remove] [$user.ip_address] from [**]`) is the general form of
+(a) and, per Sentry's docs, *"Adding such a rule ultimately overrules any other
+logic."*
+
+**Would a single org toggle settle the question regardless of platform? For the IP,
+yes — and it is unnecessary today.** Turning on the org-level "Prevent Storing of IP
+Addresses" makes the answer platform-independent and immune to the `platform ==
+"other"` fragility identified in §3, at zero cost to a project that has no use for
+IPs. That is the recommendation. But it is belt-and-braces, not a fix: the SDKs
+already withhold the IP.
+
+**For the geo, no — the toggle does not reach it.** As quoted in §3,
+`normalize_user_geoinfo` is passed `config.client_ip` and not the
+`infer_ip_address`-filtered value, and `user.geo` is not in `KNOWN_IP_FIELDS`. An
+explicit advanced-scrubbing rule on `$user.geo` would be needed, and I have not
+verified that `$user.geo` is a valid selector. Two further limits, both from the
+hint text: the toggle applies to **new events** only, and nothing here is
+retroactive over the 30-day window #878 established.
+
+## 5. What is not settled, and how to settle it
+
+Three things, in descending order of how much they matter.
+
+**(i) Does Sentry SaaS actually populate `user.geo`?** Not answerable from source
+(§3). **The measurement is a single lookup and needs no code:** open any existing
+event in `opennutritracker.sentry.io` — the org already holds ~3K of them per
+#878 — and read its JSON (the "JSON" link on the event page, or
+`GET /api/0/projects/{org}/{project}/events/{event_id}/`). Look at `user`. If it
+contains a `geo` object with `country_code`, geo is live and the policy must
+account for coarse location. If `user` holds only `id`, it is not. This settles
+§3's open link and simultaneously *confirms* the whole of this document against
+production rather than against source, which is why it is first.
+
+**(ii) A CI regression check for the payload.** The finding in §3 — that the Dart
+path is protected only by `platform == "other"` — is exactly the kind of thing an
+SDK upgrade changes silently, and this map has now watched prose drift from code
+several times. #748's precedent applies: add a check to the `ios-integration-tests`
+job in [`.github/workflows/default_workflow.yml:266`](.github/workflows/default_workflow.yml:266)
+rather than waiting for a device.
+
+Concretely, and not implemented here: add
+`integration_test/sentry_payload_test.dart`, run by the existing
+`flutter test integration_test/ -d "$DEVICE_UDID" --flavor full` step (which runs the
+whole directory from one build, so no workflow edit is needed). In it, start an
+`HttpServer.bind(InternetAddress.loopbackIPv4, 0)` inside the test process, call
+`SentryFlutter.init` with the app's own `configureSentryOptions` but a DSN pointing
+at that port, capture an exception, await the request, gunzip and split the
+envelope on newlines, and assert on the event item:
+
+- `json['platform'] == 'other'`
+- `json['user']?['ip_address'] == null`
+- `json['sdk']?['settings'] == null` (this is the assertion that would catch a
+  future SDK starting to send `infer_ip: "auto"`)
+
+Note what this does and does not prove. It pins the **payload the SDK emits**,
+which is the half that can regress on a version bump. It cannot exercise Relay, and
+it cannot exercise the native crash path — a real `SIGSEGV` would tear down the
+test host, and the crash is only converted and sent on the *next* launch, which a
+single `flutter test` run cannot observe. The native path's `infer_ip: "never"` is
+established from source in §2a and is the more robust of the two anyway; it is the
+Dart path that is worth guarding.
+
+**(iii) The stale Apple documentation.** Worth reporting upstream to
+`getsentry/sentry-docs` and to the `SentryOptions.h` comment, since it is the
+reason this ticket existed. Not a blocker for anything here.
+
+## 6. Does Android differ?
+
+**No, and it was never at risk — for a third, independent reason.**
+
+`sendDefaultPii` propagates on Android too, through a JNI call rather than a method
+channel:
+
+> `androidOptions.setSendDefaultPii(options.sendDefaultPii);`
+> — `~/.pub-cache/hosted/pub.dev/sentry_flutter-9.19.0/lib/src/native/java/sentry_native_java_init.dart:241`
+
+The pinned native SDK is `io.sentry:sentry-android:8.39.1`
+(`sentry_flutter-9.19.0/android/build.gradle:65`), which still uses the older
+`{{auto}}` mechanism and gates it on the flag:
+
+> ```java
+> if (user.getIpAddress() == null && options.isSendDefaultPii()) {
+>   user.setIpAddress(IpAddressUtils.DEFAULT_IP_ADDRESS);
+> }
+> ```
+> — [`getsentry/sentry-java@8.39.1`, `sentry/src/main/java/io/sentry/MainEventProcessor.java:210`](https://github.com/getsentry/sentry-java/blob/8.39.1/sentry/src/main/java/io/sentry/MainEventProcessor.java)
+
+`grep` for `infer_ip` across `getsentry/sentry-java` returns nothing, so Android
+events carry no `sdk.settings` either and also land in Relay's `Legacy` default.
+But the Android platform string is `"java"`:
+
+> `public static final String DEFAULT_PLATFORM = "java";`
+> — [`sentry-java@8.39.1`, `sentry/src/main/java/io/sentry/SentryBaseEvent.java:25`](https://github.com/getsentry/sentry-java/blob/8.39.1/sentry/src/main/java/io/sentry/SentryBaseEvent.java)
+
+which is not in Relay's `javascript`/`cocoa`/`objc` list. So Android is protected
+twice over — the SDK withholds `{{auto}}`, and the legacy backfill would not fire
+even if it did not. The layering worry that motivated this ticket has no Android
+analogue.
+
+## 7. Incidental, and it is not the IP
+
+**Both platforms attach a stable per-installation UUID as `user.id`, and neither
+gates it on `sendDefaultPii`.** On iOS:
+
+> ```objc
+> // We only want to set the id if the customer didn't set a user so we at least set something to
+> // identify the user.
+> if (event.user == nil) {
+>     SentryUser *user = [[SentryUser alloc] init];
+>     user.userId = [SentryInstallation idWithCacheDirectoryPath:self.options.cacheDirectoryPath];
+> ```
+> — `sentry-cocoa@8.58.1`, `Sources/Sentry/SentryClient.m:979-986`
+
+On Android, `user.setId(Installation.id(context))` sits immediately *above* the
+`isSendDefaultPii()` check quoted in §6 and outside it
+(`sentry-java@8.39.1`, `DefaultAndroidEventProcessor.java:176-181`). And the value
+reaches Dart-originated events too, because `LoadContextsIntegration` copies the
+native user onto the event when the event has none
+(`sentry_flutter-9.19.0/lib/src/integrations/load_contexts_integration.dart:205-208`).
+
+So every event this app sends, on both platforms, carries a random identifier that
+is stable for the life of the install. That is a weaker identifier than an IP — no
+location, no network, no cross-app linkage — and it is what makes "how many users
+hit this crash" work at all. It is flagged rather than resolved: it is an
+identifier the current policy does not mention, and it belongs to whichever ticket
+owns the Sentry payload description, not to this one.
+
+---
+
+## What this means for the policy
+
+**The IP is not a category the policy must declare, on iOS or Android.** The
+worry in #889 was specific and checkable, and it does not survive contact with the
+pinned versions: `sendDefaultPii` propagates to sentry-cocoa (§1), sentry-cocoa
+8.58.1 turns it into `infer_ip: "never"` (§2a), and the Dart path escapes Relay's
+legacy backfill on its `platform` string (§3). #870's conclusion — that
+`sendDefaultPii = false` genuinely withholds the IP — **holds on iOS**, though not
+quite for the reason #870 gave, since the reasoning it applied was Dart-side and
+the native path needed a different argument.
+
+**Android does not differ**, and is protected by two independent mechanisms rather
+than one (§6). There is no iOS/Android asymmetry to write into the documents.
+
+**A server-side setting removes the question, and it should be turned on anyway.**
+The org-level "Prevent Storing of IP Addresses" at
+`/settings/opennutritracker/security-and-privacy/` (§4a) makes the answer
+platform-independent and version-independent. It costs nothing — this project has
+no use for an IP — and it retires the one fragility this research found: the Dart
+path is currently protected by `platform == "other"`, a value chosen for unrelated
+reasons that an SDK upgrade could change without a changelog entry anyone here
+would read. **That is the most useful outcome available and it is a one-click
+change**, so it is recommended plainly rather than left as an option.
+
+**One thing got worse, and it is not the IP.** #870 recorded that Relay infers geo
+only when `ip_address` is present. On Relay 26.8.0 the geo lookup falls back to the
+connection IP regardless (§3), and the "Prevent Storing of IP Addresses" toggle
+does **not** cover it. If SaaS ships a GeoIP database — the one link not settled
+from source — then every event already carries an approximate country, and *that*
+is a category the policy would have to declare, on both platforms, with the same
+US-region third-country transfer #878 established. **This should be settled before
+the Sentry passage is written**, and it is one lookup in an event the org already
+holds (§5i). Writing the policy on the assumption that no location is stored would
+repeat exactly the kind of drift this map keeps finding.
+
+---
+
+## Sources
+
+- Pinned locally: `~/.pub-cache/hosted/pub.dev/sentry_flutter-9.19.0/`, `~/.pub-cache/hosted/pub.dev/sentry-9.19.0/`
+- [getsentry/sentry-cocoa @ 8.58.1](https://github.com/getsentry/sentry-cocoa/tree/8.58.1) — the version in `ios/Podfile.lock`
+- [getsentry/sentry-java @ 8.39.1](https://github.com/getsentry/sentry-java/tree/8.39.1) — the version in `sentry_flutter`'s `android/build.gradle`
+- [getsentry/relay @ 26.8.0](https://github.com/getsentry/relay/tree/26.8.0) — latest release at time of writing
+- [getsentry/sentry `fieldRegistry.generated.ts`](https://github.com/getsentry/sentry/blob/master/static/app/views/settings/fieldRegistry.generated.ts)
+- [SDK Interface — Sentry developer documentation](https://develop.sentry.dev/sdk/foundations/envelopes/event-payloads/sdk/)
+- [Users — Sentry Apple documentation](https://docs.sentry.io/platforms/apple/enriching-events/identify-user/)
+- [Users — Sentry Flutter documentation](https://docs.sentry.io/platforms/dart/guides/flutter/enriching-events/identify-user/)
+- [sentry-cocoa PR #5877](https://github.com/getsentry/sentry-cocoa/pull/5877)

--- a/docs/privacy-sentry-payload.md
+++ b/docs/privacy-sentry-payload.md
@@ -5,6 +5,22 @@ map [#867](https://github.com/simonoppowa/OpenNutriTracker/issues/867). Research
 2026-08-27 against Sentry's own documentation, the `sentry-dart` source at tag
 `9.19.0` (the version this app pins), and this repo's `main`.
 
+> [!WARNING]
+> **Superseded in part.** This document concludes that server-side geolocation is gated on
+> `ip_address` being present on the event. That is **wrong**, and it was disproved by
+> [#889](https://github.com/simonoppowa/OpenNutriTracker/issues/889) by reading a live event in
+> this project's Sentry organisation: `user.geo` was populated with `country_code`, `city` and
+> `region` while `user.ip_address` was `null`. Relay resolves geo from the **connection** IP
+> before the filtering step, so the city of every crash is stored on both platforms, and the
+> organisation's *Prevent Storing of IP Addresses* setting does not cover it.
+>
+> #889 also found a **stable per-install UUID** in `user.id`, ungated by `sendDefaultPii`,
+> which this document does not mention at all. See `docs/privacy-sentry-ios-ip.md`.
+>
+> Everything else here — the trace-sampling analysis, the print-breadcrumb finding that led to
+> [#877](https://github.com/simonoppowa/OpenNutriTracker/issues/877), and the retention figures —
+> stands. The error is preserved rather than edited away so the correction is visible.
+
 **The short answer: transactions do add a category — timings, spans, measurements and
 a `ui.load` app-start trace — but the payload that actually matters for the policy is
 not the transaction. It is the breadcrumb trail, which rides on *both* error events

--- a/docs/privacy-sentry-payload.md
+++ b/docs/privacy-sentry-payload.md
@@ -1,0 +1,596 @@
+# What does Sentry receive at 100% trace sampling?
+
+Research for [#870](https://github.com/simonoppowa/OpenNutriTracker/issues/870), on
+map [#867](https://github.com/simonoppowa/OpenNutriTracker/issues/867). Researched
+2026-08-27 against Sentry's own documentation, the `sentry-dart` source at tag
+`9.19.0` (the version this app pins), and this repo's `main`.
+
+**The short answer: transactions do add a category — timings, spans, measurements and
+a `ui.load` app-start trace — but the payload that actually matters for the policy is
+not the transaction. It is the breadcrumb trail, which rides on *both* error events
+and transactions, and which in release builds contains every `debugPrint` line this
+app emits — including two log lines that print the full Open Food Facts and USDA FDC
+search URLs, user's search term and all.** `sendDefaultPii` is left at its default
+`false`, which does keep the IP address off the event on Android; on Apple platforms
+Sentry documents that it does not. Sentry is a US entity offering a Frankfurt region
+chosen once at organisation creation and never changeable, so where this project's
+events land is a fact about the account, not about the code.
+
+---
+
+## 0. What this app actually configures
+
+`lib/main.dart` on `main` sets exactly two options:
+
+```dart
+await SentryFlutter.init(
+  (options) {
+    options.dsn = Env.sentryDns;
+    options.tracesSampleRate = 1.0;
+  },
+  appRunner: () => runAppWithChangeNotifiers(...),
+);
+```
+
+Everything else is SDK default. `pubspec.yaml` declares `sentry_flutter: ^9.19.0` and
+`pubspec.lock` pins `9.19.0`, so every claim below is checked against that tag.
+
+Three absences matter and are established by reading `main.dart`:
+
+- **No `SentryNavigatorObserver`.** The `MaterialApp` built in
+  `_buildMaterialApp` sets `routes`, `initialRoute`, `localizationsDelegates` and
+  friends, but never `navigatorObservers`.
+- **No `SentryWidget`.** `runAppWithChangeNotifiers` calls
+  `runApp(MultiProvider(... child: OpenNutriTrackerApp(...)))` directly.
+- **No `SentryHttpClient`.** `lib/core/utils/ont_http_client.dart` wraps a plain
+  `http.BaseClient` to set a `User-Agent`, and the data sources construct it over a
+  vanilla `http.Client`.
+
+Sentry initialises only in release builds and only after consent
+(`if (kReleaseMode && hasAcceptedAnonymousData)`).
+
+`tracesSampleRate = 1.0` means every trace is kept:
+
+> Setting a uniform sample rate for all transactions/service spans using the
+> `tracesSampleRate` option in your SDK config to a number between `0` and `1`.
+
+> For example, to send 20% of transactions/service spans, set `tracesSampleRate` to
+> `0.2`
+
+— https://docs.sentry.io/platforms/dart/guides/flutter/tracing/
+
+## 1. What a transaction event contains that an error event does not
+
+A transaction is a distinct event type with its own schema. Sentry's SDK
+specification lists these as required:
+
+> **type** — A Transaction has to have this value set to `transaction`.
+
+> **start_timestamp** — A timestamp representing when the measuring started.
+
+> **timestamp** — A timestamp representing when the measuring finished.
+
+> **contexts.trace** — [containing] `trace_id`, `span_id`, `parent_span_id`, `op`,
+> `description`, `status`
+
+and these as recommended or optional:
+
+> **spans** — A list of Spans.
+
+Each span carries `start_timestamp`, `timestamp`, `description`, `op`, `span_id`,
+`trace_id`, `parent_span_id`, `tags` and `data`.
+
+> **measurements** — An object containing standard/custom measurements with keys
+> signifying the name of the measurement
+
+> **transaction_info.source** — [`custom`] User-defined name; [`url`] Raw URL,
+> potentially containing identifiers; [`route`] Parametrized URL / route; [`view`]
+> Name of the view handling the request
+
+— https://develop.sentry.dev/sdk/data-model/event-payloads/transaction/
+
+So the *additional* categories relative to an error event are: **wall-clock
+timings**, a **span tree** with per-span operation names and free-text descriptions,
+**numeric measurements**, and a **transaction name** whose `source` may legitimately
+be a raw URL or a route.
+
+**What a transaction does *not* add is device metadata or breadcrumbs — because error
+events already carry those, and transactions carry them too.** This is worth stating
+plainly because it is the opposite of the intuition in the ticket. In
+`packages/dart/lib/src/scope.dart` at `9.19.0`, `applyToEvent` attaches breadcrumbs to
+every event except user feedback:
+
+```dart
+if (event.type != 'feedback') {
+  event.breadcrumbs = (event.breadcrumbs?.isNotEmpty ?? false)
+      ? event.breadcrumbs
+      : List.from(_breadcrumbs);
+```
+
+and `SentryClient.captureTransaction` runs the full event-processor chain
+(`runEventProcessors(preparedTransaction, hint, _options.eventProcessors, _options)`),
+which is the same chain that `LoadContextsIntegration` registers its device/OS/app
+context merge into. A transaction therefore ships the same contexts and the same
+breadcrumb buffer as a crash does.
+
+## 2. What this app's transactions actually contain
+
+Given the three absences in §0, most of Sentry's automatic instrumentation is inert
+here. One is not.
+
+**Routing instrumentation is off.** Sentry's Flutter integration list marks *Routing*
+as opt-in, and the routing page requires the developer to wire the observer in:
+
+> ```dart
+> MaterialApp(
+>   navigatorObservers: [
+>     SentryNavigatorObserver(),
+>   ],
+>   ...
+> )
+> ```
+
+— https://docs.sentry.io/platforms/dart/guides/flutter/integrations/routing-instrumentation/
+
+`main.dart` does not do this, so no `ui.load` transaction is named after a screen and
+no navigation breadcrumbs are produced by the Dart layer.
+
+**User-interaction tracing is off in practice.** The options default to on —
+`bool enableUserInteractionBreadcrumbs = true;` and
+`bool enableUserInteractionTracing = true;` in
+`packages/flutter/lib/src/sentry_flutter_options.dart` — but the documented
+prerequisite is:
+
+> Wrap your root widget with `SentryWidget`
+
+— https://docs.sentry.io/platforms/dart/guides/flutter/integrations/user-interaction-instrumentation/
+
+which this app does not do. The same page notes that even when it is on, breadcrumbs
+exclude "widget labels and text to avoid capturing personally identifiable
+information (PII)" unless `sendDefaultPii` is set.
+
+**HTTP instrumentation is off.** The HTTP integration is a client you must
+construct — the docs describe instantiating `SentryHttpClient()` directly or via
+`runWithClient`
+(https://docs.sentry.io/platforms/dart/guides/flutter/integrations/http-integration/),
+and the integration index lists *Http* and *Dio* under opt-in
+(https://docs.sentry.io/platforms/dart/guides/flutter/integrations/). This app's
+`ONTHttpClient` wraps a plain `http.Client`, so no HTTP spans and no HTTP breadcrumbs
+are created by the SDK.
+
+**One transaction is emitted per launch anyway.** `NativeAppStartIntegration` is added
+unconditionally on iOS, Android and macOS in `_createDefaultIntegrations`, and it
+returns early only when tracing is disabled:
+
+```dart
+if (!options.isTracingEnabled()) {
+  options.log(SentryLevel.info,
+      'Skipping $integrationName integration because tracing is disabled.');
+  return;
+}
+...
+context = SentryTransactionContext(
+  'root /',
+  SentrySpanOperations.uiLoad,
+  origin: SentryTraceOrigins.autoUiTimeToDisplay,
+);
+```
+
+With `tracesSampleRate = 1.0` tracing *is* enabled, so the app produces an app-start
+transaction named `root /` with operation `ui.load` on every cold start.
+`native_app_start_handler.dart` then adds an app-start measurement and finished child
+spans described by `appStartTypeDescription`, `pluginRegistrationDescription`,
+`sentrySetupDescription` and `firstFrameRenderDescription`. `FramesTrackingIntegration`
+is likewise added unconditionally on non-web platforms and contributes slow/frozen
+frame measurements.
+
+So: setting `tracesSampleRate = 1.0` in this app buys one launch-timing transaction
+per session, plus whatever breadcrumbs and contexts the scope holds at that moment —
+not a stream of screen-by-screen or request-by-request traces.
+
+## 3. What `sendDefaultPii = false` suppresses, and the IP question
+
+The option is not set in `main.dart`, so it is at its default:
+
+> If this flag is enabled, certain personally identifiable information (PII) is added
+> by active integrations. By default, no such data is sent.
+
+— https://docs.sentry.io/platforms/dart/guides/flutter/configuration/options/ (default `false`)
+
+Sentry's per-SDK data inventory splits it cleanly. Held back at `false`:
+
+> **HTTP Headers** — By default, the Sentry SDK doesn't send any HTTP headers.
+
+> **Information About Logged-in User** — By default, the Sentry SDK doesn't send any
+> information about the logged-in user, such as email address, user ID, or username.
+
+> **Users' IP Addresses** — By default, the Sentry SDK doesn't send the user's IP
+> address.
+
+> **Device Information** — By default the Sentry SDK does not send the name of the
+> device.
+
+> **File I/O** — By default the Sentry SDK does not send the name or path of files
+> when instrumenting File I/O.
+
+Sent regardless:
+
+> **Request URL** — The full request URL of outgoing and incoming HTTP requests is
+> always sent to Sentry.
+
+> **Request Query String** — The full request query string of outgoing and incoming
+> HTTP requests is always sent to Sentry.
+
+> **Runtime Information** — By default, the SDK collects basic runtime information
+> like the Dart version and platform.
+
+> **User Interaction Data** — By default, the SDK collects basic UI interaction data
+> while protecting sensitive information by excluding text content.
+
+— https://docs.sentry.io/platforms/dart/guides/flutter/data-management/data-collected/
+
+Note that the two "always sent" URL entries are conditional on HTTP instrumentation
+being active, which per §2 it is not in this app. They describe the SDK's behaviour
+when the integration is used, not an unconditional upload.
+
+### The `{{auto}}` mechanism
+
+> The user's IP address. If the user is unauthenticated, Sentry uses the IP address as
+> a unique identifier for the user.
+
+> You can set `ip_address = "{{auto}}"` to allow Sentry to automatically determine the
+> IP address from the connection.
+
+and, decisively for the geolocation half of the question:
+
+> [`geo`] An optional object describing the geographical location of the end user or
+> device. […] this object is automatically inferred by Relay if `ip_address` is
+> provided.
+
+— https://develop.sentry.dev/sdk/data-model/event-payloads/user/
+
+So server-side geolocation is gated on `ip_address` being present on the event —
+including the `{{auto}}` placeholder, which is the instruction that makes Relay look at
+the connection.
+
+### Does this app send `{{auto}}`?
+
+**On Android and Dart-side: no.** `packages/dart/lib/src/sentry_client.dart` at
+`9.19.0`:
+
+```dart
+/// Default value for [SentryUser.ipAddress]. It gets set when an event does not have
+/// a user and IP address. Only applies if [SentryOptions.sendDefaultPii] is set
+/// to true.
+const _defaultIpAddress = '{{auto}}';
+```
+
+```dart
+final effectiveIpAddress =
+    user?.ipAddress ?? (_options.sendDefaultPii ? _defaultIpAddress : null);
+```
+
+`_createUserOrSetDefaultIpAddress` is called on both `captureEvent` and
+`captureTransaction`, and the SDK's own tests assert `expect(actualIp, isNull)` for the
+`sendDefaultPii = false` case. With PII off, no `user.ip_address` is attached, so Relay
+has nothing to infer `geo` from.
+
+**On Apple platforms: yes, and Sentry says so explicitly.**
+
+> Due to backward compatibility concerns, Sentry sets the IP address to `"{{auto}}"`
+> out of the box for Apple. Therefore setting `sendDefaultPii` to `false` won't stop
+> Sentry from collecting users' IP addresses via the client connection.
+
+— https://docs.sentry.io/platforms/apple/guides/ios/enriching-events/identify-user/
+
+This is not contradicted anywhere in the Flutter documentation, and the mechanism by
+which it would reach a Flutter event exists: `LoadContextsIntegration` copies the
+native user object onto the event when the Dart event has none
+(`if (event.user == null && userMap != null && userMap.isNotEmpty)`). **What I could
+not settle from documentation is whether `SentryFlutter`'s propagation of
+`sendDefaultPii` to the Cocoa SDK changes that Apple default for Flutter apps
+specifically.** The Flutter data-collected page states flatly that the IP address is
+not sent by default and does not carve out Apple; the Apple page states the opposite
+for its own SDK. Treat iOS as unresolved rather than assuming either way.
+
+### The distinction the ticket asks about
+
+**Sentry's ingest necessarily receives the client IP — it is the source address of the
+HTTPS connection to `*.ingest.sentry.io`. What `sendDefaultPii = false` controls is
+whether that address is *recorded on the event* and thus whether `geo` is derived from
+it.** The documentation is explicit about the second half and silent about the first;
+no Sentry page states that the ingest endpoint discards or never observes the
+connection IP. There is no primary-source basis for claiming Sentry does not receive
+the IP, only for claiming it is not attached to the event on Android.
+
+## 4. What `sentry_flutter` 9.19.0 turns on without being asked
+
+From `_createDefaultIntegrations` in `packages/flutter/lib/src/sentry_flutter.dart` at
+tag `9.19.0`, the unconditional additions are `WidgetsFlutterBindingIntegration`,
+`OnErrorIntegration`, `FlutterErrorIntegration`, `WidgetsBindingIntegration`, the
+Flutter framework feature-flag integration, `SentryViewHierarchyIntegration`,
+`DebugPrintIntegration`, and (off web) `ThreadInfoIntegration`; with a native binding
+present it also adds `LoadReleaseIntegration`, the native SDK integration,
+`createLoadDebugImagesIntegration`, `LoadContextsIntegration`,
+`FramesTrackingIntegration`, `NativeAppStartIntegration` and `ReplayIntegration`.
+
+Reading each for its gate:
+
+| Default integration | Actually active here? |
+|---|---|
+| Device / OS / app contexts (`LoadContextsIntegration`) | **Yes**, on all events including transactions |
+| App-start tracing (`NativeAppStartIntegration`) | **Yes** — tracing is enabled |
+| Slow/frozen frames (`FramesTrackingIntegration`) | **Yes** |
+| `debugPrint` → breadcrumbs (`DebugPrintIntegration`) | **Yes**, release builds only — see §5 |
+| Native breadcrumbs (`enableAutoNativeBreadcrumbs = true`) | **Yes** |
+| Screenshots (`ScreenshotIntegration`) | **No** — gated on `attachScreenshot`, default `false` |
+| View hierarchy (`SentryViewHierarchyIntegration`) | **No** — gated on `attachViewHierarchy`, default `false` |
+| Session replay (`ReplayIntegration`) | **No** — sample rates default to null/0 |
+| Routing / navigation breadcrumbs | **No** — needs `SentryNavigatorObserver` |
+| User-interaction tracing and breadcrumbs | **No** — needs `SentryWidget` |
+| HTTP / Dio instrumentation | **No** — needs `SentryHttpClient` |
+
+Sources for the gates: `attachScreenshot` "Takes a screenshot of the application when
+an error happens and includes it as an attachment", default `false`;
+`attachViewHierarchy` "Renders a JSON representation of the entire view hierarchy of
+the application when an error happens and includes it as an attachment", default
+`false`; `maxBreadcrumbs` "This variable controls the total amount of breadcrumbs that
+should be captured", default `100`; `enableAutoNativeBreadcrumbs` "Set this boolean to
+`false` to disable automatic breadcrumbs on the Native platforms", default `true`
+(https://docs.sentry.io/platforms/dart/guides/flutter/configuration/options/). The
+screenshot and view-hierarchy integrations are added to the list unconditionally but
+return without registering an event processor unless their option is on —
+`if (options.attachScreenshot) { … }` and
+`if (!options.attachViewHierarchy || options.platform.isWeb) { return; }` in the
+9.19.0 sources. Replay reads `options.replay.sessionSampleRate ?? 0` and
+`sentry_replay_options.dart` declares `double? _sessionSampleRate;` with no default.
+
+**Device and OS metadata is therefore attached to everything.** The context schema
+that `LoadContextsIntegration` populates is large — device `family`, `model`,
+`model_id`, `arch`, `manufacturer`, `brand`, `battery_level`, `orientation`,
+`screen_resolution`, `screen_density`, `memory_size`, `free_memory`, `storage_size`,
+`free_storage`, `boot_time`, `timezone`, `language`, `processor_count`, `simulator`,
+`device_unique_identifier`; OS `name`, `version`, `build`, `kernel_version`, `rooted`,
+`theme`; app `app_start_time`, `app_identifier`, `app_name`, `app_version`,
+`app_build`, `app_memory`, `in_foreground`, `permissions`, `view_names`
+(https://develop.sentry.dev/sdk/data-model/event-payloads/contexts/). **Which subset
+each platform populates is not documented per-field**; the schema is the upper bound,
+not a promise. Device *name* is confirmed excluded at `sendDefaultPii = false`.
+
+The Android native breadcrumb integrations enabled by `enableAutoNativeBreadcrumbs`
+are, per Sentry's Android documentation, Activity Lifecycle, App Lifecycle, System
+Events, App Components and User Interaction — each nameable in the manifest to turn it
+off (`io.sentry.breadcrumbs.activity-lifecycle`, `…app-lifecycle`,
+`…system-events`, `…app-components`, `…user-interaction`)
+(https://docs.sentry.io/platforms/android/enriching-events/breadcrumbs/).
+
+## 5. How food-search terms reach Sentry anyway
+
+This is the finding the ticket did not anticipate, and it does not depend on trace
+sampling at all.
+
+`DebugPrintIntegration` is added unconditionally and replaces Flutter's `debugPrint`:
+
+```dart
+/// Integration which intercepts Flutters [debugPrint] method.
+/// If this integration is added, all calls to [debugPrint] a redirected to
+/// add a [Breadcrumb]. [debugPrint] is not outputting to the console anymore!
+```
+
+It self-disables only in debug builds:
+
+```dart
+final isDebug = options.runtimeChecker.isDebugMode();
+final enablePrintBreadcrumbs = options.enablePrintBreadcrumbs;
+if (isDebug || !enablePrintBreadcrumbs) {
+  return;
+}
+```
+
+and the replacement is a straight breadcrumb:
+
+```dart
+_hub.addBreadcrumb(Breadcrumb.console(
+  message: message,
+  level: SentryLevel.debug,
+));
+```
+
+`enablePrintBreadcrumbs` defaults to `true` in `packages/dart/lib/src/sentry_options.dart`:
+
+> Enable this option if you want to record calls to `print()` as breadcrumbs. In a
+> Flutter environment, this setting also toggles recording of `debugPrint` calls.
+> `debugPrint` calls are only recorded in release builds, though.
+
+Sentry only runs in this app in release builds, which is exactly the case in which the
+integration is live.
+
+`lib/core/utils/logger_config.dart` routes the entire application log into
+`debugPrint` at every level:
+
+```dart
+Logger.root.level = Level.ALL;
+Logger.root.onRecord.listen((record) {
+  debugPrint(
+    '${record.level.name}: ${record.loggerName}: ${record.message}',
+  );
+});
+```
+
+And three call sites log a search URL:
+
+- `lib/features/add_meal/data/data_sources/fdc_data_source.dart:24` —
+  `log.fine('Fetching FDC results from: $searchUrlString');`
+- `lib/features/add_meal/data/data_sources/off_data_source.dart:94` —
+  `log.fine('Fetching OFF results from: $searchUrl');`
+- `lib/features/add_meal/data/data_sources/off_data_source.dart:115` —
+  `log.fine('Fetching OFF result from: $searchUrl');`
+
+Those URLs are built by `OFFConst.getOffWordSearchUrl(searchString, …)` and the FDC
+equivalent, so the query string contains the user's typed food-search term. In a
+release build with consent given, each becomes a console breadcrumb, and the most
+recent 100 breadcrumbs ride along on the next event of any type — crash *or*
+app-start transaction.
+
+The Supabase path is better behaved by accident: `sp_food_data_source.dart` logs
+`'Successful localized ($locale) response from Supabase'` and `'Successful response
+from Supabase'` without the term. But its `catch` block, like the OFF and FDC ones,
+calls `Sentry.captureException(exception, stackTrace: stacktrace)`, and `off_data_source`
+additionally logs `'Search-a-licious failed ($error); …'` — whether a given exception's
+`toString()` embeds the request URI depends on the exception type and is not something
+documentation can settle. **I have not verified on-device what a real
+`ClientException` or `PostgrestException` message contains here.**
+
+Nothing in Sentry's documentation is wrong about this; it is a property of this
+codebase meeting an SDK default.
+
+## 6. Retention and data region
+
+**Retention**, from Sentry's own table:
+
+| Data type | Developer | Team | Business / Enterprise |
+|---|---|---|---|
+| Errors | 30 days | 90 days | 90 days |
+| Spans / transactions | 30 days | 30 days | 30 days + 13 months sampled |
+| Attachments | 30 days | 90 days | 90 days |
+| Session replays | 30 days | 90 days | 90 days |
+| Profiles | 30 days | 30 days | 30 days |
+
+with the exception that Team or Business plans on transaction-based billing get 90-day
+transaction retention and no sampled-span retention, and:
+
+> Retention periods are set at the time data is ingested, based on the then-current
+> plan. This means plan upgrades or downgrades affect retention for new data only;
+> existing data retains its original retention period.
+
+— https://docs.sentry.io/security-legal-pii/security/data-retention-periods/
+
+**Which row applies to this project depends on its Sentry plan, which is not
+determinable from the repository.**
+
+**Region.** An EU region exists. Sentry offers storage in "United States of America
+(US)", physically in Iowa, and "European Union (EU)", in Frankfurt, Germany. The
+choice is made once:
+
+> once selected, your data storage location can't be changed
+
+and for an existing SaaS organisation "the only way to switch it is by creating a new
+organization". Error events, transactions, spans, profiles, logs, metrics and session
+replays live in the selected region; **user accounts, organization settings, access
+tokens and audit logs are always stored in the US regardless** of the selection
+(https://docs.sentry.io/organization/data-storage-location/).
+
+**Which region this project's DSN points at cannot be determined from the repo.** The
+DSN is an obfuscated build secret (`@EnviedField(varName: 'SENTRY_DNS', obfuscate: true)`
+in `lib/core/utils/env.dart`, supplied from `secrets.SENTRY_DNS` in CI); every
+committed value is the placeholder `https://stub@sentry.io/0`. The region is readable
+from the real DSN's hostname, and that is a one-look check for whoever holds the
+account.
+
+**The entity and the transfer mechanism.** Sentry's DPA names the contracting party
+"Functional Software, Inc. d/b/a Sentry" and states that Sentry "may store and process
+Customer Data in the United States and any other country in which we or our
+Subprocessors maintain data processing operations", relying on the Data Privacy
+Framework and, "in the event that the Data Privacy Framework is invalidated, or the
+Data Privacy Framework does not otherwise apply", on the Standard Contractual Clauses
+(https://sentry.io/legal/dpa/). The privacy policy confirms the split hosting:
+
+> our Site and Service are hosted in the United States and Germany
+
+— https://sentry.io/privacy/
+
+That page also draws the line that matters for reading it: "This Privacy Policy does
+not apply to data submitted to the Service ("Service Data")" — event payloads are
+governed by the Customer Agreement and DPA, not by the policy Sentry publishes for its
+own website visitors.
+
+---
+
+## What this means for the policy
+
+**The data categories Sentry actually receives from this app, given today's
+configuration:**
+
+1. Crash and error events with Dart stack traces (`captureException` sites across
+   `add_meal`, `edit_meal`, `meal_detail`, `add_activity` and the quick-add sheets),
+   plus native crashes via the platform SDKs.
+2. One app-start performance transaction per launch — `root /`, operation `ui.load`,
+   with timing spans and app-start and frame measurements.
+3. Device, OS and app contexts on every event and every transaction — model, family,
+   architecture, manufacturer, memory and storage figures, screen metrics, timezone,
+   language, OS version and build, app version and build. Device *name* is excluded.
+4. Up to 100 breadcrumbs on every event and every transaction, comprising native
+   lifecycle and system-event breadcrumbs and — the material item — the app's entire
+   `logging` output, which includes Open Food Facts and USDA FDC search URLs
+   containing the user's search terms.
+5. Release, environment, SDK version and integration list.
+6. On Apple platforms, possibly the client IP via `{{auto}}` — unresolved, see §3.
+
+Not received: screenshots, view hierarchy, session replay, HTTP headers, request
+bodies, user identifiers, device name, file paths, route or screen names, tap targets.
+
+**Is the "crash traces, app and OS version, device model" claim complete? No.** That
+exact sentence does not appear on `main`; the nearest in-repo statements are
+`README.md:55` — "Anonymous crash reporting is opt-in during onboarding, can be turned
+off at any time" — and the settings string `dataCollectionLabel`: "Send anonymous
+crash reports to help fix bugs. No food log, weight, or personal data is included."
+Whichever wording the policy inherits, three things are missing from it:
+
+- **Performance/transaction data is a separate category from crash reports** and is
+  collected unconditionally at `tracesSampleRate = 1.0`. iOS already declares
+  `NSPrivacyCollectedDataTypePerformanceData` alongside `…CrashData` in
+  `ios/Runner/PrivacyInfo.xcprivacy`; the README and the consent string do not.
+- **Breadcrumbs carrying food-search terms.** "No food log, weight, or personal data is
+  included" is a claim about the payload that the debug-print breadcrumb path
+  contradicts for search terms specifically. This is a code-level defect as much as a
+  wording problem — a build ticket that stops logging URLs, or sets
+  `enablePrintBreadcrumbs = false`, would make the existing sentence true again and is
+  cheaper than describing the leak.
+- **Device metadata is broader than "device model"** — memory, storage, screen, battery,
+  timezone and language are in scope per the context schema.
+
+**A third-country transfer must be disclosed.** Functional Software, Inc. is a US
+entity; its DPA reserves processing in the US "and any other country in which we or
+our Subprocessors maintain data processing operations", relying on the Data Privacy
+Framework with SCCs as fallback; and even an EU-region organisation has its account
+and organisation records stored in the US by design. Selecting the Frankfurt region
+would narrow but not eliminate the transfer, and it cannot be selected retroactively
+for an existing organisation.
+
+**One open item blocks a complete disclosure and is a lookup, not research:** which
+region and which plan tier this project's Sentry organisation uses. Region fixes the
+processing location and the transfer wording; plan tier fixes whether errors are kept
+30 or 90 days. Both are visible in the Sentry account and neither is inferable from
+the code.
+
+---
+
+## Sources
+
+- [Options — Sentry for Flutter](https://docs.sentry.io/platforms/dart/guides/flutter/configuration/options/)
+- [Data Collected — Sentry for Flutter](https://docs.sentry.io/platforms/dart/guides/flutter/data-management/data-collected/)
+- [Integrations — Sentry for Flutter](https://docs.sentry.io/platforms/dart/guides/flutter/integrations/)
+- [Routing Instrumentation — Sentry for Flutter](https://docs.sentry.io/platforms/dart/guides/flutter/integrations/routing-instrumentation/)
+- [User Interaction Instrumentation — Sentry for Flutter](https://docs.sentry.io/platforms/dart/guides/flutter/integrations/user-interaction-instrumentation/)
+- [HTTP Integration — Sentry for Flutter](https://docs.sentry.io/platforms/dart/guides/flutter/integrations/http-integration/)
+- [Set Up Tracing — Sentry for Flutter](https://docs.sentry.io/platforms/dart/guides/flutter/tracing/)
+- [Users — Sentry for Flutter](https://docs.sentry.io/platforms/dart/guides/flutter/enriching-events/identify-user/)
+- [Users — Sentry for iOS](https://docs.sentry.io/platforms/apple/guides/ios/enriching-events/identify-user/)
+- [Breadcrumbs — Sentry for Android](https://docs.sentry.io/platforms/android/enriching-events/breadcrumbs/)
+- [Transaction Payload — Sentry Developer Documentation](https://develop.sentry.dev/sdk/data-model/event-payloads/transaction/)
+- [User Interface — Sentry Developer Documentation](https://develop.sentry.dev/sdk/data-model/event-payloads/user/)
+- [Contexts Interface — Sentry Developer Documentation](https://develop.sentry.dev/sdk/data-model/event-payloads/contexts/)
+- [Data Retention Periods — Sentry](https://docs.sentry.io/security-legal-pii/security/data-retention-periods/)
+- [Data Storage Location — Sentry](https://docs.sentry.io/organization/data-storage-location/)
+- [Data Processing Addendum — Sentry](https://sentry.io/legal/dpa/)
+- [Privacy Policy — Sentry](https://sentry.io/privacy/)
+- `getsentry/sentry-dart` at tag `9.19.0`: `packages/flutter/lib/src/sentry_flutter.dart`,
+  `packages/flutter/lib/src/sentry_flutter_options.dart`,
+  `packages/flutter/lib/src/integrations/debug_print_integration.dart`,
+  `packages/flutter/lib/src/integrations/screenshot_integration.dart`,
+  `packages/flutter/lib/src/integrations/native_app_start_integration.dart`,
+  `packages/flutter/lib/src/integrations/native_app_start_handler.dart`,
+  `packages/flutter/lib/src/integrations/load_contexts_integration.dart`,
+  `packages/flutter/lib/src/view_hierarchy/view_hierarchy_integration.dart`,
+  `packages/dart/lib/src/sentry_client.dart`, `packages/dart/lib/src/scope.dart`,
+  `packages/dart/lib/src/sentry_options.dart`

--- a/docs/privacy-supabase-subprocessors.md
+++ b/docs/privacy-supabase-subprocessors.md
@@ -1,0 +1,446 @@
+# Is Cloudflare a named sub-processor under a Supabase DPA?
+
+Research for [#890](https://github.com/simonoppowa/OpenNutriTracker/issues/890), on
+map [#867](https://github.com/simonoppowa/OpenNutriTracker/issues/867). Researched
+2026-08-27 against Supabase's own published terms, sub-processor list and
+documentation, plus Cloudflare's documentation where the Supabase side is silent.
+
+**The short answer: yes, on all counts, and nothing needs signing.** Cloudflare, Inc
+is a named sub-processor on Supabase's published list. The DPA is incorporated into
+the Terms of Service by its own words and is effective from the moment the account
+was created — there is no button to press and no document to sign. Sub-processor
+changes carry a 30-day notice with an objection right, but **only if you subscribe**,
+which is the one action the maintainer would have to take. Supabase's own
+documentation names Cloudflare twice, in writing, as part of the platform's request
+path. And Supabase's GDPR guide states outright that sub-processors "can affect your
+data residency" — so the Frankfurt claim survives only if it is stated as
+*storage and primary processing*, not as "the data never leaves the EU".
+
+The obvious URL is a red herring: `https://supabase.com/legal/subprocessors` really
+does return **404** (confirmed on the wire, 2026-08-27). It was never the right URL.
+
+---
+
+## 1. Where Supabase publishes the sub-processor list
+
+**Live URL:
+[`https://supabase.com/legal/customer-resources/subprocessor-list`](https://supabase.com/legal/customer-resources/subprocessor-list)**
+(HTTP 200). It is linked from the [Legal Hub](https://supabase.com/legal) under
+*Customer Legal Resources*, and — decisively — it is the URL the DPA itself names as
+the operative list (clause 6.2, quoted in §3 below).
+
+The page is a wrapper. The list is a PDF:
+
+> The third-party sub-processors Supabase engages to help provide its services are
+> indicated in the latest linked Subprocessor List available below. This page is
+> updated with an updated Subprocessor List as our sub-processors change. You can
+> subscribe to receive notifications of updates to this page, below.
+
+Current document:
+[Subprocessor List — Updated June 1, 2026](https://supabase.com/legal/subprocessor-list/June-1-2026.pdf).
+
+**Cloudflare is on it**, verbatim:
+
+> | Name of Sub-processor | Description of Processing |
+> | --- | --- |
+> | Cloudflare, Inc | Provision of hosting services |
+
+**The stated purpose is "Provision of hosting services". No location is stated —
+for Cloudflare or for anyone.** The PDF has exactly two columns, *Name of
+Sub-processor* and *Description of Processing*. There is no country column, no
+processing-location column, and no entity address. This matters for a policy
+disclosure that wants to say *where* data goes: the list identifies **who**, and
+Supabase does not publish **where** for any of them.
+
+The full list, June 1 2026, reproduced in the order printed:
+
+| Name of Sub-processor | Description of Processing |
+| --- | --- |
+| Supabase, Inc. | Provision of support services |
+| Active Campaign, LLC d/b/a Postmark | Communication with Authorized Users in connection with the provision of the Services and support |
+| Amazon Web Services, Inc | Provision of hosting services |
+| Atlassian Corporation Plc | Provision of status page services |
+| Braintrust Data, Inc | Provision of monitoring and tracing |
+| Clay Labs Inc. | Provision of customer insight services |
+| Clazar, Inc | Provision of marketplace services |
+| **Cloudflare, Inc** | **Provision of hosting services** |
+| ConfigCat Korlátolt Felelősségű Társaság | Feature flagging |
+| Google, LLC | Provision of hosting services |
+| Fly.io, Inc | Provision of hosting services |
+| FrontApp, Inc | Communication with Authorized Users in connection with the provision of the Services and support |
+| Functional Software, Inc d/b/a Sentry | Error monitoring and tracing |
+| Github, Inc | Authorized Users account authentication |
+| Hex Technologies, Inc | Provision of data analytics services |
+| Hubspot, Inc | Communication with Authorized Users in connection with the provision of the Services and support |
+| Notion Labs, Inc | Communication with Authorized Users in connection with the provision of the Services and support |
+| Sublime Security Inc | Email Security |
+| Latacora, LLC | Managed Security Service Provider |
+| OpenAI, LLC | Provision of natural language processing and generation services |
+| PandaDoc, Inc | Communication with Authorized Users in connection with the provision of the Services and support |
+| Slack Technologies, LLC | Communication with Authorized Users in connection with the provision of the Services and support |
+| Upstash, Inc | Provision of serverless data hosting services |
+| Vercel, Inc | Provision of hosting services |
+
+Two observations for the policy author:
+
+- **The list is not segmented by service.** Most of these entries — Postmark, Front,
+  Hubspot, Notion, PandaDoc, Slack, Clay, Clazar, Hubspot — are described as
+  *communication with Authorized Users*, i.e. they process the **maintainer's** account
+  and support data, not app end-user data. Nothing on the page says which entries touch
+  which data, so the list cannot be copied into a user-facing policy wholesale without
+  overstating who sees end-user food searches.
+- **`Supabase, Inc.` appears as a sub-processor of `Supabase Pte. Ltd.`** The
+  contracting party in the Terms of Service is *SUPABASE PTE. LTD., a Singapore
+  entity with a registered address of 65 Chulia Street #38-02/03, OCBC Centre,
+  Singapore 049513*. The US entity is a sub-processor beneath it. If the policy names
+  the processor, that is the entity to name.
+
+## 2. Is a DPA in force on a Free-plan account by default?
+
+**Yes. It is in force automatically, it requires no signature, and there is nothing
+in the dashboard to accept.** Three independent statements, none of which is
+conditioned on plan or on any customer action.
+
+The Terms of Service define the DPA and then incorporate it, in §7(b) (*Customer
+Data*):
+
+> The Parties agree to comply with the Data Processing Addendum, which is
+> incorporated into this Agreement.
+
+> "Data Processing Addendum" means the Data Processing Addendum available at
+> https://supabase.com/legal/customer-resources/data-processing-addendum, or, if the
+> Parties have a separately executed agreement in effect that covers the same subject
+> matter, the separately executed agreement.
+
+— [Terms of Service](https://supabase.com/terms). Note the fallback runs the *other*
+way from what one might expect: the published DPA is the default, and a separately
+executed agreement is the exception.
+
+The DPA says the same thing from its own side, and dates itself to account creation
+([Data Processing Addendum](https://supabase.com/legal/customer-resources/data-processing-addendum),
+Version 1 — August 1, 2026):
+
+> This Data Processing Addendum (the "DPA") supplements and forms part of the Supabase
+> Terms of Service available at https://supabase.com/terms, or such other agreement
+> entered into between the Customer and Supabase Pte. Ltd ("Supabase") relevant to
+> Customer's use of the Services (the "Agreement"), and in case of any conflict,
+> supersedes the Agreement in relation to the transfer and processing of Covered Data
+> in connection with the performance of the Services. **This DPA is effective as of the
+> Effective Date of the Agreement.**
+
+And the Agreement's Effective Date is *use*, not signature:
+
+> THIS AGREEMENT TAKES EFFECT WHEN YOU CLICK THE "I ACCEPT" BUTTON BELOW OR BY
+> ACCESSING OR USING THE SERVICES (the "Effective Date").
+
+Even the Standard Contractual Clauses annexed to the DPA need no separate signing
+(DPA clause 12.2, *Signature of the SCCs*):
+
+> The Parties agree that acceptance of the Agreement shall have the same effect as
+> signing the SCCs.
+
+The DPA also fixes the roles the way [#873](https://github.com/simonoppowa/OpenNutriTracker/issues/873)
+adjudicated them, without needing anyone to argue it (clause 2, *Role of the Parties*):
+
+> The Parties acknowledge and agree that Supabase acts as a processor/service provider,
+> and Customer as controller/business under the Agreement and this DPA.
+
+**No Free-plan carve-out exists.** The word "plan" does not appear anywhere in the
+Terms of Service; the Agreement governs "your access to and use of the Cloud Services"
+without tier distinction, and neither the DPA nor its sub-processor clauses condition
+anything on a paid subscription. (By contrast, the docs *are* explicit when something
+is tier-gated — the ISO 27001 certificate is "Enterprise and Team customers", and a
+HIPAA BAA must be separately signed. The DPA is described with no such qualifier.)
+
+**So what would the maintainer actually have to DO?** For the DPA itself: nothing.
+One thing is worth doing, and it is not the DPA:
+
+- **Subscribe to sub-processor change notifications** at the bottom of the
+  [sub-processor list page](https://supabase.com/legal/customer-resources/subprocessor-list)
+  (first name, last name, email). Per §3 below, the 30-day notice and the objection
+  right are **conditional on having subscribed**. Without it, the list can change
+  silently and the policy goes stale unnoticed.
+
+**Not established from documentation:** whether the dashboard *also* surfaces a
+countersigned/counterparty-executed DPA PDF for download (the org dashboard has a
+*Legal Documents* section that serves SOC 2 and similar). That would be cosmetic —
+the contract is already in force — but if a countersigned copy is wanted for the
+record, the org dashboard's documents page is where to look, and Supabase support is
+what would confirm it. Nothing was signed or clicked in the course of this research.
+
+## 3. The Art. 28 sub-processor terms
+
+DPA **clause 6.2 (Authorization)** is a general (blanket) authorization pinned to the
+published list:
+
+> Customer grants Supabase general authorization (or, where applicable, has Customer's
+> Controller's general authorization) to engage any of the Sub-processors provided in
+> Supabase's Sub-processor list, available at
+> https://supabase.com/legal/customer-resources/subprocessor-list ("Subprocessor
+> List"), as amended from time to time in accordance with clause 6.3 (the "Authorized
+> Sub-processors"), to Process Covered Data. Supabase shall: (a) enter into a written
+> agreement with each Authorized Sub-processor imposing data protection obligations
+> that, in substance, are no less protective of Covered Data than Supabase's
+> obligations under this DPA; and (b) remain liable for each Authorized Sub-processor's
+> compliance with the obligations under this DPA.
+
+That is Art. 28(2) general written authorization plus Art. 28(4) flow-down and
+retained liability. The SCC counterpart is elected explicitly in Schedule 2:
+
+> 1.3 Option 2 of Clause 9(a) (General written authorization) shall apply, and the time
+> period to be specified is determined in clause 6.3 of the DPA.
+
+DPA **clause 6.3 (Updates to the Subprocessor List)** carries the notice and objection
+machinery — quoted in full because the conditional in the second sentence is the
+load-bearing part:
+
+> Supabase offers a mechanism for Customer to subscribe to notifications of changes to
+> the Subprocessor List via
+> https://supabase.com/legal/customer-resources/subprocessor-list. **If Customer
+> subscribes to receive such updates**, Supabase will provide Customer with at least
+> thirty (30) days' notice of any proposed changes to the Authorized Sub-processors.
+> Customer shall notify Supabase if it objects to the proposed change to the Authorized
+> Sub-processors (including, where applicable, when exercising its right to object
+> under clause 9(a) of the SCCs) by providing Supabase with written notice of the
+> objection within five (5) days after Supabase has provided notice to Customer of such
+> proposed change (an "Objection"). In the event Customer submits an Objection to
+> Supabase, Supabase and Customer shall work together in good faith to find a mutually
+> acceptable resolution to address such Objection. If Supabase and Customer are unable
+> to reach a mutually acceptable resolution within a reasonable timeframe, which shall
+> not exceed thirty (30) days, Customer may terminate the portion of the Agreement
+> relating to the Services affected by such change by providing written notice to
+> Supabase.
+
+To answer the ticket's three sub-questions plainly:
+
+- **How are changes notified?** By email, to subscribers only. The page is also
+  updated, but there is no push to non-subscribers.
+- **Is there an objection right?** Yes — written objection, then good-faith
+  negotiation, then a right to terminate the affected portion of the Agreement.
+  There is **no right to block the change**; the remedy is exit, not veto.
+- **Notice period?** At least **30 days** before the change. The window to object is
+  **5 days** after notice, and resolution is capped at **30 days**.
+
+The 5-day objection window is short and starts on Supabase's notice, which is another
+reason to subscribe rather than to poll the page.
+
+Retention has a matching flow-down (clause 11): on expiry of the retention period
+Supabase "shall delete all copies of Covered Data Processed by Supabase or any
+Authorized Sub-processors."
+
+## 4. Does Supabase document the Cloudflare layer specifically?
+
+**Yes — twice in the product documentation, and once as a global status component.**
+[#869](https://github.com/simonoppowa/OpenNutriTracker/issues/869) measured it; these
+are Supabase acknowledging it in writing, which is what a paper trail needs.
+
+The logging documentation describes the API path as running through Cloudflare, and
+names exactly the field prefix #869 observed
+([Logs](https://supabase.com/docs/guides/monitoring-and-debugging/logs)):
+
+> API logs run through the Cloudflare edge servers and will have attached Cloudflare
+> metadata under the `metadata.request.cf.*` fields.
+
+The same page defines the `edge_logs` source as Cloudflare-sourced:
+
+> `edge_logs`: Edge network logs, containing request and response metadata retrieved
+> from Cloudflare.
+
+It also publishes the allow-list of headers retained in API logs, which includes two
+Cloudflare-injected headers on the request side and two on the response side:
+
+> Request headers: `accept` `cf-connecting-ip` `cf-ipcountry` `host` `user-agent`
+> `x-forwarded-proto` `referer` `content-length` `x-real-ip` `x-client-info`
+> `x-forwarded-user-agent` `range` `prefer`
+>
+> Response headers: `cf-cache-status` `cf-ray` `content-location` `content-range`
+> `content-type` `content-length` `date` `transfer-encoding` `x-kong-proxy-latency`
+> `x-kong-upstream-latency` `sb-gateway-mode` `sb-gateway-version`
+
+Note `cf-ipcountry` in particular: Supabase documents that a **country derived from
+the end user's IP** is retained in project logs by default. That is a per-request
+location inference about the app's users, published as a documented platform
+behaviour, not something the project configured.
+
+The security guide names Cloudflare as the DDoS layer
+([Supabase Security](https://supabase.com/docs/guides/security)):
+
+> Supabase protects against Distributed Denial of Service (DDoS) attacks at the edge
+> via Cloudflare.
+
+And the status page treats the gateway as a **global, non-regional** component:
+[status.supabase.com](https://status.supabase.com) lists `API Gateway` — described as
+"API Gateway for all Supabase Products" — in the same flat list as the per-region
+components (`eu-central-1`, `us-east-1`, and so on), i.e. it is not scoped to a region
+the way Database and Storage are.
+
+**What the documentation does *not* say anywhere:** that this layer is optional,
+configurable, or avoidable. It is described as how the platform works. That is
+consistent with #869's finding and is the point that matters — the project is not
+using a feature it could turn off, so Cloudflare is in the path of every request by
+design, and the sub-processor listing is the right and only place it is disclosed.
+
+The storage CDN documentation is a near-miss worth recording so nobody re-searches
+it: [Storage CDN](https://supabase.com/docs/guides/storage/cdn/fundamentals) describes
+the CDN in detail — "All requests to the Supabase Storage API are routed to the CDN
+first" — but never names the provider. The provider identification comes from the two
+pages quoted above, not from there.
+
+## 5. Supabase's stated position on EU data residency
+
+**Supabase scopes its residency claim to storage and primary processing, and states
+explicitly that sub-processors can affect the residency analysis. It does not address
+Cloudflare edge termination specifically.**
+
+The DPA's location clause (**clause 6.1, *Location***) is the contractual position, and
+it is carefully bounded:
+
+> Supabase may Process Covered Data anywhere that Supabase or its Sub-processors
+> maintain facilities, subject to the remainder of this clause 6, its obligations with
+> respect to data transfers as required by Applicable Data Protection Laws and clause
+> 12 of this DPA. **Where Customer directs Supabase to Process Covered Data in a
+> specific geographical region, Supabase shall ensure that such Covered Data is stored
+> and primarily Processed in that region unless otherwise required to comply with
+> Customer's additional instructions, applicable law or as necessary to provide
+> Services requested by Customer.**
+
+Three limits in one sentence: **"stored and primarily Processed"** (not exclusively),
+and two carve-outs, one of which — "as necessary to provide Services requested by
+Customer" — is exactly the shape of a global edge gateway. The default, absent a region
+direction, is that processing may occur "anywhere that Supabase or its Sub-processors
+maintain facilities".
+
+The GDPR guide says the same thing in plain language, and names sub-processors as a
+residency factor
+([GDPR compliance and Supabase](https://supabase.com/docs/guides/security/gdpr-compliance)):
+
+> Each Supabase project is deployed to a single primary region, and your project's
+> primary Postgres database, Auth service, and Storage objects are hosted in that
+> region. Choosing a specific region within the EU pins these services to that exact
+> AWS region.
+
+> Choosing a region is a data-location control and does not make your application GDPR
+> compliant on its own. **Backups, logs, data exported to external systems, Edge
+> Function execution, and sub-processors can affect your data residency and
+> international transfer analysis.**
+
+The regions page repeats the framing
+([Available regions](https://supabase.com/docs/guides/platform/regions)):
+
+> The region you choose also determines where your primary project data is stored.
+> [...] Region selection is a data-location control, not proof of regulatory compliance.
+
+Incidentally relevant to this project's configuration: the same page warns that the
+general "Europe" grouping includes London and Zurich, which are not EU member states,
+and advises choosing a specific region if EU-only matters. This project uses the
+**specific** region `eu-central-1` (Frankfurt), so it is already on the right side of
+that warning — the Postgres database, Auth and Storage objects are pinned to Frankfurt.
+
+**Nothing in Supabase's documentation or terms addresses TLS termination at the edge.**
+No page states where the Cloudflare layer decrypts, whether it can be regionalised, or
+whether an EU project's requests are terminated in the EU. The transfer machinery in
+DPA clause 12 and Schedule 2 (EU SCCs, Module Two controller-to-processor, Irish
+governing law, UK Addendum, Swiss regime) is what covers transfers out of the EEA in
+the abstract — it is a lawful-transfer mechanism, not a claim that transfers do not
+happen.
+
+Cloudflare's own documentation supplies the missing behaviour, and it points the
+unhelpful way. Restricting decryption to a region is a **separate paid product**,
+[Regional Services](https://developers.cloudflare.com/data-localization/regional-services/),
+part of the Data Localization Suite:
+
+> With Regional Services, TLS termination — the point at which encrypted HTTPS traffic
+> is decrypted so Cloudflare can inspect and apply your security rules — only occurs
+> inside the configured region. For example, if a hostname is configured to
+> regionalize to the European Union (EU), any HTTPS request from the United States (US)
+> will be forwarded in encrypted form to an EU data center before being decrypted.
+
+The existence of that product is the proof of the default: without it, decryption
+happens at the data centre that receives the connection, which #869 measured as the
+PoP nearest the end user (`cf.colo` varying by client location). **There is no
+published evidence that Supabase enables Regional Services on customer project
+hostnames**, and no Supabase page mentions it.
+
+**This is the one question documentation cannot settle, and it is worth asking.** The
+precise question is: *does Cloudflare terminate TLS for `*.supabase.co` project
+endpoints at the PoP nearest the client, or is Regional Services (or equivalent)
+applied for projects in EU regions?* That wants **a written question to Supabase
+support**, and the answer should be recorded here when it arrives. Until then the
+honest reading is the conservative one: request metadata for an EU project is
+processed at a Cloudflare PoP wherever the user happens to be, including outside the
+EEA, under the SCCs in DPA Schedule 2.
+
+---
+
+## What this means for the policy
+
+**Two parties must be named, and the Frankfurt claim survives only in Supabase's own
+narrower wording.**
+
+**Processor: Supabase Pte. Ltd.** — the Singapore entity named in the Terms of Service,
+not "Supabase" loosely and not Supabase, Inc. (which is itself a sub-processor
+beneath it). The processor relationship is not an inference the project has to defend;
+DPA clause 2 states it: Supabase "acts as a processor/service provider, and Customer as
+controller/business".
+
+**Sub-processor: Cloudflare, Inc.** — named on the published list with the stated
+purpose *"Provision of hosting services"*, and independently acknowledged in Supabase's
+documentation as the edge the API path runs through. Both the naming and the purpose
+can be quoted from primary sources. **No location can be quoted for it**, because
+Supabase publishes none; a policy that wants to state where Cloudflare processes must
+either say "worldwide edge locations, selected by proximity to the user" on the
+strength of #869's measurement plus Cloudflare's own routing documentation, or say
+nothing about location for that entity.
+
+**Amazon Web Services, Inc.** should be named too if the policy names the hosting
+chain at all: it is on the same list with the same stated purpose, and the GDPR guide
+confirms the project's Postgres, Auth and Storage sit in an AWS region. Naming
+Cloudflare but not AWS would describe the transit layer while omitting the layer that
+actually stores the data.
+
+**The other twenty-one entries should not be copied across.** Most are described as
+*communication with Authorized Users* — the maintainer's own account, support and
+marketing contact data — and nothing on the list suggests they touch app end-user food
+searches. The list is Supabase's, covering all of its services and all of its customer
+relationships; a user-facing policy that reproduced it wholesale would tell users that
+Slack, Hubspot and OpenAI process their data, which is not established and is probably
+false for this project. If the policy wants completeness, link the list rather than
+inline it — that also keeps it accurate as the list changes.
+
+**On residency: do not write "your data stays in the EU". Write what Supabase writes.**
+The defensible sentence is that the database, authentication and stored objects are
+hosted in Frankfurt (`eu-central-1`), because that is what
+[the GDPR guide](https://supabase.com/docs/guides/security/gdpr-compliance) claims and
+what DPA clause 6.1 obliges — *stored and primarily Processed* in the directed region.
+The indefensible sentence is any claim that requests never leave the EU. They do:
+every request terminates at a Cloudflare PoP chosen by proximity to the user, request
+metadata including IP-derived country lands in the project's logs, and Supabase's own
+guide warns that "logs [...] and sub-processors can affect your data residency and
+international transfer analysis". Transfers outside the EEA are **covered** by the
+SCCs in DPA Schedule 2 rather than avoided, and that is a different — and honest —
+thing to say.
+
+**No contractual gap was found, and nothing needs signing.** The paper trail
+[#873](https://github.com/simonoppowa/OpenNutriTracker/issues/873) went looking for
+exists: a DPA in force by default, a general authorization pinned to a published list,
+Cloudflare on that list, flow-down obligations and retained liability, and SCCs
+executed by acceptance. The only outstanding action is a free one — **subscribe to
+sub-processor change notifications**, without which the 30-day notice and 5-day
+objection right in clause 6.3 never fire.
+
+---
+
+## Sources
+
+- [Supabase Legal Hub](https://supabase.com/legal)
+- [Supabase Terms of Service](https://supabase.com/terms)
+- [Supabase Data Processing Addendum, Version 1 — August 1, 2026](https://supabase.com/legal/customer-resources/data-processing-addendum) (`https://supabase.com/legal/dpa` 308-redirects here)
+- [Supabase Subprocessor List page](https://supabase.com/legal/customer-resources/subprocessor-list) — and the [June 1, 2026 PDF](https://supabase.com/legal/subprocessor-list/June-1-2026.pdf)
+- `https://supabase.com/legal/subprocessors` — **HTTP 404**, confirmed 2026-08-27
+- [Logs — Supabase Docs](https://supabase.com/docs/guides/monitoring-and-debugging/logs)
+- [Supabase Security — Supabase Docs](https://supabase.com/docs/guides/security)
+- [GDPR compliance and Supabase — Supabase Docs](https://supabase.com/docs/guides/security/gdpr-compliance)
+- [Available regions — Supabase Docs](https://supabase.com/docs/guides/platform/regions)
+- [Storage CDN — Supabase Docs](https://supabase.com/docs/guides/storage/cdn/fundamentals)
+- [Supabase status page](https://status.supabase.com)
+- [Regional Services — Cloudflare Data Localization Suite](https://developers.cloudflare.com/data-localization/regional-services/)


### PR DESCRIPTION
The six research documents behind the privacy-policy spec (#895), brought onto `main` so its citations resolve.

Each arrived as its own branch and is cherry-picked here unchanged, so the individual commits and their reasoning survive. One annotation was added on top — see below.

| Document | Question it answers | Ticket |
| :-- | :-- | :-- |
| `privacy-fdc-reachability.md` | Does the app still call the USDA FoodData Central API? (No — the client is wired but has zero callers) | #868 |
| `privacy-permission-audit.md` | What does the released build actually request? (Six permissions, from a real merged release manifest) | #872 |
| `privacy-sentry-payload.md` | What does Sentry receive at `tracesSampleRate = 1.0`? | #870 |
| `privacy-iubenda-expressiveness.md` | What can the generator be made to say? | #871 |
| `privacy-supabase-subprocessors.md` | Is Cloudflare a named sub-processor under a DPA? | #890 |
| `privacy-sentry-ios-ip.md` | Does iOS send the client IP despite `sendDefaultPii`? | #889 |

## Why these are worth keeping

The load-bearing findings in the spec were **measured rather than reasoned**, and these documents are where the measurements live: the merged release manifest that showed no storage permission exists, the gateway log record pairing a search term with a postal code and a TLS fingerprint, the sub-processor PDF, the live Sentry event. Each claim carries a quote and a `file:line` or URL.

They also record what was *rejected*, which the spec cannot — a spec states conclusions, and half the value of an audit is knowing which plausible answer was wrong and why.

## One document is annotated rather than corrected

`privacy-sentry-payload.md` concluded that Sentry infers geolocation only when `ip_address` is present on the event. **That is wrong.** #889 disproved it by reading a live event in this project's own organisation: `user.geo` carried country, city and region while `user.ip_address` was `null`, because Relay resolves geo from the *connection* IP before the filtering step.

The final commit adds a warning callout at the top of that document instead of editing the claim away. The point of keeping research in the repo is that its reasoning can be checked, and a document silently corrected teaches nobody which step was wrong. Everything else in it stands — including the print-breadcrumb finding that led to #877, which turned out to be a live diary leak in the shipped release.

## Notes

Docs only; no code paths touched. The six source branches remain pushed and can be deleted once this merges.
