### PR TITLE
ci: stop the project-board adds racing each other

### DIFF
--- a/.github/workflows/add-issues-to-projects.yml
+++ b/.github/workflows/add-issues-to-projects.yml
@@ -17,7 +17,14 @@
 #
 # Re-adding an item that is already on a board is a no-op (the underlying
 # addProjectV2ItemById mutation returns the existing item), so the repeated
-# `labeled` firings do not create duplicates.
+# `labeled` firings do not create duplicates — but only when they arrive one
+# at a time. Filing an issue *with* labels attached fires `opened` and one
+# `labeled` per label within the same second, and two of those runs adding the
+# same item concurrently makes the API answer one of them with
+# "Content already exists in this project", which fails the job. The
+# concurrency group below serialises runs per issue so the second one is the
+# harmless no-op this paragraph describes. It went unnoticed for a long time
+# because issues are normally labelled minutes or days after they are filed.
 #
 # REQUIRED SECRET: `PROJECTS_TOKEN` — this must be a *classic* PAT carrying the
 # `project` scope (plus `public_repo`). Fine-grained tokens cannot do this job:
@@ -37,6 +44,14 @@ on:
 
 permissions:
   contents: read
+
+# Keyed on the issue, not the workflow: two different issues filed at once are
+# not in conflict and should still run in parallel. `cancel-in-progress` stays
+# false because each run is doing real work — cancelling the first would drop
+# the add it was in the middle of, which is the opposite of the fix.
+concurrency:
+  group: add-issues-to-projects-${{ github.event.issue.number }}
+  cancel-in-progress: false
 
 jobs:
   roadmap:


### PR DESCRIPTION
## Summary

Filing an issue with labels attached fires `opened` and one `labeled` per label within the same second. Each starts its own run of this workflow, and two of them adding the same item concurrently makes the API answer one with:

```
##[error]Request failed due to following response errors:
 - Content already exists in this project
```

Three issues filed in five minutes (#925, #926, #927) produced two red runs out of eight. It is probabilistic, which is what a race looks like:

| Issue | Labels | Runs | Result |
|---|---|---|---|
| #925 | 1 | 2 | 1 pass, 1 fail |
| #926 | 2 | 3 | 3 pass |
| #927 | 2 | 3 | 2 pass, 1 fail |

**Nothing was actually broken.** Every issue reached the board, because at least one run per issue won. The cost is a workflow that cries wolf on the tab where a real failure of this job — a missing or expired `PROJECTS_TOKEN` — would otherwise be obvious.

## Type of change
- [x] Bug fix
- [ ] New feature
- [ ] Refactor / cleanup
- [ ] Documentation
- [x] CI / tooling
- [ ] Localization
- [ ] Other

## Related issues
None. Found while filing #925, #926 and #927.

## Changes

A `concurrency` group keyed on the issue number, so runs for the same issue serialise and the second one is the harmless no-op the file's own comment already describes.

**Keyed on the issue, not the workflow** — two different issues filed at once are not in conflict and should still run in parallel. `cancel-in-progress` stays `false` because each run is doing real work; cancelling the first would drop the add it was in the middle of, which is the opposite of the fix.

**Not `continue-on-error`.** That would also swallow the missing-`PROJECTS_TOKEN` failure this same file warns about at length — the one failure that has to stay loud. Making reality match the comment is better than tolerating the error.

The comment block is updated too. It said re-adding an item is a harmless no-op, which is true and stays true when the calls arrive one at a time; the concurrency is what it did not account for. Leaving that paragraph as-is would send the next reader looking for a bug in the wrong place.

## Screenshots / recordings

n/a.

## Test plan
- [x] Described steps below were followed locally
- [ ] Unit / widget tests added or updated (if applicable)
- [ ] Manual check on Android
- [ ] Manual check on iOS (if applicable)

There is nothing to unit-test here, and the change cannot be exercised before it is on the default branch.

**This does not take effect until it reaches `main`** — workflow files run from the default branch — so it ships with 2.1.0 and the red runs continue until then. Verification is therefore after the release: file an issue with two labels and confirm all three runs are green.

### Steps
1. YAML parses and the structure is unchanged apart from the added block — checked with `yaml.safe_load`: triggers still `issues: [opened, labeled, transferred]`, jobs still `roadmap` and `contributors`, `concurrency` group resolves as intended.

## Checklist
- [x] Code follows project style (`just format` / 120-char line width)
- [x] New interactive widgets include `Semantics(identifier: '...')` where needed
- [x] Localization updated in ARBs **and** `lib/generated/` when user-facing strings change
- [x] Codegen ran if DBOs/DTOs/env changed (`just build`)
- [x] No secrets or `.env` values committed
- [x] PR title follows conventional commit style (e.g. `feat:`, `fix:`, `chore:`)
