### PR TITLE
docs: write our own App Store Connect clause instead of iubenda's

### DIFF
--- a/docs/privacy-policy/de.txt
+++ b/docs/privacy-policy/de.txt
@@ -14,7 +14,7 @@ E-Mail-Adresse des Anbieters: opennutritracker-dev@pm.me
 Arten der erhobenen Daten
 
 Zu den personenbezogenen Daten, die diese Anwendung selbstständig oder durch Dritte verarbeitet, gehören:
-Nutzungsdaten; Diagnosedaten; E-Mail; Informationen über die Anwendung; Gerätelogs; Geräteinformationen; Während der Nutzung des Dienstes übermittelte Daten.
+Nutzungsdaten; E-Mail; Informationen über die Anwendung; Gerätelogs; Geräteinformationen; Während der Nutzung des Dienstes übermittelte Daten.
 
 Vollständige Details zu jeder Art von verarbeiteten personenbezogenen Daten werden in den dafür vorgesehenen Abschnitten dieser Datenschutzerklärung oder punktuell durch Erklärungstexte bereitgestellt, die vor der Datenerhebung angezeigt werden.
 Personenbezogene Daten können vom Nutzer freiwillig angegeben oder, im Falle von Nutzungsdaten, automatisch erhoben werden, wenn diese Anwendung genutzt wird.
@@ -161,14 +161,17 @@ Verarbeitungsort: Vereinigte Staaten – Datenschutzerklärung; Irland – Daten
 
 App Store Connect (Apple Inc.)
 
-Diese Anwendung wird im App Store von Apple vertrieben, einer Plattform für den Vertrieb mobiler Anwendungen, die von Apple Inc. bereitgestellt wird.
+Diese Anwendung wird über den App Store von Apple vertrieben; App Store Connect ist die Konsole, die Apple dem Anbieter für deren Verwaltung bereitstellt.
 
