### PR TITLE
docs: a language code leaves the device, not a country code

### DIFF
--- a/README.md
+++ b/README.md
@@ -130,7 +130,7 @@ No account, no sign-in, no analytics, no ads. Your profile, diary, activities, w
 
 | Destination | When | What is sent |
 | :-- | :-- | :-- |
-| [Open Food Facts](https://world.openfoodfacts.org/) | Food search or barcode scan | The search term or barcode, plus a country tag from your device locale for ranking |
+| [Open Food Facts](https://world.openfoodfacts.org/) | Food search or barcode scan | The search term or barcode. A word search also sends your device's **language** code to rank results; the fallback search and the barcode lookup send no locale at all. Your **country is never sent** — the country boost is applied on your device, to the results that come back |
 | Supabase reference backend | Food search | The search term |
 | [Sentry](https://sentry.io) | **Only if you opt in** | Crash traces, app and OS version, device model |
 

--- a/test/unit_test/off_request_locale_test.dart
+++ b/test/unit_test/off_request_locale_test.dart
@@ -1,0 +1,61 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:opennutritracker/core/utils/off_const.dart';
+
+/// Pins what a request to Open Food Facts carries about the user's locale.
+///
+/// The README and the published Data policy both described this as a *country*
+/// code for a long time, which is a coarse location signal and is not what the
+/// app sends. A country tag does exist in the tree — `OffCountry.fromLocale`
+/// builds one — but `products_repository.dart` compares it against the
+/// `countries_tags` of results that have already come back, so the boost is
+/// applied on the device and the country never enters a request.
+///
+/// Prose drifting from the wire is what the privacy audit kept finding, so the
+/// claim is asserted here rather than left to be re-read correctly next time.
+void main() {
+  group('what a word search sends', () {
+    test('carries the language code, under langs', () {
+      final url = OFFConst.getOffWordSearchUrl('apple', langs: 'de,en');
+
+      expect(url.queryParameters['langs'], 'de,en');
+    });
+
+    test('carries no country parameter of any kind', () {
+      final url = OFFConst.getOffWordSearchUrl('apple', langs: 'de,en');
+
+      // `fields` legitimately names countries_tags — that asks OFF to return
+      // which countries a product is sold in, which is a property of the
+      // product and not of the person searching. Everything else must be free
+      // of the user's country.
+      for (final entry in url.queryParameters.entries) {
+        if (entry.key == 'fields') continue;
+        expect(
+          entry.value.toLowerCase(),
+          isNot(contains('countr')),
+          reason: '${entry.key} looks like it carries a country',
+        );
+      }
+      expect(url.queryParameters.containsKey('cc'), isFalse);
+      expect(url.queryParameters.containsKey('country'), isFalse);
+    });
+  });
+
+  group('what the other two requests send', () {
+    test('the fallback word search sends no locale at all', () {
+      // Search-a-licious being down must not change what leaves the device.
+      final url = OFFConst.getOffLegacyWordSearchUrl('apple');
+
+      expect(url.queryParameters.containsKey('langs'), isFalse);
+      expect(url.queryParameters.containsKey('lc'), isFalse);
+      expect(url.queryParameters.containsKey('cc'), isFalse);
+    });
+
+    test('the barcode lookup sends no locale at all', () {
+      final url = OFFConst.getOffBarcodeSearchUri('737628064502');
+
+      expect(url.queryParameters.containsKey('langs'), isFalse);
+      expect(url.queryParameters.containsKey('lc'), isFalse);
+      expect(url.queryParameters.containsKey('cc'), isFalse);
+    });
+  });
+}


### PR DESCRIPTION
The Privacy section said a food search sends *"a country tag from your device locale for ranking"*. No country reaches Open Food Facts.

## What is actually sent

A **language** code, in the `langs` parameter — `off_data_source.dart:48-52` builds it and passes it at `:66` into `OFFConst.getOffWordSearchUrl`, which places it under `_salLangsTag = "langs"` (`off_const.dart:36, 108-117`).

Only the Search-a-licious word search carries it. The legacy fallback search (`off_const.dart:124-136`) and the barcode lookup (`:138-148`) send **no locale at all**.

## Why the wrong word survived so long

A country tag genuinely exists in the tree, which makes the sentence look supported by a grep. `OffCountry.fromLocale` builds one — `en:germany`, `en:united-kingdom` — and `products_repository.dart:45` uses it.

It uses it against `dto.countries_tags`, on results that **have already come back**:

```dart
final inUserCountry = userCountryTag != null &&
    (dto.countries_tags?.contains(userCountryTag) ?? false);
```

So the country boost is real, and it is applied **on the device**. The country never enters a request. *"For ranking"* was right; *"is sent"* was not. `countries_tags` also appears in the request's `fields` list, but that asks OFF to return which countries a **product** is sold in — a property of the product, not of the person searching.

## Why it matters enough to fix

The two are not interchangeable. A country code is a coarse location signal; a language code is not. This over-disclosed — it made the app sound worse than it is, in the one section where a reader is deciding whether to trust it.

## The test

`off_request_locale_test.dart` pins all three request shapes: the word search carries `langs` and nothing country-shaped, and the other two carry no locale at all.

Prose drifting from the wire is what the audit behind this kept turning up — four times. A sentence is easier to keep true when something fails on the way past it.

## Not in this PR

The published Data policy repeats the same error, in both the English and German documents:

> […] together with a country code derived from your device's language settings, which the service uses to rank results.

That text is not in this repo and is corrected separately.
