### PR TITLE
ci(ios): reboot the simulator between integration-test attempts

### DIFF
--- a/.github/workflows/default_workflow.yml
+++ b/.github/workflows/default_workflow.yml
@@ -391,24 +391,36 @@ jobs:
       # means to app_boot_test.dart: attempt 1 may have left the app and its
       # Hive boxes behind.
       #
+      # The host needs the same treatment. A step killed by its own
+      # timeout-minutes takes the shell with it but not necessarily the dart
+      # processes it spawned, and one leftover Dart Development Service fails
+      # attempt 2 before it even loads the test — that is how run 33067097364
+      # died ("Failed to start Dart Development Service"), on a diff that
+      # touched only the justfile and a markdown file. simctl cleans the
+      # device; nothing cleans the host, so sweep it first. The sweep cannot
+      # hit its own shell: Actions runs a `run:` block from a temp script file
+      # (`/bin/bash -e <path>.sh`), so the pattern is in the file rather than
+      # on any command line pkill sees.
+      #
       # 5 minutes: measured at 73s on macos-15 with this path forced end to
       # end, against the 80s and 124s the plain boot in `Pick + boot iPhone
       # simulator` took on the two runs before it — a post-erase first boot
       # spends ~40s of that waiting on Data Migration. `shutdown` tolerates an
       # already-dead device (it exits non-zero on one), which is the state a
       # hung attempt tends to leave.
-      - name: Reboot simulator before retry
+      - name: Reset device and host state before retry
         if: steps.ios-integration.outcome == 'failure'
         timeout-minutes: 5
         run: |
-          echo "::warning::iOS integration tests failed or hung; rebooting the simulator before attempt 2 of 2"
+          echo "::warning::iOS integration tests failed or hung; resetting the device and host before attempt 2 of 2"
+          pkill -f 'flutter_tools\.snapshot|dart-sdk/bin/dart|dartaotruntime' || true
           xcrun simctl shutdown "$DEVICE_UDID" || true
           xcrun simctl erase "$DEVICE_UDID"
           xcrun simctl boot "$DEVICE_UDID"
           xcrun simctl bootstatus "$DEVICE_UDID"
 
-      # Skipped if the reboot above fails: a runner that cannot erase and boot
-      # a simulator has nothing to offer attempt 2, and the failed reboot step
+      # Skipped if the reset above fails: a runner that cannot erase and boot
+      # a simulator has nothing to offer attempt 2, and the failed reset step
       # says so more precisely than a second lost device would.
       - name: Run integration tests (retry once)
         if: steps.ios-integration.outcome == 'failure'

--- a/.github/workflows/default_workflow.yml
+++ b/.github/workflows/default_workflow.yml
@@ -391,10 +391,12 @@ jobs:
       # means to app_boot_test.dart: attempt 1 may have left the app and its
       # Hive boxes behind.
       #
-      # 5 minutes: `Pick + boot iPhone simulator` above took 80s and 124s on
-      # the two most recent runs, and this repeats that boot plus a shutdown
-      # and an erase. `shutdown` tolerates an already-dead device (it exits
-      # non-zero on one), which is the state a hung attempt tends to leave.
+      # 5 minutes: measured at 73s on macos-15 with this path forced end to
+      # end, against the 80s and 124s the plain boot in `Pick + boot iPhone
+      # simulator` took on the two runs before it — a post-erase first boot
+      # spends ~40s of that waiting on Data Migration. `shutdown` tolerates an
+      # already-dead device (it exits non-zero on one), which is the state a
+      # hung attempt tends to leave.
       - name: Reboot simulator before retry
         if: steps.ios-integration.outcome == 'failure'
         timeout-minutes: 5

--- a/.github/workflows/default_workflow.yml
+++ b/.github/workflows/default_workflow.yml
@@ -282,12 +282,14 @@ jobs:
     # carries its own 20-minute bound, so a hang is a failed attempt the
     # retry can act on; this bound only stops a job drifting toward GitHub's
     # 6-hour default if something escapes both. It has to hold two cold
-    # builds — 30 was too tight and got cancelled mid-retry.
+    # builds and the simulator reboot between them — 30 was too tight and got
+    # cancelled mid-retry, and 50 no longer clears 20 + 5 + 20 with the ~5m40s
+    # of setup and teardown around them.
     #
     # It used to be the only bound, and a hang cost the whole 50 minutes of
     # macOS time, reported as a cancelled job rather than a failed test —
     # which `gh pr checks` renders as `fail` on a PR that is fine (#823).
-    timeout-minutes: 50
+    timeout-minutes: 55
     permissions:
       contents: read
     steps:
