### PR TITLE
docs(android): record what the minSdk 26 floor actually costs

### DIFF
--- a/android/app/build.gradle
+++ b/android/app/build.gradle
@@ -61,7 +61,16 @@ android {
     defaultConfig {
         applicationId "com.opennutritracker.ont.opennutritracker"
         // The health package's Health Connect client requires API 26; Flutter's
-        // default is lower, so the floor is pinned here.
+        // default is 24, so the floor is pinned here.
+        //
+        // The cost, which #651 raised the floor without measuring: this drops
+        // Android 7.0 and 7.1. Play counts that as 1,399 device models — a
+        // number that sounds alarming and is not, because measured against
+        // real installs on 2026-08-29 it was **3 of 9,580 active users**,
+        // 0.03% (#959). Accepted deliberately on that evidence: Health
+        // Connect cannot ship below 26, so the alternative was dropping the
+        // feature, and 1,399 models is a device-catalogue figure rather than
+        // an audience.
         minSdkVersion 26
         targetSdkVersion 36
         versionCode flutterVersionCode.toInteger()


### PR DESCRIPTION
## Summary

Records what the `minSdkVersion 26` floor costs, next to the reason it exists. Comment only, no behaviour change.

Fixes #959 — and corrects two claims that issue made.

## The measurement

Play's release review reports **1,399 device models no longer supported**, which is the figure a reader meets first and is easy to panic about. Measured against real installs in Play Console on 2026-08-29:

| | Active users | Share |
| --- | --- | --- |
| All Android versions | **9,580** | 100 % |
| Android 7.0 (API 24) | **2** | 0.02 % |
| Android 7.1 (API 25) | **1** | 0.01 % |
| Android 6.0 (API 23) | – | 0 |

**Three people.** A device-catalogue count is not an audience, and the comment now says so.

## Two corrections to #959

That issue was filed in a hurry off the release warning, and got two things wrong:

1. **"minSdkVersion 26 is hardcoded with no comment."** False — `af28c39f` added the comment in the same commit as the bump, and it already explained that Health Connect requires API 26.
2. **"The #651 commit body … does not mention the minSdk change or its cost at all."** Half false. The body carries a dedicated conventional-commit subject, *"build(android): raise minSdk to 26 for the Health Connect client"*.

What #651 genuinely did not do was **measure the cost**, and that is the only real gap. This PR closes it.

## Type of change
- [ ] Bug fix
- [ ] New feature
- [ ] Refactor / cleanup
- [x] Documentation
- [ ] CI / tooling
- [ ] Localization
- [ ] Other

## Related issues

Fixes #959. Refs #651, #934.

## Changes

`android/app/build.gradle` — the comment above `minSdkVersion 26` now states which Android versions are dropped, what that is worth in measured users, and that the trade was accepted deliberately on that evidence.

## Test plan
- [x] Described steps below were followed locally
- [x] Unit / widget tests added or updated (if applicable) — n/a, comment only
- [ ] Manual check on Android
- [ ] Manual check on iOS (if applicable)

### Steps
1. Comment-only change inside `defaultConfig`; no Gradle value altered. `minSdkVersion 26` is byte-identical.
2. Figures read directly from Play Console → Statistiken, dimension *Android-Version*, metric *Zielgruppe mit installierter App*, 2026-08-01 → 2026-08-28.

## Checklist
- [x] Code follows project style (`just format` / 120-char line width)
- [x] New interactive widgets include `Semantics(identifier: '...')` — n/a
- [x] Localization updated in ARBs **and** `lib/generated/` — n/a
- [x] Codegen ran if DBOs/DTOs/env changed — n/a
- [x] No secrets or `.env` values committed
- [x] PR title follows conventional commit style

## Why not do more

The alternatives in #959 — shipping the health import behind a higher floor while keeping the app at 24, or reverting the feature — are not proportionate to three users, and the first is not achievable with a single bundle. The decision is to accept, and the point of this change is that the next person meeting the 1,399 figure can see it was a decision rather than an oversight.
