### PR TITLE
fix(core): stop the health-import tombstone list growing forever

### DIFF
--- a/lib/core/data/data_source/config_data_source.dart
+++ b/lib/core/data/data_source/config_data_source.dart
@@ -60,6 +60,7 @@ class ConfigDataSource {
       merged.healthWorkoutKcalMultiplier = profile.healthWorkoutKcalMultiplier;
       merged.healthLastImportAt = profile.healthLastImportAt;
       merged.healthDeletedExternalIds = profile.healthDeletedExternalIds;
+      merged.healthDeletedWorkouts = profile.healthDeletedWorkouts;
     } else {
       // Explicitly clear personal fields so they don't leak from the
       // app box after a profile reset. A fresh profile therefore reads as
@@ -75,6 +76,7 @@ class ConfigDataSource {
       merged.healthWorkoutKcalMultiplier = null;
       merged.healthLastImportAt = null;
       merged.healthDeletedExternalIds = null;
+      merged.healthDeletedWorkouts = null;
     }
     return merged;
   }
@@ -332,15 +334,63 @@ class ConfigDataSource {
     await _update((c) => c.healthLastImportAt = importedAt);
   }
 
-  /// Records that the imported workout behind [externalId] was deleted, so
-  /// the importer stops re-creating it. Appends into a fresh list so Hive
-  /// sees a distinct object reference on save.
-  Future<void> addConfigHealthDeletedExternalId(String externalId) async {
+  /// Records that the imported workout behind [externalId], which started at
+  /// [startedAt], was deleted — so the importer stops re-creating it.
+  ///
+  /// [startedAt] is the workout's own start time rather than the moment of
+  /// deletion, because it is what the import window is compared against: the
+  /// tombstone stops being useful when the *workout* falls out of range, not
+  /// when the deletion does. Writes a fresh map so Hive sees a distinct object
+  /// reference on save.
+  Future<void> addConfigHealthDeletedWorkout(
+    String externalId,
+    DateTime startedAt,
+  ) async {
     await _update((c) {
-      final current = c.healthDeletedExternalIds;
-      if (current != null && current.contains(externalId)) return;
-      c.healthDeletedExternalIds = <String>[...?current, externalId];
+      final current = _mergedDeletedWorkouts(c);
+      if (current[externalId] == startedAt) return;
+      c.healthDeletedWorkouts = {...current, externalId: startedAt};
+      c.healthDeletedExternalIds = null;
     });
+  }
+
+  /// Drops tombstones for workouts that started before [cutoff].
+  ///
+  /// Those can never match again — the platform will not return them for any
+  /// window a future import asks for — so they are dead weight rather than
+  /// protection. See `ConfigEntity.oldestUsefulTombstone` for how the caller
+  /// arrives at [cutoff]. A no-op when nothing is stale, so the common case
+  /// costs no write.
+  Future<void> pruneConfigHealthDeletedWorkouts(DateTime cutoff) async {
+    await _update((c) {
+      final current = _mergedDeletedWorkouts(c);
+      final kept = <String, DateTime>{
+        for (final entry in current.entries)
+          if (!entry.value.isBefore(cutoff)) entry.key: entry.value,
+      };
+      if (kept.length == current.length && c.healthDeletedExternalIds == null) {
+        return;
+      }
+      c.healthDeletedWorkouts = kept;
+      c.healthDeletedExternalIds = null;
+    });
+  }
+
+  /// The dated tombstones, with any undated legacy ids folded in.
+  ///
+  /// Before #768 a tombstone was an id with no date, so there is nothing to
+  /// compare a legacy entry against. It is dated *now* instead, which keeps it
+  /// for one more full window and then lets it drain — erring toward keeping a
+  /// deletion honoured, which is the direction that cannot annoy anyone.
+  ///
+  /// Only pre-release installs can carry any: #651 has not shipped. This can
+  /// be deleted once 2.1.0 is out and no dev build predates it.
+  static Map<String, DateTime> _mergedDeletedWorkouts(ConfigDBO config) {
+    final dated = config.healthDeletedWorkouts ?? const <String, DateTime>{};
+    final legacy = config.healthDeletedExternalIds;
+    if (legacy == null || legacy.isEmpty) return dated;
+    final now = DateTime.now();
+    return {for (final id in legacy) id: now, ...dated};
   }
 
   Future<ConfigDBO> getConfig() async => _readMerged();

--- a/lib/core/data/dbo/config_dbo.dart
+++ b/lib/core/data/dbo/config_dbo.dart
@@ -150,8 +150,23 @@ class ConfigDBO extends HiveObject {
   // over again. Kept indefinitely — it only grows by one entry per deletion,
   // and forgetting an entry resurrects the workout it stands for. Null means
   // nothing has been deleted.
+  // Superseded by [healthDeletedWorkouts], which carries the date each
+  // tombstone needs in order to be prunable. Read once and folded into the
+  // new field, then cleared — see `ConfigDataSource._migrateDeletedWorkouts`.
+  // Only pre-release installs can have anything here; #651 has not shipped.
   @HiveField(36)
   List<String>? healthDeletedExternalIds;
+  // External record ids of imported workouts the user deleted, mapped to the
+  // workout's own start time. The importer skips them, so a deletion sticks
+  // instead of being undone by the next overlapping read.
+  //
+  // The date is what makes this boundable (#768). A tombstone is only ever
+  // consulted against workouts the platform returns for the import window, so
+  // once its workout falls outside the widest window any future run could ask
+  // for, it can never match again and is dropped. Without a date the list grew
+  // with the lifetime of the install rather than with recent activity.
+  @HiveField(38)
+  Map<String, DateTime>? healthDeletedWorkouts;
   // Which revision of the privacy policy the user has been *shown a notice
   // about* — not which one they accepted, which `hasAcceptedPolicy` cannot
   // answer because it is an unversioned bool (#887).
@@ -203,6 +218,7 @@ class ConfigDBO extends HiveObject {
     this.healthLastImportAt,
     this.healthDeletedExternalIds,
     this.policyNoticeRevisionSeen,
+    this.healthDeletedWorkouts,
   });
 
   factory ConfigDBO.empty() =>

--- a/lib/core/data/dbo/config_dbo.g.dart
+++ b/lib/core/data/dbo/config_dbo.g.dart
@@ -52,6 +52,7 @@ class ConfigDBOAdapter extends TypeAdapter<ConfigDBO> {
         healthLastImportAt: fields[35] as DateTime?,
         healthDeletedExternalIds: (fields[36] as List?)?.cast<String>(),
         policyNoticeRevisionSeen: (fields[37] as num?)?.toInt(),
+        healthDeletedWorkouts: (fields[38] as Map?)?.cast<String, DateTime>(),
       )
       ..userCarbGoalPct = (fields[6] as num?)?.toDouble()
       ..userProteinGoalPct = (fields[7] as num?)?.toDouble()
@@ -61,7 +62,7 @@ class ConfigDBOAdapter extends TypeAdapter<ConfigDBO> {
   @override
   void write(BinaryWriter writer, ConfigDBO obj) {
     writer
-      ..writeByte(38)
+      ..writeByte(39)
       ..writeByte(0)
       ..write(obj.hasAcceptedDisclaimer)
       ..writeByte(1)
@@ -137,7 +138,9 @@ class ConfigDBOAdapter extends TypeAdapter<ConfigDBO> {
       ..writeByte(36)
       ..write(obj.healthDeletedExternalIds)
       ..writeByte(37)
-      ..write(obj.policyNoticeRevisionSeen);
+      ..write(obj.policyNoticeRevisionSeen)
+      ..writeByte(38)
+      ..write(obj.healthDeletedWorkouts);
   }
 
   @override
@@ -207,6 +210,10 @@ ConfigDBO _$ConfigDBOFromJson(Map<String, dynamic> json) =>
                 .toList(),
         policyNoticeRevisionSeen: (json['policyNoticeRevisionSeen'] as num?)
             ?.toInt(),
+        healthDeletedWorkouts:
+            (json['healthDeletedWorkouts'] as Map<String, dynamic>?)?.map(
+              (k, e) => MapEntry(k, DateTime.parse(e as String)),
+            ),
       )
       ..userCarbGoalPct = (json['userCarbGoalPct'] as num?)?.toDouble()
       ..userProteinGoalPct = (json['userProteinGoalPct'] as num?)?.toDouble()
@@ -250,6 +257,9 @@ Map<String, dynamic> _$ConfigDBOToJson(ConfigDBO instance) => <String, dynamic>{
   'healthWorkoutKcalMultiplier': instance.healthWorkoutKcalMultiplier,
   'healthLastImportAt': instance.healthLastImportAt?.toIso8601String(),
   'healthDeletedExternalIds': instance.healthDeletedExternalIds,
+  'healthDeletedWorkouts': instance.healthDeletedWorkouts?.map(
+    (k, e) => MapEntry(k, e.toIso8601String()),
+  ),
   'policyNoticeRevisionSeen': instance.policyNoticeRevisionSeen,
 };
 

--- a/lib/core/data/repository/config_repository.dart
+++ b/lib/core/data/repository/config_repository.dart
@@ -196,7 +196,17 @@ class ConfigRepository {
     await _configDataSource.setConfigHealthLastImportAt(importedAt);
   }
 
-  Future<void> addConfigHealthDeletedExternalId(String externalId) async {
-    await _configDataSource.addConfigHealthDeletedExternalId(externalId);
+  Future<void> addConfigHealthDeletedWorkout(
+    String externalId,
+    DateTime startedAt,
+  ) async {
+    await _configDataSource.addConfigHealthDeletedWorkout(
+      externalId,
+      startedAt,
+    );
+  }
+
+  Future<void> pruneConfigHealthDeletedWorkouts(DateTime cutoff) async {
+    await _configDataSource.pruneConfigHealthDeletedWorkouts(cutoff);
   }
 }

--- a/lib/core/domain/entity/config_entity.dart
+++ b/lib/core/domain/entity/config_entity.dart
@@ -109,10 +109,62 @@ class ConfigEntity extends Equatable {
   /// [healthImportBackfillDays] on the first run).
   final DateTime? healthLastImportAt;
 
-  /// External record ids of imported workouts the user deleted. The importer
-  /// skips them, so a deletion sticks instead of being undone by the next
-  /// overlapping read. Empty when nothing has been deleted.
-  final Set<String> healthDeletedExternalIds;
+  /// External record ids of imported workouts the user deleted, mapped to the
+  /// workout's own start time. The importer skips them, so a deletion sticks
+  /// instead of being undone by the next overlapping read. Empty when nothing
+  /// has been deleted.
+  ///
+  /// The date is what bounds the list (#768): see
+  /// [oldestUsefulTombstone] for the instant before which a tombstone can
+  /// never match again.
+  final Map<String, DateTime> healthDeletedWorkouts;
+
+  /// Undated tombstones from before #768, which only a pre-release install can
+  /// have. Kept separate rather than given an invented date, so that mapping a
+  /// stored config into an entity stays a pure function of that config.
+  ///
+  /// They are folded into the dated map — and cleared — by the next write
+  /// through `ConfigDataSource`. Until then they still have to be *visible*,
+  /// which is what [healthDeletedExternalIds] is for: a read path that ignored
+  /// them would re-import every workout the user had already deleted.
+  final Set<String> legacyHealthDeletedExternalIds;
+
+  /// Every id the importer must skip, dated or not. All its dedupe set needs.
+  Set<String> get healthDeletedExternalIds => {
+    ...healthDeletedWorkouts.keys,
+    ...legacyHealthDeletedExternalIds,
+  };
+
+  /// The earliest instant any future import could ask the platform about, and
+  /// therefore the point before which a tombstone is dead weight rather than
+  /// protection.
+  ///
+  /// Two windows have to be survivable, so this is the earlier of them:
+  ///
+  ///  * the window the *next* run will use — [healthLastImportAt] pushed back
+  ///    by the importer's overlap tolerance;
+  ///  * a full backfill, which is what a run with no watermark asks for.
+  ///
+  /// The watermark only ever moves forward, so the first of those advances and
+  /// the list drains. The second is the floor: if a watermark were ever lost
+  /// without the tombstones going with it, the next run would reach back
+  /// [healthImportBackfillDays] and needs its tombstones intact. Taking the
+  /// earlier of the two costs a few stale entries and cannot prune one that is
+  /// still doing work.
+  static DateTime oldestUsefulTombstone({
+    required DateTime now,
+    required DateTime? lastImportAt,
+    required Duration overlapTolerance,
+  }) {
+    final backfillFloor = now
+        .subtract(const Duration(days: healthImportBackfillDays))
+        .subtract(overlapTolerance);
+    if (lastImportAt == null) return backfillFloor;
+    final nextWindowStart = lastImportAt.subtract(overlapTolerance);
+    return nextWindowStart.isBefore(backfillFloor)
+        ? nextWindowStart
+        : backfillFloor;
+  }
 
   /// Which revision of the privacy policy the user has been shown a *notice*
   /// about. Zero for every install that predates the field, which is exactly
@@ -208,7 +260,8 @@ class ConfigEntity extends Equatable {
     this.healthImportEnabled = false,
     this.healthWorkoutKcalMultiplier,
     this.healthLastImportAt,
-    this.healthDeletedExternalIds = const <String>{},
+    this.healthDeletedWorkouts = const <String, DateTime>{},
+    this.legacyHealthDeletedExternalIds = const <String>{},
     this.policyNoticeRevisionSeen = 0,
   });
 
@@ -325,7 +378,10 @@ class ConfigEntity extends Equatable {
     ),
     healthLastImportAt: dbo.healthLastImportAt,
     policyNoticeRevisionSeen: dbo.policyNoticeRevisionSeen ?? 0,
-    healthDeletedExternalIds: dbo.healthDeletedExternalIds != null
+    healthDeletedWorkouts: dbo.healthDeletedWorkouts != null
+        ? Map<String, DateTime>.from(dbo.healthDeletedWorkouts!)
+        : const <String, DateTime>{},
+    legacyHealthDeletedExternalIds: dbo.healthDeletedExternalIds != null
         ? Set<String>.from(dbo.healthDeletedExternalIds!)
         : const <String>{},
   );
@@ -429,7 +485,8 @@ class ConfigEntity extends Equatable {
     healthImportEnabled,
     healthWorkoutKcalMultiplier,
     healthLastImportAt,
-    healthDeletedExternalIds,
+    healthDeletedWorkouts,
+    legacyHealthDeletedExternalIds,
     policyNoticeRevisionSeen,
   ];
 }

