### PR TITLE
fix(ios): declare the HealthKit write purpose string TestFlight demands

### DIFF
--- a/ios/Runner/Info.plist
+++ b/ios/Runner/Info.plist
@@ -65,6 +65,8 @@
     <string>Used to attach a photo to a custom meal so it's easier to recognise in your saved list, and for exporting data.</string>
 	<key>NSHealthShareUsageDescription</key>
 	<string>Read access to your workouts and body fat percentage is used to import workouts into your diary and to suggest how much of their energy to credit toward your daily goal. Nothing is written back to Health, and the data stays on your device.</string>
+	<key>NSHealthUpdateUsageDescription</key>
+	<string>OpenNutriTracker does not write anything to Health. It only reads finished workouts and your most recent body fat percentage, and the activities it creates from them stay in your diary on this device. iOS asks for this description because the health framework the app uses includes write access, which the app never requests.</string>
 	<key>UIApplicationSceneManifest</key>
 	<dict>
 		<key>UIApplicationSupportsMultipleScenes</key>

--- a/test/unit_test/ios_health_purpose_strings_test.dart
+++ b/test/unit_test/ios_health_purpose_strings_test.dart
@@ -1,0 +1,58 @@
+import 'dart:io';
+
+import 'package:flutter_test/flutter_test.dart';
+
+/// Pins the HealthKit purpose strings in `ios/Runner/Info.plist` (#956).
+///
+/// Nothing in CI catches a missing purpose string. `ios-build` runs with
+/// `--no-codesign` and never uploads, `ios-package` only signs, and the first
+/// thing that inspects the bundle is Apple's `altool` at the moment it
+/// rejects the upload — which is how 2.1.0's first release attempt failed,
+/// after every other job had passed.
+///
+/// **`NSHealthUpdateUsageDescription` is required even though the app never
+/// writes to Health.** Apple's check is static: the `health` plugin links
+/// HealthKit's write APIs, and its own error says that "while your app might
+/// not use these APIs, a purpose string is still required". So the absence of
+/// a write call is not a reason to drop this key — it is the reason the key
+/// needs a comment explaining itself.
+void main() {
+  final infoPlist = File('ios/Runner/Info.plist').readAsStringSync();
+
+  String? valueFor(String key) => RegExp(
+        '<key>$key</key>\\s*<string>(.*?)</string>',
+        dotAll: true,
+      ).firstMatch(infoPlist)?.group(1);
+
+  group('HealthKit purpose strings', () {
+    test('the read string is present and says what is read', () {
+      final share = valueFor('NSHealthShareUsageDescription');
+      expect(share, isNotNull);
+      expect(share, contains('workouts'));
+    });
+
+    // The one that was missing. Apple rejects the upload without it, and the
+    // rejection arrives only after a full build, sign and package cycle.
+    test('the write string is present, despite the app never writing', () {
+      expect(
+        valueFor('NSHealthUpdateUsageDescription'),
+        isNotNull,
+        reason: 'altool rejects the build with error 90683 without this key, '
+            'even though no write call exists anywhere in lib/',
+      );
+    });
+
+    // A write string that claimed the app writes data would contradict both
+    // the read string beside it and the in-app disclosure (#926), which tell
+    // the user nothing is written back.
+    test('the write string does not claim the app writes to Health', () {
+      final update = valueFor('NSHealthUpdateUsageDescription')!;
+      expect(
+        update.toLowerCase(),
+        contains('does not write'),
+        reason: 'the read string and the #926 disclosure both promise nothing '
+            'is written back; this must not contradict them',
+      );
+    });
+  });
+}


### PR DESCRIPTION
## Summary

Puts [#957](https://github.com/simonoppowa/OpenNutriTracker/pull/957) on `main` so the 2.1.0 iOS upload can succeed. Cherry-pick of `68d9b612`; the diff against `main` is exactly the two files that PR touched.

`altool` rejected the first release attempt with error **90683** — the bundle must carry `NSHealthUpdateUsageDescription`. `main` is still at `e0a2e2e3` without it, so **re-running the failed run cannot help**: it would replay the same commit and fail identically.

## Why a cherry-pick and not a `develop → main` release PR

`e0a2e2e3` has a **single parent** — [#934](https://github.com/simonoppowa/OpenNutriTracker/pull/934) was squash-merged, so `main` does not share `develop`'s history. A `develop → main` merge therefore resolves its base to a commit predating 2.1.0 and reports a **content conflict in `ios/Runner/Info.plist`**, despite the real difference being two added lines. Cherry-picking reaches the identical tree with no conflict to hand-resolve.

**Worth deciding separately:** every future release PR will hit the same thing for the same reason, and it will get worse as the branches drift. Either release merges stop being squashed, or `main` gets reconciled with `develop`'s history once. Not fixed here.

## Type of change
- [x] Bug fix
- [ ] New feature
- [ ] Refactor / cleanup
- [ ] Documentation
- [ ] CI / tooling
- [ ] Localization
- [ ] Other

## Related issues

Fixes #956. Refs #934, #942, #957.

## Changes

- `ios/Runner/Info.plist` — adds `NSHealthUpdateUsageDescription`.
- `test/unit_test/ios_health_purpose_strings_test.dart` — asserts both health purpose strings exist and that the write string does not claim the app writes to Health.

## Test plan
- [x] Described steps below were followed locally
- [x] Unit / widget tests added or updated (if applicable)
- [ ] Manual check on Android
- [ ] Manual check on iOS (if applicable)

### Steps
1. `fvm flutter test test/unit_test/ios_health_purpose_strings_test.dart` on this branch — 3 pass.
2. The cherry-pick applied cleanly; `git diff origin/main` shows exactly the two files, +60.
3. Real proof is `ios-deploy` on the run this merge triggers. Nothing local can talk to App Store Connect.

## Checklist
- [x] Code follows project style (`just format` / 120-char line width)
- [x] New interactive widgets include `Semantics(identifier: '...')` — n/a
- [x] Localization updated in ARBs **and** `lib/generated/` — n/a
- [x] Codegen ran if DBOs/DTOs/env changed — n/a
- [x] No secrets or `.env` values committed
- [x] PR title follows conventional commit style

## This unblocks iOS only

Merging triggers a fresh pipeline. `ios-package` already proved signing works on the regenerated profile, so `ios-deploy` should now get through.

**`android-deploy` will fail again**, and no merge changes that. It is [#942](https://github.com/simonoppowa/OpenNutriTracker/issues/942): a known, open, unowned defect where the Play Publishing API rejects health-permission bundles at `EditService.Validate`/`Commit` **regardless of the declaration**, which is complete and re-verified in the console. Manual console uploads are the only reported workaround. So expect this run to end red on the Android half even when everything else passes.

No version bump anywhere: both uploads were rejected before acceptance, so `2.1.0+62` is still available.