-App Store Connect ermöglicht es dem Anbieter, diese Anwendung im App Store von Apple zu verwalten. Je nach Konfiguration stellt App Store Connect dem Anbieter statistische Daten über Nutzerbindung und App-Entdeckung, Marketingkampagnen, Verkäufe, In-App-Käufe und Zahlungen zur Verfügung, um die Leistung von diese Anwendung zu messen.
-App Store Connect sammelt solche Daten nur von Nutzern, die zugestimmt haben, sie mit dem Anbieter zu teilen. Nutzer finden weitere Informationen darüber, wie sie sich über ihre Geräteeinstellungen abmelden können [hier] (https://support.apple.com/de-de/HT202100).
+Apple meldet dem Anbieter zusammengefasste Kennzahlen zum App-Store-Eintrag — wie viele Menschen ihn gesehen, die App installiert und weiter genutzt haben — sowie Absturz- und Diagnoseberichte von Geräten. Diese Angaben kommen bereits aggregiert von Apple und nur von Nutzern, die in ihren Geräteeinstellungen der Weitergabe von Analysedaten an Entwickler zugestimmt haben. Diese Anwendung verkauft nichts und bietet weder Käufe noch Abonnements an; entsprechende Daten fallen daher nicht an.
+
+Der Anbieter kann Sie daraus nicht identifizieren, und nichts davon ist mit Ihrem Ernährungstagebuch verknüpft, das Ihr Gerät nie verlässt.
+
+Sie können dies für alle Apps zugleich abschalten, unter iOS-Einstellungen → Datenschutz & Sicherheit → Analyse & Verbesserungen. Apple erklärt es hier.
 
 Verarbeitete personenbezogene Daten: Diagnosedaten.
 
-Verarbeitungsort: Vereinigte Staaten – Datenschutzerklärung.
+Verarbeitungsort: Vereinigte Staaten — Datenschutzerklärung.
 
 Zugriff auf Profile von Drittanbietern
 

--- a/docs/privacy-policy/en.txt
+++ b/docs/privacy-policy/en.txt
@@ -14,7 +14,7 @@ Owner contact email: opennutritracker-dev@pm.me
 Types of Data collected
 
 Among the types of Personal Data that this Application collects, by itself or through third parties, there are:
-Usage Data; diagnostics; email address; app information; device logs; device information; Data communicated while using the service.
+Usage Data; email address; app information; device logs; device information; Data communicated while using the service.
 
 Complete details on each type of Personal Data collected are provided in the dedicated sections of this privacy policy or by specific explanation texts displayed prior to the Data collection.
 Personal Data may be freely provided by the User, or, in case of Usage Data, collected automatically when using this Application.
@@ -209,14 +209,17 @@ Place of processing: United States – Privacy Policy; Ireland – Privacy Polic
 
 App Store Connect (Apple Inc.)
 
-This Application is distributed on Apple's App Store, a platform for the distribution of mobile apps, provided by Apple Inc.
+This Application is distributed through Apple's App Store, and App Store Connect is the console Apple gives the Owner to manage it there.
 
-App Store Connect enables the Owner to manage this Application on Apple's App Store. Depending on the configuration, App Store Connect provides the Owner with analytics data on user engagement and app discovery, marketing campaigns, sales, in-app purchases, and payments to measure the performance of this Application.
-App Store Connect only collects such data from Users who have agreed to share them with the Owner. Users may find more information on how to opt out via their device settings here.
+Apple reports back aggregate figures about the App Store listing — how many people saw it, installed it, and kept using it — together with crash and diagnostic reports from devices. These arrive already aggregated, and only from Users who chose to share analytics with developers in their device settings. This Application makes no sales and offers no purchases or subscriptions, so nothing of that kind is reported.
+
+The Owner cannot identify you from any of it, and none of it is linked to your food diary, which never leaves your device.
+
+You can turn this off for every app at once under iOS Settings → Privacy & Security → Analytics & Improvements. Apple explains it here.
 
 Personal Data processed: diagnostics.
 
-Place of processing: United States – Privacy Policy.
+Place of processing: United States — Privacy Policy.
 
 Further Information for Users
 


### PR DESCRIPTION
## Summary

iubenda's German App Store Connect clause emitted the opt-out link as **literal markdown** — `[hier] (https://support.apple.com/de-de/HT202100)` — so German readers saw raw text and *hier* was not clickable. English rendered a proper anchor.

[#963](https://github.com/simonoppowa/OpenNutriTracker/issues/963) established the text is iubenda's catalogue translation and **not editable from this account**: the service's editor offers a Personal Data field, an AI checkbox and a cookie category, with no Name, Description or translation tabs — unlike the five custom services here, which have all three.

**So the clause is now ours.** The catalogue service was replaced with a custom one under the same purpose (*Platform services and hosting*), which is how five of the nine services were already maintained.

## Three things improve beyond the link

- **Boilerplate that was never true is gone.** The template claimed App Store Connect reports *"marketing campaigns, sales, in-app purchases, and payments"*. None applies — there is no `in_app_purchase`, StoreKit or billing dependency anywhere in the tree, verified before writing. The clause now states plainly that the app makes no sales and offers no purchases or subscriptions.
- **A German grammar error goes with it** — the template read *"um die Leistung von **diese** Anwendung zu messen"*.
- **Both place-of-processing links are anchors too**, not just the opt-out one.

## Type of change
- [ ] Bug fix
- [ ] New feature
- [ ] Refactor / cleanup
- [x] Documentation
- [ ] CI / tooling
- [ ] Localization
- [ ] Other

## Related issues

Fixes #963. Refs #871, #888, #953.

## Changes

`docs/privacy-policy/{en,de}.txt` — regenerated snapshots carrying the new clause. The live documents are already updated; this is the change record.

## Test plan
- [x] Described steps below were followed locally
- [x] Unit / widget tests added or updated (if applicable) — n/a
- [ ] Manual check on Android
- [ ] Manual check on iOS (if applicable)

### Steps

1. Custom service created with **Specify service translations** on, both languages written by hand, purpose set to *Platform services and hosting*, processing marked as **third party**. Verified in-page before saving: purpose and radio correct, name set, German body 1,164 characters.
2. Catalogue service removed only **after** the custom one saved, so the policy was never missing the disclosure — briefly duplicated instead, which is the safer direction.
3. `fvm dart run tool/policy_snapshot.dart` — **the `linked hosts differ: support.apple.com` warning is gone.** Structural check passes: 7 purposes and 9 services per language, back to 9 after the add-then-remove.
4. Both published documents re-fetched and the anchors asserted directly:

```
en: <a href="https://support.apple.com/en-gb/HT202100">here</a>   literal markdown: none
de: <a href="https://support.apple.com/de-de/HT202100">hier</a>   literal markdown: none
```

**`URLConst.policyRevision` stays at 1** — no user has seen a revision-1 notice yet, so this becomes part of what they are eventually told rather than a change made underneath them.

## Checklist
- [x] Code follows project style (`just format` / 120-char line width)
- [x] New interactive widgets include `Semantics(identifier: '...')` — n/a
- [x] Localization updated in ARBs **and** `lib/generated/` — n/a
- [x] Codegen ran if DBOs/DTOs/env changed — n/a
- [x] No secrets or `.env` values committed
- [x] PR title follows conventional commit style

## The trade being made

Owning the clause means it no longer tracks iubenda's template if they revise it — the same trade already accepted for the other five custom services, and the reason #871 recorded that *every clause this project wrote is a custom clause*. Given the template was wrong in three separate ways here, that seems the right side of the trade.
