### PR TITLE
ci: keep a change record of the published privacy policy, and check it

### DIFF
--- a/.github/workflows/policy-snapshot.yml
+++ b/.github/workflows/policy-snapshot.yml
@@ -1,0 +1,122 @@
+# Keep a change record of the two published privacy-policy documents, and fail
+# when they drift apart.
+#
+# iubenda offers no version history and no "what changed" view (#871), so the
+# only way to answer "what did the policy say in March" is to keep the text
+# somewhere that has history. Committing it here makes git that record, which
+# is what #887 settled on when deciding what is owed to users who acknowledged
+# an older policy.
+#
+# The check half exists because **every clause in this policy is custom**, and
+# custom clauses do not propagate between languages in iubenda. #888 caught the
+# German document left behind in exactly that way. A check that needs no
+# discipline beats one that relies on someone being conscientious.
+#
+# What it compares, and why only those things: `tool/policy_snapshot.dart`
+# carries the reasoning. In short, only signals that survive translation can be
+# compared — the purpose taxonomy ids, the service count per purpose, and the
+# last-updated date. Service ids cannot: iubenda mints them per language.
+#
+# Divergences the maintainer cannot fix only warn. iubenda's own template text
+# differs between its languages in places (measured 2026-08-27: the English
+# App Store Connect section links support.apple.com for opt-out guidance, the
+# German one omits the sentence), and a check nobody can satisfy is a check
+# that gets ignored.
+#
+# The snapshot has the owner's postal address replaced with a placeholder. It is
+# on the published page already, so nothing is being hidden — but a public
+# repository's history is permanent in a way an editable page is not, and #886
+# recorded a preference for a c/o address over the residential one. The script
+# throws rather than writing a snapshot it cannot redact.
+#
+# TWO THINGS TO KNOW ABOUT WHERE THIS RUNS:
+#
+#  * Workflow files only take effect once they are on the **default branch**, so
+#    neither the schedule nor the manual trigger does anything while this lives
+#    on a feature branch. That is also why the first snapshot was committed by
+#    hand from a local run: a before-and-after diff of the policy correction was
+#    only available before the edits were made, and CI could not have run in
+#    time to capture it.
+#  * A scheduled run therefore starts on `main` — but `CONTRIBUTING.md` reserves
+#    `main` for release merges only. So this checks out and commits to
+#    `develop` explicitly rather than to whatever ref it was triggered on.
+#
+# No secrets. The read API is public and unauthenticated.
+
+name: Privacy policy snapshot
+
+on:
+  schedule:
+    # Weekly. The documents change a handful of times a year, and a daily run
+    # would mostly be a daily no-op against a third party.
+    - cron: '23 6 * * 1'
+  workflow_dispatch:
+  # Also on any change to the checker itself, so a broken parser is caught by
+  # the pull request that breaks it rather than by a Monday-morning cron.
+  pull_request:
+    paths:
+      - 'tool/policy_snapshot.dart'
+      - '.github/workflows/policy-snapshot.yml'
+
+permissions:
+  contents: read
+
+jobs:
+  # On a pull request: check only. Nothing may be committed — the branch is not
+  # necessarily ours, and a bot commit would rewrite a contributor's PR.
+  check:
+    if: github.event_name == 'pull_request'
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v7
+
+      - name: Setup Flutter + cache packages
+        uses: ./.github/actions/setup-flutter-cache
+
+      - name: Install Flutter packages
+        run: flutter pub get
+
+      - name: Check the two documents agree
+        run: dart run tool/policy_snapshot.dart --check
+
+  snapshot:
+    if: github.event_name != 'pull_request'
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+    steps:
+      - name: Checkout develop
+        uses: actions/checkout@v7
+        with:
+          # Not the triggering ref. A scheduled run fires on the default
+          # branch, and `main` takes release merges only.
+          ref: develop
+
+      - name: Setup Flutter + cache packages
+        uses: ./.github/actions/setup-flutter-cache
+
+      - name: Install Flutter packages
+        run: flutter pub get
+
+      - name: Snapshot both documents and check they agree
+        run: dart run tool/policy_snapshot.dart
+
+      # Runs even when the check failed: a divergence is exactly the state
+      # worth having a record of, and discarding the snapshot would throw away
+      # the evidence of the thing the job just complained about.
+      - name: Commit the snapshot if it changed
+        if: always()
+        run: |
+          set -euo pipefail
+          if git diff --quiet -- docs/privacy-policy; then
+            echo "Neither document changed."
+            exit 0
+          fi
+          git config user.name  "github-actions[bot]"
+          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
+          git add docs/privacy-policy
+          git commit -m "docs: snapshot the published privacy policy"
+          git push origin HEAD:develop

