### PR TITLE
chore: record the published policy after the 2.1.0 clause paste

### DIFF
--- a/docs/privacy-policy/de.txt
+++ b/docs/privacy-policy/de.txt
@@ -44,7 +44,7 @@ Sofern in diesem Dokument nicht anderweitig festgelegt, werden personenbezogene 
 Zwecke der Verarbeitung
 
 Personenbezogene Daten über den Nutzer werden erhoben, damit der Anbieter den Dienst erbringen und des Weiteren seinen gesetzlichen Verpflichtungen nachkommen, auf Durchsetzungsforderungen reagieren, seine Rechte und Interessen (oder die der Nutzer oder Dritter) schützen, böswillige oder betrügerische Aktivitäten aufdecken kann. Darüber hinaus werden Daten zu folgenden Zwecken erhoben:
-Plattform-Dienste und Hosting, Beta-Tests, Anzeigen von Inhalten externer Plattformen, Hosting und Backend-Infrastruktur, Überwachung der Infrastruktur und Zugriff auf Profile von Drittanbietern.
+Plattform-Dienste und Hosting, Beta-Tests, Anzeigen von Inhalten externer Plattformen, Hosting und Backend-Infrastruktur, Überwachung der Infrastruktur, Zugriff auf Profile von Drittanbietern und Handhabung von Aktivitätsdaten .
 
 Nutzer können im Abschnitt “Ausführliche Angaben über die Verarbeitung personenbezogener Daten” dieses Dokuments weitere detaillierte Informationen zu diesen Verarbeitungszwecken und die zu den für den jeweiligen Zweck verwendeten personenbezogenen Daten vorfinden.
 
@@ -60,13 +60,19 @@ Diese Art von Dienst kann möglicherweise immer noch Web-Traffic-Daten für die 
 
 Open Food Facts
 
-Wenn Sie ein Lebensmittel suchen oder einen Barcode scannen, sendet diese Anwendung den Suchbegriff bzw. den Barcode an Open Food Facts, zusammen mit einem aus den Spracheinstellungen Ihres Geräts abgeleiteten Ländercode, den der Dienst zur Sortierung der Ergebnisse verwendet.
+Wenn Sie ein Lebensmittel suchen oder einen Barcode scannen, sendet diese Anwendung den Suchbegriff bzw. den Barcode an Open Food Facts. Bei einer Textsuche wird zusätzlich die Sprache übermittelt, auf die Ihr Gerät eingestellt ist, ergänzt um Englisch als Rückfallsprache; der Dienst verwendet sie zur Sortierung der Ergebnisse. Ein Ländercode oder ein anderer Teil der Standort- oder Regionseinstellungen Ihres Geräts wird nicht übermittelt, und bei einer Barcode-Abfrage wird gar keine Sprache mitgesendet.
+
+Open Food Facts beantwortet Suchen, Produktabfragen und Produktfotos über mehrere eigene Hosts; welchen davon diese Anwendung erreicht, hängt davon ab, welcher gerade erreichbar ist. Suchen und Produktabfragen nennen die App mit Name, Plattform und Version; beim Laden von Fotos geschieht das nicht.
+
+Das Foto eines Lebensmittels wird von Open Food Facts geladen, sobald es angezeigt wird — in den Suchergebnissen, auf einem Mahlzeitenbildschirm und auf der Tagebuchkarte einer bereits eingetragenen Mahlzeit. Die Adresse eines Fotos enthält den Barcode des jeweiligen Produkts. Fotos werden bis zu 30 Tage und höchstens 200 Stück auf Ihrem Gerät vorgehalten; ein Foto, das Sie danach erneut ansehen, wird noch einmal geladen.
 
 Open Food Facts ist ein unabhängiger gemeinnütziger Verein. Der Verein entscheidet selbst darüber, wie er die erhaltenen Daten verarbeitet, und handelt nicht auf Weisung des Anbieters dieser Anwendung; für diese Verarbeitung gilt daher seine eigene Datenschutzerklärung. Es werden kein Konto, kein Profil und keine Gerätekennung übermittelt, und Ihr Ernährungstagebuch wird nie übermittelt.
 
 Diese Verarbeitung beruht auf dem berechtigten Interesse des Anbieters, die Lebensmittelsuche bereitzustellen, für die diese Anwendung gedacht ist. Sie können dieser Verarbeitung jederzeit widersprechen und sie in der Praxis vollständig vermeiden: Eine Suche findet nur statt, wenn Sie sie starten, und selbst gespeicherte Mahlzeiten können Sie ohne jede Suche hinzufügen.
 
