### PR TITLE
docs: reword the gateway retention clause so it cannot go stale

### DIFF
--- a/docs/privacy-policy/de.txt
+++ b/docs/privacy-policy/de.txt
@@ -131,7 +131,7 @@ Lebensmittel-Referenzdatenbank (Supabase)
 
 Lebensmittelsuchen werden von einer Referenzdatenbank beantwortet, die der Anbieter dieser Anwendung auf der Managed-Cloud-Plattform von Supabase betreibt. Bei einer Suche werden der von Ihnen eingegebene Text übermittelt, außerdem Ihre App-Sprache, sofern diese Anwendung Lebensmittelübersetzungen dafür mitbringt, und — falls Sie in den Einstellungen eine der Lebensmitteldatenbanken abgeschaltet haben — die Liste der von Ihnen aktiv gelassenen Datenbanken. Es werden kein Konto, kein Profil und keine Gerätekennung mitgesendet, und Ihr Ernährungstagebuch wird nie übermittelt.
 
-Da die Anfrage über das Internet übertragen wird, protokolliert das Gateway der Plattform für 24 Stunden die Adresse, von der die Anfrage kam, einen daraus abgeleiteten ungefähren Standort (Land, Region, Ort und Postleitzahl), den Namen Ihres Internetanbieters sowie einen Fingerprint der verschlüsselten Verbindung.
+Da die Anfrage über das Internet übertragen wird, protokolliert das Gateway der Plattform die Adresse, von der die Anfrage kam, einen daraus abgeleiteten ungefähren Standort (Land, Region, Ort und Postleitzahl), den Namen Ihres Internetanbieters sowie einen Fingerprint der verschlüsselten Verbindung. Diese Daten werden so lange aufbewahrt, wie der Hosting-Tarif die Gateway-Protokolle vorhält — derzeit 24 Stunden.
 
 Die Datenbank wird in Frankfurt (Deutschland) gespeichert und überwiegend dort verarbeitet. Die Supabase Pte. Ltd. handelt als Auftragsverarbeiter auf Weisung des Anbieters; zu ihren Unterauftragsverarbeitern gehören die Cloudflare, Inc. und die Amazon Web Services, Inc. Anfragen erreichen zunächst einen Cloudflare-Standort in Ihrer Nähe und dann die Datenbank. Übermittlungen außerhalb des Europäischen Wirtschaftsraums sind durch Standardvertragsklauseln abgedeckt.
 
@@ -348,4 +348,4 @@ Rechtlicher Hinweis
 
 Diese Erklärung bezieht sich ausschließlich auf diese Anwendung, sofern in diesem Dokument nicht anders angegeben.
 
-Letzte Aktualisierung: 27. August 2026
+Letzte Aktualisierung: 29. August 2026

--- a/docs/privacy-policy/en.txt
+++ b/docs/privacy-policy/en.txt
@@ -159,7 +159,7 @@ Food reference backend (Supabase)
 
 Food searches are answered by a reference database that the Owner of this Application operates on Supabase's managed cloud platform. A search sends the text you typed; your app language too, when it is one this Application has food translations for; and, if you have switched any of the food databases off in Settings, the list of the ones you left on. No account, profile or device identifier is attached, and your food diary is never sent.
 
-Because the request travels over the internet, the platform's gateway records for 24 hours the address the request came from, an approximate location derived from that address (country, region, city and postal code), the name of your internet access provider, and a fingerprint of the encrypted connection.
+Because the request travels over the internet, the platform's gateway records the address the request came from, an approximate location derived from that address (country, region, city and postal code), the name of your internet access provider, and a fingerprint of the encrypted connection. These are kept for as long as the hosting plan retains its gateway logs — currently 24 hours.
 
 The database is stored and primarily processed in Frankfurt, Germany. Supabase Pte. Ltd. acts as a processor on the Owner's instructions, with Cloudflare, Inc. and Amazon Web Services, Inc. among its sub-processors; requests reach a Cloudflare location close to you before the database. Transfers outside the European Economic Area are covered by standard contractual clauses.
 