--- a/docs/privacy-policy/de.txt
+++ b/docs/privacy-policy/de.txt
@@ -1,0 +1,322 @@
+Datenschutzerklärung von OpenNutriTracker
+
+Diese Anwendung erhebt personenbezogene Daten von ihren Nutzern.
+
+Dieses Dokument kann zu Zwecken der Aufbewahrung über den Befehl „Drucken“ im Browser ausgedruckt werden.
+
+Anbieter und Verantwortlicher
+
+Simon Oppowa
+[postal address — see the published policy]
+
+E-Mail-Adresse des Anbieters: opennutritracker-dev@pm.me
+
+Arten der erhobenen Daten
+
+Zu den personenbezogenen Daten, die diese Anwendung selbstständig oder durch Dritte verarbeitet, gehören:
+Nutzungsdaten; Diagnosedaten; E-Mail; Informationen über die Anwendung; Gerätelogs; Geräteinformationen; Während der Nutzung des Dienstes übermittelte Daten.
+
+Vollständige Details zu jeder Art von verarbeiteten personenbezogenen Daten werden in den dafür vorgesehenen Abschnitten dieser Datenschutzerklärung oder punktuell durch Erklärungstexte bereitgestellt, die vor der Datenerhebung angezeigt werden.
+Personenbezogene Daten können vom Nutzer freiwillig angegeben oder, im Falle von Nutzungsdaten, automatisch erhoben werden, wenn diese Anwendung genutzt wird.
+Sofern nicht anders angegeben, ist die Angabe aller durch diese Anwendung angeforderten Daten obligatorisch. Weigert sich der Nutzer, die Daten anzugeben, kann dies dazu führen, dass diese Anwendung dem Nutzer ihre Dienste nicht zur Verfügung stellen kann. In Fällen, in denen diese Anwendung die Angabe personenbezogener Daten ausdrücklich als freiwillig bezeichnet, dürfen sich die Nutzer dafür entscheiden, diese Daten ohne jegliche Folgen für die Verfügbarkeit oder die Funktionsfähigkeit des Dienstes nicht anzugeben.
+Nutzer, die sich darüber im Unklaren sind, welche personenbezogenen Daten obligatorisch sind, können sich an den Anbieter wenden.
+Jegliche Verwendung von Cookies – oder anderer Tracking-Tools – durch diese Anwendung oder Anbieter von Drittdiensten, die durch diese Anwendung eingesetzt werden, dient dem Zweck, den vom Nutzer gewünschten Dienst zu erbringen, und allen anderen Zwecken, die im vorliegenden Dokument beschrieben sind.
+
+Die Nutzer sind für alle personenbezogenen Daten Dritter verantwortlich, die durch diese Anwendung beschafft, veröffentlicht oder weitergegeben werden.
+
+Art und Ort der Datenverarbeitung
+
+Verarbeitungsmethoden
+
+Der Anbieter verarbeitet die personenbezogenen Daten der Nutzer auf ordnungsgemäße Weise und ergreift angemessene Sicherheitsmaßnahmen, um den unbefugten Zugriff und die unbefugte Weiterleitung, Veränderung oder Vernichtung von Daten zu vermeiden.
+Die Datenverarbeitung wird mittels Computern oder IT-basierten Systemen nach organisatorischen Verfahren und Verfahrensweisen durchgeführt, die gezielt auf die angegebenen Zwecke abstellen. Zusätzlich zum Verantwortlichen könnten auch andere Personen intern (Personalverwaltung, Vertrieb, Marketing, Rechtsabteilung, Systemadministratoren) oder extern – und in dem Fall soweit erforderlich, vom Verantwortlichen als Auftragsverarbeiter benannt (wie Anbieter technischer Dienstleistungen, Zustellunternehmen, Hosting-Anbieter, IT-Unternehmen oder Kommunikationsagenturen) - diese Anwendung betreiben und damit Zugriff auf die Daten haben. Eine aktuelle Liste dieser Beteiligten kann jederzeit vom Anbieter verlangt werden.
+
+Ort
+
+Die Daten werden in der Niederlassung des Anbieters und an allen anderen Orten, an denen sich die an der Datenverarbeitung beteiligten Stellen befinden, verarbeitet.
+
+Je nach Standort der Nutzer können Datenübertragungen die Übertragung der Daten des Nutzers in ein anderes Land als das eigene beinhalten. Um mehr über den Ort der Verarbeitung der übermittelten Daten zu erfahren, können die Nutzer den Abschnitt mit den ausführlichen Angaben zur Verarbeitung der personenbezogenen Daten konsultieren.
+
+Speicherdauer
+
+Sofern in diesem Dokument nicht anderweitig festgelegt, werden personenbezogene Daten so lange verarbeitet und gespeichert, wie es der Zweck erfordert, zu dem sie erhoben wurden, und können ggf. aufgrund einer zu erfüllenden rechtlichen Verpflichtung oder basierend auf der Einwilligung des Nutzers auch länger aufbewahrt werden.
+
+Zwecke der Verarbeitung
+
+Personenbezogene Daten über den Nutzer werden erhoben, damit der Anbieter den Dienst erbringen und des Weiteren seinen gesetzlichen Verpflichtungen nachkommen, auf Durchsetzungsforderungen reagieren, seine Rechte und Interessen (oder die der Nutzer oder Dritter) schützen, böswillige oder betrügerische Aktivitäten aufdecken kann. Darüber hinaus werden Daten zu folgenden Zwecken erhoben:
+Plattform-Dienste und Hosting, Beta-Tests, Anzeigen von Inhalten externer Plattformen, Hosting und Backend-Infrastruktur, Überwachung der Infrastruktur und Zugriff auf Profile von Drittanbietern.
+
+Nutzer können im Abschnitt “Ausführliche Angaben über die Verarbeitung personenbezogener Daten” dieses Dokuments weitere detaillierte Informationen zu diesen Verarbeitungszwecken und die zu den für den jeweiligen Zweck verwendeten personenbezogenen Daten vorfinden.
+
+Ausführliche Angaben über die Verarbeitung personenbezogener Daten
+
+Personenbezogene Daten werden zu folgenden Zwecken unter Inanspruchnahme folgender Dienstleistungen erhoben:
+
+Anzeigen von Inhalten externer Plattformen
+
+Mit dieser Art von Diensten können Nutzer sich Inhalte, die auf externen Plattformen gehostet werden, direkt über diese Anwendung anzeigen lassen und mit ihnen interagieren. Solche Dienste werden häufig als Widgets bezeichnet, d. h. als kleine Elemente, die auf einer Website oder in einer Anwendung platziert werden. Sie bieten bestimmte Informationen oder führen eine bestimmte Funktion aus und ermöglichen oft eine Interaktion mit dem Nutzer.
+
+Diese Art von Dienst kann möglicherweise immer noch Web-Traffic-Daten für die Seiten erheben, auf denen der Dienst installiert ist, auch wenn Nutzer ihn nicht verwenden.
+
+Open Food Facts
+
+Wenn Sie ein Lebensmittel suchen oder einen Barcode scannen, sendet diese Anwendung den Suchbegriff bzw. den Barcode an Open Food Facts, zusammen mit einem aus den Spracheinstellungen Ihres Geräts abgeleiteten Ländercode, den der Dienst zur Sortierung der Ergebnisse verwendet.
+
+Open Food Facts ist ein unabhängiger gemeinnütziger Verein. Der Verein entscheidet selbst darüber, wie er die erhaltenen Daten verarbeitet, und handelt nicht auf Weisung des Anbieters dieser Anwendung; für diese Verarbeitung gilt daher seine eigene Datenschutzerklärung. Es werden kein Konto, kein Profil und keine Gerätekennung übermittelt, und Ihr Ernährungstagebuch wird nie übermittelt.
+
+Diese Verarbeitung beruht auf dem berechtigten Interesse des Anbieters, die Lebensmittelsuche bereitzustellen, für die diese Anwendung gedacht ist. Sie können dieser Verarbeitung jederzeit widersprechen und sie in der Praxis vollständig vermeiden: Eine Suche findet nur statt, wenn Sie sie starten, und selbst gespeicherte Mahlzeiten können Sie ohne jede Suche hinzufügen.
+
+Verarbeitete personenbezogene Daten: Suchbegriffe; Barcodes; ein Ländercode; Nutzungsdaten.
+
+Ort der Verarbeitung: Frankreich — Datenschutzerklärung.
+
+Beta-Tests
+
+Diese Art von Diensten ermöglicht es, den Nutzerzugriff auf diese Anwendung oder Teile davon zu verwalten, um eine bestimmte Funktion oder die gesamte Anwendung zu testen.
+
+Der Dienstanbieter kann automatisch Daten über Abstürze und Statistiken im Zusammenhang mit der Nutzung von dieser Anwendung (diese Anwendung) durch den Nutzer in einer persönlich identifizierbaren Form sammeln.
+
+TestFlight (Apple Inc.)
+
+TestFlight ist ein Beta-Test-Dienst von Apple Inc.
+
+Verarbeitete personenbezogene Daten: E-Mail; Geräteinformationen; Gerätelogs; Informationen über die Anwendung.
+
+Verarbeitungsort: Vereinigte Staaten – Datenschutzerklärung.
+
+Google Play Beta Testing (Google Ireland Limited)
+
+Google Play Beta Testing ist ein Beta-Test-Dienst von Google Ireland Limited.
+
+Verarbeitete personenbezogene Daten: Geräteinformationen; Nutzungsdaten; Während der Nutzung des Dienstes übermittelte Daten.
+
+Verarbeitungsort: Irland – Datenschutzerklärung.
+
+Hosting und Backend-Infrastruktur
+
+Diese Art von Dienst hat den Zweck, Daten und Dateien zu hosten, die für diese Anwendung den Betrieb und die Verbreitung möglich machen, oder eine fertige Infrastruktur zur Verfügung zu stellen, um für diese Anwendung bestimmte Funktionen oder Teile auszuführen.
+
+Einige der unten aufgeführten Dienste können, müssen aber nicht, über geografisch verteilte Server funktionieren, was es schwierig macht, den tatsächlichen Speicherort der personenbezogenen Daten zu bestimmen.
+
+Lebensmittel-Referenzdatenbank (Supabase)
+
+Lebensmittelsuchen werden von einer Referenzdatenbank beantwortet, die der Anbieter dieser Anwendung auf der Managed-Cloud-Plattform von Supabase betreibt. Bei einer Suche wird der von Ihnen eingegebene Text übermittelt. Es werden kein Konto, kein Profil und keine Gerätekennung mitgesendet, und Ihr Ernährungstagebuch wird nie übermittelt.
+
+Da die Anfrage über das Internet übertragen wird, protokolliert das Gateway der Plattform für 24 Stunden die Adresse, von der die Anfrage kam, einen daraus abgeleiteten ungefähren Standort (Land, Region, Ort und Postleitzahl), den Namen Ihres Internetanbieters sowie einen Fingerprint der verschlüsselten Verbindung.
+
+Die Datenbank wird in Frankfurt (Deutschland) gespeichert und überwiegend dort verarbeitet. Die Supabase Pte. Ltd. handelt als Auftragsverarbeiter auf Weisung des Anbieters; zu ihren Unterauftragsverarbeitern gehören die Cloudflare, Inc. und die Amazon Web Services, Inc. Anfragen erreichen zunächst einen Cloudflare-Standort in Ihrer Nähe und dann die Datenbank. Übermittlungen außerhalb des Europäischen Wirtschaftsraums sind durch Standardvertragsklauseln abgedeckt.
+
+Diese Verarbeitung beruht auf dem berechtigten Interesse des Anbieters, die Lebensmittelsuche bereitzustellen, für die diese Anwendung gedacht ist. Sie können dieser Verarbeitung jederzeit widersprechen und sie in der Praxis vollständig vermeiden: Eine Suche findet nur statt, wenn Sie sie starten, und selbst gespeicherte Mahlzeiten können Sie ohne jede Suche hinzufügen.
+
+Verarbeitete personenbezogene Daten: Suchbegriffe; IP-Adresse; ungefährer Standort; Verbindungskennungen; Nutzungsdaten.
+
+Ort der Verarbeitung: Deutschland — Singapur.
+
+Plattform-Dienste und Hosting
+
+Diese Dienste haben den Zweck, Hauptkomponenten der Applikation für diese Anwendung zu hosten und zu betreiben, damit diese Anwendung aus einer einheitlichen Plattform angeboten werden kann. Solche Plattformen stellen dem Anbieter eine ganze Reihe von Werkzeugen zur Verfügung – zum Beispiel Analyse- und Kommentarfunktionen, Nutzer- und Datenbankverwaltung, E-Commerce und Zahlungsabwicklung – welche die Verarbeitung von personenbezogenen Daten beinhalten.
+
+Einige dieser Dienste arbeiten mit geografisch verteilten Servern, so dass es schwierig ist, den Ort zu bestimmen, an dem die personenbezogenen Daten gespeichert sind.
+
+Google Play Store (Google LLC)
+
+Diese Anwendung wird im Google Play Store vertrieben, einer Plattform für den Vertrieb von mobilen Apps, die von Google LLC oder von Google Ireland Limited, je nachdem, wie der Anbieter die Datenverarbeitung verwaltet, bereitgestellt wird.
+
+Dadurch, dass diese Anwendung über diesen Kanal verteilt wird, erhebt Google Nutzungs- und Diagnoseinformationen und teilt diese mit dem Anbieter. Ein Großteil dieser Informationen wird auf Opt-in-Basis verarbeitet.
+
+Nutzer können diese Analysefunktion direkt über ihre Geräteeinstellungen deaktivieren. Weitere Informationen zur Verwaltung der Analyseeinstellungen findet der Nutzer auf dieser Seite.
+
+Verarbeitete personenbezogene Daten: Nutzungsdaten.
+
+Verarbeitungsort: Vereinigte Staaten – Datenschutzerklärung; Irland – Datenschutzerklärung.
+
+App Store Connect (Apple Inc.)
+
+Diese Anwendung wird im App Store von Apple vertrieben, einer Plattform für den Vertrieb mobiler Anwendungen, die von Apple Inc. bereitgestellt wird.
+
+App Store Connect ermöglicht es dem Anbieter, diese Anwendung im App Store von Apple zu verwalten. Je nach Konfiguration stellt App Store Connect dem Anbieter statistische Daten über Nutzerbindung und App-Entdeckung, Marketingkampagnen, Verkäufe, In-App-Käufe und Zahlungen zur Verfügung, um die Leistung von diese Anwendung zu messen.
+App Store Connect sammelt solche Daten nur von Nutzern, die zugestimmt haben, sie mit dem Anbieter zu teilen. Nutzer finden weitere Informationen darüber, wie sie sich über ihre Geräteeinstellungen abmelden können [hier] (https://support.apple.com/de-de/HT202100).
+
+Verarbeitete personenbezogene Daten: Diagnosedaten.
+
+Verarbeitungsort: Vereinigte Staaten – Datenschutzerklärung.
+
+Zugriff auf Profile von Drittanbietern
+
+Diese Anwendung liest mittels dieser Art von Diensten Profilinformationen Ihrer Profile bei Drittanbietern aus und setzt diese in Aktionen um.
+
+Diese Dienste werden nicht automatisch aktiviert, sondern bedürfen der expliziten Zustimmung des Nutzers.
+
+KI-Unterstützung bei Mahlzeiten (eigener Anbieter)
+
+Die KI-Unterstützung bei Mahlzeiten ist deaktiviert, bis Sie Ihren eigenen API-Schlüssel für einen von Ihnen gewählten Anbieter eintragen. Bis dahin wird nichts übermittelt.
+
+Ist sie aktiviert, wird nur die von Ihnen eingegebene Beschreibung der Mahlzeit — oder ein von Ihnen bewusst ausgewähltes Foto — an diesen Anbieter übermittelt, damit dieser Lebensmittelnamen und Mengen zurückgeben kann. Ihr Ernährungstagebuch, Ihr Gewicht und Ihr Profil werden nie übermittelt.
+
+Der Anbieter ist der von Ihnen gewählte, und das Konto ist Ihres: Für die weitere Verarbeitung gilt Ihr Verhältnis zu diesem Anbieter und dessen eigene Datenschutzerklärung. Der Anbieter dieser Anwendung hat darauf keinen Zugriff, zahlt nichts dafür und erhält nichts zurück.
+
+Wenn Sie OpenRouter wählen, erreicht Ihre Anfrage OpenRouter und den Anbieter, der das von Ihnen gewählte Modell bereitstellt — also zwei Empfänger, nicht einen — und eine kontobezogene Kennung wird an diesen Anbieter weitergegeben und lässt sich nicht abschalten. Wenn Sie einen eigenen Server konfigurieren, geht die Anfrage an die von Ihnen eingetragene Adresse, die dem Anbieter dieser Anwendung nicht bekannt ist: Kein Dritter erhält die Daten, sie verlassen Ihr Gerät jedoch dennoch.
+
+Ihr API-Schlüssel wird im sicheren Anmeldedatenspeicher Ihres Geräts aufbewahrt und verlässt das Gerät nur als der Header, der Ihre Anfrage authentifiziert.
+
+Verarbeitete personenbezogene Daten: der Text oder das Foto, das Sie zur Auswertung übermitteln; Ihre App-Sprache.
+
+Ort der Verarbeitung: das Land des von Ihnen gewählten Anbieters — siehe dessen eigene Datenschutzerklärung.
+
+Dieser Dienst nutzt künstliche Intelligenz. Bestimmte Funktionen von KI-Unterstützung bei Mahlzeiten (eigener Anbieter) basieren auf automatisierten Systemen, die Daten verarbeiten, um das Nutzererlebnis zu personalisieren oder zu verbessern.
+
+Überwachung der Infrastruktur
+
+Mit dieser Art von Diensten kann diese Anwendung zur Verbesserung der Leistung, des Betriebs, der Wartung und der Fehlersuche die Nutzung und das Verhalten ihrer einzelnen Bestandteile überwachen.
+
+Welche personenbezogenen Daten verarbeitet werden, hängt von den Eigenschaften und der Art der Ausführung der Dienste ab, deren Funktion das Filtern der über diese Anwendung stattfindenden Aktivitäten ist.
+
+Sentry
+
+Die Absturzberichterstattung ist deaktiviert, bis Sie sie in den Einstellungen aktivieren, und sie läuft nur in veröffentlichten Versionen der App.
+
+Ist sie aktiviert, wird bei einem Absturz ein technischer Bericht übermittelt — der Fehler und sein Stacktrace, die App-Version, die Version des Betriebssystems und das Gerätemodell — zusammen mit einer zufällig erzeugten Kennung für Ihre Installation. Ihr Ernährungstagebuch, Ihr Gewicht und Ihr Profil werden nie übermittelt, und die App übermittelt Ihre IP-Adresse nicht. Die Server von Sentry können aus der Verbindung, über die der Bericht eingeht, einen ungefähren Standort (Land, Region und Ort) ableiten.
+
+Berichte werden 30 Tage lang aufbewahrt.
+
+Diese Verarbeitung beruht auf Ihrer Einwilligung. Sie können diese jederzeit widerrufen, indem Sie die Absturzberichterstattung in den Einstellungen deaktivieren; die Übermittlung endet dann sofort.
+
+Verarbeitete personenbezogene Daten: Diagnosedaten; Geräteinformationen; Gerätelogs; eine Installationskennung; ungefährer Standort; Nutzungsdaten.
+
+Ort der Verarbeitung: Vereinigte Staaten — Übermittlungen sind durch das EU-US Data Privacy Framework und Standardvertragsklauseln abgedeckt.
+
+Weitere Informationen für Nutzer
+
+Rechtsgrundlagen der Verarbeitung
+
+Der Anbieter darf personenbezogene Daten von Nutzern nur dann verarbeiten, wenn einer der folgenden Punkte zutrifft:
+
+Die Nutzer haben ihre Einwilligung für einen oder mehrere bestimmte Zwecke erteilt.
+
+die Datenerhebung ist für die Erfüllung eines Vertrages mit dem Nutzer und/oder für vorvertragliche Maßnahmen daraus erforderlich;
+
+die Verarbeitung ist für die Erfüllung einer rechtlichen Verpflichtung, der der Anbieter unterliegt, erforderlich;
+
+die Verarbeitung steht im Zusammenhang mit einer Aufgabe, die im öffentlichen Interesse oder in Ausübung hoheitlicher Befugnisse, die dem Anbieter übertragen wurden, durchgeführt wird;
+
+die Verarbeitung ist zur Wahrung der berechtigten Interessen des Anbieters oder eines Dritten erforderlich.
+
+In jedem Fall erteilt der Anbieter gerne Auskunft über die konkrete Rechtsgrundlage, auf der die Verarbeitung beruht, insbesondere darüber, ob die Angabe personenbezogener Daten eine gesetzliche oder vertragliche Verpflichtung oder eine Voraussetzung für den Abschluss eines Vertrages ist.
+
+Weitere Informationen zur Speicherdauer
+
+Sofern in diesem Dokument nicht anderweitig festgelegt, werden personenbezogene Daten so lange verarbeitet und gespeichert, wie es der Zweck erfordert, zu dem sie erhoben wurden, und können ggf. aufgrund einer zu erfüllenden rechtlichen Verpflichtung oder basierend auf der Einwilligung des Nutzers auch länger aufbewahrt werden.
+
+Daher gilt:
+
+Personenbezogene Daten, die zu Zwecken der Erfüllung eines zwischen dem Anbieter und dem Nutzer geschlossenen Vertrages erhoben werden, werden bis zur vollständigen Erfüllung dieses Vertrages gespeichert.
+
+Personenbezogene Daten, die zur Wahrung der berechtigten Interessen des Anbieters erhoben werden, werden so lange aufbewahrt, wie es zur Erfüllung dieser Zwecke erforderlich ist. Nutzer können nähere Informationen über die berechtigten Interessen des Anbieters in den entsprechenden Abschnitten dieses Dokuments oder durch Kontaktaufnahme zum Anbieter erhalten.
+
+Darüber hinaus ist es dem Anbieter gestattet, personenbezogene Daten für einen längeren Zeitraum zu speichern, wenn der Nutzer in eine solche Verarbeitung eingewilligt hat, solange die Einwilligung nicht widerrufen wird. Darüber hinaus kann der Anbieter verpflichtet sein, personenbezogene Daten für einen längeren Zeitraum aufzubewahren, wenn dies zur Erfüllung einer gesetzlichen Verpflichtung oder auf Anordnung einer Behörde erforderlich ist.
+
+Nach Ablauf der Aufbewahrungsfrist werden personenbezogene Daten gelöscht. Daher können das Auskunftsrecht, das Recht auf Löschung, das Recht auf Berichtigung und das Recht auf Datenübertragbarkeit nach Ablauf der Aufbewahrungsfrist nicht geltend gemacht werden.
+
+Die Rechte der Nutzer nach der Datenschutz-Grundverordnung (DSGVO)
+
+Die Nutzer können bestimmte Rechte in Bezug auf ihre vom Anbieter verarbeiteten Daten ausüben.
+
+Nutzer haben im gesetzlich zulässigen Umfang insbesondere das Recht, Folgendes zu tun:
+
+Die Einwilligungen jederzeit widerrufen. Hat der Nutzer zuvor in die Verarbeitung personenbezogener Daten eingewilligt, so kann er die eigene Einwilligung jederzeit widerrufen.
+
+Widerspruch gegen die Verarbeitung ihrer Daten einlegen. Der Nutzer hat das Recht, der Verarbeitung seiner Daten zu widersprechen, wenn die Verarbeitung auf einer anderen Rechtsgrundlage als der Einwilligung erfolgt.
+
+Auskunft bezüglich ihrer Daten erhalten. Der Nutzer hat das Recht zu erfahren, ob die Daten vom Anbieter verarbeitet werden, über einzelne Aspekte der Verarbeitung Auskunft zu erhalten und eine Kopie der Daten zu erhalten.
+
+Überprüfen und berichtigen lassen. Der Nutzer hat das Recht, die Richtigkeit seiner Daten zu überprüfen und deren Aktualisierung oder Berichtigung zu verlangen.
+
+Einschränkung der Verarbeitung ihrer Daten verlangen. Die Nutzer haben das Recht, die Verarbeitung ihrer Daten einzuschränken. In diesem Fall wird der Anbieter die Daten zu keinem anderen Zweck als der Speicherung verarbeiten.
+
+Löschung oder anderweitiges Entfernen der personenbezogenen Daten verlangen. Die Nutzer haben das Recht, vom Anbieter die Löschung ihrer Daten zu verlangen.
+
+Ihre Daten erhalten und an einen anderen Verantwortlichen übertragen lassen. Der Nutzer hat das Recht, seine Daten in einem strukturierten, gängigen und maschinenlesbaren Format zu erhalten und, sofern technisch möglich, ungehindert an einen anderen Verantwortlichen übermitteln zu lassen.
+
+Beschwerde einreichen. Die Nutzer haben das Recht, eine Beschwerde bei der zuständigen Aufsichtsbehörde einzureichen.
+
+Die Nutzer haben auch das Recht, sich über die Rechtsgrundlage der Datenübermittlung ins Ausland oder an eine internationale Organisation, die dem Völkerrecht unterliegt oder von zwei oder mehr Ländern gegründet wurde, wie beispielsweise die UNO, sowie sich über die vom Anbieter ergriffenen Sicherheitsmaßnahmen zum Schutz ihrer Daten aufklären zu lassen.
+
+Details zum Widerspruchsrecht bezüglich der Verarbeitung
+
+Werden personenbezogene Daten im öffentlichen Interesse, in Ausübung eines dem Anbieter übertragenen hoheitlichen Befugnisses oder zur Wahrung der berechtigten Interessen des Anbieters verarbeitet, kann der Nutzer dieser Verarbeitung widersprechen, indem er einen Rechtfertigungsgrund angibt, der sich auf seine besondere Situation bezieht.
+
+Nutzer werden darüber informiert, dass sie der Verarbeitung der personenbezogenen Daten für Direktwerbung jederzeit unentgeltlich ohne Angabe von Gründen widersprechen können. Widerspricht der Nutzer der Verarbeitung für Zwecke der Direktwerbung, so werden die personenbezogenen Daten nicht mehr für diese Zwecke verarbeitet. Ob der Anbieter personenbezogene Daten für Direktwerbungszwecke verarbeitet, können die Nutzer den entsprechenden Abschnitten dieses Dokuments entnehmen.
+
+Wie die Rechte ausgeübt werden können
+
+Alle Anfragen zur Ausübung der Nutzerrechte können über die in diesem Dokument angegebenen Kontaktdaten an den Eigentümer gerichtet werden. Diese Anfragen können kostenlos gestellt werden und werden vom Anbieter so früh wie möglich, spätestens innerhalb eines Monats, beantwortet und den Nutzern die gesetzlich vorgeschriebenen Informationen zur Verfügung gestellt. Jede Berichtigung oder Löschung personenbezogener Daten oder die Einschränkung der Verarbeitung teilt der Anbieter allen Empfängern, denen personenbezogene Daten offengelegt wurden, mit, falls es welche gibt. Es sei denn, dies erweist sich als unmöglich oder ist mit einem unverhältnismäßigen Aufwand verbunden. Der Anbieter unterrichtet den Nutzer über diese Empfänger, wenn der Nutzer dies verlangt.
+
+Weitere Informationen über die Erhebung und Verarbeitung von Daten
+
+Rechtliche Maßnahmen
+
+Die personenbezogenen Daten des Nutzers können vom Anbieter zu Zwecken der Rechtsdurchsetzung innerhalb oder in Vorbereitung gerichtlicher Verfahren verarbeitet werden, die sich daraus ergeben, dass diese Anwendung oder die dazugehörigen Dienste nicht ordnungsgemäß genutzt wurden.
+
+Der Nutzer erklärt, sich dessen bewusst zu sein, dass der Anbieter von den Behörden zur Herausgabe von personenbezogenen Daten verpflichtet werden könnte.
+
+Weitere Informationen über die personenbezogenen Daten des Nutzers
+
+Zusätzlich zu den in dieser Datenschutzerklärung aufgeführten Informationen kann diese Anwendung dem Nutzer auf Anfrage weitere kontextbezogene Informationen zur Verfügung stellen, die sich auf bestimmte Dienste oder auf die Erhebung und Verarbeitung personenbezogener Daten beziehen.
+
+Systemprotokolle und Wartung
+
+Diese Anwendung und die Dienste von Dritten können zu Betriebs- und Wartungszwecken Dateien erfassen, die die über diese Anwendung stattfindende Interaktion aufzeichnen (Systemprotokolle), oder andere personenbezogene Daten (z. B. IP-Adresse) zu diesem Zweck verwenden.
+
+Nicht in dieser Datenschutzerklärung enthaltene Informationen
+
+Weitere Informationen über die Erhebung oder Verarbeitung personenbezogener Daten können jederzeit vom Anbieter über die aufgeführten Kontaktangaben angefordert werden.
+
+Änderungen dieser Datenschutzerklärung
+
+Der Anbieter behält sich vor, jederzeit Änderungen an dieser Datenschutzerklärung vorzunehmen, indem Nutzer auf dieser Seite und gegebenenfalls über diese Anwendung und/oder - soweit technisch und rechtlich möglich – durch das Versenden einer Mitteilung über dem Anbieter vorliegende Kontaktdaten der Nutzer informiert werden. Nutzern wird daher nahegelegt, diese Seite regelmäßig aufzurufen und insbesondere das am Seitenende angegebene Datum der letzten Änderung zu prüfen.
+
+Soweit Änderungen eine auf der Einwilligung des Nutzers basierte Datennutzung betreffen, so wird der Anbieter - soweit erforderlich - eine neue Einwilligung einholen.
+
+Begriffsbestimmungen und rechtliche Hinweise
+
+Personenbezogene Daten (oder Daten)
+
+Alle Informationen, durch die direkt oder in Verbindung mit weiteren Informationen die Identität einer natürlichen Person bestimmt wird oder werden kann.
+
+Nutzungsdaten
+
+Informationen, die diese Anwendung (oder Dienste Dritter, die diese Anwendung in Anspruch nimmt), automatisch erhebt, z. B.: die IP-Adressen oder Domain-Namen der Computer von Nutzern, die diese Anwendung verwenden, die URI-Adressen (Uniform Resource Identifier), den Zeitpunkt der Anfrage, die Methode, die für die Übersendung der Anfrage an den Server verwendet wurde, die Größe der empfangenen Antwort-Datei, der Zahlencode, der den Status der Server-Antwort anzeigt (erfolgreiches Ergebnis, Fehler etc.), das Herkunftsland, die Funktionen des vom Nutzer verwendeten Browsers und Betriebssystems, die diversen Zeitangaben pro Aufruf (z. B. wie viel Zeit auf jeder Seite der Anwendung verbracht wurde) und Angaben über den Pfad, dem innerhalb einer Anwendung gefolgt wurde, insbesondere die Reihenfolge der besuchten Seiten, sowie sonstige Informationen über das Betriebssystem des Geräts und/oder die IT-Umgebung des Nutzers.
+
+Nutzer
+
+Die diese Anwendung verwendende Person, die, soweit nicht anders bestimmt, mit dem Betroffenen übereinstimmt.
+
+Betroffener
+
+Die natürliche Person, auf die sich die personenbezogenen Daten beziehen.
+
+Auftragsverarbeiter (oder Auftragsbearbeiter)
+
+Natürliche oder juristische Person, Behörde, Einrichtung oder andere Stelle, die personenbezogene Daten im Auftrag des Verantwortlichen verarbeitet, wie in dieser Datenschutzerklärung beschrieben.
+
+Verantwortlicher (oder Anbieter, teilweise auch Eigentümer)
+
+Die natürliche oder juristische Person, Behörde, Einrichtung oder andere Stelle, die allein oder gemeinsam mit anderen über die Zwecke und Mittel der Verarbeitung personenbezogener Daten sowie die hierfür verwendeten Mittel entscheidet, einschließlich der Sicherheitsmaßnahmen bezüglich des sich auf diese Anwendung beziehenden Betriebs und der Nutzung. Soweit nichts anderes angegeben ist, ist der Verantwortliche die natürliche oder juristische Person, über welche diese Anwendung angeboten wird.
+
+Diese Anwendung
+
+Das Hardware- oder Software-Tool, mit dem die personenbezogenen Daten des Nutzers erhoben und verarbeitet werden.
+
+Dienst
+
+Der durch diese Anwendung angebotene Dienst, wie in den entsprechenden AGBs (falls vorhanden) und auf dieser Website/Anwendung beschrieben.
+
+Europäische Union (oder EU)
+
+Sofern nicht anders angegeben, beziehen sich alle Verweise in diesem Dokument auf die Europäische Union auf alle derzeitigen Mitgliedstaaten der Europäischen Union und den Europäischen Wirtschaftsraum (EWR).
+
+Rechtlicher Hinweis
+
+Diese Erklärung bezieht sich ausschließlich auf diese Anwendung, sofern in diesem Dokument nicht anders angegeben.
+
+Letzte Aktualisierung: 27. August 2026

--- a/docs/privacy-policy/en.txt
+++ b/docs/privacy-policy/en.txt
@@ -1,0 +1,321 @@
+Privacy Policy of OpenNutriTracker
+
+This Application collects some Personal Data from its Users.
+
+This document can be printed for reference by using the print command in the settings of any browser.
+
+Owner and Data Controller
+
+Simon Oppowa
+[postal address — see the published policy]
+
+Owner contact email: opennutritracker-dev@pm.me
+
+Types of Data collected
+
+Among the types of Personal Data that this Application collects, by itself or through third parties, there are:
+Usage Data; diagnostics; email address; app information; device logs; device information; Data communicated while using the service.
+
+Complete details on each type of Personal Data collected are provided in the dedicated sections of this privacy policy or by specific explanation texts displayed prior to the Data collection.
+Personal Data may be freely provided by the User, or, in case of Usage Data, collected automatically when using this Application.
+Unless specified otherwise, all Data requested by this Application is mandatory and failure to provide this Data may make it impossible for this Application to provide its services. In cases where this Application specifically states that some Data is not mandatory, Users are free not to communicate this Data without consequences to the availability or the functioning of the Service.
+Users who are uncertain about which Personal Data is mandatory are welcome to contact the Owner.
+Any use of Cookies – or of other tracking tools — by this Application or by the owners of third-party services used by this Application serves the purpose of providing the Service required by the User, in addition to any other purposes described in the present document.
+
+Users are responsible for any third-party Personal Data obtained, published or shared through this Application.
+
+Mode and place of processing the Data
+
+Methods of processing
+
+The Owner takes appropriate security measures to prevent unauthorized access, disclosure, modification, or unauthorized destruction of the Data.
+The Data processing is carried out using computers and/or IT enabled tools, following organizational procedures and modes strictly related to the purposes indicated. In addition to the Owner, in some cases, the Data may be accessible to certain types of persons in charge, involved with the operation of this Application (administration, sales, marketing, legal, system administration) or external parties (such as third-party technical service providers, mail carriers, hosting providers, IT companies, communications agencies) appointed, if necessary, as Data Processors by the Owner. The updated list of these parties may be requested from the Owner at any time.
+
+Place
+
+The Data is processed at the Owner's operating offices and in any other places where the parties involved in the processing are located.
+
+Depending on the User's location, data transfers may involve transferring the User's Data to a country other than their own. To find out more about the place of processing of such transferred Data, Users can check the section containing details about the processing of Personal Data.
+
+Retention time
+
+Unless specified otherwise in this document, Personal Data shall be processed and stored for as long as required by the purpose they have been collected for and may be retained for longer due to applicable legal obligation or based on the Users’ consent.
+
+The purposes of processing
+
+The Data concerning the User is collected to allow the Owner to provide its Service, comply with its legal obligations, respond to enforcement requests, protect its rights and interests (or those of its Users or third parties), detect any malicious or fraudulent activity, as well as the following:
+Platform services and hosting, Beta Testing, Displaying content from external platforms, Hosting and backend infrastructure, Infrastructure monitoring and Access to third-party accounts.
+
+For specific information about the Personal Data used for each purpose, the User may refer to the section “Detailed information on the processing of Personal Data”.
+
+Detailed information on the processing of Personal Data
+
+Personal Data is collected for the following purposes and using the following services:
+
+Access to third-party accounts
+
+This type of service allows this Application to access Data from your account on a third-party service and perform actions with it.
+
+These services are not activated automatically, but require explicit authorization by the User.
+
+AI meal assistance (your own provider)
+
+AI meal assistance is switched off until you enter your own API key for a provider you have chosen. Nothing is sent anywhere until you do.
+
+When it is on, only the meal description you type — or a photo you deliberately pick — is sent to that provider, so that it can return food names and amounts. Your food diary, your weight and your profile are never sent.
+
+The provider is the one you selected and the account is yours: your relationship with that provider, and their own privacy policy, governs what they do with what they receive. The Owner of this Application has no access to it, pays nothing for it and receives nothing back.
+
+If you choose OpenRouter, your request reaches OpenRouter and the vendor serving the model you picked — two recipients, not one — and an account-level identifier is passed on to that vendor and cannot be switched off. If you configure your own server, the request goes to the address you entered, which the Owner cannot know: no third party receives it, though it does still leave your device.
+
+Your API key is held in your device's own secure credential store and leaves the device only as the header that authenticates your request.
+
+Personal Data processed: the text or the photo you submit for interpretation; your app language.
+
+Place of processing: the country of the provider you choose — see that provider's own privacy policy.
+
+This service uses artificial intelligence. Certain features of AI meal assistance (your own provider) are powered by automated systems that process your data to personalise or improve your experience.
+
+Beta Testing
+
+This type of service makes it possible to manage User access to this Application, or parts of it, for the purpose of testing a certain feature or the entire Application.
+
+The service provider may automatically collect data related to crashes and statistics related to the User's use of this Application in a personally identifiable form.
+
+TestFlight (Apple Inc.)
+
+TestFlight is a beta testing service provided by Apple Inc.
+
+Personal Data processed: app information; device information; device logs; email address.
+
+Place of processing: United States – Privacy Policy.
+
+Google Play Beta Testing (Google Ireland Limited)
+
+Google Play Beta Testing is a beta testing service provided by Google Ireland Limited.
+
+Personal Data processed: Data communicated while using the service; device information; Usage Data.
+
+Place of processing: Ireland – Privacy Policy.
+
+Displaying content from external platforms
+
+This type of service allows you to view content hosted on external platforms directly from the pages of this Application and interact with them. Such services are often referred to as widgets, which are small elements placed on a website or app. They provide specific information or perform a particular function and often allow for user interaction.
+
+This type of service might still collect web traffic data for the pages where the service is installed, even when Users do not use it.
+
+Open Food Facts
+
+When you search for a food or scan a barcode, this Application sends the search term or the barcode to Open Food Facts, together with a country code derived from your device's language settings, which the service uses to rank results.
+
+Open Food Facts is an independent non-profit association. It decides for itself how it handles what it receives and does not act on the instructions of the Owner of this Application, so its own privacy policy governs that handling. No account, profile or device identifier is sent, and your food diary is never sent.
+
+This processing rests on the Owner's legitimate interest in providing the food search this Application exists to offer. You can object to it at any time, and in practice you can avoid it altogether: a search happens only when you start one, and meals you have saved yourself can be added without any search.
+
+Personal Data processed: search terms; barcodes; a country code; Usage Data.
+
+Place of processing: France — Privacy Policy.
+
+Hosting and backend infrastructure
+
+This type of service has the purpose of hosting Data and files that enable this Application to run and be distributed or to provide a ready-made infrastructure to run specific features or parts of this Application.
+
+Some services among those listed below, if any, may work through geographically distributed servers, making it difficult to determine the actual location where the Personal Data are stored.
+
+Food reference backend (Supabase)
+
+Food searches are answered by a reference database that the Owner of this Application operates on Supabase's managed cloud platform. A search sends the text you typed. No account, profile or device identifier is attached, and your food diary is never sent.
+
+Because the request travels over the internet, the platform's gateway records for 24 hours the address the request came from, an approximate location derived from that address (country, region, city and postal code), the name of your internet access provider, and a fingerprint of the encrypted connection.
+
+The database is stored and primarily processed in Frankfurt, Germany. Supabase Pte. Ltd. acts as a processor on the Owner's instructions, with Cloudflare, Inc. and Amazon Web Services, Inc. among its sub-processors; requests reach a Cloudflare location close to you before the database. Transfers outside the European Economic Area are covered by standard contractual clauses.
+
+This processing rests on the Owner's legitimate interest in providing the food search this Application exists to offer. You can object to it at any time, and in practice you can avoid it altogether: a search happens only when you start one, and meals you have saved yourself can be added without any search.
+
+Personal Data processed: search terms; IP address; approximate location; connection identifiers; Usage Data.
+
+Place of processing: Germany — Singapore.
+
+Infrastructure monitoring
+
+This type of service allows this Application to monitor the use and behavior of its components so its performance, operation, maintenance and troubleshooting can be improved.
+
+Which Personal Data are processed depends on the characteristics and mode of implementation of these services, whose function is to filter the activities of this Application.
+
+Sentry
+
+Crash reporting is switched off unless you turn it on in Settings, and it runs only in released builds of the app.
+
+When it is on, a crash sends a technical report — the error and its stack trace, the app version, the operating system version and the device model — together with a randomly generated identifier for your installation. Your food diary, your weight and your profile are never sent, and the app does not attach your IP address. Sentry's servers may derive an approximate location (country, region and city) from the connection the report arrives on.
+
+Reports are kept for 30 days.
+
+This processing is based on your consent. You can withdraw it at any time by switching crash reporting off in Settings, which stops reporting immediately.
+
+Personal Data processed: diagnostics; device information; device logs; an installation identifier; approximate location; Usage Data.
+
+Place of processing: United States — transfers are covered by the EU–US Data Privacy Framework and standard contractual clauses.
+
+Platform services and hosting
+
+These services have the purpose of hosting and running key components of this Application, therefore allowing the provision of this Application from within a unified platform. Such platforms provide a wide range of tools to the Owner – e.g. analytics, user registration, commenting, database management, e-commerce, payment processing – that imply the collection and handling of Personal Data.
+
+Some of these services work through geographically distributed servers, making it difficult to determine the actual location where the Personal Data are stored.
+
+Google Play Store (Google LLC)
+
+This Application is distributed on the Google Play Store, a platform for the distribution of mobile apps, provided by Google LLC or by Google Ireland Limited, depending on how the Owner manages the Data processing.
+
+By virtue of being distributed via this app store, Google collects usage and diagnostics data and share aggregate information with the Owner. Much of this information is processed on an opt-in basis.
+
+Users may opt-out of this analytics feature directly through their device settings. More information on how to manage analysis settings can be found on this page.
+
+Personal Data processed: Usage Data.
+
+Place of processing: United States – Privacy Policy; Ireland – Privacy Policy.
+
+App Store Connect (Apple Inc.)
+
+This Application is distributed on Apple's App Store, a platform for the distribution of mobile apps, provided by Apple Inc.
+
+App Store Connect enables the Owner to manage this Application on Apple's App Store. Depending on the configuration, App Store Connect provides the Owner with analytics data on user engagement and app discovery, marketing campaigns, sales, in-app purchases, and payments to measure the performance of this Application.
+App Store Connect only collects such data from Users who have agreed to share them with the Owner. Users may find more information on how to opt out via their device settings here.
+
+Personal Data processed: diagnostics.
+
+Place of processing: United States – Privacy Policy.
+
+Further Information for Users
+
+Legal basis of processing
+
+The Owner may process Personal Data relating to Users if one of the following applies:
+
+Users have given their consent for one or more specific purposes.
+
+provision of Data is necessary for the performance of an agreement with the User and/or for any pre-contractual obligations thereof;
+
+processing is necessary for compliance with a legal obligation to which the Owner is subject;
+
+processing is related to a task that is carried out in the public interest or in the exercise of official authority vested in the Owner;
+
+processing is necessary for the purposes of the legitimate interests pursued by the Owner or by a third party.
+
+In any case, the Owner will gladly help to clarify the specific legal basis that applies to the processing, and in particular whether the provision of Personal Data is a statutory or contractual requirement, or a requirement necessary to enter into a contract.
+
+Further information about retention time
+
+Unless specified otherwise in this document, Personal Data shall be processed and stored for as long as required by the purpose they have been collected for and may be retained for longer due to applicable legal obligation or based on the Users’ consent.
+
+Therefore:
+
+Personal Data collected for purposes related to the performance of a contract between the Owner and the User shall be retained until such contract has been fully performed.
+
+Personal Data collected for the purposes of the Owner’s legitimate interests shall be retained as long as needed to fulfill such purposes. Users may find specific information regarding the legitimate interests pursued by the Owner within the relevant sections of this document or by contacting the Owner.
+
+The Owner may be allowed to retain Personal Data for a longer period whenever the User has given consent to such processing, as long as such consent is not withdrawn. Furthermore, the Owner may be obliged to retain Personal Data for a longer period whenever required to fulfil a legal obligation or upon order of an authority.
+
+Once the retention period expires, Personal Data shall be deleted. Therefore, the right of access, the right to erasure, the right to rectification and the right to data portability cannot be enforced after expiration of the retention period.
+
+The rights of Users based on the General Data Protection Regulation (GDPR)
+
+Users may exercise certain rights regarding their Data processed by the Owner.
+
+In particular, Users have the right to do the following, to the extent permitted by law:
+
+Withdraw their consent at any time. Users have the right to withdraw consent where they have previously given their consent to the processing of their Personal Data.
+
+Object to processing of their Data. Users have the right to object to the processing of their Data if the processing is carried out on a legal basis other than consent.
+
+Access their Data. Users have the right to learn if Data is being processed by the Owner, obtain disclosure regarding certain aspects of the processing and obtain a copy of the Data undergoing processing.
+
+Verify and seek rectification. Users have the right to verify the accuracy of their Data and ask for it to be updated or corrected.
+
+Restrict the processing of their Data. Users have the right to restrict the processing of their Data. In this case, the Owner will not process their Data for any purpose other than storing it.
+
+Have their Personal Data deleted or otherwise removed. Users have the right to obtain the erasure of their Data from the Owner.
+
+Receive their Data and have it transferred to another controller. Users have the right to receive their Data in a structured, commonly used and machine readable format and, if technically feasible, to have it transmitted to another controller without any hindrance.
+
+Lodge a complaint. Users have the right to bring a claim before their competent data protection authority.
+
+Users are also entitled to learn about the legal basis for Data transfers abroad including to any international organization governed by public international law or set up by two or more countries, such as the UN, and about the security measures taken by the Owner to safeguard their Data.
+
+Details about the right to object to processing
+
+Where Personal Data is processed for a public interest, in the exercise of an official authority vested in the Owner or for the purposes of the legitimate interests pursued by the Owner, Users may object to such processing by providing a ground related to their particular situation to justify the objection.
+
+Users must know that, however, should their Personal Data be processed for direct marketing purposes, they can object to that processing at any time, free of charge and without providing any justification. Where the User objects to processing for direct marketing purposes, the Personal Data will no longer be processed for such purposes. To learn whether the Owner is processing Personal Data for direct marketing purposes, Users may refer to the relevant sections of this document.
+
+How to exercise these rights
+
+Any requests to exercise User rights can be directed to the Owner through the contact details provided in this document. Such requests are free of charge and will be answered by the Owner as early as possible and always within one month, providing Users with the information required by law. Any rectification or erasure of Personal Data or restriction of processing will be communicated by the Owner to each recipient, if any, to whom the Personal Data has been disclosed unless this proves impossible or involves disproportionate effort. At the Users’ request, the Owner will inform them about those recipients.
+
+Additional information about Data collection and processing
+
+Legal action
+
+The User's Personal Data may be used for legal purposes by the Owner in Court or in the stages leading to possible legal action arising from improper use of this Application or the related Services.
+The User declares to be aware that the Owner may be required to reveal personal data upon request of public authorities.
+
+Additional information about User's Personal Data
+
+In addition to the information contained in this privacy policy, this Application may provide the User with additional and contextual information concerning particular Services or the collection and processing of Personal Data upon request.
+
+System logs and maintenance
+
+For operation and maintenance purposes, this Application and any third-party services may collect files that record interaction with this Application (System logs) or use other Personal Data (such as the IP Address) for this purpose.
+
+Information not contained in this policy
+
+More details concerning the collection or processing of Personal Data may be requested from the Owner at any time. Please see the contact information at the beginning of this document.
+
+Changes to this privacy policy
+
+The Owner reserves the right to make changes to this privacy policy at any time by notifying its Users on this page and possibly within this Application and/or - as far as technically and legally feasible - sending a notice to Users via any contact information available to the Owner. It is strongly recommended to check this page often, referring to the date of the last modification listed at the bottom.
+
+Should the changes affect processing activities performed on the basis of the User’s consent, the Owner shall collect new consent from the User, where required.
+
+Definitions and legal references
+
+Personal Data (or Data)
+
+Any information that directly, indirectly, or in connection with other information — including a personal identification number — allows for the identification or identifiability of a natural person.
+
+Usage Data
+
+Information collected automatically through this Application (or third-party services employed in this Application), which can include: the IP addresses or domain names of the computers utilized by the Users who use this Application, the URI addresses (Uniform Resource Identifier), the time of the request, the method utilized to submit the request to the server, the size of the file received in response, the numerical code indicating the status of the server's answer (successful outcome, error, etc.), the country of origin, the features of the browser and the operating system utilized by the User, the various time details per visit (e.g., the time spent on each page within the Application) and the details about the path followed within the Application with special reference to the sequence of pages visited, and other parameters about the device operating system and/or the User's IT environment.
+
+User
+
+The individual using this Application who, unless otherwise specified, coincides with the Data Subject.
+
+Data Subject
+
+The natural person to whom the Personal Data refers.
+
+Data Processor (or Processor)
+
+The natural or legal person, public authority, agency or other body which processes Personal Data on behalf of the Controller, as described in this privacy policy.
+
+Data Controller (or Owner)
+
+The natural or legal person, public authority, agency or other body which, alone or jointly with others, determines the purposes and means of the processing of Personal Data, including the security measures concerning the operation and use of this Application. The Data Controller, unless otherwise specified, is the Owner of this Application.
+
+This Application
+
+The means by which the Personal Data of the User is collected and processed.
+
+Service
+
+The service provided by this Application as described in the relative terms (if available) and on this site/application.
+
+European Union (or EU)
+
+Unless otherwise specified, all references made within this document to the European Union include all current member states to the European Union and the European Economic Area.
+
+Legal information
+
+This policy relates solely to this Application, if not stated otherwise within this document.
+
+Latest update: August 27, 2026

--- a/test/unit_test/policy_snapshot_test.dart
+++ b/test/unit_test/policy_snapshot_test.dart
@@ -1,0 +1,247 @@
+import 'package:flutter_test/flutter_test.dart';
+
+import '../../tool/policy_snapshot.dart';
+
+/// The drift guard for the two published policy documents (#887, #888).
+///
+/// Fixtures rather than the network: the real check runs in CI against the live
+/// API, and a unit test that depended on a third party would fail for reasons
+/// that have nothing to do with this code.
+///
+/// The shapes below are taken from the live documents on 2026-08-27 — the
+/// `iub-purpose-<n>` / `iub-service-<n>` classes, the two spellings of the
+/// last-updated line, and the German document's named entities are all real.
+String _document({
+  required String lastUpdatedLine,
+  required List<(String purpose, int services)> groups,
+  List<String> hosts = const [],
+  String ownerHeading = 'Owner and Data Controller',
+  String contactLine = 'Owner contact email: someone@example.invalid',
+  List<String> ownerLines = const [
+    'A Maintainer',
+    '1 Example Street',
+    '12345 Town',
+  ],
+}) {
+  final buffer = StringBuffer()
+    ..writeln('<h1>Privacy Policy of OpenNutriTracker</h1>')
+    ..writeln('<p>$lastUpdatedLine</p>')
+    ..writeln('<h2>$ownerHeading</h2>')
+    ..writeln('<p>${ownerLines.join('<br/>')}</p>')
+    ..writeln('<p>$contactLine</p>');
+
+  for (final (purpose, services) in groups) {
+    buffer.writeln('<h3 class="iub-purpose iub-purpose-$purpose">Group</h3>');
+    for (var i = 0; i < services; i++) {
+      buffer.writeln(
+        '<h4 class="iub-service iub-service-${purpose}0$i">A service</h4>',
+      );
+    }
+  }
+  for (final host in hosts) {
+    buffer.writeln('<p><a href="https://$host/path">link</a></p>');
+  }
+  return buffer.toString();
+}
+
+void main() {
+  group('structure extracted from the rendered document', () {
+    test('purpose ids come out of the taxonomy classes', () {
+      final html = _document(
+        lastUpdatedLine: 'Latest update: August 27, 2026',
+        groups: const [('16', 1), ('46', 2)],
+      );
+
+      expect(purposeIds(html), {'16', '46'});
+    });
+
+    test('services are counted per purpose, not in total', () {
+      // A total would miss a service moving between groups, and it is the
+      // per-group count that says "this language is missing an entry".
+      final html = _document(
+        lastUpdatedLine: 'Latest update: August 27, 2026',
+        groups: const [('16', 1), ('46', 2), ('61', 2)],
+      );
+
+      expect(serviceCountsByPurpose(html), {'16': 1, '46': 2, '61': 2});
+    });
+
+    test('a purpose with no services still appears, with a count of zero', () {
+      final html = _document(
+        lastUpdatedLine: 'Latest update: August 27, 2026',
+        groups: const [('16', 0)],
+      );
+
+      expect(serviceCountsByPurpose(html), {'16': 0});
+    });
+  });
+
+  group('the last-updated date, in both languages', () {
+    test('reads the English format', () {
+      expect(
+        lastUpdated('<p>Latest update: August 27, 2026</p>'),
+        '2026-08-27',
+      );
+    });
+
+    test('reads the German format, which orders it differently', () {
+      expect(
+        lastUpdated('<p>Letzte Aktualisierung: 27. August 2026</p>'),
+        '2026-08-27',
+      );
+    });
+
+    test('reads a German month name that is not spelled as in English', () {
+      expect(
+        lastUpdated('<p>Letzte Aktualisierung: 3. März 2026</p>'),
+        '2026-03-03',
+      );
+      expect(lastUpdated('<p>Latest update: March 3, 2026</p>'), '2026-03-03');
+    });
+
+    test('returns null rather than guessing when the line is missing', () {
+      expect(lastUpdated('<p>Nothing to see</p>'), isNull);
+    });
+  });
+
+  group('comparing the two documents', () {
+    String en({
+      String updated = 'Latest update: August 27, 2026',
+      List<(String, int)> groups = const [('16', 1), ('46', 2)],
+      List<String> hosts = const ['example.invalid'],
+    }) => _document(lastUpdatedLine: updated, groups: groups, hosts: hosts);
+
+    String de({
+      String updated = 'Letzte Aktualisierung: 27. August 2026',
+      List<(String, int)> groups = const [('16', 1), ('46', 2)],
+      List<String> hosts = const ['example.invalid'],
+    }) => _document(
+      lastUpdatedLine: updated,
+      groups: groups,
+      hosts: hosts,
+      ownerHeading: 'Anbieter und Verantwortlicher',
+      contactLine: 'E-Mail-Adresse des Anbieters: someone@example.invalid',
+    );
+
+    test('two documents in step pass', () {
+      final report = comparePolicies(en(), de());
+
+      expect(report.failures, isEmpty);
+    });
+
+    test('a clause reaching only one language fails', () {
+      // #888's failure, exactly: a custom clause added in English and never
+      // translated. Custom clauses do not propagate in iubenda.
+      final report = comparePolicies(
+        en(groups: const [('16', 1), ('46', 3)]),
+        de(groups: const [('16', 1), ('46', 2)]),
+      );
+
+      expect(report.failures, hasLength(1));
+      expect(report.failures.single, contains('purpose 46'));
+    });
+
+    test('a whole service group missing in one language fails', () {
+      final report = comparePolicies(
+        en(groups: const [('16', 1), ('46', 2), ('61', 1)]),
+        de(groups: const [('16', 1), ('46', 2)]),
+      );
+
+      expect(report.failures, isNotEmpty);
+      expect(report.failures.first, contains('61'));
+    });
+
+    test('one document edited without the other fails', () {
+      // The most direct signal there is: the documents disagree about when
+      // they were last touched.
+      final report = comparePolicies(
+        en(updated: 'Latest update: August 27, 2026'),
+        de(updated: 'Letzte Aktualisierung: 1. August 2026'),
+      );
+
+      expect(report.failures, hasLength(1));
+      expect(report.failures.single, contains('2026-08-01'));
+    });
+
+    test(
+      'a differing link only warns, because iubenda differs from itself',
+      () {
+        // Measured 2026-08-27: the English App Store Connect section links
+        // support.apple.com for opt-out guidance and the German one omits the
+        // sentence. That is the vendor's own template, so failing a build over
+        // it would be a check nobody can satisfy.
+        final report = comparePolicies(
+          en(hosts: const ['example.invalid', 'support.apple.com']),
+          de(hosts: const ['example.invalid']),
+        );
+
+        expect(report.failures, isEmpty);
+        expect(report.warnings, hasLength(1));
+        expect(report.warnings.single, contains('support.apple.com'));
+      },
+    );
+  });
+
+  group('the postal address never reaches the snapshot', () {
+    test('the address is replaced and the name kept', () {
+      final text = htmlToText(
+        _document(
+          lastUpdatedLine: 'Latest update: August 27, 2026',
+          groups: const [('16', 1)],
+        ),
+      );
+
+      final redacted = redactPostalAddress(text);
+
+      expect(redacted, contains('A Maintainer'));
+      expect(redacted, contains(postalAddressPlaceholder));
+      expect(redacted, isNot(contains('1 Example Street')));
+      expect(redacted, isNot(contains('12345 Town')));
+      expect(redacted, contains('someone@example.invalid'));
+    });
+
+    test('works on the German document, whose headings differ', () {
+      final text = htmlToText(
+        _document(
+          lastUpdatedLine: 'Letzte Aktualisierung: 27. August 2026',
+          groups: const [('16', 1)],
+          ownerHeading: 'Anbieter und Verantwortlicher',
+          contactLine: 'E-Mail-Adresse des Anbieters: someone@example.invalid',
+        ),
+      );
+
+      final redacted = redactPostalAddress(text);
+
+      expect(redacted, isNot(contains('1 Example Street')));
+      expect(redacted, contains(postalAddressPlaceholder));
+    });
+
+    test('an owner block with only a name is left alone', () {
+      // If #886's preference lands and the address goes, there is nothing to
+      // redact and no placeholder should appear.
+      final text = htmlToText(
+        _document(
+          lastUpdatedLine: 'Latest update: August 27, 2026',
+          groups: const [('16', 1)],
+          ownerLines: const ['A Maintainer'],
+        ),
+      );
+
+      final redacted = redactPostalAddress(text);
+
+      expect(redacted, contains('A Maintainer'));
+      expect(redacted, isNot(contains(postalAddressPlaceholder)));
+    });
+
+    test('an unrecognisable owner block throws rather than leaking', () {
+      // The address cannot be searched for — it must not be written down in
+      // this repository, which is the point — so recognition is structural.
+      // If iubenda reworded the heading, a silent no-op would commit the
+      // address on the next run.
+      expect(
+        () => redactPostalAddress('Some other document\n\nwith no owner block'),
+        throwsStateError,
+      );
+    });
+  });
+}

--- a/tool/policy_snapshot.dart
+++ b/tool/policy_snapshot.dart
@@ -1,0 +1,422 @@
+// Fetches both published privacy-policy documents, writes a readable snapshot
+// of each into the repository, and compares their structure.
+//
+// Two jobs in one script, because they need the same fetch:
+//
+//  1. **The change record.** iubenda keeps no version history and offers no
+//     "tell me what changed" view (#871). Committing the rendered text gives
+//     git's history as a substitute, which is what #887 settled on when it
+//     decided what is owed to users who acknowledged an older policy.
+//
+//  2. **The drift guard.** Every clause this project wrote is a *custom*
+//     clause, and custom clauses do not propagate between languages in
+//     iubenda (#871) — #888 caught exactly that in the wild, with the German
+//     document left behind. A check that needs no discipline beats one that
+//     relies on someone remembering.
+//
+// The API returns the *rendered document*, not the configuration
+// (verified in #871), so every comparison here has to be derived from HTML.
+// What makes that tractable is that some of the markup is language-independent:
+//
+//  * `iub-purpose-<n>` ids come from iubenda's fixed taxonomy and are
+//    identical in both documents. Measured 2026-08-27: {16, 25, 30, 42, 46, 61}
+//    in both.
+//  * `iub-service-<n>` ids are **not** — they are minted per language
+//    (13427280 vs 13427279 and so on), so they cannot be a comparison key.
+//    The service *count per purpose* can be, and is.
+//  * The set of linked hosts is language-independent, but see the note on
+//    `hostDifferences` for why it only warns.
+//
+// Usage:
+//   dart run tool/policy_snapshot.dart            # write snapshots, check
+//   dart run tool/policy_snapshot.dart --check    # check only, write nothing
+
+import 'dart:convert';
+import 'dart:io';
+
+import 'package:http/http.dart' as http;
+
+/// The two published documents. Both are rendered from configurations in the
+/// same iubenda project; see `URLConst.privacyPolicyFor` for which locale is
+/// sent to which.
+const policyDocuments = <String, String>{'en': '53501884', 'de': '53922100'};
+
+/// Where the snapshots live. One file per language, plain text, so a git diff
+/// reads like a diff of the policy rather than of HTML.
+const snapshotDirectory = 'docs/privacy-policy';
+
+Future<void> main(List<String> args) async {
+  final checkOnly = args.contains('--check');
+  final documents = <String, String>{};
+
+  for (final entry in policyDocuments.entries) {
+    stdout.writeln('Fetching ${entry.key} (${entry.value})…');
+    documents[entry.key] = await fetchPolicy(entry.value);
+  }
+
+  if (!checkOnly) {
+    Directory(snapshotDirectory).createSync(recursive: true);
+    for (final entry in documents.entries) {
+      final file = File('$snapshotDirectory/${entry.key}.txt');
+      file.writeAsStringSync(redactPostalAddress(htmlToText(entry.value)));
+      stdout.writeln('Wrote ${file.path}');
+    }
+  }
+
+  final report = comparePolicies(documents['en']!, documents['de']!);
+  stdout.writeln('\n$report');
+
+  if (report.failures.isNotEmpty) {
+    stderr.writeln(
+      'The two documents disagree on something the maintainer controls. '
+      'Every clause in this policy is custom, and custom clauses do not '
+      'propagate between languages — see #888.',
+    );
+    exit(1);
+  }
+}
+
+/// The rendered document for [publicId], as HTML.
+///
+/// `no-markup` of the three documented endpoints: it keeps the heading
+/// structure the comparison needs while dropping iubenda's presentational
+/// wrapper, so the snapshot diffs are about words rather than styling.
+Future<String> fetchPolicy(String publicId) async {
+  final url = Uri.https(
+    'www.iubenda.com',
+    '/api/privacy-policy/$publicId/no-markup',
+  );
+  final response = await http.get(url);
+
+  if (response.statusCode != 200) {
+    throw StateError('$url returned HTTP ${response.statusCode}');
+  }
+
+  final body = jsonDecode(utf8.decode(response.bodyBytes));
+  if (body is! Map || body['success'] != true) {
+    // The documented failure is a plan downgrade: "To access this privacy
+    // policy via API, convert it to Pro". Worth failing loudly, because it
+    // silently ends the change record.
+    throw StateError(
+      '$url reported failure: ${body is Map ? body['error'] : body}',
+    );
+  }
+
+  final content = body['content'];
+  if (content is! String || content.isEmpty) {
+    throw StateError('$url returned no content');
+  }
+  return content;
+}
+
+/// A readable, diffable rendering of [html].
+///
+/// Not a general HTML converter — it only has to be stable, so that a diff
+/// between two snapshots shows editorial changes and nothing else.
+String htmlToText(String html) {
+  var text = html
+      .replaceAll(RegExp(r'<(script|style)[^>]*>.*?</\1>', dotAll: true), '')
+      .replaceAll(RegExp(r'<br\s*/?>', caseSensitive: false), '\n')
+      // A blank line before each block element, so headings and paragraphs
+      // stay separate lines and a one-clause edit stays a one-hunk diff.
+      .replaceAll(
+        RegExp(r'<(h[1-6]|p|div|li|tr)[^>]*>', caseSensitive: false),
+        '\n\n',
+      )
+      .replaceAll(RegExp(r'<[^>]+>'), '');
+
+  text = _unescapeEntities(text);
+
+  final lines = text
+      .split('\n')
+      .map((line) => line.replaceAll(RegExp(r'[ \t]+'), ' ').trim())
+      .toList();
+
+  final out = <String>[];
+  for (final line in lines) {
+    if (line.isEmpty && (out.isEmpty || out.last.isEmpty)) continue;
+    out.add(line);
+  }
+  return '${out.join('\n').trim()}\n';
+}
+
+String _unescapeEntities(String input) {
+  const named = <String, String>{
+    '&amp;': '&',
+    '&lt;': '<',
+    '&gt;': '>',
+    '&quot;': '"',
+    '&#39;': "'",
+    '&apos;': "'",
+    '&nbsp;': ' ',
+    '&mdash;': '—',
+    '&ndash;': '–',
+    '&hellip;': '…',
+    // The German document arrives with its umlauts as named entities.
+    '&auml;': 'ä', '&ouml;': 'ö', '&uuml;': 'ü',
+    '&Auml;': 'Ä', '&Ouml;': 'Ö', '&Uuml;': 'Ü',
+    '&szlig;': 'ß',
+    '&eacute;': 'é', '&egrave;': 'è', '&agrave;': 'à', '&ccedil;': 'ç',
+    '&laquo;': '«', '&raquo;': '»', '&bdquo;': '„', '&ldquo;': '“',
+    '&rdquo;': '”', '&lsquo;': '‘', '&rsquo;': '’', '&sbquo;': '‚',
+  };
+  var out = input;
+  named.forEach((entity, char) => out = out.replaceAll(entity, char));
+  return out.replaceAllMapped(
+    RegExp(r'&#(\d+);'),
+    (m) => String.fromCharCode(int.parse(m.group(1)!)),
+  );
+}
+
+/// Headings that open the owner block, and the contact lines that close it.
+/// Both languages, because the snapshot is taken of both.
+const _ownerHeadings = [
+  'Owner and Data Controller',
+  'Anbieter und Verantwortlicher',
+];
+const _ownerContactPrefixes = [
+  'Owner contact email',
+  'E-Mail-Adresse des Anbieters',
+];
+
+/// Marker left in place of the owner's postal address.
+const postalAddressPlaceholder = '[postal address — see the published policy]';
+
+/// Replaces the owner's postal address with [postalAddressPlaceholder].
+///
+/// The address is on the published page already, so this is not hiding it. It
+/// keeps a maintainer's home address out of a public repository's *permanent*
+/// history, which is a different and much longer-lived thing than a page that
+/// can be edited. #886 also recorded a preference for a c/o or service address
+/// over the residential one, and nothing here should quietly outrun that.
+///
+/// Structural rather than a search for the address itself: the address must not
+/// be written down in this repository, which is the whole point, so it cannot
+/// be the thing matched on. The owner block runs from a known heading to the
+/// contact-email line, and everything between the name and that line is the
+/// address.
+///
+/// **Throws when the block cannot be recognised.** A silent no-op here would
+/// mean an iubenda wording change quietly commits the address, so the failure
+/// mode is a loud one.
+String redactPostalAddress(String text) {
+  final lines = text.split('\n');
+  final headingIndex = lines.indexWhere(
+    (line) => _ownerHeadings.contains(line.trim()),
+  );
+  if (headingIndex < 0) {
+    throw StateError(
+      'Owner block not found — refusing to write a snapshot that may carry a '
+      'postal address. Headings looked for: $_ownerHeadings',
+    );
+  }
+
+  final contactIndex = lines.indexWhere(
+    (line) => _ownerContactPrefixes.any((p) => line.trim().startsWith(p)),
+    headingIndex,
+  );
+  if (contactIndex < 0) {
+    throw StateError(
+      'Owner contact line not found after the owner heading — refusing to '
+      'write a snapshot that may carry a postal address.',
+    );
+  }
+
+  // Between the heading and the contact line: a blank, the name, then the
+  // address lines. Keep the name, replace the rest.
+  final body = <String>[];
+  for (var i = headingIndex + 1; i < contactIndex; i++) {
+    if (lines[i].trim().isNotEmpty) body.add(lines[i]);
+  }
+  if (body.isEmpty) return text;
+
+  return [
+    ...lines.sublist(0, headingIndex + 1),
+    '',
+    body.first,
+    if (body.length > 1) postalAddressPlaceholder,
+    '',
+    ...lines.sublist(contactIndex),
+  ].join('\n');
+}
+
+/// Purpose ids, from iubenda's fixed taxonomy. Identical in both documents,
+/// which is what makes them usable as a comparison key.
+Set<String> purposeIds(String html) => RegExp(
+  r'iub-purpose-(\d+)',
+).allMatches(html).map((m) => m.group(1)!).toSet();
+
+/// How many service entries sit under each purpose, keyed by purpose id.
+///
+/// Counts rather than ids: `iub-service-<n>` is minted per language, so the
+/// ids differ between the documents even when they describe the same service.
+/// A count is the strongest language-independent claim available — it catches
+/// a service declared in one language and not the other, which is #888.
+Map<String, int> serviceCountsByPurpose(String html) {
+  final counts = <String, int>{};
+  String? current;
+  for (final match in RegExp(
+    r'iub-purpose-(\d+)|iub-service-(\d+)',
+  ).allMatches(html)) {
+    final purpose = match.group(1);
+    if (purpose != null) {
+      current = purpose;
+      counts.putIfAbsent(current, () => 0);
+    } else if (current != null) {
+      counts[current] = counts[current]! + 1;
+    }
+  }
+  return counts;
+}
+
+/// Hosts the document links out to.
+Set<String> linkedHosts(String html) => RegExp(
+  r'href="https?://([^/"]+)',
+).allMatches(html).map((m) => m.group(1)!).toSet();
+
+/// Month names in the two languages the documents are published in, lowercased.
+const _monthNames = <String, int>{
+  'january': 1,
+  'februar': 2,
+  'february': 2,
+  'march': 3,
+  'april': 4,
+  'may': 5,
+  'june': 6,
+  'july': 7,
+  'august': 8,
+  'september': 9,
+  'october': 10,
+  'november': 11,
+  'december': 12,
+  'januar': 1,
+  'märz': 3,
+  'mai': 5,
+  'juni': 6,
+  'juli': 7,
+  'oktober': 10,
+  'dezember': 12,
+};
+
+/// The document's own "last updated" date, as `yyyy-mm-dd`, or null when it
+/// cannot be parsed.
+///
+/// The single most direct signal for #888's failure: one document edited and
+/// the other left behind. The two languages format it differently — *Latest
+/// update: August 27, 2026* against *Letzte Aktualisierung: 27. August 2026* —
+/// so both shapes are parsed rather than compared as strings.
+String? lastUpdated(String html) {
+  final text = htmlToText(html);
+  final match = RegExp(
+    r'(?:Latest update|Letzte Aktualisierung)\s*:\s*([^\n]+)',
+    caseSensitive: false,
+  ).firstMatch(text);
+  if (match == null) return null;
+
+  final value = match.group(1)!.trim();
+  final year = RegExp(r'\b(\d{4})\b').firstMatch(value)?.group(1);
+  final day = RegExp(r'\b(\d{1,2})\b').firstMatch(value)?.group(1);
+  final monthWord = RegExp(
+    r'\b([A-Za-zÄÖÜäöüß]+)\b',
+  ).firstMatch(value)?.group(1);
+  if (year == null || day == null || monthWord == null) return null;
+
+  final month = _monthNames[monthWord.toLowerCase()];
+  if (month == null) return null;
+
+  final dd = day.padLeft(2, '0');
+  final mm = month.toString().padLeft(2, '0');
+  return '$year-$mm-$dd';
+}
+
+/// What the comparison found. Failures fail the build; warnings only report.
+class PolicyComparison {
+  final List<String> failures;
+  final List<String> warnings;
+  final List<String> notes;
+
+  PolicyComparison(this.failures, this.warnings, this.notes);
+
+  @override
+  String toString() => [
+    ...notes.map((n) => '  $n'),
+    ...warnings.map((w) => 'WARN  $w'),
+    ...failures.map((f) => 'FAIL  $f'),
+    failures.isEmpty
+        ? 'Both documents agree on everything checked.'
+        : '${failures.length} divergence(s).',
+  ].join('\n');
+}
+
+/// Compares the two rendered documents.
+///
+/// Only things the maintainer can actually fix are failures. iubenda's own
+/// template text differs between its languages in places — measured
+/// 2026-08-27, the English App Store Connect section links
+/// `support.apple.com` for opt-out guidance and the German one omits the whole
+/// sentence — and failing a build over a vendor's translation would be a check
+/// nobody can satisfy. Those surface as warnings, and the committed snapshots
+/// are what make them reviewable.
+PolicyComparison comparePolicies(String enHtml, String deHtml) {
+  final failures = <String>[];
+  final warnings = <String>[];
+  final notes = <String>[];
+
+  final enPurposes = purposeIds(enHtml);
+  final dePurposes = purposeIds(deHtml);
+  notes.add('purposes: ${enPurposes.length} en, ${dePurposes.length} de');
+  if (enPurposes.length != dePurposes.length ||
+      !enPurposes.containsAll(dePurposes)) {
+    failures.add(
+      'purpose sets differ — en only: ${_sorted(enPurposes.difference(dePurposes))}, '
+      'de only: ${_sorted(dePurposes.difference(enPurposes))}',
+    );
+  }
+
+  final enServices = serviceCountsByPurpose(enHtml);
+  final deServices = serviceCountsByPurpose(deHtml);
+  notes.add('services: ${_total(enServices)} en, ${_total(deServices)} de');
+  for (final purpose in {...enServices.keys, ...deServices.keys}) {
+    final en = enServices[purpose] ?? 0;
+    final de = deServices[purpose] ?? 0;
+    if (en != de) {
+      failures.add(
+        'purpose $purpose declares $en service(s) in English and $de in German',
+      );
+    }
+  }
+
+  final enUpdated = lastUpdated(enHtml);
+  final deUpdated = lastUpdated(deHtml);
+  notes.add(
+    'last updated: ${enUpdated ?? "unparsed"} en, ${deUpdated ?? "unparsed"} de',
+  );
+  if (enUpdated == null || deUpdated == null) {
+    warnings.add(
+      'could not parse a last-updated date from both documents; the date '
+      'wording or format may have changed',
+    );
+  } else if (enUpdated != deUpdated) {
+    failures.add(
+      'last updated $enUpdated in English but $deUpdated in German — one '
+      'document was edited without the other',
+    );
+  }
+
+  final hostDifferences = linkedHosts(enHtml)
+      .difference(linkedHosts(deHtml))
+      .union(linkedHosts(deHtml).difference(linkedHosts(enHtml)));
+  if (hostDifferences.isNotEmpty) {
+    warnings.add(
+      'linked hosts differ: ${_sorted(hostDifferences)} — check whether this is '
+      'iubenda template text or a clause of ours that only reached one language',
+    );
+  }
+
+  return PolicyComparison(failures, warnings, notes);
+}
+
+String _sorted(Set<String> values) => (values.toList()..sort()).join(', ');
+
+int _total(Map<String, int> counts) =>
+    counts.values.fold(0, (sum, value) => sum + value);


### PR DESCRIPTION
#887's other half. It also captures the **"before" snapshot** of both documents — which is only available until you paste the corrected clauses, and is the reason this came forward rather than waiting for a later release.

## Two jobs, one fetch

**The change record.** iubenda keeps no version history and offers no "what changed" view (#871). Committing the rendered text makes git that record.

**The drift guard.** Every clause in this policy is custom, and custom clauses do not propagate between languages in iubenda — #888 caught the German document left behind in exactly that way, and #918 was the same failure in the app's own strings. A check that needs no discipline beats one that relies on someone being conscientious.

## What can actually be compared

The API returns the **rendered document, not the configuration**, so everything is derived from HTML. Only signals that survive translation are usable, and working out which those are was most of the work:

| Signal | Usable? | Why |
| :-- | :-- | :-- |
| `iub-purpose-<n>` | **yes** | iubenda's fixed taxonomy — `{16, 25, 30, 42, 46, 61}` in both documents |
| `iub-service-<n>` | **no** | minted per language: `13427280` against `13427279` |
| services per purpose | **yes** | a count is language-independent, and catches a service declared in one language only |
| last-updated date | **yes** | parsed from both *"Latest update: August 27, 2026"* and *"Letzte Aktualisierung: 27. August 2026"* |
| linked hosts | **warn only** | see below |

The date check is the most direct signal for #888's failure: the two documents disagreeing about when they were last touched.

## Why linked hosts only warn

Because it already fires, and the cause is not fixable here. Measured today: the **English** App Store Connect section links `support.apple.com` for opt-out guidance and the **German** one omits the sentence entirely. That is iubenda's own template text, in its own translation.

A check nobody can satisfy is a check that gets ignored, so it reports rather than fails. The committed snapshots are what make it reviewable — a genuinely new divergence shows up in the diff regardless.

## The postal address is redacted

The snapshot would otherwise put your home address into this repository's **permanent** history. It is on the published page already, so nothing is being hidden — but an editable page and a git history are different things, and #886 recorded a preference for a c/o address over the residential one. Say the word if you would rather it went in verbatim.

The redaction is **structural** — it finds the owner block between its heading and the contact line — because the address must not be written down here, so it cannot be the thing matched on. And it **throws rather than writing a snapshot it could not redact**: a silent no-op after an iubenda wording change would commit the address on the next run. That failure mode has its own test.

## Where it runs, and why not where you would expect

Workflow files only take effect on the default branch, so nothing here runs until it reaches `main`. That is also why **the first snapshot is committed from a local run** — CI could not have captured the before-state in time.

And a scheduled run fires on `main`, which `CONTRIBUTING.md:14` reserves for release merges. So the job checks out and commits to **`develop`** explicitly rather than to its triggering ref.

On a pull request it runs `--check` only and commits nothing — the branch is not necessarily ours, and a bot commit would rewrite a contributor's PR.

## Verification

Full suite green (1123). 16 tests on the parsing and comparison, against fixtures rather than the network — the live check belongs in CI, and a unit test depending on a third party fails for reasons that have nothing to do with this code.

Run against the live documents just now:

```
purposes: 6 en, 6 de
services: 8 en, 8 de
last updated: 2026-08-27 en, 2026-08-27 de
WARN  linked hosts differ: support.apple.com
Both documents agree on everything checked.
```

No secrets — the read API is public and unauthenticated.
