### PR TITLE
docs(core): say what the policy revision constant does not prove

### DIFF
--- a/lib/core/utils/url_const.dart
+++ b/lib/core/utils/url_const.dart
@@ -30,11 +30,17 @@ class URLConst {
   /// to every existing user on their next launch, and a notice that cries wolf
   /// is worth less than no notice at all.
   ///
-  /// Revision 1 is the correction that followed the audit in #867: recipients
-  /// that were always receiving data got named, a health-data section was
-  /// added for the Health Connect / Apple Health import, and an approximate
-  /// location the Supabase gateway keeps for a day was disclosed. None of it
-  /// changed what the app does.
+  /// Revision 1 is the correction that follows the audit in #867: recipients
+  /// that were always receiving data get named, a health-data section is added
+  /// for the Health Connect / Apple Health import, and an approximate location
+  /// the Supabase gateway keeps for a day is disclosed. None of it changes what
+  /// the app does.
+  ///
+  /// Those edits are drafted in #915, #919 and #920 and are applied by hand in
+  /// iubenda, so this constant records which revision the app *claims*, not
+  /// which one is published. Both documents have to carry the edits before a
+  /// build with this value ships, or the notice sends people to a policy that
+  /// still reads the old way. `tool/policy_snapshot.dart` is what confirms it.
   static const policyRevision = 1;
 
   // Citations for the in-app medical/health calculations. Surfaced on the


### PR DESCRIPTION
## Summary

The doc comment on `URLConst.policyRevision` described revision 1 in the past tense — "recipients … **got** named, a health-data section **was** added, an approximate location **was** disclosed" — for edits that exist only as drafts in #915, #919 and #920.

The iubenda documents are edited by hand in iubenda's own UI. Nothing in this repository can make that sentence true, and no code change ever will. Read as evidence that the published policy covers health data, the comment is simply wrong.

That matters more than a stale comment usually would, because this is exactly the claim someone verifies by reading the code rather than the policy — which is how the audit in #867 found most of what it found. The constant sits next to `PolicyChangeDialog`, whose entire job is to tell users the policy changed; a comment asserting the change already happened is the worst place for a hopeful tense.

## Type of change
- [ ] Bug fix
- [ ] New feature
- [ ] Refactor / cleanup
- [x] Documentation
- [ ] CI / tooling
- [ ] Localization
- [ ] Other

## Related issues
Refs #887, #915, #919, #920

## Changes

- Present tense for what revision 1 *is*, rather than past tense for what was done.
- A second paragraph saying the quiet part: this constant records the revision the app **claims**, not the one that is published. Both documents have to carry the edits before a build with this value ships, or `PolicyChangeDialog` sends people to a policy that still reads the old way.
- Points at `tool/policy_snapshot.dart` (#923) as the thing that can actually confirm publication, since a constant cannot.

The bump rule above it is untouched, and `policyRevision` keeps its value of `1`.

## Screenshots / recordings

n/a — comment only.

## Test plan
- [x] Described steps below were followed locally
- [ ] Unit / widget tests added or updated (if applicable)
- [ ] Manual check on Android
- [ ] Manual check on iOS (if applicable)

No test: there is no behaviour here to pin. The claim the comment was getting wrong is asserted by `tool/policy_snapshot.dart` against the live documents, which is the only place it can be asserted.

### Steps
1. `fvm dart format --output=none --set-exit-if-changed lib/core/utils/url_const.dart` — clean.
2. `fvm dart analyze lib/core/utils/url_const.dart` — no issues.

## Checklist
- [x] Code follows project style (`just format` / 120-char line width)
- [x] New interactive widgets include `Semantics(identifier: '...')` where needed
- [x] Localization updated in ARBs **and** `lib/generated/` when user-facing strings change
- [x] Codegen ran if DBOs/DTOs/env changed (`just build`)
- [x] No secrets or `.env` values committed
- [x] PR title follows conventional commit style (e.g. `feat:`, `fix:`, `chore:`)
