### PR TITLE
fix(add-meal): strip a photo's metadata when no encoder ran

### DIFF
--- a/lib/features/add_meal/util/meal_photo_encoder.dart
+++ b/lib/features/add_meal/util/meal_photo_encoder.dart
@@ -4,6 +4,7 @@ import 'package:flutter/foundation.dart';
 import 'package:flutter_image_compress/flutter_image_compress.dart';
 import 'package:opennutritracker/core/utils/ai_credential_storage.dart';
 import 'package:opennutritracker/features/add_meal/domain/meal_photo_interpreter.dart';
+import 'package:opennutritracker/features/add_meal/util/photo_metadata.dart';
 
 /// The container a photo is encoded into. **Quality and size are identical
 /// either way** — only the container changes.
@@ -37,9 +38,7 @@ enum MealPhotoFormat {
   /// Exhaustive on purpose. A fifth provider has to answer this question
   /// rather than inherit whichever answer a wildcard happened to give it.
   static MealPhotoFormat forProvider(AiProvider provider) => switch (provider) {
-    AiProvider.anthropic ||
-    AiProvider.openrouter ||
-    AiProvider.openai => webp,
+    AiProvider.anthropic || AiProvider.openrouter || AiProvider.openai => webp,
     AiProvider.ownServer => jpeg,
   };
 }
@@ -138,7 +137,24 @@ class MealPhotoEncoder {
     if (mediaType == null) return null;
     final raw = await _rawBytes(sourcePath);
     if (raw == null) return null;
-    return _fitting(raw, mediaType);
+
+    // These bytes have not been through an encoder, so they still carry
+    // whatever the camera wrote into them — including the GPS block, which is
+    // the one thing in a meal photo that is about the user rather than the
+    // meal. The normal path is clean for free, because re-encoding writes a
+    // container with no metadata in it; this path has to be cleaned.
+    //
+    // Null when the file cannot be parsed as the type its extension claims.
+    // That narrows the fallback, on purpose: an unreadable file is the one
+    // most likely to be carrying something, and "pick another photo" is a
+    // better answer than sending bytes we could not account for.
+    final stripped = PhotoMetadata.stripped(raw, mediaType);
+    if (stripped == null) return null;
+
+    // What survives is still full-resolution — stripping metadata is not
+    // resizing, and there is no encoder here to resize with. The size ceiling
+    // in [maxBytes] is what bounds it.
+    return _fitting(stripped, mediaType);
   }
 
   /// The provider media type for a path's extension, or null when it is one