-Verarbeitete personenbezogene Daten: Suchbegriffe; Barcodes; ein Ländercode; Nutzungsdaten.
+Der Anbieter dieser Anwendung bewahrt aus diesen Anfragen nichts auf. Wie lange Open Food Facts die erhaltenen Daten speichert, entscheidet Open Food Facts selbst; Näheres regelt dessen eigene Datenschutzerklärung.
+
+Verarbeitete personenbezogene Daten: Suchbegriffe; Barcodes; ein Sprachcode des Geräts; Name und Version der App; Nutzungsdaten.
 
 Ort der Verarbeitung: Frankreich — Datenschutzerklärung.
 
@@ -92,6 +98,29 @@ Verarbeitete personenbezogene Daten: Geräteinformationen; Nutzungsdaten; Währe
 
 Verarbeitungsort: Irland – Datenschutzerklärung.
 
+Handhabung von Aktivitätsdaten
+
+Diese Art von Diensten ermöglichen es dem Anbieter, Aktivitätsdaten oder biometrische Daten für diese Anwendung zu nutzen, um bestimmte Funktionen auszuführen oder bereitzustellen. Die von Ihrem Gerät erfassten Daten können Bewegungen, Herzschlag, Höhenunterschiede oder Umgebungsdaten beinhalten. Je nachdem, was nachfolgend beschrieben wird, können Dritte an der Aktivitätserfassung beteiligt sein. Bei den meisten Geräten können Nutzer festlegen, welche Daten abgerufen oder gespeichert werden.
+
+Gesundheits- und Fitnessdaten (Trainingsimport)
+
+Diese Anwendung kann Trainings aus Health Connect (Android) bzw. Apple Health (iOS) importieren. Die Funktion ist deaktiviert, bis Sie sie einschalten (Einstellungen → Gesundheitsdaten-Sync); erst dann erscheint die Berechtigungsabfrage der Plattform.
+
+Ist sie aktiviert, liest diese Anwendung aus dem Gesundheitsspeicher der Plattform:
+
+- Trainings (Trainingseinheiten) und
+- den Körperfettanteil.
+
+Unter Android werden zusätzlich der Gesamtenergieverbrauch, die Distanz und die Schrittzahl gelesen, die zu einer Trainingseinheit erfasst wurden. Health Connect verweigert die Abfrage von Trainings vollständig, solange diese Zugriffe nicht ebenfalls erteilt sind; sie werden deshalb angefragt, damit der Import funktioniert, und für nichts anderes verwendet.
+
+Trainings werden in Ihr Tagebuch übernommen. Der Körperfettanteil wird, sofern vorhanden, ausschließlich dazu verwendet, den Vorschlag zu personalisieren, wie viel der Trainingsenergie auf Ihr Tagesziel angerechnet wird.
+
+Der Zugriff erfolgt ausschließlich lesend. Es wird nichts nach Health Connect oder Apple Health zurückgeschrieben.
+
+Diese Daten werden nicht übertragen. Sie liegen in der verschlüsselten Datenbank auf Ihrem Gerät, werden weder an den Eigentümer noch an Dritte gesendet und verlassen das Gerät nur durch ein Backup oder einen Export, den Sie selbst vornehmen.
+
+Sie können den Zugriff jederzeit in Health Connect bzw. Apple Health widerrufen oder die Funktion in den Einstellungen ausschalten. Bereits importierte Einträge bleiben in Ihrem Tagebuch, bis Sie sie löschen.
+
 Hosting und Backend-Infrastruktur
 
 Diese Art von Dienst hat den Zweck, Daten und Dateien zu hosten, die für diese Anwendung den Betrieb und die Verbreitung möglich machen, oder eine fertige Infrastruktur zur Verfügung zu stellen, um für diese Anwendung bestimmte Funktionen oder Teile auszuführen.
