### PR TITLE
DO NOT MERGE — throwaway: verify the iOS retry gate

### DIFF
--- a/.github/workflows/default_workflow.yml
+++ b/.github/workflows/default_workflow.yml
@@ -260,129 +260,45 @@ jobs:
         # App Store install and isn't what CI should validate.
         run: flutter build ios --no-codesign --release --flavor full
 
+  # Two calls on two runners, not two attempts on one. See the header of
+  # .github/workflows/ios-integration-attempt.yml for why: the hang this suite
+  # suffers is runner-sticky, so an in-place retry never recovers from it while
+  # a fresh runner has every time. Neither call fails on its own — each reports
+  # a verdict, and ios-integration-tests-result below turns the pair into the
+  # single required check.
   ios-integration-tests:
-    # Runs from the start of the workflow, in parallel with everything else.
-    # Not gated on ios-build: this job rebuilds the app itself (it compiles
-    # its own test binary), so the dependency shared no output and only
-    # serialised ~6-11 min of build in front of it. The cost is one extra
-    # macOS build when the app doesn't compile, which this job's own build
-    # surfaces regardless.
-    #
-    # Pinned to macos-15, not macos-26. On the macos-26 image Flutter builds
-    # and launches the app on the iPhone 17 Pro / iOS 26.4 simulator but then
-    # hangs forever on "Waiting for VM Service port to be available" — the Dart
-    # VM-service URL is never discovered on that simulator, so the test never
-    # connects (the same suite passes on the Android emulator and on the iOS 18
-    # simulator here). macos-15 ships the Xcode 16 / iOS 18 simulator this
-    # Flutter supports. Revisit macos-26 once Flutter discovers the iOS 26
-    # simulator's VM service. ios-build / package / deploy stay on macos-26 —
-    # they build/sign and never launch a simulator, so they're unaffected.
-    runs-on: macos-15
-    # The backstop, not the thing that catches hangs. Each attempt below
-    # carries its own 20-minute bound, so a hang is a failed attempt the
-    # retry can act on; this bound only stops a job drifting toward GitHub's
-    # 6-hour default if something escapes both. It has to hold two cold
-    # builds — 30 was too tight and got cancelled mid-retry.
-    #
-    # It used to be the only bound, and a hang cost the whole 50 minutes of
-    # macOS time, reported as a cancelled job rather than a failed test —
-    # which `gh pr checks` renders as `fail` on a PR that is fine (#823).
-    timeout-minutes: 50
+    uses: ./.github/workflows/ios-integration-attempt.yml
+
+  # Only when the first runner did not pass. An empty output counts as "did not
+  # pass": that is what a job killed by its own timeout-minutes leaves behind.
+  ios-integration-tests-retry:
+    needs: ios-integration-tests
+    if: ${{ !cancelled() && needs.ios-integration-tests.outputs.passed != 'true' }}
+    uses: ./.github/workflows/ios-integration-attempt.yml
+
+  # The check to require in branch protection — the two jobs above are green
+  # even when their tests fail, by design, so requiring either of them directly
+  # would require nothing at all.
+  ios-integration-tests-result:
+    needs:
+      - ios-integration-tests
+      - ios-integration-tests-retry
+    if: ${{ !cancelled() }}
+    runs-on: ubuntu-latest
     permissions:
       contents: read
     steps:
