### PR TITLE
feat(core): do not show the policy-change notice for revision 1

### DIFF
--- a/lib/core/presentation/main_screen.dart
+++ b/lib/core/presentation/main_screen.dart
@@ -1,15 +1,12 @@
 import 'package:flutter/material.dart';
-import 'package:opennutritracker/core/domain/usecase/add_config_usecase.dart';
 import 'package:opennutritracker/core/domain/usecase/get_config_usecase.dart';
 import 'package:opennutritracker/core/presentation/widgets/add_item_bottom_sheet.dart';
 import 'package:opennutritracker/core/presentation/widgets/demo_mode_banner.dart';
-import 'package:opennutritracker/core/presentation/widgets/policy_change_dialog.dart';
 import 'package:opennutritracker/core/styles/app_palette.dart';
 import 'package:opennutritracker/core/utils/health_rationale_service.dart';
 import 'package:opennutritracker/core/utils/locator.dart';
 import 'package:opennutritracker/core/utils/meal_type_suggester.dart';
 import 'package:opennutritracker/core/utils/navigation_options.dart';
-import 'package:opennutritracker/core/utils/url_const.dart';
 import 'package:opennutritracker/features/diary/diary_page.dart';
 import 'package:opennutritracker/core/presentation/widgets/home_appbar.dart';
 import 'package:opennutritracker/features/home/home_page.dart';
@@ -61,18 +58,24 @@ class _MainScreenState extends State<MainScreen> with WidgetsBindingObserver {
     }
   }
 
-  // One config read for both. Checked once per screen instance rather than
-  // kept live — leaving demo mode always replaces this whole screen with the
-  // onboarding route (see DemoModeBanner), so there's no in-place transition
-  // to react to, and the policy notice is by definition a once-ever event.
+  // Checked once per screen instance rather than kept live — leaving demo mode
+  // always replaces this whole screen with the onboarding route (see
+  // DemoModeBanner), so there is no in-place transition to react to.
+  //
+  // The policy-change notice #887 specified is deliberately **not** shown for
+  // revision 1. #887's reasoning stands on the record and was not refuted —
+  // the corrections name recipients that were always receiving data, so users
+  // were under-informed for the whole time rather than recently — but the call
+  // was made not to spend a first-launch dialog on it. The mechanism itself is
+  // kept, not deleted: `URLConst.policyRevision`, the seeding in
+  // `OnboardingBloc.saveOnboardingData` and `PolicyChangeDialog` are all still
+  // live and tested, so a future revision that does warrant telling people can
+  // restore this by calling the dialog again. What is gone is one call, not
+  // the ability to notify.
   Future<void> _loadConfigDrivenUi() async {
     final config = await locator<GetConfigUsecase>().getConfig();
     if (!mounted) return;
     setState(() => _isDemoData = config.isDemoData);
-    await _maybeShowPolicyChangeNotice(config.policyNoticeRevisionSeen);
-    // After the notice rather than beside it: a cold start launched by Health
-    // Connect can owe the user both, and pushing a route out from under a
-    // dialog would leave the dialog orphaned over the wrong screen.
     await _maybeOpenHealthRationale();
   }
 
@@ -94,26 +97,6 @@ class _MainScreenState extends State<MainScreen> with WidgetsBindingObserver {
     }
     if (!requested || !mounted) return;
     await Navigator.of(context).pushNamed(NavigationOptions.healthSyncRoute);
-  }
-
-  /// Shows the policy-change notice once, to users who onboarded against an
-  /// older revision (#887).
-  ///
-  /// The revision is recorded when the dialog closes rather than when it
-  /// opens, so a user who kills the app mid-dialog is told again rather than
-  /// silently skipped. Recording on open would lose the notice for exactly
-  /// the person who never saw it.
-  Future<void> _maybeShowPolicyChangeNotice(int revisionSeen) async {
-    if (revisionSeen >= URLConst.policyRevision) return;
-
-    await showDialog<void>(
-      context: context,
-      builder: (_) => const PolicyChangeDialog(),
-    );
-
-    await locator<AddConfigUsecase>().setConfigPolicyNoticeRevisionSeen(
-      URLConst.policyRevision,
-    );
   }
 
   @override