@@ -100,7 +129,7 @@ Einige der unten aufgeführten Dienste können, müssen aber nicht, über geogra
 
 Lebensmittel-Referenzdatenbank (Supabase)
 
-Lebensmittelsuchen werden von einer Referenzdatenbank beantwortet, die der Anbieter dieser Anwendung auf der Managed-Cloud-Plattform von Supabase betreibt. Bei einer Suche wird der von Ihnen eingegebene Text übermittelt. Es werden kein Konto, kein Profil und keine Gerätekennung mitgesendet, und Ihr Ernährungstagebuch wird nie übermittelt.
+Lebensmittelsuchen werden von einer Referenzdatenbank beantwortet, die der Anbieter dieser Anwendung auf der Managed-Cloud-Plattform von Supabase betreibt. Bei einer Suche werden der von Ihnen eingegebene Text übermittelt, außerdem Ihre App-Sprache, sofern diese Anwendung Lebensmittelübersetzungen dafür mitbringt, und — falls Sie in den Einstellungen eine der Lebensmitteldatenbanken abgeschaltet haben — die Liste der von Ihnen aktiv gelassenen Datenbanken. Es werden kein Konto, kein Profil und keine Gerätekennung mitgesendet, und Ihr Ernährungstagebuch wird nie übermittelt.
 
 Da die Anfrage über das Internet übertragen wird, protokolliert das Gateway der Plattform für 24 Stunden die Adresse, von der die Anfrage kam, einen daraus abgeleiteten ungefähren Standort (Land, Region, Ort und Postleitzahl), den Namen Ihres Internetanbieters sowie einen Fingerprint der verschlüsselten Verbindung.
 
@@ -108,7 +137,7 @@ Die Datenbank wird in Frankfurt (Deutschland) gespeichert und überwiegend dort 
 
 Diese Verarbeitung beruht auf dem berechtigten Interesse des Anbieters, die Lebensmittelsuche bereitzustellen, für die diese Anwendung gedacht ist. Sie können dieser Verarbeitung jederzeit widersprechen und sie in der Praxis vollständig vermeiden: Eine Suche findet nur statt, wenn Sie sie starten, und selbst gespeicherte Mahlzeiten können Sie ohne jede Suche hinzufügen.
 
-Verarbeitete personenbezogene Daten: Suchbegriffe; IP-Adresse; ungefährer Standort; Verbindungskennungen; Nutzungsdaten.
+Verarbeitete personenbezogene Daten: Suchbegriffe; App-Sprache; Auswahl der Lebensmitteldatenbanken; IP-Adresse; ungefährer Standort; Verbindungskennungen; Nutzungsdaten.
 
 Ort der Verarbeitung: Deutschland — Singapur.
 

--- a/docs/privacy-policy/en.txt
+++ b/docs/privacy-policy/en.txt
@@ -44,7 +44,7 @@ Unless specified otherwise in this document, Personal Data shall be processed an
 The purposes of processing
 
 The Data concerning the User is collected to allow the Owner to provide its Service, comply with its legal obligations, respond to enforcement requests, protect its rights and interests (or those of its Users or third parties), detect any malicious or fraudulent activity, as well as the following:
-Platform services and hosting, Beta Testing, Displaying content from external platforms, Hosting and backend infrastructure, Infrastructure monitoring and Access to third-party accounts.
+Platform services and hosting, Beta Testing, Displaying content from external platforms, Hosting and backend infrastructure, Infrastructure monitoring, Access to third-party accounts and Handling activity data.
 
 For specific information about the Personal Data used for each purpose, the User may refer to the section “Detailed information on the processing of Personal Data”.
 
@@ -106,15 +106,48 @@ This type of service might still collect web traffic data for the pages where th
 
 Open Food Facts
 
