### PR TITLE
fix(core): send crash reports, not a report every time the app opens

### DIFF
--- a/lib/core/utils/sentry_config.dart
+++ b/lib/core/utils/sentry_config.dart
@@ -21,10 +21,34 @@ import 'package:sentry_flutter/sentry_flutter.dart';
 /// line can leave the device.
 void configureSentryOptions(SentryOptions options, {required String dsn}) {
   options.dsn = dsn;
-  options.tracesSampleRate = 1.0;
+  options.tracesSampleRate = _tracesSampleRate;
   options.enablePrintBreadcrumbs = false;
   options.beforeSend = _stripUser;
 }
+
+/// Null, which is what switches performance monitoring off: `isTracingEnabled`
+/// is `tracesSampleRate != null || tracesSampler != null`, so a null rate means
+/// no transaction is ever sampled or sent.
+///
+/// It was `1.0`. A traces sample rate is what turns transaction sending on, and
+/// `enableAutoPerformanceTracing` defaults to true, so app-start and
+/// screen-load transactions were produced for ordinary sessions at a 100%
+/// sample rate — with no crash involved.
+///
+/// The switch the user actually agreed to says *"Send crash reports to help fix
+/// bugs"*. A report every time the app opens is not that. It also changes how
+/// often Sentry observes the coarse location it derives server-side from the
+/// connection: once per session rather than once per crash, which is a
+/// materially different picture from the one the consent describes.
+///
+/// Written as an explicit null rather than an omitted line, because an absent
+/// setting reads as an oversight and this one is a decision.
+///
+/// The alternative was to keep the tracing and widen the consent string and the
+/// policy to "crash and performance reports". That stays available — nothing
+/// here is hard to reverse — but it asks the user for more, and nothing in this
+/// repository reads the performance data.
+const double? _tracesSampleRate = null;
 
 /// Drops the `user` block from every event before it leaves the device.
 ///

--- a/test/unit_test/sentry_config_test.dart
+++ b/test/unit_test/sentry_config_test.dart
@@ -29,12 +29,30 @@ void main() {
     expect(beforeSend, isNotNull, reason: 'no beforeSend hook is configured');
 
     final event = SentryEvent(
-      user: SentryUser(id: 'a-per-install-uuid', geo: SentryGeo(city: 'Essen')),
+      user: SentryUser(
+        id: 'a-per-install-uuid',
+        geo: SentryGeo(city: 'Essen'),
+      ),
     );
     final sent = await beforeSend!(event, Hint());
 
     expect(sent, isNotNull, reason: 'the hook must not drop the event itself');
     expect(sent!.user, isNull);
+  });
+
+  test('release options send no performance transactions', () {
+    // A traces sample rate is what turns transaction sending on, and
+    // enableAutoPerformanceTracing defaults to true — so a non-null rate here
+    // means app-start and screen-load transactions for ordinary sessions, with
+    // no crash involved. The switch says "Send crash reports to help fix bugs".
+    final options = configured();
+
+    expect(options.tracesSampleRate, isNull);
+    expect(
+      options.isTracingEnabled(),
+      isFalse,
+      reason: 'tracing is on, so ordinary sessions reach the network',
+    );
   });
 
   test('release options do not attach default PII', () {


### PR DESCRIPTION
`tracesSampleRate` was `1.0`.

A traces sample rate is what turns transaction sending on — `isTracingEnabled()` is `tracesSampleRate != null || tracesSampler != null` — and `enableAutoPerformanceTracing` defaults to `true`. So app-start and screen-load transactions were produced for **ordinary sessions, at a 100% sample rate, with no crash involved**.

## Why that is a problem rather than a preference

The switch the user agreed to says:

> Send crash reports to help fix bugs. No food log or weight data is included.

— `dataCollectionLabel`, `intl_en.arb:335`

A report every time the app opens is not that. The published Data policy scopes it the same narrow way: *"When **a crash** sends a technical report […]"*.

There is a second consequence that is easy to miss. The policy concedes that *"Sentry's servers may derive an approximate location (country, region and city) from the connection"*. At `1.0` that concession applies **once per session** rather than once per crash — a materially different picture of how often a coarse location is observed, and it cannot be fixed client-side, because Relay derives it server-side at ingest after `beforeSend` has run (see the doc comment on `_stripUser`, and #900).

## The change

One line, plus the reasoning next to it. `null` is what switches performance monitoring off, so no transaction is ever sampled or sent.

Written as an **explicit null rather than a deleted line**, matching `enablePrintBreadcrumbs` directly above it: this file exists so that "the one setting which must not drift can be pinned by a test rather than by a reviewer noticing an absent line", and an absent setting reads as an oversight where this one is a decision.

`sentry_config_test.dart` gains a case asserting both the null rate and `isTracingEnabled() == false`.

## The alternative, deliberately not taken

Keep the tracing and widen the consent string and both policy documents to "crash **and performance** reports". That stays available and nothing here is hard to reverse — **say so and I will do it instead**. It was not the default choice because it asks the user for more than they were asked for, and nothing in this repository reads the performance data.

## Scope note

This targets `develop`, per `CONTRIBUTING.md:14`. Worth knowing that `origin/main` also carries `tracesSampleRate = 1.0` (it is three commits past `v2.0.2` and has `sentry_config.dart` with `enablePrintBreadcrumbs = false` but no `beforeSend`), so whichever branch the next release is cut from, it currently ships 100% tracing.

Found while auditing the published Data policy against the source. The policy half of this finding — the sentence that says only a crash sends anything — is being drafted separately.
