### PR TITLE
ci(android): tolerate the known Play health-declaration defect, nothing else

### DIFF
--- a/.github/workflows/default_workflow.yml
+++ b/.github/workflows/default_workflow.yml
@@ -926,12 +926,80 @@ jobs:
           name: android-aab
           path: release-assets/android
 
+      # Tolerates exactly one upstream defect, and nothing else.
+      #
+      # Since 2.1.0 the bundle declares `android.permission.health.*`, and the
+      # Play Publishing API rejects health-permission bundles at
+      # `EditService.Validate`/`Commit` with "You must let us know whether your
+      # app includes any health features" — **regardless of the declaration**,
+      # which is complete and was re-verified across four console surfaces
+      # (#942). Uploading the same bundle by hand through the console asks no
+      # health question at all and succeeds. It is a known, open, unowned
+      # defect: fastlane#22204 was closed unfixed, fastlane#27960 reopened it,
+      # and expo/eas-cli#3275 reports it from a different toolchain, which
+      # rules out fastlane's request construction as the sole cause.
+      #
+      # So the attempt stays. Deleting the step would go silently green and
+      # nobody would notice the day Google fixes it; `continue-on-error` would
+      # swallow real failures too. Matching the one error string keeps every
+      # other failure — bad credentials, a consumed versionCode, a rejected
+      # bundle — loud, and lets this heal itself with no further change.
+      #
+      # Note what a failing upload also costs, learned the hard way in #959:
+      # the API never reaches the point where Play returns its release
+      # warnings, so a minSdk bump that dropped 1,399 device models went
+      # unseen for eight days. The manual upload is where those warnings
+      # appear, which is why the summary below insists on reading them.
       - name: Upload Android App Bundle to Google Play Internal Testing via Fastlane
         working-directory: android
-        run: bundle exec fastlane android internal
         env:
           GOOGLE_PLAY_SERVICE_ACCOUNT_JSON: ${{ secrets.GOOGLE_PLAY_SERVICE_ACCOUNT_JSON }}
           ANDROID_AAB_PATH: ${{ github.workspace }}/release-assets/android/app-release.aab
+        run: |
+          set +e
+          log="$RUNNER_TEMP/play-upload.log"
+          bundle exec fastlane android internal 2>&1 | tee "$log"
+          status=${PIPESTATUS[0]}
+          set -e
+
+          [ "$status" -eq 0 ] && exit 0
+
+          if ! grep -qF \
+            'You must let us know whether your app includes any health features' \
+            "$log"; then
+            echo "::error::Play upload failed for a reason other than the known health-declaration defect (#942). Not tolerated."
+            exit "$status"
+          fi
+
+          echo "::warning::Play rejected the API upload with the known health-declaration defect (#942). The Android bundle needs uploading by hand; iOS is unaffected."
+
+          {
+            echo '### Android upload needs doing by hand'
+            echo
+            echo 'The Play Publishing API rejected this bundle with:'
+            echo
+            echo '> Google Api Error: Invalid request - You must let us know whether your app includes any health features.'
+            echo
+            echo 'This is [#942](https://github.com/simonoppowa/OpenNutriTracker/issues/942):'
+            echo 'a known upstream defect, not a missing declaration. The declaration is'
+            echo 'complete, and the console asks no health question when the same bundle is'
+            echo 'uploaded by hand.'
+            echo
+            echo '**To finish the release:**'
+            echo
+            echo '1. Download the `android-aab` artifact from this run, or take the AAB'
+            echo '   attached to the GitHub release this workflow creates.'
+            echo '2. Play Console → Testen und veröffentlichen → Interner Test →'
+            echo '   **Neuen Release erstellen**, and drop the AAB in.'
+            echo '3. **Read the warnings on the review step before publishing.** This is the'
+            echo '   only place Play reports them, and a failing API upload never gets far'
+            echo '   enough to return them — which is how the minSdk regression in'
+            echo '   [#959](https://github.com/simonoppowa/OpenNutriTracker/issues/959) went'
+            echo '   unnoticed for eight days.'
+            echo
+            echo 'This step will start passing on its own once Google fixes the API; nothing'
+            echo 'here needs changing when that happens.'
+          } >> "$GITHUB_STEP_SUMMARY"
 
   github-release:
     if: |


### PR DESCRIPTION
## Summary

`android-deploy` has failed on every 2.1.0 release attempt and will keep failing. This makes the job tolerate **exactly that one upstream defect** and nothing else.

