### PR TITLE
fix(ios): declare why the app may touch the local network

### DIFF
--- a/ios/Runner/Info.plist
+++ b/ios/Runner/Info.plist
@@ -65,6 +65,8 @@
     <string>Used to attach a photo to a custom meal so it's easier to recognise in your saved list, and for exporting data.</string>
 	<key>NSHealthShareUsageDescription</key>
 	<string>Read access to your workouts and body fat percentage is used to import workouts into your diary and to suggest how much of their energy to credit toward your daily goal. Nothing is written back to Health, and the data stays on your device.</string>
+	<key>NSLocalNetworkUsageDescription</key>
+	<string>Local network access is used only when you point AI meal logging at a server you run yourself — Ollama, LM Studio, llama.cpp or vLLM — at an address you type in. Nothing is sent unless you enter that address, and the app never discovers or contacts any other device on your network.</string>
 	<key>UIApplicationSceneManifest</key>
 	<dict>
 		<key>UIApplicationSupportsMultipleScenes</key>


### PR DESCRIPTION
## Summary

The own-server AI provider connects to an address the user types in, which on a home network is a private IPv4 literal. Since iOS 14 that needs the **Local Network** privilege, and the alert the system raises is sourced from `NSLocalNetworkUsageDescription`. There was no such key in `ios/Runner/Info.plist`.

**Why this was not obvious:** the neighbouring question looks settled, and its answer is the wrong shape. #746 and #748 measured that App Transport Security does not reach `dart:io` — BSD sockets, not `NSURLSession` — and `plaintext_destination_guard.dart` records that conclusion. Local network privacy is enforced in the opposite place. From Apple's **TN3179: Understanding local network privacy**:

> The system implements these TCP and UDP checks deep in the networking stack, and thus they apply to all networking APIs. This includes […] framework, BSD Sockets […]

And its operations table:

> Making an outgoing TCP connection — **yes**

So the argument that clears ATS is precisely what convicts this. I verified both quotes against the technote's own source rather than the rendered page, which is JavaScript-only.

TN3179 also explains why CI has been quiet:

> The simulator doesn't support local network privacy. Test your local network privacy behavior on a real device.

`ios-integration-tests` runs on a simulator, so it has been green on a question it cannot answer. That is not a criticism of #748, which proved what it set out to prove and said so carefully.

## Type of change
- [x] Bug fix
- [ ] New feature
- [ ] Refactor / cleanup
- [ ] Documentation
- [ ] CI / tooling
- [ ] Localization
- [ ] Other

## Related issues
Refs #922, #746, #748.

## Changes

One key. The string names the four servers the provider is for, says nothing leaves unless the user types an address, and says the app never discovers or contacts anything else on the network — all three true, and the third worth saying because the permission's *name* implies otherwise to anyone reading the alert.

**No `NSBonjourServices`.** The app does no Bonjour, and per WWDC24 session 10123 declaring services turns the usage string from a *should* into a hard *must*. No multicast entitlement, and no `Platform.isIOS` gate on the provider.

## What this deliberately does **not** do

TN3179 recommends retry logic where a waiting API is unavailable, because the system may deny the triggering operation before the user has answered the alert — and `dart:io` has no waiting mode, unlike Network framework or `URLSession` with `waitsForConnectivity`.

I have not added one, for two reasons:

1. **Whether attempt 1 actually fails is a five-minute measurement on real hardware**, and it is the open question in #922. The expected shape is *tap → fails → alert → grant → tap again → works*, but expected is not measured.
2. **Every other failure mode on that path is deliberately not retried** (`ai_model_list_api.dart:24-37`). Adding a retry to this one branch would put it somewhere the code has already decided against one, for a state nobody has yet observed.

Two other things #922 should decide rather than have pre-empted here: whether the `unreachable` copy needs rewording (a denied toggle may be indistinguishable from a sleeping server — `EHOSTUNREACH`, per an Apple DTS reply on the forums rather than documentation), and whether the endpoint probe's deliberate outliving of the settings dialog is safe on iOS, since TN3179 says a **backgrounded** app performing a local network operation while the privilege is undetermined is denied *with no alert and the decision not recorded*.

## Screenshots / recordings

None — the alert can only be seen on a real device, which is #922.

## Test plan
- [x] Described steps below were followed locally
- [ ] Unit / widget tests added or updated (if applicable)
- [ ] Manual check on Android
- [ ] Manual check on iOS (if applicable)

No test: a plist key has no Dart-visible behaviour, and the thing it changes is an OS alert that no simulator will raise.

**Worth doing on the device when #922 is run:** read the string in the alert. It is 282 characters, comparable to the existing `NSHealthShareUsageDescription`, but the alert is where truncation would show.

### Steps
1. `plistlib.load` parses the file — 24 keys, the new one present, `NSBonjourServices` absent.
2. `ios_localizations_drift_test.dart`, the only test that reads `Info.plist` — passes.

## Checklist
- [x] Code follows project style (`just format` / 120-char line width)
- [x] New interactive widgets include `Semantics(identifier: '...')` where needed
- [x] Localization updated in ARBs **and** `lib/generated/` when user-facing strings change
- [x] Codegen ran if DBOs/DTOs/env changed (`just build`)
- [x] No secrets or `.env` values committed
- [x] PR title follows conventional commit style (e.g. `feat:`, `fix:`, `chore:`)
