### PR TITLE
docs: say that `Fixes #N` does not close issues merged into develop

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -421,6 +421,14 @@ When filing issues or opening PRs, prefer these templates. Product/food-database
 
 Blank issues are disabled (`blank_issues_enabled: false`). Add or edit YAML forms in `.github/ISSUE_TEMPLATE/`; keep labels (`bug`, `enhancement`, `question`) aligned with any repo label setup.
 
+### `Fixes #N` does not close the issue here
+
+Feature work targets **`develop`**, but the default branch is **`main`**. GitHub only acts on a closing keyword when the referencing commit reaches the *default* branch, so a `Fixes #123` in a PR merged into `develop` **leaves the issue open** — often for weeks, until a release merge carries it to `main`.
+
+Write the reference anyway: it links the PR to the issue and closes it when the release lands. But **close the issue by hand once the PR merges**, with a comment saying where the fix is. Three issues sat open for exactly this reason on 2026-08-29 alone.
+
+The exception is a PR that targets `main` directly — a release PR or a hotfix — where the keyword behaves as expected.
+
 ## Naming Conventions
 
 | Suffix                     | Meaning                                                       |


### PR DESCRIPTION
## Summary

Documents a trap that caught three issues in one day: **`Fixes #N` does not close an issue when the PR merges into `develop`.**

Feature work targets `develop`; the default branch is `main`. GitHub only acts on a closing keyword once the referencing commit reaches the *default* branch, so the reference sits inert until a release merge carries it across — which can be weeks.

On 2026-08-29 this left [#944](https://github.com/simonoppowa/OpenNutriTracker/issues/944), [#959](https://github.com/simonoppowa/OpenNutriTracker/issues/959) and [#954](https://github.com/simonoppowa/OpenNutriTracker/issues/954) open after their fixes had merged. Each was found by chance and closed by hand.

It is not a bug to fix — it follows from the branching model — so the only useful remedy is knowing about it.

## Type of change
- [ ] Bug fix
- [ ] New feature
- [ ] Refactor / cleanup
- [x] Documentation
- [ ] CI / tooling
- [ ] Localization
- [ ] Other

## Related issues

Refs #944, #954, #959.

## Changes

`AGENTS.md` — new subsection under **GitHub issue and PR templates**, which is where someone reading about how issues and PRs work here would look. Eight lines. It says to:

- **keep writing the reference** — it still links the PR, and still closes the issue when the release lands;
- **close by hand on merge**, with a comment saying where the fix is;
- expect the keyword to behave normally on PRs that target `main` directly, such as a release PR or hotfix.

## Test plan
- [x] Described steps below were followed locally
- [x] Unit / widget tests added or updated (if applicable) — n/a
- [ ] Manual check on Android
- [ ] Manual check on iOS (if applicable)

### Steps
Prose only; no code path touched. The behaviour it documents was observed three times today, each confirmed by the issue still being open after its PR had merged.

## Checklist
- [x] Code follows project style (`just format` / 120-char line width)
- [x] New interactive widgets include `Semantics(identifier: '...')` — n/a
- [x] Localization updated in ARBs **and** `lib/generated/` — n/a
- [x] Codegen ran if DBOs/DTOs/env changed — n/a
- [x] No secrets or `.env` values committed
- [x] PR title follows conventional commit style

## A note on the irony

This PR targets `develop`, so it carries no `Fixes` line — there is no issue to close, and if there were, it would not have closed.