@@ -351,4 +351,4 @@ Legal information
 
 This policy relates solely to this Application, if not stated otherwise within this document.
 
-Latest update: August 27, 2026
+Latest update: August 29, 2026


### PR DESCRIPTION
## Summary

The published clause promised the gateway keeps request metadata **"for 24 hours"** — a number the project cannot control. Retention is a read-only entitlement and the ladder is **Free 1 day → Pro 7 → Team 28 → Enterprise 90** ([#950](https://github.com/simonoppowa/OpenNutriTracker/issues/950)), so any plan upgrade would have made the sentence false at the moment it happened, with nothing to catch it.

**Both live documents are already edited.** This PR carries the regenerated snapshots.

| | Before | After |
| --- | --- | --- |
| EN | …the platform's gateway records **for 24 hours** the address the request came from… | …the platform's gateway records the address the request came from… **These are kept for as long as the hosting plan retains its gateway logs — currently 24 hours.** |
| DE | …protokolliert das Gateway der Plattform **für 24 Stunden** die Adresse… | …protokolliert das Gateway der Plattform die Adresse… **Diese Daten werden so lange aufbewahrt, wie der Hosting-Tarif die Gateway-Protokolle vorhält — derzeit 24 Stunden.** |

The criterion becomes the promise; the number survives as an illustration. An upgrade now *dates* the illustration rather than falsifying the commitment.

Dropping the number entirely was considered and rejected in [#953](https://github.com/simonoppowa/OpenNutriTracker/issues/953): a day and ninety days read very differently, and GDPR Art. 13(2)(a) asks for the period **or** the criteria used to determine it — this keeps both.

## Type of change
- [ ] Bug fix
- [ ] New feature
- [ ] Refactor / cleanup
- [x] Documentation
- [ ] CI / tooling
- [ ] Localization
- [ ] Other

## Related issues

Fixes #954. Refs #950, #953, #938, #888.

## Changes

`docs/privacy-policy/{en,de}.txt` — regenerated snapshots. Four lines: the reworded sentence in each language, and each document's "last updated" stamp moving to 29 August 2026.

**`URLConst.policyRevision` deliberately stays at 1.** No user has yet seen a revision-1 notice — `v2.0.2` is the latest published tag and revision 1 ships first in 2.1.0 — so there is nobody to re-notify, and the corrected wording simply becomes part of what they are eventually told.

## Test plan
- [x] Described steps below were followed locally
- [x] Unit / widget tests added or updated (if applicable) — n/a
- [ ] Manual check on Android
- [ ] Manual check on iOS (if applicable)

### Steps
1. Edited by hand in **both** iubenda documents — EN `53501884`, DE `53922100`. Custom clauses do not propagate between languages, which is the drift [#888](https://github.com/simonoppowa/OpenNutriTracker/issues/888) caught in the wild, so the German one is the failure mode to guard against and was done deliberately alongside.
2. Before saving, each textarea's full value was read back and compared: the only difference from the previous text is the intended sentence, everything else byte-identical. English grew 1,630 → 1,711 characters.
3. `fvm dart run tool/policy_snapshot.dart` — both documents fetched, both now stamp 29 August 2026, structural check passes: **7 purposes and 9 services in each**.
4. `git diff` on the snapshots shows exactly four changed lines and nothing else.

### Pre-existing, untouched

The snapshot tool warns that `support.apple.com` is linked from the **German document only**. Verified as pre-existing — identical counts at `HEAD` and after this change (0 in EN, 1 in DE). Not caused here, and not fixed here; it is the same class of cross-language drift as #888 and probably wants its own look.

## Checklist
- [x] Code follows project style (`just format` / 120-char line width)
- [x] New interactive widgets include `Semantics(identifier: '...')` — n/a
- [x] Localization updated in ARBs **and** `lib/generated/` — n/a
- [x] Codegen ran if DBOs/DTOs/env changed — n/a
- [x] No secrets or `.env` values committed
- [x] PR title follows conventional commit style