Since 2.1.0 the bundle declares `android.permission.health.*`, and the Play Publishing API rejects health-permission bundles at `EditService.Validate`/`Commit`:

```
Google Api Error: Invalid request -
You must let us know whether your app includes any health features.
```

**The declaration is not missing.** It was re-verified across four console surfaces — the Gesundheits-Apps form (both steps, `Speichern` disabled so it cannot even be re-saved), App content's *Überprüfung erforderlich* tab (empty), Richtlinienstatus (clean), and the release track. And the same bundle uploaded by hand through the console **is asked no health question at all** and publishes fine — which is how `2.1.0+62` reached Internal Testing on 2026-08-29.

Known, open and unowned upstream: [fastlane#22204](https://github.com/fastlane/fastlane/issues/22204) closed unfixed, [fastlane#27960](https://github.com/fastlane/fastlane/issues/27960) reopened because it persists, and [expo/eas-cli#3275](https://github.com/expo/eas-cli/issues/3275) reports it from a different toolchain — which rules out fastlane's request construction as the sole cause. Google's reported position is that it is a fastlane issue; fastlane's is that it is a Play issue.

## Type of change
- [ ] Bug fix
- [ ] New feature
- [ ] Refactor / cleanup
- [ ] Documentation
- [x] CI / tooling
- [ ] Localization
- [ ] Other

## Related issues

Refs #942, #959, #934.

## Changes

`.github/workflows/default_workflow.yml` — the Play upload step now captures its output and:

- **exit 0** → passes, unchanged;
- **fails with the known string** → `::warning::`, writes a step summary explaining the manual upload, exits 0;
- **fails any other way** → `::error::`, exits with the original status.

### Why not the two obvious alternatives

- **Delete the step.** Goes silently green, and nobody notices the day Google fixes it. The attempt is what makes this self-healing: when the API starts working, the step simply passes and nothing here needs changing.
- **`continue-on-error: true`.** Swallows *real* failures too — bad credentials, a consumed versionCode, a rejected bundle. Matching the one string keeps every other failure loud.

### The part that motivated the summary text

A failing upload does not only cost a manual step — **it suppresses Play's release warnings.** The API never reaches the point where they are returned, so the minSdk 24 → 26 bump that dropped **1,399 device models** ([#959](https://github.com/simonoppowa/OpenNutriTracker/issues/959)) went unseen for eight days and was found by accident during the manual upload. The step summary therefore tells the operator, in the strongest terms available, to read the warnings on the review screen before publishing.

## Test plan
- [x] Described steps below were followed locally
- [x] Unit / widget tests added or updated (if applicable) — n/a, workflow change
- [ ] Manual check on Android
- [ ] Manual check on iOS (if applicable)

### Steps

The step's shell body was extracted from the parsed YAML and exercised against a stubbed `bundle`, covering all three outcomes:

| Scenario | Expected | Result |
| --- | --- | --- |
| Known health-declaration error | exit 0, summary written | **exit 0**, summary written |
| Any other Play error | non-zero, no summary | **exit 1**, summary empty (0 bytes) |
| Successful upload | exit 0, no summary | **exit 0** |

Plus `yaml.safe_load` on the whole workflow (11 jobs) and `bash -n` on the extracted body.

Real proof is the next release; nothing local can talk to the Publishing API.

## Checklist
- [x] Code follows project style (`just format` / 120-char line width)
- [x] New interactive widgets include `Semantics(identifier: '...')` — n/a
- [x] Localization updated in ARBs **and** `lib/generated/` — n/a
- [x] Codegen ran if DBOs/DTOs/env changed — n/a
- [x] No secrets or `.env` values committed
- [x] PR title follows conventional commit style

## One consequence to decide on, deliberately left as-is

With `android-deploy` now passing, **`github-release` will run**, creating a GitHub release with both assets while Play has not actually been updated.

I left it that way on purpose: it gives the AAB a stable home for the manual upload rather than a 90-day artifact, and the iOS half genuinely did ship. But it does mean a GitHub release implying more completeness than exists. Gating `github-release` on a genuine upload is possible and costs more plumbing — worth a decision rather than a default.

## Not a fix for #942

This makes a known-broken step honest; it does not make the Android upload work. [#942](https://github.com/simonoppowa/OpenNutriTracker/issues/942)'s other open question — whether every release now carries a manual Android step — stays open, and this PR is the answer to only the second half of it.