-      - name: Checkout code
-        uses: actions/checkout@v7
-
-      - name: Setup Flutter + cache packages
-        uses: ./.github/actions/setup-flutter-cache
-
-      # Match ios-podfile-lock-guard and ios-build: SPM is enabled by
-      # default on Flutter's stable channel, so `flutter test` would spend
-      # ~150s "Adding Swift Package Manager integration" and resolve plugins
-      # via the SPM graph instead of the CocoaPods one those jobs pin to.
-      # Disable it here too so this job builds the same pinned graph and
-      # skips that avoidable per-build cost.
-      - name: Disable Swift Package Manager
-        run: flutter config --no-enable-swift-package-manager
-
-      - name: Cache CocoaPods
-        uses: actions/cache@v6
-        with:
-          path: ios/Pods
-          key: ${{ runner.os }}-pods-${{ hashFiles('ios/Podfile.lock') }}
-          restore-keys: |
-            ${{ runner.os }}-pods-
-
-      - name: Generate stub .env for CI
-        uses: ./.github/actions/write-env-file
-        with:
-          sentry_dns: https://stub@sentry.io/0
-          supabase_project_url: https://stub.supabase.co
-          supabase_project_anon_key: ci-stub
-
-      - name: Install Flutter packages
-        run: flutter pub get
-
-      - name: Generate code
-        run: dart run build_runner build --delete-conflicting-outputs
-
-      - name: Pod install (regenerate lockfile if constraints have shifted)
-        run: .github/scripts/pod_install_with_targeted_fallback.sh
-
-      # Pick any available iPhone simulator on the runner. macos-26
-      # ships several preinstalled; we don't care which exact model — the
-      # boot-smoke test is platform-bridge driven, not display-pixel driven.
-      - name: Pick + boot iPhone simulator
+      - name: Require one of the two runners to have passed
         run: |