### PR DESCRIPTION
## Summary

No user is told the privacy policy changed when 2.1.0 reaches them. Removes the `_maybeShowPolicyChangeNotice` call and method from `MainScreen`, plus three imports that became unused.

**This reverses [#887](https://github.com/simonoppowa/OpenNutriTracker/issues/887), deliberately, and its reasoning is not refuted here.** #887 decided a one-time non-blocking notice was owed because the corrections name recipients that were *always* receiving data — in its own words, *"heavier, because users were under-informed for the whole time rather than recently."* Since then [#951](https://github.com/simonoppowa/OpenNutriTracker/issues/951) permanently accepted the approximate-location logging on the grounds that it cannot be switched off, so the disclosure is doing more work now than when #887 was written.

Against that: no legal basis rests on the acknowledgement ([#874](https://github.com/simonoppowa/OpenNutriTracker/issues/874)), the processing itself never changed — only its description — and a first-launch dialog is a scarce thing to spend on a description-only change in a release whose first launch already carries the health-import work.

The reversal is [recorded on #887](https://github.com/simonoppowa/OpenNutriTracker/issues/887#issuecomment-5461026361) so its resolution does not keep reading as current.

## Type of change
- [ ] Bug fix
- [x] New feature
- [ ] Refactor / cleanup
- [ ] Documentation
- [ ] CI / tooling
- [ ] Localization
- [ ] Other

## Related issues

Refs #887, #874, #921, #951. Must land before #934.

## Changes

- `MainScreen._loadConfigDrivenUi` no longer calls the notice; `_maybeShowPolicyChangeNotice` is deleted.
- Unused imports dropped: `add_config_usecase`, `policy_change_dialog`, `url_const`.
- A comment in `main_screen.dart` records *why* the call is absent, so it reads as a decision rather than an oversight.

### Kept on purpose — only the call site is gone

- `URLConst.policyRevision` stays at **1**.
- `OnboardingBloc.saveOnboardingData` still seeds `policyNoticeRevisionSeen`, so anyone onboarding is correctly recorded as having read the current revision.
- `PolicyChangeDialog`, `policy_change_dialog_test.dart` and `policy_change_notice_test.dart` all remain live and passing.

A future revision that does warrant telling people restores this by calling the dialog again. What is gone is one call, not the ability to notify.

## Screenshots / recordings

None — this removes a dialog. It was verified rendering correctly in German on a Pixel 6 earlier today, which is what it will no longer do.

## Test plan
- [x] Described steps below were followed locally
- [x] Unit / widget tests added or updated (if applicable) — none needed; existing coverage kept and still passing
- [ ] Manual check on Android
- [ ] Manual check on iOS (if applicable)

### Steps
1. `fvm flutter test` — **1164/1164 pass**, including the 12 in `policy_change_dialog_test.dart` and `policy_change_notice_test.dart`, which still cover the retained mechanism.
2. `fvm flutter analyze lib test` — no issues.
3. Not re-verified on device: the change is the *absence* of a dialog, and the device pass earlier today already established the dialog fires on upgrade — which is precisely what this removes.

## Checklist
- [x] Code follows project style (`just format` / 120-char line width)
- [x] New interactive widgets include `Semantics(identifier: '...')` — n/a, nothing added
- [x] Localization updated in ARBs **and** `lib/generated/` — n/a, no strings changed
- [x] Codegen ran if DBOs/DTOs/env changed — n/a
- [x] No secrets or `.env` values committed
- [x] PR title follows conventional commit style

### One loose end, not a blocker

`PolicyChangeDialog`'s ARB body still says the backend *"keeps for 24 hours"* — the same claim [#954](https://github.com/simonoppowa/OpenNutriTracker/issues/954) is about to reword in the published documents. Dormant while the dialog is unshown, so #954's scope is unchanged, but those strings should be corrected alongside if the dialog is ever restored.