@@ -361,8 +363,9 @@ jobs:
       #
       # 20 minutes per attempt: the slowest healthy run of this step in the
       # last twenty was 15m36s (the range is 8m53s-15m36s, and it includes the
-      # cold Xcode build), and two 20-minute attempts still fit the job's 50
-      # with the ~5m40s of setup and teardown around them.
+      # cold Xcode build), and two 20-minute attempts plus the 5-minute reboot
+      # between them still fit the job's 55 with the ~5m40s of setup and
+      # teardown around them.
       - name: Run integration tests (attempt 1)
         id: ios-integration
         continue-on-error: true
@@ -374,14 +377,41 @@ jobs:
 
       # Retry once: integration tests occasionally flake on a slow simulator
       # (a dropped frame, a transient launch hiccup, a build that never
-      # returns). A second attempt on the same booted sim clears those without
-      # masking a real failure, since a genuine break fails both attempts.
+      # returns). The device attempt 1 broke on is not the device to retry on,
+      # though — reusing it is how a runner-side flake takes down *both*
+      # attempts and reads as the genuine break the retry is supposed to
+      # distinguish. On #904 attempt 1 hung for its full 20 minutes and
+      # attempt 2 then lost the same simulator three seconds after launch
+      # ("No tests were found", exit 79) on a docs-only diff that re-ran green
+      # untouched.
+      #
+      # So give attempt 2 a clean device, which is what the retry over in
+      # android-integration-tests already gets for free by re-running the
+      # emulator-runner action. Erasing also restores what "fresh install"
+      # means to app_boot_test.dart: attempt 1 may have left the app and its
+      # Hive boxes behind.
+      #
+      # 5 minutes: `Pick + boot iPhone simulator` above took 80s and 124s on
+      # the two most recent runs, and this repeats that boot plus a shutdown
+      # and an erase. `shutdown` tolerates an already-dead device (it exits
+      # non-zero on one), which is the state a hung attempt tends to leave.
+      - name: Reboot simulator before retry
+        if: steps.ios-integration.outcome == 'failure'
+        timeout-minutes: 5
+        run: |
+          echo "::warning::iOS integration tests failed or hung; rebooting the simulator before attempt 2 of 2"
+          xcrun simctl shutdown "$DEVICE_UDID" || true
+          xcrun simctl erase "$DEVICE_UDID"
+          xcrun simctl boot "$DEVICE_UDID"
+          xcrun simctl bootstatus "$DEVICE_UDID"
+
+      # Skipped if the reboot above fails: a runner that cannot erase and boot
+      # a simulator has nothing to offer attempt 2, and the failed reboot step
+      # says so more precisely than a second lost device would.
       - name: Run integration tests (retry once)
         if: steps.ios-integration.outcome == 'failure'
         timeout-minutes: 20
-        run: |
-          echo "::warning::iOS integration tests failed or hung; retrying (attempt 2 of 2)"
-          flutter test integration_test/ -d "$DEVICE_UDID" --flavor full --reporter expanded
+        run: flutter test integration_test/ -d "$DEVICE_UDID" --flavor full --reporter expanded
 
   android-build:
     runs-on: ubuntu-latest