--- a/lib/core/domain/usecase/delete_user_activity_usecase.dart
+++ b/lib/core/domain/usecase/delete_user_activity_usecase.dart
@@ -18,7 +18,14 @@ class DeleteUserActivityUsecase {
       // The importer dedupes against the activities on file, and its window
       // deliberately overlaps the last one — so a deleted workout would be
       // read again and filed again. Remember that this record is unwanted.
-      await _configRepository.addConfigHealthDeletedExternalId(externalId);
+      //
+      // The activity's date is the workout's own start time, which is what
+      // lets the tombstone be dropped once that workout falls outside any
+      // window a future import will ask for (#768).
+      await _configRepository.addConfigHealthDeletedWorkout(
+        externalId,
+        activityEntity.date,
+      );
     }
   }
 }

--- a/lib/core/domain/usecase/import_workouts_usecase.dart
+++ b/lib/core/domain/usecase/import_workouts_usecase.dart
@@ -162,6 +162,18 @@ class ImportWorkoutsUsecase {
     // Written even when nothing was imported: the watermark is also what
     // debounces the next run, and an empty window is still a window covered.
     await _configRepository.setConfigHealthLastImportAt(to);
+
+    // Drop tombstones whose workouts can no longer be returned by any window
+    // a future run will ask for (#768). Done here rather than on deletion
+    // because this is where the window is already known, and after the
+    // watermark is written so the cutoff reflects the run that just finished.
+    await _configRepository.pruneConfigHealthDeletedWorkouts(
+      ConfigEntity.oldestUsefulTombstone(
+        now: to,
+        lastImportAt: to,
+        overlapTolerance: overlapTolerance,
+      ),
+    );
     if (imported > 0) {
       _log.info('Imported $imported workout(s) from the platform health store');
     }

--- a/test/unit_test/config_health_fields_test.dart
+++ b/test/unit_test/config_health_fields_test.dart
@@ -178,23 +178,25 @@ void main() {
     });
 
     test('deletion tombstones stay with the profile that made them', () async {
+      final first = DateTime(2026, 5, 23, 7);
+      final second = DateTime(2026, 5, 24, 18);
       final profileA = sourceFor(profileABox);
       await profileA.initializeConfig();
-      await profileA.addConfigHealthDeletedExternalId('record-1');
-      // Recording the same deletion twice must not grow the list.
-      await profileA.addConfigHealthDeletedExternalId('record-1');
-      await profileA.addConfigHealthDeletedExternalId('record-2');
+      await profileA.addConfigHealthDeletedWorkout('record-1', first);
+      // Recording the same deletion twice must not grow the map.
+      await profileA.addConfigHealthDeletedWorkout('record-1', first);
+      await profileA.addConfigHealthDeletedWorkout('record-2', second);
 
       final profileB = sourceFor(profileBBox);
       await profileB.initializeConfig();
 
       expect(
-        (await profileA.getConfig()).healthDeletedExternalIds,
-        equals(<String>['record-1', 'record-2']),
+        (await profileA.getConfig()).healthDeletedWorkouts,
+        equals(<String, DateTime>{'record-1': first, 'record-2': second}),
       );
       // The other profile never imported that workout, so it has nothing to
       // remember about it either.
-      expect((await profileB.getConfig()).healthDeletedExternalIds, isNull);
+      expect((await profileB.getConfig()).healthDeletedWorkouts, isNull);
     });
 
     test(

--- a/test/unit_test/health_tombstone_pruning_test.dart
+++ b/test/unit_test/health_tombstone_pruning_test.dart
@@ -1,0 +1,293 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:hive_ce/hive.dart';
+import 'package:opennutritracker/core/data/data_source/config_data_source.dart';
+import 'package:opennutritracker/core/data/dbo/app_theme_dbo.dart';
+import 'package:opennutritracker/core/data/dbo/config_dbo.dart';
+import 'package:opennutritracker/core/domain/entity/config_entity.dart';
+import 'package:opennutritracker/core/domain/usecase/import_workouts_usecase.dart';
+
+import '../helpers/fake_hive_db_provider.dart';
+import '../helpers/hive_test_setup.dart';
+
+/// Bounding the deletion tombstone list (#768).
+///
+/// A tombstone exists so a deleted workout is not re-imported by the next
+/// overlapping read. It stops being useful the moment its workout falls
+/// outside any window a future import could ask for — and the risk in pruning
+/// is dropping one that is still doing work, so the boundary is where the
+/// tests are concentrated.
+void main() {
+  const overlap = ImportWorkoutsUsecase.overlapTolerance;
+  final now = DateTime(2026, 8, 27, 12);
+
+  group('the instant before which a tombstone is dead weight', () {
+    test('with no watermark it is a full backfill plus the overlap', () {
+      // What a first run asks for, so nothing inside it may be pruned.
+      final cutoff = ConfigEntity.oldestUsefulTombstone(
+        now: now,
+        lastImportAt: null,
+        overlapTolerance: overlap,
+      );
+
+      expect(
+        cutoff,
+        now
+            .subtract(
+              const Duration(days: ConfigEntity.healthImportBackfillDays),
+            )
+            .subtract(overlap),
+      );
+    });
+
+    test('a recent watermark does not raise the cutoff above the floor', () {
+      // The next run only needs 24 hours back, but a watermark that was lost
+      // without its tombstones would send the run after that on a full
+      // backfill. Keeping the floor costs a few stale entries; ignoring it
+      // would resurrect deleted workouts.
+      final cutoff = ConfigEntity.oldestUsefulTombstone(
+        now: now,
+        lastImportAt: now,
+        overlapTolerance: overlap,
+      );
+
+      expect(cutoff, now.subtract(const Duration(days: 31)));
+    });
+
+    test('a watermark older than the floor lowers the cutoff to it', () {
+      // Health import switched off for months, then back on: the next window
+      // reaches back to that old watermark, and every tombstone inside it is
+      // still protecting something.
+      final stale = now.subtract(const Duration(days: 120));
+
+      final cutoff = ConfigEntity.oldestUsefulTombstone(
+        now: now,
+        lastImportAt: stale,
+        overlapTolerance: overlap,
+      );
+
+      expect(cutoff, stale.subtract(overlap));
+    });
+
+    test('the cutoff never sits after the start of the next window', () {
+      // The property that matters, stated directly: whatever the watermark,
+      // a workout the next run can still see must not have been pruned.
+      for (final watermark in <DateTime?>[
+        null,
+        now,
+        now.subtract(const Duration(hours: 1)),
+        now.subtract(const Duration(days: 5)),
+        now.subtract(const Duration(days: 31)),
+        now.subtract(const Duration(days: 400)),
+      ]) {
+        final nextWindowStart =
+            (watermark ??
+                    now.subtract(
+                      const Duration(
+                        days: ConfigEntity.healthImportBackfillDays,
+                      ),
+                    ))
+                .subtract(overlap);
+        final cutoff = ConfigEntity.oldestUsefulTombstone(
+          now: now,
+          lastImportAt: watermark,
+          overlapTolerance: overlap,
+        );
+
+        expect(
+          cutoff.isAfter(nextWindowStart),
+          isFalse,
+          reason:
+              'watermark $watermark: cutoff $cutoff would prune a tombstone '
+              'the next window ($nextWindowStart onwards) still needs',
+        );
+      }
+    });
+  });
+
+  group('pruning against a live config box', () {
+    late Box<ConfigDBO> appBox;
+    late Box<ConfigDBO> profileBox;
+    late ConfigDataSource source;
+
+    setUpAll(() {
+      TestWidgetsFlutterBinding.ensureInitialized();
+      registerHiveAdaptersOnce();
+    });
+
+    setUp(() async {
+      Hive.init('.');
+      appBox = await Hive.openBox<ConfigDBO>('tombstone_app_test');
+      profileBox = await Hive.openBox<ConfigDBO>('tombstone_profile_test');
+      await appBox.clear();
+      await profileBox.clear();
+      source = ConfigDataSource(
+        FakeHiveDBProvider(configBox: profileBox, appConfigBox: appBox),
+      );
+      await source.initializeConfig();
+    });
+
+    tearDown(() async {
+      await Hive.close();
+      await Hive.deleteFromDisk();
+    });
+
+    test('a tombstone older than the cutoff is dropped', () async {
+      await source.addConfigHealthDeletedWorkout(
+        'ancient',
+        now.subtract(const Duration(days: 200)),
+      );
+      await source.addConfigHealthDeletedWorkout(
+        'recent',
+        now.subtract(const Duration(hours: 3)),
+      );
+
+      await source.pruneConfigHealthDeletedWorkouts(
+        now.subtract(const Duration(days: 31)),
+      );
+
+      final config = await source.getConfig();
+      expect(config.healthDeletedWorkouts?.keys, ['recent']);
+    });
+
+    test('a tombstone exactly on the cutoff is kept', () async {
+      // The window is inclusive of its start, so an entry sitting on the
+      // boundary can still be returned by the next read.
+      final cutoff = now.subtract(const Duration(days: 31));
+      await source.addConfigHealthDeletedWorkout('on-the-line', cutoff);
+
+      await source.pruneConfigHealthDeletedWorkouts(cutoff);
+
+      final config = await source.getConfig();
+      expect(config.healthDeletedWorkouts?.keys, ['on-the-line']);
+    });
+
+    test('pruning with nothing stale leaves the map alone', () async {
+      await source.addConfigHealthDeletedWorkout('a', now);
+      await source.addConfigHealthDeletedWorkout('b', now);
+
+      await source.pruneConfigHealthDeletedWorkouts(
+        now.subtract(const Duration(days: 31)),
+      );
+
+      final config = await source.getConfig();
+      expect(config.healthDeletedWorkouts, hasLength(2));
+    });
+
+    test('the same deletion recorded twice does not grow the map', () async {
+      final started = DateTime(2026, 8, 1, 9);
+      await source.addConfigHealthDeletedWorkout('dup', started);
+      await source.addConfigHealthDeletedWorkout('dup', started);
+
+      final config = await source.getConfig();
+      expect(config.healthDeletedWorkouts, hasLength(1));
+    });
+  });
+
+  group('the undated ids a pre-release install may carry', () {
+    late Box<ConfigDBO> appBox;
+    late Box<ConfigDBO> profileBox;
+    late ConfigDataSource source;
+
+    setUpAll(() {
+      TestWidgetsFlutterBinding.ensureInitialized();
+      registerHiveAdaptersOnce();
+    });
+
+    setUp(() async {
+      Hive.init('.');
+      appBox = await Hive.openBox<ConfigDBO>('tombstone_legacy_app_test');
+      profileBox = await Hive.openBox<ConfigDBO>('tombstone_legacy_test');
+      await appBox.clear();
+      await profileBox.clear();
+      source = ConfigDataSource(
+        FakeHiveDBProvider(configBox: profileBox, appConfigBox: appBox),
+      );
+    });
+
+    tearDown(() async {
+      await Hive.close();
+      await Hive.deleteFromDisk();
+    });
+
+    Future<void> seedLegacy(List<String> ids) async {
+      final dbo = ConfigDBO(
+        false,
+        true,
+        false,
+        AppThemeDBO.system,
+        healthDeletedExternalIds: ids,
+      );
+      await appBox.put('ConfigKey', ConfigDBO.fromJson(dbo.toJson()));
+      await profileBox.put('ConfigKey', ConfigDBO.fromJson(dbo.toJson()));
+    }
+
+    test('an undated id survives the move to dated tombstones', () async {
+      // Before #768 a tombstone was an id and nothing else. Dropping them on
+      // upgrade would resurrect workouts the user had already deleted.
+      await seedLegacy(['legacy-1', 'legacy-2']);
+
+      await source.addConfigHealthDeletedWorkout('new-one', now);
+
+      final config = await source.getConfig();
+      expect(
+        config.healthDeletedWorkouts?.keys,
+        containsAll(<String>['legacy-1', 'legacy-2', 'new-one']),
+      );
+      expect(
+        config.healthDeletedExternalIds,
+        isNull,
+        reason: 'the legacy list should be cleared once it has been folded in',
+      );
+    });
+
+    test('an undated id is not pruned immediately', () async {
+      // It is dated "now" because there is nothing to date it from, which
+      // keeps it for one more full window and then lets it drain. Erring
+      // toward honouring the deletion is the direction that cannot annoy.
+      await seedLegacy(['legacy-1']);
+
+      await source.pruneConfigHealthDeletedWorkouts(
+        DateTime.now().subtract(const Duration(days: 31)),
+      );
+
+      final config = await source.getConfig();
+      expect(config.healthDeletedWorkouts?.keys, ['legacy-1']);
+    });
+
+    test('the importer sees legacy ids before any write migrates them', () {
+      // The migration happens on the next write, so a read that ignored the
+      // undated list would let the importer re-file every workout the user had
+      // already deleted — the exact bug the tombstones exist to prevent.
+      final config = ConfigEntity.fromConfigDBO(
+        ConfigDBO(
+          false,
+          true,
+          false,
+          AppThemeDBO.system,
+          healthDeletedExternalIds: ['legacy-1', 'legacy-2'],
+        ),
+      );
+
+      // ImportWorkoutsUsecase reads exactly this.
+      expect(
+        config.healthDeletedExternalIds,
+        containsAll(<String>['legacy-1', 'legacy-2']),
+      );
+    });
+
+    test('dated and undated ids are both visible at once', () {
+      final config = ConfigEntity.fromConfigDBO(
+        ConfigDBO(
+          false,
+          true,
+          false,
+          AppThemeDBO.system,
+          healthDeletedExternalIds: ['legacy-1'],
+          healthDeletedWorkouts: {'dated-1': now},
+        ),
+      );
+
+      expect(config.healthDeletedExternalIds, {'legacy-1', 'dated-1'});
+    });
+  });
+}


### PR DESCRIPTION
Closes #768.

## The shape of the fix

A tombstone is only ever consulted against workouts the platform returns for the import window. Once its workout falls outside the widest window any future run could ask for, it can **never match again** — dead weight rather than protection.

That needs a date, which the tombstone did not carry. It now maps id → the workout's **own start time**. The start, not the moment of deletion: the start is what the window is compared against, so a workout deleted today but recorded last year is prunable immediately.

## Where the cutoff comes from

`ConfigEntity.oldestUsefulTombstone` takes the **earlier** of two instants:

- the window the next run will use — `healthLastImportAt` pushed back by `overlapTolerance`;
- a full backfill, `healthImportBackfillDays` plus the overlap.

The watermark only ever moves forward, so the first advances and the list drains. The second is the **floor**: if a watermark were ever lost without its tombstones going with it, the next run reaches back a full backfill and needs them intact. Taking the earlier of the two costs a handful of stale entries and cannot prune one that is still doing work.

That property is asserted directly rather than by example — a loop over six watermark shapes, including none at all and one 400 days old, checks that the cutoff never sits after the start of the next window.

## Where the prune runs

In the importer, where the window is already known, and **after** the watermark is written so the cutoff reflects the run that just finished. Pruning before that write would have dropped tombstones the run itself still needed — the ordering is load-bearing, not incidental.

It is a no-op when nothing is stale, so the common case costs no write.

## The undated ids

Field 36 stays, read as legacy. Only a pre-release install can carry any, since #651 has not shipped.

I nearly got this wrong: the migration happens on the next *write*, so a read path that ignored field 36 would let the importer re-file every workout the user had already deleted — the exact bug tombstones exist to prevent. Writing the test is what surfaced it. The entity now unions the undated ids into what the importer sees, and the next write folds them into the dated map and clears the old field.

They are dated "now" because there is nothing to date them from, which keeps them one more full window and then lets them drain — erring toward honouring a deletion, the direction that cannot annoy anyone. The whole legacy path can be deleted once 2.1.0 is out and no dev build predates it.

## Verification

Full suite green (1147). Three mutations, each caught by the test that should catch it:

| Mutation | Test that failed |
| :-- | :-- |
| pruning keeps everything | `a tombstone older than the cutoff is dropped` |
| cutoff ignores the backfill floor | `a recent watermark does not raise the cutoff above the floor` |
| read path drops legacy ids | `the importer sees legacy ids before any write migrates them` |

Boundary case included: a tombstone sitting exactly on the cutoff is kept, because the window is inclusive of its start.

## Scope

Nothing user-visible, and nothing was broken before this — as #768 says, someone would have to delete a great many imported workouts for the old behaviour to be measurable. It is worth doing before the list has years to grow rather than after, and #651 has not shipped yet, so this lands before any real install has a tombstone at all.
