### PR TITLE
fix(core): stop crash reports carrying a per-install identifier

### DIFF
--- a/lib/core/utils/sentry_config.dart
+++ b/lib/core/utils/sentry_config.dart
@@ -23,4 +23,31 @@ void configureSentryOptions(SentryOptions options, {required String dsn}) {
   options.dsn = dsn;
   options.tracesSampleRate = 1.0;
   options.enablePrintBreadcrumbs = false;
+  options.beforeSend = _stripUser;
+}
+
+/// Drops the `user` block from every event before it leaves the device.
+///
+/// The native SDKs attach a randomly generated per-installation UUID as
+/// `user.id`, and `sendDefaultPii` does not gate it — it is set regardless,
+/// then carried onto Dart events along with the rest of the native user map.
+/// Measured on a live event: the id is stable across launches, so every crash
+/// from one installation is linkable to every other.
+///
+/// That makes the reports *pseudonymous*, and the consent the user gave calls
+/// them anonymous. Removing the identifier is what makes the claim true, and
+/// it restores the README's "no user or device identifier" rather than
+/// requiring the sentence to be qualified a third time.
+///
+/// The cost is deliberate: `user.id` is what Sentry counts to say how many
+/// users an issue affects, so an issue can no longer distinguish one
+/// installation crash-looping from many installations hitting the same bug.
+///
+/// This cannot reach `user.geo` — the country, region and city Sentry records
+/// per event. That is derived server-side at ingest from the connection
+/// address, which the client never sends, so it has to be dealt with by a
+/// data-scrubbing rule on the organisation instead.
+SentryEvent? _stripUser(SentryEvent event, Hint hint) {
+  event.user = null;
+  return event;
 }

--- a/test/unit_test/sentry_config_test.dart
+++ b/test/unit_test/sentry_config_test.dart
@@ -19,6 +19,24 @@ void main() {
     expect(configured().enablePrintBreadcrumbs, isFalse);
   });
 
+  test('release options strip the user block before sending', () async {
+    // The native SDKs attach a stable per-install UUID as user.id regardless
+    // of sendDefaultPii, so an event that still carries a user block is one
+    // that carries an identifier. The consent the user gave calls these
+    // reports anonymous; this hook is what makes that true.
+    final options = configured();
+    final beforeSend = options.beforeSend;
+    expect(beforeSend, isNotNull, reason: 'no beforeSend hook is configured');
+
+    final event = SentryEvent(
+      user: SentryUser(id: 'a-per-install-uuid', geo: SentryGeo(city: 'Essen')),
+    );
+    final sent = await beforeSend!(event, Hint());
+
+    expect(sent, isNotNull, reason: 'the hook must not drop the event itself');
+    expect(sent!.user, isNull);
+  });
+
   test('release options do not attach default PII', () {
     // Not set by `configureSentryOptions` — this pins the SDK's own default,
     // because the README states that `sendDefaultPii` stays false and an SDK


### PR DESCRIPTION
Crash reports were carrying a stable per-install identifier. The consent they are collected under calls them anonymous.

## What was happening

The native SDKs attach a randomly generated per-installation UUID as `user.id`, and **`sendDefaultPii` does not gate it** — it is set regardless, then carried onto Dart events with the rest of the native user map.

Measured on a live event in this project's own Sentry organisation:

```
user.id         : 36-character UUID   ← stable across launches
user.geo        : { country_code, city, region }
user.ip_address : null                ← the IP itself is correctly withheld
```

The id is stable, so **every crash from one installation is linkable to every other**, and it arrives alongside a city. That is pseudonymous, not anonymous — and the label it is collected under is the *basis* of the consent rather than marketing copy, so its accuracy is load-bearing:

> Send **anonymous** crash reports to help fix bugs. No food log, weight, or personal data is included.

## The fix

Strip the `user` block in `beforeSend` rather than describe it.

Removing the identifier **restores the README's "no user or device identifier"** instead of requiring that sentence to be qualified a third time — #891 already corrected it once for the Supabase path — and it makes the consent label true rather than longer.

Pinned by a test alongside the existing cases for `enablePrintBreadcrumbs` and `sendDefaultPii`. The test fails if the hook is removed.

## The cost, stated rather than buried

`user.id` is what Sentry counts to report how many users an issue affects. **Triage can no longer distinguish one installation crash-looping from many installations hitting the same bug** — which matters more than usual on an organisation already near its error quota.

A per-session id was considered as a middle path and rejected: it would turn that number into a sessions count that still *reads* as users, and a metric that lies is worse than one that is absent.

## What this does not fix

**`user.geo`** — the country, region and city Sentry records per event. That is derived **server-side at ingest** from the connection address, which the client never sends, so no client hook can reach it. It needs an Advanced Data Scrubbing rule on the organisation, verified against a real event. Tracked in #900.

**The consent label** still says "anonymous" and still needs correcting, across nine locales. Also #900.

Decided in #894 on map #867; implements the client-side part of #900. Unblocked by #893, which brought `sentry_config.dart` onto `develop`.