-When you search for a food or scan a barcode, this Application sends the search term or the barcode to Open Food Facts, together with a country code derived from your device's language settings, which the service uses to rank results.
+When you search for a food or scan a barcode, this Application sends the search term or the barcode to Open Food Facts. A text search also sends the language your device is set to, with English appended as a fallback, which the service uses to rank results. No country code and no other part of your device's location or region settings is sent, and a barcode lookup sends no language at all.
+
+Open Food Facts serves searches, product lookups and product photographs from more than one of its own hosts, and which of them this Application reaches depends on which is up. Searches and product lookups identify the app by name, platform and version; photograph downloads do not.
+
+A food's photograph is downloaded from Open Food Facts whenever it is shown — in search results, on a meal screen, and on the diary card of a meal you have already logged. The address of a photograph contains that product's barcode. Photographs are kept on your device for up to 30 days and no more than 200 at a time, so one you keep coming back to is downloaded again after that.
 
 Open Food Facts is an independent non-profit association. It decides for itself how it handles what it receives and does not act on the instructions of the Owner of this Application, so its own privacy policy governs that handling. No account, profile or device identifier is sent, and your food diary is never sent.
 
 This processing rests on the Owner's legitimate interest in providing the food search this Application exists to offer. You can object to it at any time, and in practice you can avoid it altogether: a search happens only when you start one, and meals you have saved yourself can be added without any search.
 
-Personal Data processed: search terms; barcodes; a country code; Usage Data.
+The Owner keeps nothing from these requests. How long Open Food Facts keeps what it receives is decided by Open Food Facts and set out in its own privacy policy.
+
+Personal Data processed: search terms; barcodes; a device language code; the app's name and version; Usage Data.
 
 Place of processing: France — Privacy Policy.
+
+Handling activity data
+
+This type of service allows the Owner to use the activity or biometric data collected by your device in order for this Application to operate or to provide specific features. This may include movements, heartbeat, change in altitude or data about the surroundings.
+
+Depending on what is described below, third parties may be involved in the activity tracking.
+
+Most devices allow for the User to control which Data is accessed or stored.
+
+Health and fitness data (workout import)
+
+This Application can import workouts from Health Connect (Android) or Apple Health (iOS). The feature is off until you switch it on in Settings → Health sync, and switching it on is what triggers the platform's own permission prompt.
+
+When enabled, this Application reads from the platform's health store:
+
+- workouts (exercise sessions), and
+- body fat percentage.
+
+On Android it additionally reads the total energy burned, distance and step count recorded against a workout session. Health Connect refuses a workout query outright unless those reads are granted as well, so they are requested to make the import work and are used for nothing else.
+
+Workouts are added to your diary. The body fat reading, where one exists, is used only to personalise how much of a workout's energy this Application suggests crediting toward your daily goal.
+
+Access is read-only. Nothing is ever written back to Health Connect or Apple Health.
+
+This data is not transmitted. It is held in the encrypted database on your device, is not sent to the Owner or to any third party, and leaves the device only through a backup or export you carry out yourself.
+
+You can withdraw access at any time in Health Connect or Apple Health, or switch the feature off in Settings. Entries already imported remain in your diary until you delete them.
 
 Hosting and backend infrastructure
 
@@ -124,7 +157,7 @@ Some services among those listed below, if any, may work through geographically 
 
 Food reference backend (Supabase)
 
-Food searches are answered by a reference database that the Owner of this Application operates on Supabase's managed cloud platform. A search sends the text you typed. No account, profile or device identifier is attached, and your food diary is never sent.
+Food searches are answered by a reference database that the Owner of this Application operates on Supabase's managed cloud platform. A search sends the text you typed; your app language too, when it is one this Application has food translations for; and, if you have switched any of the food databases off in Settings, the list of the ones you left on. No account, profile or device identifier is attached, and your food diary is never sent.
 
 Because the request travels over the internet, the platform's gateway records for 24 hours the address the request came from, an approximate location derived from that address (country, region, city and postal code), the name of your internet access provider, and a fingerprint of the encrypted connection.
 
@@ -132,7 +165,7 @@ The database is stored and primarily processed in Frankfurt, Germany. Supabase P
 
 This processing rests on the Owner's legitimate interest in providing the food search this Application exists to offer. You can object to it at any time, and in practice you can avoid it altogether: a search happens only when you start one, and meals you have saved yourself can be added without any search.
 
-Personal Data processed: search terms; IP address; approximate location; connection identifiers; Usage Data.
+Personal Data processed: search terms; app language; food-database preferences; IP address; approximate location; connection identifiers; Usage Data.
 
 Place of processing: Germany — Singapore.
 


