### PR TITLE
docs: describe the real localization workflow

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -177,7 +177,7 @@ Semantics(
 |---|---|
 | `ListTile` / `InkWell` / `GestureDetector` with an `onTap` | Pure display — `Text`, `Icon`, `Image`, `Divider`, charts |
 | Buttons — `ElevatedButton`, `TextButton`, `IconButton`, `FloatingActionButton`, `FilledButton` (when they have `onPressed`) | Layout — `Container` without `onTap`, `Padding`, `SizedBox`, `Row`, `Column` |
-| Input — `TextField`, `TextFormField`, `Slider`, `Switch`, `SwitchListTile`, `Checkbox` (the actual checkbox, not its label) | Generated code (`*.g.dart`, `messages_*.dart`, `l10n.dart`) |
+| Input — `TextField`, `TextFormField`, `Slider`, `Switch`, `SwitchListTile`, `Checkbox` (the actual checkbox, not its label) | Generated code (`*.g.dart`, `l10n.dart`, `l10n_<locale>.dart`) |
 | Selection — `ChoiceChip`, `FilterChip`, `RadioListTile`, `SegmentedButton`, `DropdownButton` | Theming, transitions, decorative wrappers |
 | Bottom sheets, dialog action buttons (Save/Cancel/OK) | Items inside `ListView.builder` / `GridView.builder` (see below) |
 
@@ -334,7 +334,7 @@ lib/
     settings/     # App settings, data export/import, day-start, theme picker
     onboarding/   # First-run user setup flow
   dev/            # Dev-only main_dev.dart entry point (never shipped) — see "Demo data" above
-  generated/      # Intl files — maintained manually (see Localization above)
+  generated/      # gen-l10n output — gitignored, never edited by hand (see Localization above)
   l10n/           # Source ARB translation files
 ```
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -28,10 +28,10 @@ architecture conventions live in [AGENTS.md](AGENTS.md).
 
 ## Adding or changing localized strings
 
-Source strings live in `lib/l10n/intl_en.arb`. Translations live in a separate ARB file per supported locale, plus manually-maintained Dart files under `lib/generated/`.
+Source strings live in `lib/l10n/intl_en.arb`, with one ARB file per supported locale beside it. The Dart files under `lib/generated/` are produced from those ARBs by `flutter gen-l10n` (configured in `l10n.yaml`) — they are gitignored, and CI regenerates them from scratch on every run.
 
 > [!IMPORTANT]
-> **For now**, the files under `lib/generated/` carry a `// GENERATED CODE - DO NOT MODIFY BY HAND` header but are **maintained manually** in this project — the upstream generator's output conflicts with the repo's 120-character formatting and would fail CI. Until the generation pipeline is reconciled with the formatting rules, edit those files by hand. Do **not** run `intl_translation:generate_from_arb` — this caveat will go away once the generator output is fixed.
+> Never hand-edit anything under `lib/generated/`. The directory is listed in `.gitignore`, so hand-edits are never committed, and the next `flutter gen-l10n` overwrites them locally — the work is lost silently. Edit the ARB files and regenerate.
 
 When adding a new string key in the same PR you must:
 
@@ -51,11 +51,13 @@ When adding a new string key in the same PR you must:
 
    Provide a real translation for each locale — do not leave the English string in as a placeholder. If you only speak one of the languages, machine translation is acceptable as a starting point; native-speaker review is welcome post-merge.
 
-2. **Add a getter to `lib/generated/l10n.dart`**, following the existing style.
+   All nine files stay at the same key count. Placeholder metadata (`"@key": {"placeholders": ...}`) only needs to be declared in the template, `intl_en.arb`.
 
-3. **Add a matching `MessageLookupByLibrary.simpleMessage(...)` entry to each `lib/generated/intl/messages_<locale>.dart` file**, one per locale.
+2. **Regenerate with `just gen_l10n`** (`flutter gen-l10n`). This rewrites `lib/generated/l10n.dart` and one `lib/generated/l10n_<locale>.dart` per locale, which is where your `S.of(context).yourNewKey` getter comes from. Nothing under `lib/generated/` belongs in the commit — the ARB files are the whole change.
 
-4. **Verify with `just check_intl`** — this is what CI runs and will fail the PR if any of the above is missing or out of sync.
+3. **Check `l10n_untranslated.json`** — `gen-l10n` writes it at the repo root (also gitignored) listing every key a locale is still missing. A missing translation does not fail the build; the string just falls back to English. The file should still read `{}` after your change.
+
+4. **Run `flutter analyze` and `just test`** before opening the PR — or `just ci` for the whole pre-flight in one go.
 
 ## Code generation
 
@@ -66,7 +68,7 @@ Some files are produced by `build_runner` (Hive type adapters and JSON serializa
 - 120-character line width (configured in `analysis_options.yaml`).
 - Format with `just format` before committing — this targets only `lib/core`, `lib/features`, `lib/l10n`, and `test` and deliberately skips `lib/generated/`.
 - Run `flutter analyze` and `just test` locally before opening the PR.
-- `just ci` runs the full CI pipeline (install, format check, intl check, build, analyze, test) and is the closest thing to a one-shot pre-flight check.
+- `just ci` runs the full CI pipeline (install, format check, l10n generation, build, analyze, test) and is the closest thing to a one-shot pre-flight check.
 
 ## Commit messages
 


### PR DESCRIPTION
## What

`CONTRIBUTING.md` told contributors that the Dart files under `lib/generated/` are **maintained manually**, that the generator's output would fail CI, and that they must not run `intl_translation:generate_from_arb`. None of that has been true since the move to `flutter gen-l10n`.

A contributor following the old instructions hand-edited files that git never saw and that the next generation overwrote — losing the work silently, with no error anywhere.

## Verified against `develop`

- `lib/generated/` is not tracked — `git ls-tree -r --name-only origin/develop lib/generated/` is empty.
- `.gitignore` lines 41-42: `# Localizations generated by flutter gen-l10n` / `lib/generated/`.
- Generation is `flutter gen-l10n`, configured in `l10n.yaml`; `intl_translation` is not a dependency of this project.
- CI regenerates on every run — `just gen_l10n` in `.github/workflows/default_workflow.yml`.

Two further errors surfaced while running the toolchain:

- **Step 3 pointed at files that do not exist.** `flutter gen-l10n` emits `lib/generated/l10n.dart` plus one `l10n_<locale>.dart` per locale. There is no `lib/generated/intl/messages_<locale>.dart` — that was the old `intl_translation` layout.
- **Step 4's verification command does not exist.** The justfile has no `check_intl` recipe, so "this is what CI runs and will fail the PR" was false as well.

And a behaviour worth documenting, confirmed by deleting a key from `intl_de.arb` and regenerating: `gen-l10n` exits 0 and records the key in the gitignored `l10n_untranslated.json`. **A missing translation does not fail the build** — the string just falls back to English. The ARB was restored afterwards; no source change in this PR.

## Changes

- `CONTRIBUTING.md` — intro and callout rewritten to describe generation from the ARBs; steps 2-4 replaced with regenerate (`just gen_l10n`) → check `l10n_untranslated.json` → analyze/test. Key-count parity and the placeholder-metadata rule folded into step 1. `just ci`'s "intl check" corrected to "l10n generation" — the last echo of the removed recipe.
- `AGENTS.md` — the Localization section was already correct, but the repo-layout tree still said `generated/ # Intl files — maintained manually`, contradicting it. Also corrected the stale `messages_*.dart` filename in the accessibility-scope table.

Docs only; no code or ARB files touched.

## Follow-up (not in this PR)

`docs/first-timer-backlog.md` lines 69-79 carry the identical stale instructions, aimed at first-time contributors. Left out to keep this diff scoped.
