### PR TITLE
feat(add-meal): search the food backend over a POST body, not a URL (#882)

### DIFF
--- a/lib/features/add_meal/data/data_sources/sp_food_data_source.dart
+++ b/lib/features/add_meal/data/data_sources/sp_food_data_source.dart
@@ -87,21 +87,41 @@ class SpFoodDataSource {
     return enabled;
   }
 
+  /// Calls [fn] and hands back its rows.
+  ///
+  /// `rpc` posts [params] as the request body and leaves the URL as a bare
+  /// `/rest/v1/rpc/<fn>` — which is the entire point of routing search this
+  /// way — but it is typed `dynamic`, where `select()` handed back a typed
+  /// list. One cast in one place rather than three.
+  Future<List<Map<String, dynamic>>> _rpcRows(
+    SupabaseClient client,
+    String fn,
+    Map<String, dynamic> params,
+  ) async {
+    final response = await client.rpc(fn, params: params);
+    // A set-returning function with no matches answers with an empty array,
+    // never null; null would mean the function itself returned NULL, which
+    // none of these can.
+    return (response as List).cast<Map<String, dynamic>>();
+  }
+
   Future<List<SpFoodDTO>> _searchEnglish(
     SupabaseClient client,
     String searchString,
     List<String>? enabledSources,
   ) async {
-    var query = client.from(SPConst.foodSummaryTable).select().textSearch(
-          SPConst.foodName,
-          searchString,
-          config: SPConst.foodNameFtsConfig,
-          type: TextSearchType.websearch,
-        );
-    if (enabledSources != null) {
-      query = query.inFilter(SPConst.foodSource, enabledSources);
-    }
-    final response = await query.limit(_candidatePoolSize);
+    // An RPC rather than a filtered select on the view, so the term travels
+    // in the POST body instead of the query string — see [SPConst
+    // .searchFoodSummaryFn]. The function returns `setof food_summary`, so
+    // the rows arrive in exactly the shape `select()` produced and
+    // [SpFoodDTO.fromJson] is unchanged. The source filter and the row cap
+    // move into the call because a filter chained onto an RPC would go back
+    // into the URL, which is the thing being removed.
+    final response = await _rpcRows(client, SPConst.searchFoodSummaryFn, {
+      'term': searchString,
+      'sources': enabledSources,
+      'max_rows': _candidatePoolSize,
+    });
 
     // PostgREST's `order` query parameter only accepts column references
     // (`.order('column')`), not computed expressions — `.order(ts_rank(...))`
@@ -121,20 +141,11 @@ class SpFoodDataSource {
     String searchString,
     List<String>? enabledSources,
   ) async {
-    final unrankedRows = await client
-        .from(SPConst.foodTranslationTable)
-        .select(
-          '${SPConst.translationFoodId}, ${SPConst.translationDescription}, '
-          '${SPConst.translationSource}',
-        )
-        .eq(SPConst.translationLocale, locale)
-        .textSearch(
-          SPConst.translationDescription,
-          searchString,
-          config: SPConst.translationFtsConfig,
-          type: TextSearchType.websearch,
-        )
-        .limit(_candidatePoolSize);
+    final unrankedRows = await _rpcRows(
+      client,
+      SPConst.searchFoodTranslationFn,
+      {'term': searchString, 'loc': locale, 'max_rows': _candidatePoolSize},
+    );
 
     if (unrankedRows.isEmpty) return const [];
 
@@ -144,8 +155,9 @@ class SpFoodDataSource {
     // ranked client-side instead of via Postgres ORDER BY (same issue as
     // _searchEnglish). Rank the whole candidate pool, then truncate — see
     // _candidatePoolSize for why truncating first would be wrong.
-    final translationRows =
-        rankAndTruncateTranslationRows([...unrankedRows], searchString);
+    final translationRows = rankAndTruncateTranslationRows([
+      ...unrankedRows,
+    ], searchString);
 
     final nameByFoodId = {
       for (final row in translationRows)
@@ -154,8 +166,7 @@ class SpFoodDataSource {
     };
     final machineTranslatedFoodIds = {
       for (final row in translationRows)
-        if (row[SPConst.translationSource] ==
-            SPConst.translationSourceMachine)
+        if (row[SPConst.translationSource] == SPConst.translationSourceMachine)
           row[SPConst.translationFoodId] as int,
     };
     // nameByFoodId's key order mirrors translationRows (a LinkedHashMap
@@ -168,14 +179,16 @@ class SpFoodDataSource {
 
     // The source filter is applied on the summary fetch rather than the
     // translation match: food_translation has no source column.
-    var query = client
-        .from(SPConst.foodSummaryTable)
-        .select()
-        .inFilter(SPConst.foodId, nameByFoodId.keys.toList());
-    if (enabledSources != null) {
-      query = query.inFilter(SPConst.foodSource, enabledSources);
-    }
-    final response = await query;
+    //
+    // An RPC for the same reason the search above is one, and it is worth
+    // being explicit about why: these ids are *derived from the search
+    // term*, so an `in.(...)` filter would put a fingerprint of what the
+    // user typed straight back into the URL the gateway logs. Removing the
+    // term while leaving its shadow behind would not be worth doing.
+    final response = await _rpcRows(client, SPConst.foodSummaryByIdsFn, {
+      'ids': nameByFoodId.keys.toList(),
+      'sources': enabledSources,
+    });
 
     // A WHERE-IN fetch has no guaranteed relationship to its id list's
     // order, so re-sort onto the translation-relevance order captured above
@@ -183,13 +196,16 @@ class SpFoodDataSource {
     final foods = response.map((food) {
       final dto = SpFoodDTO.fromJson(food);
       dto.localizedName = nameByFoodId[dto.foodId];
-      dto.localizedNameIsMachineTranslated =
-          machineTranslatedFoodIds.contains(dto.foodId);
+      dto.localizedNameIsMachineTranslated = machineTranslatedFoodIds.contains(
+        dto.foodId,
+      );
       return dto;
     }).toList();
-    mergeSort(foods,
-        compare: (a, b) => (rankByFoodId[a.foodId] ?? rankByFoodId.length)
-            .compareTo(rankByFoodId[b.foodId] ?? rankByFoodId.length));
+    mergeSort(
+      foods,
+      compare: (a, b) => (rankByFoodId[a.foodId] ?? rankByFoodId.length)
+          .compareTo(rankByFoodId[b.foodId] ?? rankByFoodId.length),
+    );
     return foods;
   }
 }
@@ -202,12 +218,17 @@ class SpFoodDataSource {
 /// directly unit-testable without mocking the Supabase client.
 @visibleForTesting
 List<SpFoodDTO> rankAndTruncateFoodsByName(
-    List<SpFoodDTO> foods, String searchString) {
+  List<SpFoodDTO> foods,
+  String searchString,
+) {
   final decorated = [
-    for (final food in foods) (food: food, score: textRelevanceScore(food.name, searchString)),
+    for (final food in foods)
+      (food: food, score: textRelevanceScore(food.name, searchString)),
   ];
   mergeSort(decorated, compare: (a, b) => b.score.compareTo(a.score));
-  return [for (final entry in decorated.take(SPConst.maxNumberOfItems)) entry.food];
+  return [
+    for (final entry in decorated.take(SPConst.maxNumberOfItems)) entry.food,
+  ];
 }
 
 /// Same idea as [rankAndTruncateFoodsByName], but for raw `food_translation`
@@ -215,14 +236,21 @@ List<SpFoodDTO> rankAndTruncateFoodsByName(
 /// into [SpFoodDTO] (see [SpFoodDataSource._searchByTranslation]).
 @visibleForTesting
 List<Map<String, dynamic>> rankAndTruncateTranslationRows(
-    List<Map<String, dynamic>> rows, String searchString) {
+  List<Map<String, dynamic>> rows,
+  String searchString,
+) {
   final decorated = [
     for (final row in rows)
       (
         row: row,
-        score: textRelevanceScore(row[SPConst.translationDescription] as String?, searchString),
+        score: textRelevanceScore(
+          row[SPConst.translationDescription] as String?,
+          searchString,
+        ),
       ),
   ];
   mergeSort(decorated, compare: (a, b) => b.score.compareTo(a.score));
-  return [for (final entry in decorated.take(SPConst.maxNumberOfItems)) entry.row];
+  return [
+    for (final entry in decorated.take(SPConst.maxNumberOfItems)) entry.row,
+  ];
 }

--- a/lib/features/add_meal/data/dto/sp/sp_const.dart
+++ b/lib/features/add_meal/data/dto/sp/sp_const.dart
@@ -45,11 +45,21 @@ class SPConst {
   /// other values (native, community, verified) involve a human and don't.
   static const translationSourceMachine = 'machine';
 
-  // Text-search configs matching the indexes in schema.sql:
-  // food.description uses to_tsvector('english', ...), food_translation
-  // uses to_tsvector('simple', ...) since it holds many languages.
-  static const foodNameFtsConfig = 'english';
-  static const translationFtsConfig = 'simple';
+  // Postgres functions the app searches through, rather than filtering the
+  // relations above over the URL.
+  //
+  // PostgREST issues a table query as a GET, so a search term travels in the
+  // query string and the Supabase API gateway log keeps it beside the
+  // caller's IP address, city, postal code, ISP and TLS fingerprint. An RPC
+  // is a POST with a JSON body, and the gateway log records no body. #882.
+  //
+  // The text-search configs these used to be called with — 'english' for
+  // food_summary.name, 'simple' for the many-language food_translation —
+  // now live inside the functions, next to the indexes that have to agree
+  // with them. See sql/schema.sql section 6b in the backend repo.
+  static const searchFoodSummaryFn = 'search_food_summary';
+  static const searchFoodTranslationFn = 'search_food_translation';
+  static const foodSummaryByIdsFn = 'food_summary_by_ids';
 
   /// food_source.code prefix shared by the USDA FDC sources
   /// (fdc_foundation, fdc_sr_legacy, fdc_survey). Only these foods have a

--- a/test/unit_test/sp_food_search_transport_test.dart
+++ b/test/unit_test/sp_food_search_transport_test.dart
@@ -1,0 +1,144 @@
+import 'dart:convert';
+
+import 'package:flutter_test/flutter_test.dart';
+import 'package:hive_ce/hive.dart';
+import 'package:http/http.dart' as http;
+import 'package:opennutritracker/core/data/data_source/config_data_source.dart';
+import 'package:opennutritracker/core/data/dbo/config_dbo.dart';
+import 'package:opennutritracker/core/utils/hive_db_provider.dart';
+import 'package:opennutritracker/core/utils/locator.dart';
+import 'package:opennutritracker/features/add_meal/data/data_sources/sp_food_data_source.dart';
+import 'package:supabase_flutter/supabase_flutter.dart';
+
+import '../helpers/hive_test_setup.dart';
+
+/// Records every request the Supabase client makes and answers each one with
+/// an empty PostgREST result set.
+class _RecordingClient extends http.BaseClient {
+  final sent = <http.Request>[];
+
+  @override
+  Future<http.StreamedResponse> send(http.BaseRequest request) async {
+    final req = request as http.Request;
+    sent.add(req);
+    return http.StreamedResponse(
+      Stream.value(utf8.encode('[]')),
+      200,
+      headers: {'content-type': 'application/json; charset=utf-8'},
+      request: request,
+    );
+  }
+}
+
+/// `_readMerged` reads both the shared app config and the active profile's
+/// own, so both getters have to answer.
+class _TestHiveDBProvider extends HiveDBProvider {
+  final Box<ConfigDBO> shared;
+  final Box<ConfigDBO> profile;
+  _TestHiveDBProvider(this.shared, this.profile);
+
+  @override
+  Box<ConfigDBO> get appConfigBox => shared;
+
+  @override
+  Box<ConfigDBO> get configBox => profile;
+}
+
+void main() {
+  TestWidgetsFlutterBinding.ensureInitialized();
+
+  late _RecordingClient http_;
+  late Box<ConfigDBO> appConfigBox;
+  late Box<ConfigDBO> profileConfigBox;
+
+  setUp(() async {
+    Hive.init('.');
+    registerHiveAdaptersOnce();
+    final tag = DateTime.now().microsecondsSinceEpoch;
+    appConfigBox = await Hive.openBox<ConfigDBO>('sp_transport_app_$tag');
+    profileConfigBox = await Hive.openBox<ConfigDBO>('sp_transport_cfg_$tag');
+
+    http_ = _RecordingClient();
+    if (locator.isRegistered<SupabaseClient>()) {
+      locator.unregister<SupabaseClient>();
+    }
+    if (locator.isRegistered<ConfigDataSource>()) {
+      locator.unregister<ConfigDataSource>();
+    }
+    locator.registerSingleton<SupabaseClient>(
+      SupabaseClient('http://backend.invalid', 'test-key', httpClient: http_),
+    );
+    locator.registerSingleton<ConfigDataSource>(
+      ConfigDataSource(_TestHiveDBProvider(appConfigBox, profileConfigBox)),
+    );
+  });
+
+  tearDown(() async {
+    locator.unregister<SupabaseClient>();
+    locator.unregister<ConfigDataSource>();
+    await Hive.deleteFromDisk();
+  });
+
+  // A term that cannot occur by accident in a URL, so a substring match on it
+  // is a real signal rather than a coincidence.
+  const term = 'zzsearchtermzz';
+
+  test('a search term never reaches the URL', () async {
+    // The point of #882. PostgREST issues a table query as a GET, so
+    // `.textSearch(...)` put the term in the query string — and the Supabase
+    // gateway log keeps that URL beside the caller's IP, city, postal code,
+    // ISP and TLS fingerprint. Asserting on the wire rather than on which
+    // method was called is deliberate: the property that matters is where the
+    // term ends up, not how the client was configured to put it there.
+    await SpFoodDataSource().fetchSearchWordResults(term);
+
+    expect(http_.sent, isNotEmpty, reason: 'no request was made at all');
+    for (final request in http_.sent) {
+      expect(
+        request.url.toString(),
+        isNot(contains(term)),
+        reason: 'term found in URL: ${request.url}',
+      );
+      expect(
+        Uri.decodeFull(request.url.toString()),
+        isNot(contains(term)),
+        reason: 'term found percent-encoded in URL: ${request.url}',
+      );
+    }
+  });
+
+  test(
+    'every backend call is a POST to an rpc endpoint with no query',
+    () async {
+      // A filter chained onto an RPC still travels in the query string, so
+      // "we switched to rpc" is not on its own enough — the URL has to stay
+      // bare. This is what would fail if someone reintroduced `.limit()` or
+      // `.inFilter()` on one of these calls.
+      await SpFoodDataSource().fetchSearchWordResults(term);
+
+      for (final request in http_.sent) {
+        expect(request.method, 'POST', reason: '${request.url}');
+        expect(
+          request.url.path,
+          startsWith('/rest/v1/rpc/'),
+          reason: '${request.url}',
+        );
+        expect(request.url.query, isEmpty, reason: '${request.url}');
+      }
+    },
+  );
+
+  test('the term travels in the request body instead', () async {
+    // The other half: it has to still be sent, or the search is broken
+    // rather than private.
+    await SpFoodDataSource().fetchSearchWordResults(term);
+
+    final bodies = http_.sent.map((r) => jsonDecode(r.body) as Map).toList();
+    expect(bodies, isNotEmpty);
+    expect(
+      bodies.any((b) => b['term'] == term),
+      isTrue,
+      reason: 'no request body carried the term: $bodies',
+    );
+  });
+}


### PR DESCRIPTION
> [!IMPORTANT]
> **Blocked on deploy, not on review.** This calls three Postgres functions that must exist first — simonoppowa/OpenNutriTracker-Backend#2. Merging this before that migration is applied breaks food search for everyone. The backend side is safe to deploy on its own: nothing calls the functions until this lands.

## Summary

Every food search a user runs is recorded in the Supabase API gateway log **next to their IP address, city, postal code, ISP and TLS fingerprint**. One day's retention, EU region, readable only by the maintainer — but the pairing is avoidable, and this removes it.

PostgREST issues a table query as a **GET**, so `.textSearch(...)` put the term in the query string:

```
/rest/v1/food_summary?select=*&name=wfts(english).<the user's term>&limit=100
```

The gateway keeps that URL twice over — as `request.url` and `request.search` — in the same record as `cf_connecting_ip`, `cf.city`, `cf.postalCode`, `cf.asOrganization` and `botManagement.ja3Hash`. An **RPC is a POST with a JSON body**, and enumerating the ~50 fields the gateway records turns up no body field.

**The IP and the geolocation are still recorded.** Those come from Cloudflare and are not ours to switch off. What goes away is their pairing with *what the user typed*.

## Type of change
- [ ] Bug fix
- [x] New feature
- [ ] Refactor / cleanup
- [ ] Documentation
- [ ] CI / tooling
- [ ] Localization
- [ ] Other

## Related issues

Fixes #882. Backend companion: simonoppowa/OpenNutriTracker-Backend#2. Found while resolving #873 on map #867, which decided to disclose the logging in the privacy policy and raise the reduction separately.

## Changes

All **three** Supabase calls move, not just the two searches:

| Was | Now |
| --- | --- |
| `.textSearch` on `food_summary.name` | `rpc('search_food_summary')` |
| `.textSearch` on `food_translation.description` | `rpc('search_food_translation')` |
| `.inFilter(food_id, ids)` on the localized path | `rpc('food_summary_by_ids')` |

**Why the third one matters.** The localized search ends by fetching summary rows for the ids its ranking kept, and **those ids are derived from the term**. Leaving that hop as an `in.(...)` filter would put a fingerprint of the search straight back into the URL. Removing the term while leaving its shadow behind would not have been worth doing.

**Ranking is untouched.** The functions return the same *unordered* candidate pool the queries returned, and `returns setof food_summary` keeps the wire shape byte-identical, so `SpFoodDTO.fromJson` and both client-side rankers are unchanged. `ts_rank` ordering in SQL would be a different change for a different reason.

The `foodNameFtsConfig` / `translationFtsConfig` constants are gone: those configs now live inside the functions, next to the indexes that have to agree with them.

## Test plan
- [x] Described steps below were followed locally
- [x] Unit / widget tests added or updated
- [ ] Manual check on Android — needs the backend deployed first
- [ ] Manual check on iOS (if applicable)

`test/unit_test/sp_food_search_transport_test.dart` is new. It drives a real `SupabaseClient` over a recording `http.Client` and asserts **on the wire**, which is the point: the property that matters is where the term ends up, not which method was called to put it there.

Three assertions:

1. **No request URL contains the term** — checked raw and percent-decoded.
2. **Every call is a POST to `/rest/v1/rpc/…` with an empty query string.** "We switched to rpc" is not sufficient on its own — a filter chained onto an RPC still travels in the query string, so this is what fails if someone reintroduces `.limit()` or `.inFilter()`.
3. **The term does travel in the body** — otherwise the search is broken rather than private.

### Steps
1. `fvm flutter test` — 1102 pass.
2. `fvm flutter analyze lib test` — clean apart from a pre-existing `unused_field` in the generated `env.g.dart`.
3. Non-vacuity: revert the English call site to `.textSearch(...)` and the suite fails printing the leaking URL verbatim —
   `http://backend.invalid/rest/v1/food_summary?select=%2A&name=wfts%28english%29.zzsearchtermzz&limit=100` — and the method assertion fails `Expected: 'POST' Actual: 'GET'`.

**Still to verify after deploy**, and it cannot be done from here: that a real search returns the same results as before, and that the term no longer appears in the gateway log. The log check is the acceptance criterion #882 actually asks for.

## Checklist
- [x] Code follows project style (`just format` / 120-char line width) — formatted the touched files only
- [x] New interactive widgets include `Semantics(identifier: '...')` where needed — none added
- [x] Localization updated in ARBs **and** `lib/generated/` when user-facing strings change — no user-facing strings change
- [x] Codegen ran if DBOs/DTOs/env changed — no DBO, DTO or env change
- [x] No secrets or `.env` values committed
- [x] PR title follows conventional commit style