@@ -171,6 +187,12 @@ class MealPhotoEncoder {
         quality: 80,
         minWidth: 1024,
         minHeight: 1024,
+        // The package's default, pinned so it is a decision rather than an
+        // inheritance. A meal photo's EXIF is the camera's GPS fix and the
+        // body's serial number; none of it helps a model read the plate, and
+        // the app promises it asks for no location. [PhotoMetadata] does the
+        // same job on the fallback path below, where no encoder runs.
+        keepExif: false,
         // `minWidth`/`minHeight` are upper bounds for the *longest* edge
         // when the source exceeds them; the compressor preserves aspect
         // ratio. Shorter-edge images pass through untouched.

--- a/lib/features/add_meal/util/photo_metadata.dart
+++ b/lib/features/add_meal/util/photo_metadata.dart
@@ -1,0 +1,278 @@
+import 'dart:typed_data';
+
+/// Removes the metadata blocks a camera writes into a photo, so a picture
+/// leaving the device carries the pixels and nothing else.
+///
+/// This exists for one caller: [MealPhotoEncoder]'s fallback path, where the
+/// device encoder failed and the app sends the picked file as it found it.
+/// The normal path has never needed it — `flutter_image_compress` defaults to
+/// `keepExif: false`, and re-encoding produces a container with no metadata
+/// to begin with.
+///
+/// The block that matters is EXIF GPS. A phone camera geotags by default, so
+/// an unprocessed original is a photograph of a meal *and* the coordinates of
+/// the room it was eaten in. The app tells people it asks for no location
+/// permission (README, "Permissions"), which stops being true the moment it
+/// forwards coordinates it read out of a file — the permission it never
+/// requested is not the only way to learn where someone is. Everything else
+/// in there leaves for the same reason: the maker notes, the body serial
+/// number some cameras write, the capture timestamp.
+///
+/// **Refuses rather than guesses.** Every parser returns null as soon as the
+/// bytes stop matching the container they claim to be, and the caller treats
+/// that as "pick another photo". Passing along bytes we could not account for
+/// is the one outcome this must not have — an unparsed file is exactly the
+/// file most likely to be hiding something.
+class PhotoMetadata {
+  /// [bytes] with every metadata block removed, or null when they cannot be
+  /// read as [mediaType].
+  ///
+  /// [mediaType] is the type the caller intends to *declare*, not a guess
+  /// from the bytes: the container has to be the one the provider is being
+  /// told to expect, or a decoder rejects it on arrival.
+  static Uint8List? stripped(Uint8List bytes, String mediaType) {
+    switch (mediaType) {
+      case 'image/jpeg':
+        return _strippedJpeg(bytes);
+      case 'image/png':
+        return _strippedPng(bytes);
+      case 'image/webp':
+        return _strippedWebp(bytes);
+      case 'image/gif':
+        // A GIF has nowhere to put coordinates. Its only metadata extensions
+        // are Comment and Application, neither of which is a geotag
+        // container, and no camera writes one anyway. Handing the bytes back
+        // unchanged is the accurate answer here, not an omission.
+        return bytes;
+      default:
+        return null;
+    }
+  }
+
+  // ---------------------------------------------------------------------------
+  // JPEG
+  // ---------------------------------------------------------------------------
+
+  static const _jpegSoi = 0xD8;
+  static const _jpegEoi = 0xD9;
+  static const _jpegSos = 0xDA;
+  static const _jpegComment = 0xFE;
+  static const _jpegTem = 0x01;
+  static const _jpegFirstRestart = 0xD0;
+  static const _jpegLastRestart = 0xD7;
+  static const _jpegFirstApp = 0xE0;
+  static const _jpegLastApp = 0xEF;
+
+  static Uint8List? _strippedJpeg(Uint8List bytes) {
+    if (bytes.length < 4 || bytes[0] != 0xFF || bytes[1] != _jpegSoi) {
+      return null;
+    }
+
+    final out = BytesBuilder(copy: false)..add(const [0xFF, _jpegSoi]);
+    var i = 2;
+
+    while (i + 1 < bytes.length) {
+      // Every segment starts on an `FF <marker>` pair. Anything else means
+      // the file is not the JPEG it claims to be, or that a length we trusted
+      // was wrong — either way we stop rather than resynchronise, because
+      // guessing where the next marker is means guessing what we skipped.
+      if (bytes[i] != 0xFF) return null;
+      final marker = bytes[i + 1];
+
+      // A run of FFs before the real marker is legal padding.
+      if (marker == 0xFF) {
+        i++;
+        continue;
+      }
+
+      // Standalone markers: no length field, no payload.
+      if (marker == _jpegTem ||
+          (marker >= _jpegFirstRestart && marker <= _jpegLastRestart)) {
+        out.add([0xFF, marker]);
+        i += 2;
+        continue;
+      }
+
+      // Scan data is not segmented, so the walk ends here. From this point
+      // the file is entropy-coded image up to the end marker: 0xFF is
+      // byte-stuffed as `FF 00` and the only markers that can appear are
+      // restarts, so the first `FF D9` really is the end of the image.
+      //
+      // Whatever follows that is dropped. It is not part of the JPEG, and it
+      // is where a phone appends its own trailer — Samsung's SEFH block,
+      // multi-picture object data, a second full-size copy of the frame.
+      if (marker == _jpegSos) {
+        final eoi = _indexOfEoi(bytes, i + 2);
+        if (eoi == null) return null;
+        out.add(Uint8List.sublistView(bytes, i, eoi + 2));
+        return out.toBytes();
+      }
+
+      if (marker == _jpegEoi) {
+        out.add(const [0xFF, _jpegEoi]);
+        return out.toBytes();
+      }
+
+      if (i + 3 >= bytes.length) return null;
+      // The length counts itself but not the two marker bytes.
+      final length = (bytes[i + 2] << 8) | bytes[i + 3];
+      if (length < 2) return null;
+      final end = i + 2 + length;
+      if (end > bytes.length) return null;
+
+      // APP1 through APP15 are where the metadata lives: EXIF and XMP in
+      // APP1, the IPTC/Photoshop block in APP13, a maker's own scratch space
+      // in most of the rest. COM is free text. APP0 stays — it is JFIF, five
+      // bytes of pixel density that some decoders look for, and it holds
+      // nothing about the photographer.
+      final drop =
+          (marker > _jpegFirstApp && marker <= _jpegLastApp) ||
+          marker == _jpegComment;
+      if (!drop) out.add(Uint8List.sublistView(bytes, i, end));
+      i = end;
+    }
+
+    // Ran out of bytes without reaching a scan or an end marker.
+    return null;
+  }
+
+  /// Index of the `FF` in the first end-of-image marker at or after [from].
+  static int? _indexOfEoi(Uint8List bytes, int from) {
+    for (var i = from; i + 1 < bytes.length; i++) {
+      if (bytes[i] == 0xFF && bytes[i + 1] == _jpegEoi) return i;
+    }
+    return null;
+  }
+
+  // ---------------------------------------------------------------------------
+  // PNG
+  // ---------------------------------------------------------------------------
+
+  static const _pngSignature = [0x89, 0x50, 0x4E, 0x47, 0x0D, 0x0A, 0x1A, 0x0A];
+
+  /// Ancillary chunks that hold metadata rather than pixels. `eXIf` is the
+  /// EXIF block proper — a screenshot has none, but a photo re-saved as PNG
+  /// by an editor keeps it. The text chunks are where captions and editing
+  /// history land, and `tIME` is a modification timestamp.
+  static const _pngMetadataChunks = {'eXIf', 'tEXt', 'zTXt', 'iTXt', 'tIME'};
+
+  static Uint8List? _strippedPng(Uint8List bytes) {
+    if (bytes.length < _pngSignature.length + 12) return null;
+    for (var i = 0; i < _pngSignature.length; i++) {
+      if (bytes[i] != _pngSignature[i]) return null;
+    }
+
+    final out = BytesBuilder(copy: false)..add(_pngSignature);
+    var i = _pngSignature.length;
+
+    while (i + 12 <= bytes.length) {
+      final length = _readUint32BigEndian(bytes, i);
+      // length field + type + data + CRC
+      final end = i + 12 + length;
+      if (length > bytes.length || end > bytes.length) return null;
+      final type = String.fromCharCodes(bytes, i + 4, i + 8);
+
+      // Chunks are copied whole, so the CRC that follows each one stays
+      // correct without being recomputed.
+      if (!_pngMetadataChunks.contains(type)) {
+        out.add(Uint8List.sublistView(bytes, i, end));
+      }
+      i = end;
+
+      // Anything after the end chunk is not part of the image.
+      if (type == 'IEND') return out.toBytes();
+    }
+
+    return null;
+  }
+
+  // ---------------------------------------------------------------------------
+  // WebP
+  // ---------------------------------------------------------------------------
+
+  /// Feature bits in the `VP8X` flags byte, as libwebp names them.
+  static const _vp8xExifFlag = 0x08;
+  static const _vp8xXmpFlag = 0x04;
+
+  /// Flags byte, 3 reserved, 3 canvas width, 3 canvas height.
+  static const _vp8xPayloadLength = 10;
+
+  static Uint8List? _strippedWebp(Uint8List bytes) {
+    if (bytes.length < 12) return null;
+    if (_readFourCc(bytes, 0) != 'RIFF' || _readFourCc(bytes, 8) != 'WEBP') {
+      return null;
+    }
+
+    final chunks = BytesBuilder(copy: false);
+    var i = 12;
+
+    while (i + 8 <= bytes.length) {
+      final type = _readFourCc(bytes, i);
+      final size = _readUint32LittleEndian(bytes, i + 4);
+      // Chunks are padded to an even length, and the pad byte is not counted
+      // in the size field.
+      final end = i + 8 + size + (size.isOdd ? 1 : 0);
+      if (size > bytes.length || end > bytes.length) return null;
+
+      if (type == 'EXIF' || type == 'XMP ') {
+        i = end;
+        continue;
+      }
+
+      if (type == 'VP8X') {
+        if (size != _vp8xPayloadLength) return null;
+        // The flags byte announces which optional chunks the file contains.
+        // Dropping a chunk without clearing its bit leaves a file promising
+        // metadata it no longer has, which a strict decoder may reject — and
+        // this path is already the one where the encoder let us down.
+        final header = Uint8List.fromList(Uint8List.sublistView(bytes, i, end));
+        header[8] &= ~(_vp8xExifFlag | _vp8xXmpFlag);
+        chunks.add(header);
+        i = end;
+        continue;
+      }
+
+      chunks.add(Uint8List.sublistView(bytes, i, end));
+      i = end;
+    }
+
+    // A partial chunk at the tail is a file we have not fully read.
+    if (i != bytes.length) return null;
+
+    final payload = chunks.toBytes();
+    final out = Uint8List(12 + payload.length);
+    out.setRange(0, 4, 'RIFF'.codeUnits);
+    // The RIFF size counts everything after this field: the 'WEBP' tag and
+    // the chunks that survived.
+    _writeUint32LittleEndian(out, 4, 4 + payload.length);
+    out.setRange(8, 12, 'WEBP'.codeUnits);
+    out.setRange(12, out.length, payload);
+    return out;
+  }
+
+  // ---------------------------------------------------------------------------
+  // Byte helpers
+  // ---------------------------------------------------------------------------
+
+  static String _readFourCc(Uint8List bytes, int offset) =>
+      String.fromCharCodes(bytes, offset, offset + 4);
+
+  static int _readUint32BigEndian(Uint8List bytes, int offset) =>
+      (bytes[offset] << 24) |
+      (bytes[offset + 1] << 16) |
+      (bytes[offset + 2] << 8) |
+      bytes[offset + 3];
+
+  static int _readUint32LittleEndian(Uint8List bytes, int offset) =>
+      bytes[offset] |
+      (bytes[offset + 1] << 8) |
+      (bytes[offset + 2] << 16) |
+      (bytes[offset + 3] << 24);
+
+  static void _writeUint32LittleEndian(Uint8List bytes, int offset, int value) {
+    bytes[offset] = value & 0xFF;
+    bytes[offset + 1] = (value >> 8) & 0xFF;
+    bytes[offset + 2] = (value >> 16) & 0xFF;
+    bytes[offset + 3] = (value >> 24) & 0xFF;
+  }
+}

--- a/test/fixture/photo_fixtures.dart
+++ b/test/fixture/photo_fixtures.dart
@@ -1,0 +1,191 @@
+import 'dart:typed_data';
+
+/// Minimal, hand-built image containers for testing metadata removal.
+///
+/// Synthetic rather than a real photograph on purpose. A committed JPEG with
+/// a real GPS fix in it is a location in the repository forever, and a
+/// checked-in binary is the one fixture nobody can read a diff of. These are
+/// structurally valid — the right signatures, real segment and chunk framing,
+/// correct padding — which is all the parsers under test look at. They are
+/// not decodable images and are not meant to be.
+///
+/// Each carries [gpsNeedle] where a camera would put the block that matters,
+/// so a test can assert on its absence by searching the bytes.
+
+// dart format off
+//
+// These are byte tables. The formatter breaks a list with a trailing comma
+// onto one element per line, which turns a readable segment header into a
+// forty-line column and hides the structure the fixtures exist to show.
+
+/// The stand-in for an EXIF GPS fix: a byte run no valid header or framing
+/// field can produce, so finding it in an output means the block survived.
+const gpsNeedle = 'GPS:52.5200,13.4050';
+
+/// Whether [needle] appears anywhere in [bytes].
+bool containsBytes(Uint8List bytes, String needle) {
+  final target = needle.codeUnits;
+  if (target.isEmpty || target.length > bytes.length) return false;
+  for (var i = 0; i <= bytes.length - target.length; i++) {
+    var match = true;
+    for (var j = 0; j < target.length; j++) {
+      if (bytes[i + j] != target[j]) {
+        match = false;
+        break;
+      }
+    }
+    if (match) return true;
+  }
+  return false;
+}
+
+// -----------------------------------------------------------------------------
+// JPEG
+// -----------------------------------------------------------------------------
+
+/// The marker payload a decoder must keep: a quantisation table is as close
+/// to the pixels as a segment gets, and dropping it would break the image.
+const jpegDqtNeedle = 'DQT-KEEP-ME';
+
+/// A JFIF density block, which stays because APP0 is not metadata.
+const jpegJfifNeedle = 'JFIF';
+
+/// A length-prefixed JPEG segment. The length counts itself and the payload,
+/// but not the two marker bytes.
+List<int> jpegSegment(int marker, List<int> payload) {
+  final length = payload.length + 2;
+  return [0xFF, marker, (length >> 8) & 0xFF, length & 0xFF, ...payload];
+}
+
+/// A JPEG carrying everything the stripper is supposed to remove — EXIF in
+/// APP1, a comment, an XMP-style APP1 and a Photoshop-style APP13 — alongside
+/// the JFIF block and quantisation table it must keep.
+///
+/// [trailer] is appended after the end-of-image marker, the way a phone
+/// appends its own block: it should not survive either.
+Uint8List jpegWithMetadata({List<int> trailer = const []}) =>
+    Uint8List.fromList([
+      0xFF, 0xD8, // SOI
+      ...jpegSegment(0xE0, [
+        ...jpegJfifNeedle.codeUnits,
+        0x00, 0x01, 0x02, 0x00, 0x00, 0x01, 0x00, 0x01, 0x00, 0x00
+      ]), // APP0/JFIF — keep
+      ...jpegSegment(0xE1, [
+        ...'Exif'.codeUnits, 0x00, 0x00, ...gpsNeedle.codeUnits
+      ]), // APP1/EXIF — drop
+      // The real APP1 XMP identifier is NUL-terminated, as is the APP13
+      // Photoshop one and a PNG text chunk's keyword. Written as escapes so
+      // the bytes stay authentic without the file reading as binary to git.
+      ...jpegSegment(0xE1, 'http://ns.adobe.com/xap/1.0/\x00tagged'.codeUnits),
+      ...jpegSegment(0xED, 'Photoshop 3.0\x00IPTC'.codeUnits), // APP13 — drop
+      ...jpegSegment(0xFE, 'a comment'.codeUnits), // COM — drop
+      ...jpegSegment(0xDB, jpegDqtNeedle.codeUnits), // DQT — keep
+      ...jpegSegment(0xDA, [0x01, 0x01, 0x00, 0x00, 0x3F, 0x00]), // SOS
+      // Entropy data, including a byte-stuffed 0xFF and a restart marker, so
+      // the walk is exercised against bytes that look like markers.
+      0x12, 0x34, 0xFF, 0x00, 0xFF, 0xD0, 0x56,
+      0xFF, 0xD9, // EOI
+      ...trailer,
+    ]);
+
+// -----------------------------------------------------------------------------
+// PNG
+// -----------------------------------------------------------------------------
+
+const pngSignature = [0x89, 0x50, 0x4E, 0x47, 0x0D, 0x0A, 0x1A, 0x0A];
+
+/// Payload that must survive, standing in for compressed pixel data.
+const pngIdatNeedle = 'IDAT-KEEP-ME';
+
+/// A PNG chunk: big-endian length, four-character type, data, CRC.
+///
+/// The CRC is a placeholder. Nothing under test validates it — chunks are
+/// copied whole, so a real file's CRCs stay correct without being recomputed,
+/// and computing one here would only be testing the test.
+List<int> pngChunk(String type, List<int> data) => [
+  (data.length >> 24) & 0xFF,
+  (data.length >> 16) & 0xFF,
+  (data.length >> 8) & 0xFF,
+  data.length & 0xFF,
+  ...type.codeUnits,
+  ...data,
+  0xDE, 0xAD, 0xBE, 0xEF,
+];
+
+/// A PNG with an `eXIf` block and two text chunks to remove, around the
+/// header and pixel chunks that have to stay.
+Uint8List pngWithMetadata({List<int> trailer = const []}) =>
+    Uint8List.fromList([
+      ...pngSignature,
+      ...pngChunk('IHDR', List.filled(13, 0x01)),
+      ...pngChunk('eXIf', gpsNeedle.codeUnits),
+      ...pngChunk('tEXt', 'Comment\x00hello'.codeUnits),
+      ...pngChunk('iTXt', 'XML:com.adobe.xmp\x00tagged'.codeUnits),
+      ...pngChunk('tIME', List.filled(7, 0x02)),
+      ...pngChunk('IDAT', pngIdatNeedle.codeUnits),
+      ...pngChunk('IEND', const []),
+      ...trailer,
+    ]);
+
+// -----------------------------------------------------------------------------
+// WebP
+// -----------------------------------------------------------------------------
+
+/// Payload that must survive, standing in for the compressed frame.
+const webpFrameNeedle = 'VP8-KEEP-ME';
+
+/// The alpha bit. Set in the fixture so a test can prove the stripper clears
+/// the two metadata bits without flattening the whole flags byte.
+const webpAlphaFlag = 0x10;
+
+/// A RIFF chunk: four-character type, little-endian size, payload, and a pad
+/// byte when the size is odd.
+List<int> webpChunk(String type, List<int> data) => [
+  ...type.codeUnits,
+  data.length & 0xFF,
+  (data.length >> 8) & 0xFF,
+  (data.length >> 16) & 0xFF,
+  (data.length >> 24) & 0xFF,
+  ...data,
+  if (data.length.isOdd) 0x00,
+];
+
+/// An extended-format WebP whose `VP8X` flags advertise EXIF and XMP, with
+/// both chunks present.
+Uint8List webpWithMetadata() {
+  final chunks = <int>[
+    ...webpChunk('VP8X', [
+      webpAlphaFlag | 0x08 | 0x04, // alpha + EXIF + XMP
+      0x00, 0x00, 0x00, // reserved
+      0xFF, 0x00, 0x00, // canvas width - 1
+      0xFF, 0x00, 0x00, // canvas height - 1
+    ]),
+    ...webpChunk('VP8 ', webpFrameNeedle.codeUnits),
+    ...webpChunk('EXIF', gpsNeedle.codeUnits),
+    ...webpChunk('XMP ', 'tagged'.codeUnits),
+  ];
+  return Uint8List.fromList([
+    ...'RIFF'.codeUnits,
+    (4 + chunks.length) & 0xFF,
+    ((4 + chunks.length) >> 8) & 0xFF,
+    ((4 + chunks.length) >> 16) & 0xFF,
+    ((4 + chunks.length) >> 24) & 0xFF,
+    ...'WEBP'.codeUnits,
+    ...chunks,
+  ]);
+}
+
+// -----------------------------------------------------------------------------
+// GIF
+// -----------------------------------------------------------------------------
+
+/// A GIF89a header with a comment extension and a trailer. Nothing in here
+/// can hold coordinates, which is the point.
+Uint8List gifWithComment() => Uint8List.fromList([
+  ...'GIF89a'.codeUnits,
+  0x01, 0x00, 0x01, 0x00, 0x00, 0x00, 0x00, // logical screen descriptor
+  0x21, 0xFE, 0x05, ...'hello'.codeUnits, 0x00, // comment extension
+  0x3B, // trailer
+]);
+
+// dart format on

--- a/test/unit_test/meal_photo_encoder_test.dart
+++ b/test/unit_test/meal_photo_encoder_test.dart
@@ -5,6 +5,8 @@ import 'package:flutter_test/flutter_test.dart';
 import 'package:opennutritracker/core/utils/ai_credential_storage.dart';
 import 'package:opennutritracker/features/add_meal/util/meal_photo_encoder.dart';
 
+import '../fixture/photo_fixtures.dart';
+
 /// Only the decisions that need no platform channel. The compression itself
 /// runs in the device encoder and is covered by driving the real flow.
 void main() {
@@ -146,23 +148,57 @@ void main() {
       }
     });
 
