### PR TITLE
fix(core): keep a workout import inside the profile that started it

### DIFF
--- a/lib/core/data/data_source/config_data_source.dart
+++ b/lib/core/data/data_source/config_data_source.dart
@@ -83,9 +83,22 @@ class ConfigDataSource {
 
   /// Persists [config] to both boxes. Each box gets its own detached copy so
   /// the same `HiveObject` instance is never shared between boxes.
+  ///
+  /// Both puts are started before either is awaited, deliberately.
+  ///
+  /// [_profileBox] resolves through [HiveDBProvider], which swaps the
+  /// per-profile box in place when the user switches profiles. Awaiting the
+  /// app-box put before resolving the profile box would leave a window for a
+  /// switch to land between them, writing the two halves of one config into
+  /// two different profiles (#944). Resolving and starting both in the same
+  /// synchronous step closes it.
   Future<void> _writeBoth(ConfigDBO config) async {
-    await _appBox.put(_configKey, ConfigDBO.fromJson(config.toJson()));
-    await _profileBox.put(_configKey, ConfigDBO.fromJson(config.toJson()));
+    final app = _appBox.put(_configKey, ConfigDBO.fromJson(config.toJson()));
+    final profile = _profileBox.put(
+      _configKey,
+      ConfigDBO.fromJson(config.toJson()),
+    );
+    await Future.wait([app, profile]);
   }
 
   Future<bool> configInitialized() async =>

--- a/lib/core/domain/usecase/import_workouts_usecase.dart
+++ b/lib/core/domain/usecase/import_workouts_usecase.dart
@@ -10,6 +10,7 @@ import 'package:opennutritracker/core/domain/entity/user_activity_entity.dart';
 import 'package:opennutritracker/core/domain/usecase/get_physical_activity_usecase.dart';
 import 'package:opennutritracker/core/domain/usecase/log_user_activity_usecase.dart';
 import 'package:opennutritracker/core/utils/calc/day_boundary_calc.dart';
+import 'package:opennutritracker/core/utils/hive_db_provider.dart';
 import 'package:opennutritracker/core/utils/id_generator.dart';
 
 /// Pulls finished workouts out of Health Connect / Apple Health and files
@@ -54,11 +55,26 @@ class ImportWorkoutsUsecase {
   /// watermark sequence is effectively serialized.
   Future<int>? _inFlight;
 
+  /// The profile [_inFlight] belongs to.
+  ///
+  /// The serialization above is only sound for callers asking the same
+  /// question. A profile switch makes it a different question: joining the
+  /// previous profile's run would report its count as this profile's and skip
+  /// the import this caller actually asked for, so a caller on another
+  /// profile starts its own run (#944).
+  String? _inFlightProfileId;
+
   final HealthImportRepository _healthImportRepository;
   final ConfigRepository _configRepository;
   final UserActivityRepository _userActivityRepository;
   final GetPhysicalActivityUsecase _getPhysicalActivityUsecase;
   final LogUserActivityUsecase _logUserActivityUsecase;
+
+  /// Consulted only for [HiveDBProvider.activeProfileId] — see
+  /// [_stillOnProfile]. The repositories above already resolve their boxes
+  /// through it; this use case needs to know *which* profile they resolved
+  /// to, which nothing else exposes.
+  final HiveDBProvider _hiveDBProvider;
 
   ImportWorkoutsUsecase(
     this._healthImportRepository,
@@ -66,6 +82,7 @@ class ImportWorkoutsUsecase {
     this._userActivityRepository,
     this._getPhysicalActivityUsecase,
     this._logUserActivityUsecase,
+    this._hiveDBProvider,
   );
 
   /// Runs an import if one is due, swallowing failures.
@@ -79,7 +96,10 @@ class ImportWorkoutsUsecase {
       // A run already under way covers this call too, and joining it beats
       // reading the platform again the moment it finishes.
       final inFlight = _inFlight;
-      if (inFlight != null) return await inFlight;
+      if (inFlight != null &&
+          _inFlightProfileId == _hiveDBProvider.activeProfileId) {
+        return await inFlight;
+      }
       final config = await _configRepository.getConfig();
       if (!config.healthImportEnabled) return 0;
       final lastImportAt = config.healthLastImportAt;
@@ -106,16 +126,24 @@ class ImportWorkoutsUsecase {
   /// in flight answers with that run's outcome rather than importing the same
   /// window a second time (see [_inFlight]).
   Future<int> importNow() {
+    final profileId = _hiveDBProvider.activeProfileId;
     final inFlight = _inFlight;
-    if (inFlight != null) return inFlight;
+    if (inFlight != null && _inFlightProfileId == profileId) return inFlight;
     final run = _import();
     _inFlight = run;
+    _inFlightProfileId = profileId;
     return run.whenComplete(() {
-      if (identical(_inFlight, run)) _inFlight = null;
+      // Not necessarily this run: a switch mid-flight lets a second run start
+      // and take the slot, and that one is the live one now.
+      if (identical(_inFlight, run)) {
+        _inFlight = null;
+        _inFlightProfileId = null;
+      }
     });
   }
 
   Future<int> _import() async {
+    final profileId = _hiveDBProvider.activeProfileId;
     final config = await _configRepository.getConfig();
     if (!config.healthImportEnabled) return 0;
 
@@ -131,6 +159,10 @@ class ImportWorkoutsUsecase {
       from: from,
       to: to,
     );
+    // The platform read is the long await, and the likeliest place for a
+    // switch to land. Everything past this point writes.
+    if (!_stillOnProfile(profileId)) return 0;
+
     final seenIds = await _userActivityRepository.getExternalIdsSince(from);
     // Deleting an imported workout has to stick. The dedupe set above is
     // built from the activities on file, so a deleted one leaves nothing
@@ -146,6 +178,12 @@ class ImportWorkoutsUsecase {
     var imported = 0;
     for (final workout in workouts) {
       if (!_isImportable(workout) || !seenIds.add(workout.id)) continue;
+      // Re-checked per workout rather than once before the loop: logging an
+      // activity is itself several awaits, so a long import has a switch
+      // window between every row. Rows already written went to the right
+      // profile; abandoning here leaves the watermark unmoved, so the next
+      // run re-reads the same window and the external-id dedupe absorbs it.
+      if (!_stillOnProfile(profileId)) return imported;
       await _logUserActivityUsecase.logActivity(
         _toUserActivity(workout, config, activityByCode),
         // A workout that started at 00:30 under an 03:00 day boundary belongs
@@ -158,6 +196,8 @@ class ImportWorkoutsUsecase {
       );
       imported++;
     }
+
+    if (!_stillOnProfile(profileId)) return imported;
 
     // Written even when nothing was imported: the watermark is also what
     // debounces the next run, and an empty window is still a window covered.
@@ -178,6 +218,26 @@ class ImportWorkoutsUsecase {
       _log.info('Imported $imported workout(s) from the platform health store');
     }
     return imported;
+  }
+
+  /// Whether the run that started under [profileId] may still write.
+  ///
+  /// Every box the writes go through is resolved from [HiveDBProvider] at the
+  /// moment of the call, and switching profiles swaps that box-set in place.
+  /// A run that began under one profile and came back from the platform under
+  /// another would file the first profile's workouts — and its watermark —
+  /// into the second, which never opted in: the flag this run checked was the
+  /// first profile's (#944).
+  ///
+  /// Abandoning is the cheap half of the trade. Nothing is written after the
+  /// switch, the watermark stays where it was, and the next launch or resume
+  /// reads the same window again for whichever profile is active by then.
+  bool _stillOnProfile(String profileId) {
+    if (_hiveDBProvider.activeProfileId == profileId) return true;
+    _log.info(
+      'Abandoning the workout import: the active profile changed mid-run',
+    );
+    return false;
   }
 
   /// A workout the app can turn into a meaningful diary row: it lasted some

--- a/lib/core/utils/locator.dart
+++ b/lib/core/utils/locator.dart
@@ -374,6 +374,7 @@ Future<void> initLocator() async {
       locator(),
       locator(),
       locator(),
+      locator(),
     ),
   );
   locator.registerLazySingleton<DeleteUserActivityUsecase>(

--- a/test/helpers/fake_hive_db_provider.dart
+++ b/test/helpers/fake_hive_db_provider.dart
@@ -30,7 +30,17 @@ class FakeHiveDBProvider extends HiveDBProvider {
   final Box<WaterIntakeDBO>? _waterIntakeBox;
   final Box<FastingSessionDBO>? _fastingBox;
 
+  /// The profile the injected boxes belong to.
+  ///
+  /// Mutable so a test can simulate a profile switch landing in the middle of
+  /// an operation (#944) — the real provider swaps its whole box-set at that
+  /// moment, but for a guard that only compares identities, moving this is
+  /// the switch.
+  @override
+  String activeProfileId;
+
   FakeHiveDBProvider({
+    this.activeProfileId = 'test-profile',
     Box<ConfigDBO>? configBox,
     Box<ConfigDBO>? appConfigBox,
     Box<IntakeDBO>? intakeBox,

--- a/test/unit_test/import_workouts_usecase_test.dart
+++ b/test/unit_test/import_workouts_usecase_test.dart
@@ -108,6 +108,7 @@ void main() {
   late GetKcalGoalUsecase getKcalGoalUsecase;
   late GetMacroGoalUsecase getMacroGoalUsecase;
   late _FakeHealthService healthService;
+  late FakeHiveDBProvider provider;
   late ImportWorkoutsUsecase usecase;
   late DeleteUserActivityUsecase deleteUsecase;
 
@@ -134,7 +135,8 @@ void main() {
     await trackedDayBox.clear();
     await userBox.clear();
 
-    final provider = FakeHiveDBProvider(
+    provider = FakeHiveDBProvider(
+      activeProfileId: 'profile-a',
       configBox: configBox,
       userActivityBox: activityBox,
       trackedDayBox: trackedDayBox,
@@ -175,6 +177,7 @@ void main() {
         getKcalGoalUsecase,
         getMacroGoalUsecase,
       ),
+      provider,
     );
 
     deleteUsecase = DeleteUserActivityUsecase(
@@ -402,6 +405,88 @@ void main() {
       expect(await usecase.importIfDue(), equals(0));
       expect(() => usecase.importNow(), throwsStateError);
     });
+  });
+
+  // #944: the boxes every write below goes through are resolved from
+  // HiveDBProvider at the moment of the call, and switching profiles swaps
+  // that box-set in place. A run that read profile A's opt-in flag and came
+  // back from the platform under profile B used to file A's workouts, and A's
+  // watermark, into B — a profile that never opted in.
+  group('ImportWorkoutsUsecase profile isolation', () {
+    test('a switch during the platform read files nothing', () async {
+      healthService.workouts = [_workout(start: DateTime(2026, 5, 23, 7, 0))];
+      healthService.readGate = Completer<void>();
+
+      final run = usecase.importNow();
+      // The switch lands while the health store is still answering, which is
+      // the long await and the likeliest moment for it.
+      provider.activeProfileId = 'profile-b';
+      healthService.readGate!.complete();
+
+      expect(await run, equals(0));
+      expect(await userActivityRepository.getAllUserActivityDBO(), isEmpty);
+    });
+
+    test(
+      'a switch during the platform read leaves the watermark alone',
+      () async {
+        // The watermark matters as much as the rows: written into B it would
+        // debounce B's own first import and silently narrow its backfill window.
+        healthService.workouts = [_workout(start: DateTime(2026, 5, 23, 7, 0))];
+        healthService.readGate = Completer<void>();
+
+        final run = usecase.importNow();
+        provider.activeProfileId = 'profile-b';
+        healthService.readGate!.complete();
+        await run;
+
+        expect((await configRepository.getConfig()).healthLastImportAt, isNull);
+      },
+    );
+
+    test('the abandoned window is imported again on the next run', () async {
+      // Abandoning is only cheap if nothing is lost by it. Switching back and
+      // running again has to produce the workout the first run walked away
+      // from.
+      healthService.workouts = [_workout(start: DateTime(2026, 5, 23, 7, 0))];
+      healthService.readGate = Completer<void>();
+
+      final abandoned = usecase.importNow();
+      provider.activeProfileId = 'profile-b';
+      healthService.readGate!.complete();
+      expect(await abandoned, equals(0));
+
+      provider.activeProfileId = 'profile-a';
+      expect(await usecase.importNow(), equals(1));
+      expect(
+        await userActivityRepository.getAllUserActivityDBO(),
+        hasLength(1),
+      );
+    });
+
+    test(
+      'a caller on another profile does not join the run in flight',
+      () async {
+        // The serialization guard is only sound for callers asking the same
+        // question. Handing B the answer to A's question would report A's count
+        // as B's and skip the import B asked for.
+        healthService.workouts = [_workout(start: DateTime(2026, 5, 23, 7, 0))];
+        healthService.readGate = Completer<void>();
+
+        final onA = usecase.importNow();
+        provider.activeProfileId = 'profile-b';
+        final onB = usecase.importNow();
+        healthService.readGate!.complete();
+
+        await onA;
+        await onB;
+        expect(
+          healthService.readWorkoutsCalls,
+          equals(2),
+          reason: 'B must read the platform for itself, not inherit A\'s read',
+        );
+      },
+    );
   });
 
   group('ImportWorkoutsUsecase serialization', () {


### PR DESCRIPTION
## Summary

A workout import that was in flight when the user switched profiles finished by writing into **whichever profile was active when it returned**, not the one that started it. Profile A's workouts, and A's import watermark, landed in profile B — a profile that never opted in.

The per-profile Hive boxes are mutable fields on `HiveDBProvider` that a profile switch swaps in place. `ImportWorkoutsUsecase` read A's opt-in flag, awaited the platform, then resolved those boxes again on the way out.

It was reachable without doing anything unusual: `importIfDue` runs at launch and on every resume from the home page, and the profile switcher sits on that same page.

The health import ships for the first time in 2.1.0, so this has never been reachable in a released build. It needs to land on `develop` before #934 merges.

## Type of change
- [x] Bug fix
- [ ] New feature
- [ ] Refactor / cleanup
- [ ] Documentation
- [ ] CI / tooling
- [ ] Localization
- [ ] Other

## Related issues

Fixes #944. Refs #651, #934.

## Changes

- **`ImportWorkoutsUsecase` captures the active profile before it reads and abandons the run rather than writing under a different one.** Abandoning costs nothing: the watermark is left where it was, so the next launch or resume re-reads the same window for whichever profile is active by then, and the external-id dedupe absorbs the overlap. The check repeats per workout, because `logActivity` is itself several awaits — a long import has a switch window between every row.
- **The in-flight guard is keyed by profile.** A second instance of the same bug, not called out in #944: handing a caller on B the result of A's run would report A's count as B's and skip the import B actually asked for.
- **`ConfigDataSource._writeBoth` starts both puts in one synchronous step.** It awaited the app-box put before resolving the per-profile box, so a switch in that gap wrote the two halves of one config into two different profiles.
- `FakeHiveDBProvider` gained a settable `activeProfileId` so a test can move the profile mid-operation.

### Deliberately not done

The guard was **not** extended into `LogUserActivityUsecase` or the other multi-await writes. A switch landing inside one of those can still split a single write, but that is a repo-wide property of the box-swap design rather than this bug, and fixing it properly is a different change.

## Screenshots / recordings

None — no UI change.

## Test plan
- [x] Described steps below were followed locally
- [x] Unit / widget tests added or updated (if applicable)
- [ ] Manual check on Android
- [ ] Manual check on iOS (if applicable)

Four new tests under `ImportWorkoutsUsecase profile isolation`, using the fake health service's existing `readGate` to hold the platform read open while the profile moves underneath it.

They were confirmed to fail with the guard disabled, reproducing #944 exactly rather than merely passing:

```
a switch during the platform read files nothing         Expected: <0>    Actual: <1>
... leaves the watermark alone                          Expected: null   Actual: 2026-05-23 12:00
the abandoned window is imported again on the next run  Expected: <0>    Actual: <1>
a caller on another profile does not join the run       Expected: <2>    Actual: <1>
```

### Steps
1. `fvm flutter test` — **1164/1164 pass**.
2. `fvm flutter analyze lib test` — no issues.
3. Manual device check is not covered here: reproducing it by hand means switching profiles inside the window of a health-store read, which the tests exercise deterministically and a person cannot time reliably.

## Checklist
- [x] Code follows project style (`just format` / 120-char line width)
- [x] New interactive widgets include `Semantics(identifier: '...')` where needed — n/a, no widgets
- [x] Localization updated in ARBs **and** `lib/generated/` when user-facing strings change — n/a, no strings
- [x] Codegen ran if DBOs/DTOs/env changed (`just build`) — n/a, no DBO/DTO change
- [x] No secrets or `.env` values committed
- [x] PR title follows conventional commit style

Note on the first box: only the touched files were formatted. A repo-wide `dart format` under the pinned SDK rewrites the initializer list in `fake_hive_db_provider.dart` and hundreds of other committed files, so that reformatting is excluded and the diff carries only real changes.
