### PR TITLE
docs: correct what the README claims about the wire

### DIFF
--- a/README.md
+++ b/README.md
@@ -136,7 +136,7 @@ No account, no sign-in, no analytics, no ads. Your profile, diary, activities, w
 
 [USDA FoodData Central](https://fdc.nal.usda.gov/), the German [BLS](https://www.blsdb.de), INDB and TBCA are where the food *data* comes from, not places your device talks to. Those datasets are ingested into the Supabase backend ahead of time ([self-hosting guide](docs/supabase-fdc-self-hosting.md)), so a search reaches that backend and stops there. Settings → Food databases chooses which datasets a search covers. Five are selectable today, with INDB and TBCA in the schema but not yet carrying data ([`sp_const.dart`](lib/features/add_meal/data/dto/sp/sp_const.dart)).
 
-Requests carry a User-Agent naming the app, platform, and version, with no user or device identifier. Search results are cached locally and pruned after 90 days.
+Requests to Open Food Facts carry a User-Agent naming the app, platform, and version; requests to the Supabase backend carry the Supabase SDK's own client headers instead. **The app generates no user or device identifier and sends none** — but a request still arrives from somewhere, and the Supabase gateway logs the address it came from along with a coarse location and a fingerprint of the TLS connection, kept for 24 hours. Search results are cached locally and pruned after 90 days.
 
 **Crash reporting** is off until you enable it, and initializes only in release builds ([`main.dart:119`](lib/main.dart:119)). `sendDefaultPii` stays `false`, so no username, email, or IP-derived identity is attached. Disabling it, or deleting your data, closes the SDK immediately.
 


### PR DESCRIPTION
Brings the README wire-claim correction onto `develop`. Same single-line change as #891, which was merged to `main` — cherry-picked here because it should have targeted `develop` in the first place.

## What was wrong

Two claims in the Privacy section, both wrong in the same direction: they described what the app *means* to send rather than what a request carries.

**"Requests carry a User-Agent naming the app, platform, and version"** — true only of Open Food Facts. `ONTHttpClient` sets that header and its only callers are in `off_data_source.dart`. The Supabase client builds its own requests; the gateway records them as `Dart/3.12 (dart:io)`.

**"with no user or device identifier"** — true of what the app generates, false of what the recipient holds. The Supabase gateway log pairs each search with the connecting IP, a city, region and postal code, the ISP name, and a JA3/JA4 fingerprint of the TLS handshake, for one day.

The fix splits the claim into what the app transmits and what any server necessarily records. Stating the second half **is** the correction — withholding it is how the sentence came to mislead a reader trusting the table above it.

## Note

Related but not covered here: #889 later found that Sentry also receives a **stable per-install UUID** and the **city** of every crash, which is a third contradiction of the same sentence and the strongest one — a persistent identifier rather than something a recipient derives. That is being decided in #894 and will need its own edit; this PR does not pre-empt it.

#893 back-ports the crash-report fix and the `AGENTS.md` correction to `develop`; this is the piece it does not carry.

Found while auditing the published Data policy against the source (#867); resolves the `develop` half of #883.