### PR DESCRIPTION
> [!IMPORTANT]
> **This does not fix the hang, and the theory below is wrong.** On this branch's own CI ([run 33069718130](https://github.com/simonoppowa/OpenNutriTracker/actions/runs/33069718130)) attempt 1 hung to its bound, the reset step ran clean in 69s — `pkill`, `shutdown`, `erase`, `boot`, `bootstatus` all fine, `bootstatus` reporting `Finished` — and the retry **hung identically anyway**: `Xcode build done`, then ~17 minutes of silence. A freshly erased device and a swept host change nothing, so leftover state from attempt 1 is not what breaks attempt 2.
>
> What the evidence now supports: the VM-service discovery hang is **runner-sticky**. Every run where attempt 1 hung also lost attempt 2 (#904, [33067097364](https://github.com/simonoppowa/OpenNutriTracker/actions/runs/33067097364), and this one), while every manual job re-run **on a fresh runner** passed first time (#904, #909). No same-runner step retry can fix that; it needs a job-level retry on a new runner.
>
> Keep this PR only as retry hygiene — a clean device costs 69s on the failure path and is the right thing to hand a retry regardless. It is not the fix. See the discussion below.

## The problem

`ios-integration-tests` retries once, on the theory that "a genuine break fails both attempts". But the retry re-ran `flutter test` against **the same booted simulator attempt 1 had just broken on**, so a runner-side fault fails both attempts too — and the retry loses exactly the signal it exists to provide.

#904 is the worked example, on a diff of two markdown files:

| | Attempt 1 | Attempt 2 |
| --- | --- | --- |
| Result | hung, killed at the 20-minute bound before the suite ran | lost the device 3s after `Starting App ...` — `No tests were found`, exit 79 |

Both attempts down, job red, `gh pr checks` reporting `fail` on a PR that was fine. Re-running the job with **the diff untouched** passed on attempt 1 in 17m21s with the retry skipped, which is what a fresh device gets you.

`android-integration-tests` does not have this problem: its retry re-runs the whole `reactivecircus/android-emulator-runner` action, so attempt 2 boots a fresh emulator. The comment at line 562 calls that out as the point of the two-step shape. iOS was the outlier.

## The fix

A `Reboot simulator before retry` step between the two attempts, on the same `if:` condition:

```
xcrun simctl shutdown "$DEVICE_UDID" || true
xcrun simctl erase "$DEVICE_UDID"
xcrun simctl boot "$DEVICE_UDID"
xcrun simctl bootstatus "$DEVICE_UDID"
```

- `shutdown` is tolerant of an already-dead device (it exits non-zero on one) — that's the state a hung attempt tends to leave, hence `|| true`.
- `erase` additionally restores what "fresh install" means to `app_boot_test.dart`; attempt 1 may have left the app and its Hive boxes on the device.
- `boot` + `bootstatus` mirror the existing `Pick + boot iPhone simulator` step, and `$DEVICE_UDID` survives an erase.
Plus a host-side sweep in the same step, added after [run 33067097364](https://github.com/simonoppowa/OpenNutriTracker/actions/runs/33067097364) showed the device half alone is not enough:

```
pkill -f 'flutter_tools\.snapshot|dart-sdk/bin/dart|dartaotruntime' || true
```

There, attempt 1 hung to its bound and attempt 2 died with `Failed to start Dart Development Service` before loading the test — a host-side orphan that `simctl erase` does not touch. ~~What poisons attempt 2 is attempt 1 being killed mid-flight, on both sides of the wire.~~ **Superseded — see the note at the top: the sweep runs clean and the retry hangs anyway.** The sweep stays because a retry deserves a clean host, not because it rescues the run.

- If the reset itself fails, the retry is skipped (a plain `if:` implies `success() &&`). A runner that cannot erase and boot a simulator has nothing to offer attempt 2, and the failed reboot step names the problem more precisely than a second lost device.

**Bounds:** the step gets 5 minutes — generous against the 73s the reboot actually measured (see Verification below), and against the 80s and 124s the plain boot took on the two runs before it. That pushes the worst case to 20 + 5 + 20 + ~5m40s = 50m40s, over the job's 50, so the backstop goes to **55**. Being cancelled mid-retry is a failure mode a too-tight bound already caused here once (the `30 was too tight` note in the same comment).

## Verification

Exercised end to end on a throwaway branch (#907, now closed): #906 plus a temp commit making attempt 1 `exit 1`, so CI ran the path a healthy PR skips. Result — [run 33059731532](https://github.com/simonoppowa/OpenNutriTracker/actions/runs/33059731532), job green:

| Step | Result |
| --- | --- |
| `Run integration tests (attempt 1)` | failed as forced, absorbed by `continue-on-error` (3s) |
| `Reboot simulator before retry` | **success, 73s** — `shutdown` → `erase` → `boot` → `bootstatus` all clean on `macos-15` (iPhone 16 Pro) |
| `Run integration tests (retry once)` | **success, 15m48s** — the real suite, against the erased device |

`bootstatus` correctly waited out the post-erase Data Migration (~40s of the 73s) rather than handing the retry a half-booted device — the failure this whole change is about. Comment updated to cite the measured 73s rather than the estimate it was sized from.

Job-timeout arithmetic confirmed against that run: setup measured 3m23s and teardown 2m9s (5m32s, matching the ~5m40s in the comment), so the worst case is 20 + 5 + 20 + 5m32s = 50m32s — over the old 50, inside the new 55.

This PR's own CI is green on all jobs, with the new step correctly skipped on the healthy path.

**Not covered by that run:** the `pkill` sweep. #907 forced attempt 1 to `exit 1`, which orphans nothing, so the run proved the simctl half and could not have exercised the host half. Verified only that the pattern parses and is self-safe — run from a script file the way Actions invokes `run:` blocks, `pgrep` matches nothing, including its own shell (matching it inline does match, which is why the distinction is in the comment). Proving the sweep end to end needs a run where attempt 1 genuinely hangs and is killed, ~40 minutes of macOS time; it is defence-in-depth either way, since `|| true` on a no-match is a no-op.