-    test('the fallback declares the file it sent, not the one asked for', () async {
-      // There is no platform channel in a unit test, so the compressor fails
-      // and `encode` takes the raw-bytes path — which is the real behaviour
-      // on a device whose encoder is missing. What it sends is the original
-      // file, so the media type has to describe *that*, not the container
-      // that was requested and never produced. Declaring `image/webp` over
-      // JPEG bytes is a 400 from Ollama, whose decodeImageURL checks the
-      // data-URI prefix.
-      final file = File('${dir.path}/original.jpg')
-        ..writeAsBytesSync(List.filled(2000, 0));
+    test(
+      'the fallback declares the file it sent, not the one asked for',
+      () async {
+        // There is no platform channel in a unit test, so the compressor fails
+        // and `encode` takes the raw-bytes path — which is the real behaviour
+        // on a device whose encoder is missing. What it sends is the original
+        // file, so the media type has to describe *that*, not the container
+        // that was requested and never produced. Declaring `image/webp` over
+        // JPEG bytes is a 400 from Ollama, whose decodeImageURL checks the
+        // data-URI prefix.
+        final file = File('${dir.path}/original.jpg')
+          ..writeAsBytesSync(jpegWithMetadata());
+
+        final photo = await MealPhotoEncoder.encode(
+          file.path,
+          format: MealPhotoFormat.webp,
+        );
+
+        expect(photo?.mediaType, 'image/jpeg');
+      },
+    );
+
+    test('the fallback does not send the camera\'s metadata', () async {
+      // The normal path is clean because re-encoding writes a container with
+      // no metadata in it. This path has no encoder to inherit that from, so
+      // it strips the file itself — otherwise a device whose encoder failed
+      // is the one device that posts its owner's GPS fix to a provider.
+      final file = File('${dir.path}/geotagged.jpg')
+        ..writeAsBytesSync(jpegWithMetadata());
 
       final photo = await MealPhotoEncoder.encode(
         file.path,
-        format: MealPhotoFormat.webp,
+        format: MealPhotoFormat.jpeg,
       );
 
-      expect(photo?.mediaType, 'image/jpeg');
+      expect(photo, isNotNull);
+      expect(containsBytes(photo!.bytes, gpsNeedle), isFalse);
+    });
+
+    test('a file that cannot be parsed is not sent at all', () async {
+      // Deliberately narrower than before: the fallback used to forward
+      // whatever bytes it found. A file that does not parse as the type its
+      // extension claims is the one most likely to be carrying something, and
+      // "pick another photo" is a better answer than sending it blind.
+      final file = File('${dir.path}/not_really.jpg')
+        ..writeAsBytesSync(List.filled(2000, 0));
+
+      expect(
+        await MealPhotoEncoder.encode(file.path, format: MealPhotoFormat.jpeg),
+        isNull,
+      );
     });
 
     test('a missing source is not an error', () async {

--- a/test/unit_test/photo_metadata_test.dart
+++ b/test/unit_test/photo_metadata_test.dart
@@ -1,0 +1,269 @@
+import 'dart:typed_data';
+
+import 'package:flutter_test/flutter_test.dart';
+import 'package:opennutritracker/features/add_meal/util/photo_metadata.dart';
+
+import '../fixture/photo_fixtures.dart';
+
+/// The guarantee under test is one sentence: a photo that leaves the device on
+/// the fallback path carries pixels and nothing about the person who took it.
+void main() {
+  group('JPEG', () {
+    test('the EXIF block does not survive', () {
+      // The whole reason this class exists. A phone geotags by default, so an
+      // unprocessed camera original says where the meal was eaten — and the
+      // app tells people it asks for no location permission.
+      final stripped = PhotoMetadata.stripped(
+        jpegWithMetadata(),
+        'image/jpeg',
+      )!;
+
+      expect(containsBytes(stripped, gpsNeedle), isFalse);
+    });
+
+    test('the other metadata segments go with it', () {
+      // XMP rides in a second APP1, the IPTC/Photoshop block in APP13, and a
+      // comment in COM. None of them is pixels.
+      final stripped = PhotoMetadata.stripped(
+        jpegWithMetadata(),
+        'image/jpeg',
+      )!;
+
+      expect(containsBytes(stripped, 'ns.adobe.com'), isFalse);
+      expect(containsBytes(stripped, 'Photoshop'), isFalse);
+      expect(containsBytes(stripped, 'a comment'), isFalse);
+    });
+
+    test('the image itself is left intact', () {
+      // Removing too much is the other way to fail: a quantisation table is
+      // as close to the pixels as a segment gets, and JFIF is pixel density
+      // rather than metadata, so both stay.
+      final stripped = PhotoMetadata.stripped(
+        jpegWithMetadata(),
+        'image/jpeg',
+      )!;
+
+      expect(containsBytes(stripped, jpegDqtNeedle), isTrue);
+      expect(containsBytes(stripped, jpegJfifNeedle), isTrue);
+      expect(stripped.sublist(0, 2), [0xFF, 0xD8]);
+      expect(stripped.sublist(stripped.length - 2), [0xFF, 0xD9]);
+    });
+
+    test('a block appended after the end marker is dropped', () {
+      // Phones append their own trailers past EOI — Samsung writes an SEFH
+      // block there, and multi-picture data can hold a second full-size copy
+      // of the frame. It is not part of the image and it is not sent.
+      final stripped = PhotoMetadata.stripped(
+        jpegWithMetadata(
+          trailer: [...'SEFH'.codeUnits, ...gpsNeedle.codeUnits],
+        ),
+        'image/jpeg',
+      )!;
+
+      expect(containsBytes(stripped, 'SEFH'), isFalse);
+      expect(containsBytes(stripped, gpsNeedle), isFalse);
+    });
+
+    test('scan data that looks like a marker is not mistaken for one', () {
+      // Entropy-coded data byte-stuffs 0xFF as `FF 00` and may carry restart
+      // markers. Copying from the scan to the end marker verbatim is what
+      // keeps that from being reinterpreted as segment framing.
+      final stripped = PhotoMetadata.stripped(
+        jpegWithMetadata(),
+        'image/jpeg',
+      )!;
+
+      expect(
+        containsBytes(stripped, String.fromCharCodes([0xFF, 0x00, 0xFF, 0xD0])),
+        isTrue,
+      );
+    });
+
+    test('bytes that are not a JPEG are refused, not passed through', () {
+      // What the encoder's fallback used to send unexamined. Refusing means
+      // the user is told to pick another photo; passing it through would mean
+      // shipping bytes nothing has accounted for.
+      expect(
+        PhotoMetadata.stripped(
+          Uint8List.fromList(List.filled(2000, 0)),
+          'image/jpeg',
+        ),
+        isNull,
+      );
+    });
+
+    test('a truncated JPEG is refused', () {
+      final full = jpegWithMetadata();
+      expect(
+        PhotoMetadata.stripped(full.sublist(0, full.length ~/ 2), 'image/jpeg'),
+        isNull,
+      );
+    });
+
+    test('a segment length running past the end is refused', () {
+      // A malformed length is how a walk gets led out of bounds, and a parser
+      // that resynchronised after one would be guessing at what it skipped.
+      final bytes = Uint8List.fromList([
+        0xFF, 0xD8,
+        0xFF, 0xE1, 0x7F, 0xFF, // APP1 claiming 32 KB in a 6-byte file
+      ]);
+
+      expect(PhotoMetadata.stripped(bytes, 'image/jpeg'), isNull);
+    });
+  });
+
+  group('PNG', () {
+    test('the eXIf and text chunks do not survive', () {
+      // A screenshot has none of this, but a photo re-saved as PNG by an
+      // editor keeps its EXIF in an `eXIf` chunk.
+      final stripped = PhotoMetadata.stripped(pngWithMetadata(), 'image/png')!;
+
+      expect(containsBytes(stripped, gpsNeedle), isFalse);
+      // The keyword is NUL-separated from the text in a tEXt chunk, so the
+      // needle has to span the NUL or the assertion passes for free.
+      expect(containsBytes(stripped, 'Comment\x00hello'), isFalse);
+      expect(containsBytes(stripped, 'com.adobe.xmp'), isFalse);
+    });
+
+    test('the header and pixel chunks are left intact', () {
+      final stripped = PhotoMetadata.stripped(pngWithMetadata(), 'image/png')!;
+
+      expect(containsBytes(stripped, 'IHDR'), isTrue);
+      expect(containsBytes(stripped, pngIdatNeedle), isTrue);
+      expect(stripped.sublist(0, 8), pngSignature);
+    });
+
+    test('anything after the end chunk is dropped', () {
+      final stripped = PhotoMetadata.stripped(
+        pngWithMetadata(trailer: gpsNeedle.codeUnits),
+        'image/png',
+      )!;
+
+      expect(containsBytes(stripped, gpsNeedle), isFalse);
+      expect(containsBytes(stripped, 'IEND'), isTrue);
+    });
+
+    test('a chunk length running past the end is refused', () {
+      final bytes = Uint8List.fromList([
+        ...pngSignature,
+        0x7F, 0xFF, 0xFF, 0xFF, // a chunk claiming two gigabytes
+        ...'IHDR'.codeUnits,
+        0x00, 0x00, 0x00, 0x00,
+      ]);
+
+      expect(PhotoMetadata.stripped(bytes, 'image/png'), isNull);
+    });
+
+    test('a PNG with no end chunk is refused', () {
+      final bytes = Uint8List.fromList([
+        ...pngSignature,
+        ...pngChunk('IHDR', List.filled(13, 0x01)),
+      ]);
+
+      expect(PhotoMetadata.stripped(bytes, 'image/png'), isNull);
+    });
+  });
+
+  group('WebP', () {
+    test('the EXIF and XMP chunks do not survive', () {
+      final stripped = PhotoMetadata.stripped(
+        webpWithMetadata(),
+        'image/webp',
+      )!;
+
+      expect(containsBytes(stripped, gpsNeedle), isFalse);
+      expect(containsBytes(stripped, 'EXIF'), isFalse);
+      expect(containsBytes(stripped, 'XMP '), isFalse);
+    });
+
+    test('the frame is left intact', () {
+      final stripped = PhotoMetadata.stripped(
+        webpWithMetadata(),
+        'image/webp',
+      )!;
+
+      expect(containsBytes(stripped, webpFrameNeedle), isTrue);
+      expect(containsBytes(stripped, 'VP8X'), isTrue);
+    });
+
+    test('the flags stop advertising metadata, without losing alpha', () {
+      // Dropping a chunk but leaving its bit set produces a file that
+      // promises metadata it does not have, which a strict decoder may
+      // reject — and this path is already the one where the encoder failed.
+      // Clearing the whole byte would lose the alpha channel instead.
+      final stripped = PhotoMetadata.stripped(
+        webpWithMetadata(),
+        'image/webp',
+      )!;
+
+      // 'RIFF' + size + 'WEBP' + 'VP8X' + size, then the flags byte.
+      const flagsOffset = 12 + 8;
+      expect(stripped[flagsOffset] & 0x08, 0, reason: 'EXIF bit still set');
+      expect(stripped[flagsOffset] & 0x04, 0, reason: 'XMP bit still set');
+      expect(stripped[flagsOffset] & webpAlphaFlag, webpAlphaFlag);
+    });
+
+    test('the RIFF size is rewritten to match what is left', () {
+      // The container declares its own length. Removing chunks without
+      // correcting it leaves a file that runs past its own end.
+      final stripped = PhotoMetadata.stripped(
+        webpWithMetadata(),
+        'image/webp',
+      )!;
+
+      final declared =
+          stripped[4] |
+          (stripped[5] << 8) |
+          (stripped[6] << 16) |
+          (stripped[7] << 24);
+
+      expect(declared, stripped.length - 8);
+    });
+
+    test('an odd-sized chunk keeps its pad byte accounted for', () {
+      // RIFF pads chunks to an even length without counting the pad in the
+      // size field. Getting that wrong walks the parser off by one and every
+      // later chunk reads as garbage.
+      final stripped = PhotoMetadata.stripped(webpWithMetadata(), 'image/webp');
+
+      // The fixture's frame payload is odd-length, so a mishandled pad byte
+      // would have made the walk fail outright.
+      expect(stripped, isNotNull);
+      expect(containsBytes(stripped!, webpFrameNeedle), isTrue);
+    });
+
+    test('bytes that are not a RIFF/WEBP container are refused', () {
+      expect(
+        PhotoMetadata.stripped(
+          Uint8List.fromList(List.filled(64, 0x41)),
+          'image/webp',
+        ),
+        isNull,
+      );
+    });
+  });
+
+  group('GIF', () {
+    test('is returned unchanged, having nowhere to hide a location', () {
+      // Comment and Application are its only extensions and neither is a
+      // geotag container. Saying so plainly beats rewriting a format no
+      // camera produces.
+      final gif = gifWithComment();
+
+      expect(PhotoMetadata.stripped(gif, 'image/gif'), gif);
+    });
+  });
+
+  test('a media type the app does not send is refused', () {
+    // HEIC never reaches here — mediaTypeForPath rejects it first — but a
+    // stripper that returned bytes for a type it cannot parse would be the
+    // silent failure this class is built to avoid.
+    expect(PhotoMetadata.stripped(jpegWithMetadata(), 'image/heic'), isNull);
+  });
+
+  test('an empty file is refused in every container', () {
+    for (final type in const ['image/jpeg', 'image/png', 'image/webp']) {
+      expect(PhotoMetadata.stripped(Uint8List(0), type), isNull, reason: type);
+    }
+  });
+}


### PR DESCRIPTION
## The leak

`MealPhotoEncoder.encode` falls back to sending the picked file exactly as it found it when the device encoder fails. That is a deliberate choice from #747 — a user whose encoder is missing has no way to install one, so failing them outright is worse than sending what we have.

What we have, on that path, is a camera original. Phones geotag by default. So the one device that cannot encode was the one device posting its owner's GPS fix to an AI provider — and the README tells people the app asks for [no location permission](https://github.com/simonoppowa/OpenNutriTracker/blob/feature/ai-assisted-meal-logging/README.md#privacy), which stops being true once it forwards coordinates it read out of a file. The permission never requested is not the only way to learn where someone is.

Found while auditing the published privacy policy against what the source actually does. This one is better fixed than disclosed.

**The normal path was never affected.** `flutter_image_compress` defaults to `keepExif: false`, so re-encoding already writes a container with no metadata in it. That default is now pinned explicitly, so it is a decision rather than something inherited from a package that could change it.

## What this does

New `PhotoMetadata`, called only from the fallback:

| Container | Removed | Kept |
| :-- | :-- | :-- |
| JPEG | APP1–APP15, COM, anything appended past the end marker | APP0/JFIF, the tables, the scan |
| PNG | `eXIf`, `tEXt`, `zTXt`, `iTXt`, `tIME` | header and pixel chunks, CRCs untouched |
| WebP | `EXIF`, `XMP `, the matching `VP8X` feature bits | alpha bit, frame, size field rewritten |
| GIF | nothing | everything |

GIF is returned unchanged on purpose. Comment and Application are its only extensions, neither is a geotag container, and no camera writes one — saying so plainly beats rewriting a format that cannot carry the thing we are removing.

The JPEG walk stops at the first `FF D9`. Entropy-coded data byte-stuffs `0xFF` as `FF 00` and its only legal markers are restarts, so that really is the end of the image — and everything after it goes, which is where a phone appends its own trailer (Samsung's SEFH block; multi-picture data that can hold a second full-size copy of the frame).

## One deliberate behaviour change

Every parser refuses rather than guesses. A file that does not read as the type its extension claims now returns `null` instead of being forwarded whole, and the user is told to pick another photo.

That narrows the fallback, on purpose. An unparseable file is the one most likely to be carrying something, and a parser that resynchronised after a bad length would be guessing at what it skipped. Sending bytes nothing has accounted for is the outcome this must not have.

## What this does not fix

The fallback still sends **full resolution** — stripping metadata is not resizing, and there is no encoder on this path to resize with. `maxBytes` is what bounds it. Changing that reopens #747 rather than closing a leak, so it is left alone.

## Verification

Full suite green (1904 tests), analyzer clean.

Mutation-checked rather than trusted green:

- making the JPEG stripper a pass-through fails 6 tests, including the end-to-end one through `encode`
- dropping `tEXt` from the PNG set fails its assertion

That second check earned its place: it caught a **vacuous assertion** in my own test. A `tEXt` chunk separates keyword from text with a NUL, and the needle had a space, so it passed regardless of what the stripper did. It now spans the NUL.

Fixtures are hand-built byte tables rather than a committed photograph — a real geotagged JPEG would be a location in the repository forever, and a checked-in binary is the one fixture nobody can read a diff of. They are structurally valid, which is all the parsers look at; they are not decodable images and are not meant to be.

The format identifiers in them contain real NUL bytes (XMP's APP1 marker and Photoshop's APP13 one genuinely are NUL-terminated). Written as `\x00` escapes so the bytes stay authentic without the file reading as binary to git.