-          DEVICE_UDID=$(xcrun simctl list devices available iPhone -j | python3 -c "
-          import sys, json
-          data = json.load(sys.stdin)
-          devices = [d for runtime in data['devices'].values() for d in runtime if d.get('isAvailable')]
-          if not devices:
-              sys.exit('No available iPhone simulators on this runner')
-          print(devices[0]['udid'])
-          ")
-          echo "Booting simulator UDID: $DEVICE_UDID"
-          xcrun simctl boot "$DEVICE_UDID"
-          xcrun simctl bootstatus "$DEVICE_UDID"
-          echo "DEVICE_UDID=$DEVICE_UDID" >> $GITHUB_ENV
-
-      # Two steps rather than a shell loop, matching android-integration-tests
-      # below. The loop this replaces retried on a non-zero exit, and so had
-      # nothing to say about `flutter test` never exiting at all: a hung
-      # attempt blocked until the job's own `timeout-minutes` killed it, and
-      # the retry — the mechanism meant to absorb simulator flakes — was
-      # skipped by the one flake mode that actually happens here. Three of
-      # sixteen runs on 2026-08-24 burned the full 50 minutes that way (#823).
-      #
-      # A step-level `timeout-minutes` turns a hang into a failed attempt, so
-      # the retry fires on it exactly as it does on a failure.
-      #
-      # 20 minutes per attempt: the slowest healthy run of this step in the
-      # last twenty was 15m36s (the range is 8m53s-15m36s, and it includes the
-      # cold Xcode build), and two 20-minute attempts still fit the job's 50
-      # with the ~5m40s of setup and teardown around them.
-      - name: Run integration tests (attempt 1)
-        id: ios-integration
-        continue-on-error: true
-        timeout-minutes: 20
-        # --flavor full so the integration-test app matches the production
-        # iOS scheme (bundle id + display name) rather than the develop one.
-        # The whole integration_test/ directory runs from a single build.
-        run: flutter test integration_test/ -d "$DEVICE_UDID" --flavor full --reporter expanded
-
-      # Retry once: integration tests occasionally flake on a slow simulator
-      # (a dropped frame, a transient launch hiccup, a build that never
-      # returns). A second attempt on the same booted sim clears those without
-      # masking a real failure, since a genuine break fails both attempts.
-      - name: Run integration tests (retry once)
-        if: steps.ios-integration.outcome == 'failure'
-        timeout-minutes: 20
-        run: |
-          echo "::warning::iOS integration tests failed or hung; retrying (attempt 2 of 2)"
-          flutter test integration_test/ -d "$DEVICE_UDID" --flavor full --reporter expanded
-
+          first='${{ needs.ios-integration-tests.outputs.passed }}'
+          second='${{ needs.ios-integration-tests-retry.outputs.passed }}'
+          echo "first runner:  ${first:-<no verdict — the job was killed>}"
+          echo "second runner: ${second:-<not run>}"
+          if [ "$first" = 'true' ] || [ "$second" = 'true' ]; then
+            exit 0
+          fi
+          echo "::error::iOS integration tests failed on two independent runners — treat this as a real break, not a flake."
+          exit 1
   android-build:
     runs-on: ubuntu-latest
     permissions:
@@ -608,7 +524,7 @@ jobs:
     needs:
       - linux-checks
       - ios-build
-      - ios-integration-tests
+      - ios-integration-tests-result
       - android-build
       - android-integration-tests
     runs-on: macos-26
@@ -770,7 +686,7 @@ jobs:
     needs:
       - linux-checks
       - ios-build
-      - ios-integration-tests
+      - ios-integration-tests-result
       - android-build
       - android-integration-tests
     runs-on: ubuntu-latest

--- a/.github/workflows/default_workflow.yml
+++ b/.github/workflows/default_workflow.yml
@@ -279,7 +279,7 @@ jobs:
     if: ${{ !cancelled() && needs.ios-integration-tests.outputs.passed != 'true' }}
     uses: ./.github/workflows/ios-integration-attempt.yml
     with:
-      force_fail: true
+      force_fail: false
 
   # The check to require in branch protection — the two jobs above are green
   # even when their tests fail, by design, so requiring either of them directly

--- a/.github/workflows/default_workflow.yml
+++ b/.github/workflows/default_workflow.yml
@@ -156,6 +156,7 @@ jobs:
           fi
 
   ios-build:
+    if: false  # TEMP (do not merge): not what this branch is testing
     runs-on: macos-26
     permissions:
       contents: write
@@ -268,6 +269,8 @@ jobs:
   # single required check.
   ios-integration-tests:
     uses: ./.github/workflows/ios-integration-attempt.yml
+    with:
+      force_fail: true
 
   # Only when the first runner did not pass. An empty output counts as "did not
   # pass": that is what a job killed by its own timeout-minutes leaves behind.
@@ -275,6 +278,8 @@ jobs:
     needs: ios-integration-tests
     if: ${{ !cancelled() && needs.ios-integration-tests.outputs.passed != 'true' }}
     uses: ./.github/workflows/ios-integration-attempt.yml
+    with:
+      force_fail: true
 
   # The check to require in branch protection — the two jobs above are green
   # even when their tests fail, by design, so requiring either of them directly
@@ -300,6 +305,7 @@ jobs:
           echo "::error::iOS integration tests failed on two independent runners — treat this as a real break, not a flake."
           exit 1
   android-build:
+    if: false  # TEMP (do not merge): not what this branch is testing
     runs-on: ubuntu-latest
     permissions:
       contents: read
@@ -363,6 +369,7 @@ jobs:
         run: flutter build apk --flavor full --debug
 
   android-integration-tests:
+    if: false  # TEMP (do not merge): not what this branch is testing
     # Same as iOS: runs in parallel from the start, gated on neither
     # android-build (it rebuilds the app itself) nor a file-discovery job.
     runs-on: ubuntu-latest

--- a/.github/workflows/ios-integration-attempt.yml
+++ b/.github/workflows/ios-integration-attempt.yml
@@ -1,0 +1,145 @@
+name: iOS integration attempt
+
+# One attempt at the iOS integration suite, on its own runner.
+#
+# default_workflow.yml calls this twice rather than retrying in place. The
+# retry it replaces re-ran `flutter test` as a second step in the same job, so
+# it landed on the same runner — and the failure this suite actually suffers is
+# runner-sticky. Every run where the first attempt hung also lost the second
+# (#904, run 33067097364, run 33069718130), in three different ways: the device
+# gone three seconds after launch, "Failed to start Dart Development Service",
+# and an identical 20-minute hang. Run 33069718130 is the one that settles it —
+# it shut down, erased and rebooted the simulator and swept the host's dart
+# processes between the attempts, and the second attempt hung anyway. Meanwhile
+# every re-run dispatched onto a *fresh* runner has passed first time.
+#
+# The hang itself is Flutter never discovering the app's VM service: the Xcode
+# build completes, the app launches, and the tool sits silent until something
+# kills it. That is the same bug the macos-15 pin below documents for macos-26;
+# it is rarer on macos-15, not absent.
+#
+# So: a second runner, not a second attempt. The job never fails — it reports
+# `passed` as an output and leaves the verdict to the caller, which is what
+# lets the second call be conditioned on the first and lets one gate job
+# require that one of them succeeded.
+
+on:
+  workflow_call:
+    outputs:
+      passed:
+        description: >-
+          "true" when the suite passed on this runner, "false" when it failed
+          or hung. Empty if the job never reached its verdict step (its own
+          timeout-minutes killed it), which callers must treat as not passed.
+        value: ${{ jobs.run.outputs.passed }}
+
+jobs:
+  run:
+    # Pinned to macos-15, not macos-26. On the macos-26 image Flutter builds
+    # and launches the app on the iPhone 17 Pro / iOS 26.4 simulator but then
+    # hangs forever on "Waiting for VM Service port to be available" — the Dart
+    # VM-service URL is never discovered on that simulator, so the test never
+    # connects (the same suite passes on the Android emulator and on the iOS 18
+    # simulator here). macos-15 ships the Xcode 16 / iOS 18 simulator this
+    # Flutter supports. Revisit macos-26 once Flutter discovers the iOS 26
+    # simulator's VM service. ios-build / package / deploy stay on macos-26 —
+    # they build/sign and never launch a simulator, so they're unaffected.
+    runs-on: macos-15
+    # The backstop, not the thing that catches hangs — the test step's own
+    # 20-minute bound does that, and turns a hang into a verdict the caller can
+    # retry on a different runner. This only stops a job drifting toward
+    # GitHub's 6-hour default if something escapes it. One attempt plus the
+    # measured ~5m30s of setup and teardown fits in 30 with room to spare.
+    #
+    # It used to be the only bound, and a hang cost the whole 50 minutes of
+    # macOS time, reported as a cancelled job rather than a failed test —
+    # which `gh pr checks` renders as `fail` on a PR that is fine (#823).
+    timeout-minutes: 30
+    permissions:
+      contents: read
+    outputs:
+      passed: ${{ steps.verdict.outputs.passed }}
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v7
+
+      - name: Setup Flutter + cache packages
+        uses: ./.github/actions/setup-flutter-cache
+
+      # Match ios-podfile-lock-guard and ios-build: SPM is enabled by
+      # default on Flutter's stable channel, so `flutter test` would spend
+      # ~150s "Adding Swift Package Manager integration" and resolve plugins
+      # via the SPM graph instead of the CocoaPods one those jobs pin to.
+      # Disable it here too so this job builds the same pinned graph and
+      # skips that avoidable per-build cost.
+      - name: Disable Swift Package Manager
+        run: flutter config --no-enable-swift-package-manager
+
+      - name: Cache CocoaPods
+        uses: actions/cache@v6
+        with:
+          path: ios/Pods
+          key: ${{ runner.os }}-pods-${{ hashFiles('ios/Podfile.lock') }}
+          restore-keys: |
+            ${{ runner.os }}-pods-
+
+      - name: Generate stub .env for CI
+        uses: ./.github/actions/write-env-file
+        with:
+          sentry_dns: https://stub@sentry.io/0
+          supabase_project_url: https://stub.supabase.co
+          supabase_project_anon_key: ci-stub
+
+      - name: Install Flutter packages
+        run: flutter pub get
+
+      - name: Generate code
+        run: dart run build_runner build --delete-conflicting-outputs
+
+      - name: Pod install (regenerate lockfile if constraints have shifted)
+        run: .github/scripts/pod_install_with_targeted_fallback.sh
+
+      # Pick any available iPhone simulator on the runner. The runner images
+      # ship several preinstalled; we don't care which exact model — the
+      # boot-smoke test is platform-bridge driven, not display-pixel driven.
+      - name: Pick + boot iPhone simulator
+        run: |
+          DEVICE_UDID=$(xcrun simctl list devices available iPhone -j | python3 -c "
+          import sys, json
+          data = json.load(sys.stdin)
+          devices = [d for runtime in data['devices'].values() for d in runtime if d.get('isAvailable')]
+          if not devices:
+              sys.exit('No available iPhone simulators on this runner')
+          print(devices[0]['udid'])
+          ")
+          echo "Booting simulator UDID: $DEVICE_UDID"
+          xcrun simctl boot "$DEVICE_UDID"
+          xcrun simctl bootstatus "$DEVICE_UDID"
+          echo "DEVICE_UDID=$DEVICE_UDID" >> $GITHUB_ENV
+
+      # continue-on-error so the job survives to report a verdict; the caller
+      # decides what a failure means. timeout-minutes is what makes a hang
+      # reportable at all — without it the tool sits there until the job bound
+      # kills the whole job, and a cancelled job has no output to hand back.
+      #
+      # 20 minutes: the slowest healthy run of this step in the last twenty was
+      # 15m36s (the range is 8m53s-15m36s, and it includes the cold Xcode
+      # build).
+      - name: Run integration tests
+        id: attempt
+        continue-on-error: true
+        timeout-minutes: 20
+        # --flavor full so the integration-test app matches the production
+        # iOS scheme (bundle id + display name) rather than the develop one.
+        # The whole integration_test/ directory runs from a single build.
+        run: flutter test integration_test/ -d "$DEVICE_UDID" --flavor full --reporter expanded
+
+      - name: Record the verdict
+        id: verdict
+        run: |
+          if [ "${{ steps.attempt.outcome }}" = "success" ]; then
+            echo "passed=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "::warning::iOS integration tests failed or hung on this runner"
+            echo "passed=false" >> "$GITHUB_OUTPUT"
+          fi

--- a/.github/workflows/ios-integration-attempt.yml
+++ b/.github/workflows/ios-integration-attempt.yml
@@ -25,6 +25,11 @@ name: iOS integration attempt
 
 on:
   workflow_call:
+    inputs:
+      force_fail:
+        description: 'TEMP (do not merge): make the attempt fail instantly.'
+        type: boolean
+        default: false
     outputs:
       passed:
         description: >-
@@ -132,7 +137,12 @@ jobs:
         # --flavor full so the integration-test app matches the production
         # iOS scheme (bundle id + display name) rather than the develop one.
         # The whole integration_test/ directory runs from a single build.
-        run: flutter test integration_test/ -d "$DEVICE_UDID" --flavor full --reporter expanded
+        run: |
+          if [ "${{ inputs.force_fail }}" = "true" ]; then
+            echo "TEMP (do not merge): forcing this attempt to fail"
+            exit 1
+          fi
+          flutter test integration_test/ -d "$DEVICE_UDID" --flavor full --reporter expanded
 
       - name: Record the verdict
         id: verdict


### PR DESCRIPTION
Throwaway for #912. **Do not merge; closed once both scenarios report.**

Scenario 1 (this commit): both attempts forced to fail fast. Expected — `ios-integration-tests` green (by design), `ios-integration-tests-retry` runs and is green, `ios-integration-tests-result` **red**. If the gate is green here it is worthless and #912 is wrong.

Scenario 2 (next commit): first forced to fail, second real. Expected — retry fires on a new runner, real suite passes, gate green.

Unrelated heavy jobs are `if: false` here to keep the throwaway cheap.