### PR DESCRIPTION
## Summary

The corrections drafted in #915, #919 and #920 are now published in both iubenda documents. This commits the after-state, which is the whole point of the change record added in #923 — iubenda keeps no version history, so git is the substitute.

The before-state was verified byte-identical to the live documents immediately beforehand, so every line in this diff is a line that was deliberately changed.

## Type of change
- [ ] Bug fix
- [ ] New feature
- [ ] Refactor / cleanup
- [x] Documentation
- [ ] CI / tooling
- [ ] Localization
- [ ] Other

## Related issues
Refs #915, #919, #920, #923, #871, #888, #887.

## What was applied

| Clause | Findings |
|---|---|
| Open Food Facts | 4, 6, 11 as one composed edit, plus 15's retention sentence |
| Supabase | 5 |
| Health and fitness (**new**) | 7 |

Both languages, every time. The `country code` that was never sent is now the `language code` that is — on text searches only, with barcode lookups sending none.

## Finding 12 is deliberately absent

Its clause describes the `beforeSend` hook that strips the installation identifier. That is on `develop` and unreleased, so publishing it now would tell everyone on 2.0.2 that something is stripped from their crash reports which is not. #920 says to hold it until the release containing `4214fb5b` is live; that instruction is being followed. **It becomes owed the moment 2.1.0 ships.**

## Two determinations that close open questions

**#915, open question 1 — answered.** iubenda has no *Health data* or *Fitness data* purpose category. Across the whole catalogue the only fit is **Handling activity data**, so the prose carries it alone, exactly as the issue anticipated it might have to.

**Finding 14 is not fixable and should be recorded as accepted.** Its preferred fix was a taxonomy data type on Supabase and Sentry. Both are *custom* services, and the custom-service form has no data-types field at all — only name, description, AI flag, provider, purpose, and where to show it. That is #920's own stated condition for declaring it not fixable. It is milder than the audit implied in any case: the Supabase clause already names approximate location in both languages, and only the opening summary omits it.

## Worth a look before this is considered finished

**iubenda's generated blurb for the new purpose hedges in a way our clause contradicts.** Adding purpose 43 pulls in template text reading *"Depending on what is described below, third parties may be involved in the activity tracking."* Two paragraphs later our own clause says the data is not transmitted and reaches no third party. Both are in the published document. The specific statement should win over the generic one, and the ordering favours it, but it is not ideal and it is not something this repository controls — the same class of problem as the `support.apple.com` host warning the checker emits.

**One German wording inconsistency, carried over from the draft.** The new clause says *"weder an den **Eigentümer** noch an Dritte"*; every other German clause in the document says *"Anbieter dieser Anwendung"*. Same role, two words. Left as drafted rather than reworded unilaterally.

## Screenshots / recordings

n/a — the rendered text *is* the diff.

## Test plan
- [x] Described steps below were followed locally
- [ ] Unit / widget tests added or updated (if applicable)
- [ ] Manual check on Android
- [ ] Manual check on iOS (if applicable)

The checker found real drift during the work and is the reason this is trustworthy: after the health clause was created it reported `purpose 43 declares 1 service(s) in English and 0 in German`. That turned out to be propagation delay rather than a lost paste — the editor held both languages — and cleared on its own. Nothing else could have distinguished "delayed" from "lost".

A note for whoever adds the next custom clause: **"Specify service translations" is off by default**, and leaving it off produces a one-language clause. That is how #888 happened.

### Steps
1. `fvm dart run tool/policy_snapshot.dart` — writes both files and checks them.
2. Final state: `purposes: 7 en, 7 de`, `services: 9 en, 9 de`, `Both documents agree on everything checked`, exit 0. The only warning is the known `support.apple.com` template artefact.

## Checklist
- [x] Code follows project style (`just format` / 120-char line width)
- [x] New interactive widgets include `Semantics(identifier: '...')` where needed
- [x] Localization updated in ARBs **and** `lib/generated/` when user-facing strings change
- [x] Codegen ran if DBOs/DTOs/env changed (`just build`)
- [x] No secrets or `.env` values committed
- [x] PR title follows conventional commit style (e.g. `feat:`, `fix:`, `chore:`)
