### PR TITLE
docs: fix the localization steps aimed at first-timers

### DIFF
--- a/docs/first-timer-backlog.md
+++ b/docs/first-timer-backlog.md
@@ -12,8 +12,9 @@ external crash dashboards (this app is privacy-first; Sentry is opt-in only).
 3. One PR per issue. Target **`develop`** (see [CONTRIBUTING.md](../CONTRIBUTING.md)).
 4. Read [AGENTS.md](../AGENTS.md) before coding:
    conventional commits, **no AI `Co-authored-by` trailers**,
-   `Semantics(identifier:)` on new interactive widgets, manual l10n under
-   `lib/l10n/` **and** `lib/generated/` when strings change.
+   `Semantics(identifier:)` on new interactive widgets, and — when strings
+   change — an ARB edit under `lib/l10n/` followed by `just gen_l10n`
+   (`lib/generated/` is gitignored output, never hand-edited).
 5. Prefer `just ci` (or format + analyze + targeted tests) before opening a PR.
 
 These are **tickets to file**, not an implemented roadmap. Refine titles/IDs
@@ -66,17 +67,21 @@ kcal/kJ labels.
 - `lib/core/presentation/widgets/edit_activity_dialog.dart` — non-custom branch
   uses the literal `'min'` as the quantity field suffix
   (`suffix = … : 'min'`).
-- Wire through existing ARB + generated l10n (add a key such as
-  `minuteShortLabel` / reuse a suitable existing string if one already means
-  “min” as a unit). Follow CONTRIBUTING: update **every** `lib/l10n/intl_*.arb`,
-  `lib/generated/l10n.dart`, and each `lib/generated/intl/messages_*.dart`.
-- Verify with `just check_intl`.
+- Wire through the ARBs (add a key such as `minuteShortLabel` / reuse a
+  suitable existing string if one already means “min” as a unit). Follow
+  CONTRIBUTING: add the key to **every** `lib/l10n/intl_*.arb`, then run
+  `just gen_l10n`. Nothing under `lib/generated/` goes into the commit — it is
+  gitignored output.
+- A locale you miss will not fail the build. The key lands in the (gitignored)
+  `l10n_untranslated.json` and the string falls back to English, so check that
+  file reads `{}` when you are done.
 
 **Acceptance criteria:**
 
 - [ ] No naked `'min'` user-facing string in that dialog.
 - [ ] All supported locales have a translation.
-- [ ] `just check_intl` passes.
+- [ ] `l10n_untranslated.json` reads `{}` after `just gen_l10n`.
+- [ ] `just ci` (or analyze + tests) passes.
 
 **Out of scope:** Reworking custom-kcal activity editing; new duration units beyond avoiding the hardcode.
 


### PR DESCRIPTION
## What

`docs/first-timer-backlog.md` carried the same stale localization workflow that #904 corrects in `CONTRIBUTING.md` — but aimed at the readers least equipped to spot that it is wrong.

It told newcomers to hand-edit `lib/generated/l10n.dart` and each `lib/generated/intl/messages_*.dart`, then verify with `just check_intl`. Every part of that fails silently:

- `lib/generated/` is gitignored (`.gitignore` 41-42) and regenerated by `flutter gen-l10n` on every CI run, so hand-edits are never committed and get overwritten locally.
- `lib/generated/intl/messages_*.dart` does not exist. `gen-l10n` emits `l10n.dart` plus one `l10n_<locale>.dart` per locale; the `intl/messages_*` layout belonged to the old `intl_translation` generator.
- `just check_intl` is not a recipe in the justfile.

A first-timer following section 2 would have produced a PR containing only an ARB change (the rest silently dropped), after being told to run a command that does not exist.

## Changes

- **Intro checklist (step 4)** — this one was not in #904's follow-up note: it told every reader of the doc, before they reach any ticket, that l10n is "manual … under `lib/l10n/` **and** `lib/generated/`". Now points at an ARB edit followed by `just gen_l10n`.
- **Section 2 scope** — add the key to every `lib/l10n/intl_*.arb`, run `just gen_l10n`, keep `lib/generated/` out of the commit. Adds the failure mode that matters for a translation ticket: a missed locale does not fail the build, it lands in the gitignored `l10n_untranslated.json` and falls back to English.
- **Section 2 acceptance criteria** — `just check_intl` replaced with checking `l10n_untranslated.json` reads `{}`, plus `just ci`.

## Verification

- Re-checked section 2's anchor against `develop`: the literal `'min'` suffix is still at `lib/core/presentation/widgets/edit_activity_dialog.dart:56`, so the ticket itself remains valid.
- No existing ARB key means "min" as a unit (`settingsDayStartMinutesPickerLabel` is a picker label), so the ticket's "add a key such as `minuteShortLabel`" advice stands as written.
- `grep` for `check_intl`, `messages_*`, and `generated/intl` across `docs/` is now clean.

Docs only. Independent of #904 — different files, no conflict, either can land first.
