### PR TITLE
fix(add-meal): stop showing an English portion word in eight other languages

### DIFF
--- a/lib/features/add_meal/presentation/screens/bulk_add_screen.dart
+++ b/lib/features/add_meal/presentation/screens/bulk_add_screen.dart
@@ -990,7 +990,10 @@ class _BulkAddScreenState extends State<BulkAddScreen> {
         UnitDropdownItem.oz => S.of(context).ozUnit,
         UnitDropdownItem.flOz => S.of(context).flOzUnit,
         UnitDropdownItem.serving =>
-          householdPortionLabel(row.meal?.servingSize) ??
+          householdPortionLabel(
+            row.meal?.servingSize,
+            languageCode: Localizations.localeOf(context).languageCode,
+          ) ??
               S.of(context).servingLabel,
       };
 

--- a/lib/features/add_meal/util/portion_label.dart
+++ b/lib/features/add_meal/util/portion_label.dart
@@ -49,7 +49,29 @@ const maxHouseholdPortionLabel = 16;
 /// Deliberately conservative: every rejection falls back to today's wording,
 /// so a miss costs nothing and a false positive would cost a wrong-looking
 /// unit on a correct number.
-String? householdPortionLabel(String? servingSize) {
+///
+/// **Only in English, because that is the only language this text exists
+/// in.** `food_summary.serving_size` is built straight from
+/// `food_portion.portion_description` with no join to
+/// `food_portion_translation`, and that table is empty — measured against the
+/// live backend, 0 rows, alongside 36,682 portions. So the word is "slice"
+/// for every locale the app ships. Food *names* are translated (20,834 rows
+/// in `food_translation`), which is what made the gap easy to miss: the row
+/// showed a German name beside an English unit.
+///
+/// The cost is admitted rather than hidden: an Open Food Facts product whose
+/// own `serving_size` happens to be in the reader's language is suppressed
+/// too, because nothing here can tell which language that field is in. That
+/// returns those rows to what they said before this function existed, which
+/// was never wrong — only less specific. Guessing the other way puts an
+/// English word in eight other languages' UI.
+///
+/// This is the gate to remove first if `food_portion_translation` is ever
+/// populated (#864).
+String? householdPortionLabel(String? servingSize, {
+  required String languageCode,
+}) {
+  if (languageCode != 'en') return null;
   if (servingSize == null) return null;
 
   final withoutWeight = servingSize.replaceFirst(_trailingWeight, '');

--- a/test/features/add_meal/presentation/bulk_add_screen_test.dart
+++ b/test/features/add_meal/presentation/bulk_add_screen_test.dart
@@ -603,6 +603,27 @@ void main() {
     expect(find.text(lookupS(const Locale('en')).servingLabel), findsNothing);
   });
 
+  testWidgets('and never in a locale that word is not written in', (
+    tester,
+  ) async {
+    // #864. The description is English on every path — `food_summary`
+    // builds it straight from `food_portion.portion_description`, and
+    // `food_portion_translation` is empty. #865 put that English word in
+    // front of all nine locales; a German row read "3 slice".
+    await _register({
+      'bread': [
+        _meal('Bread', servingQuantity: 38, servingSize: '1 slice (38 g)'),
+      ],
+    });
+
+    await tester.pumpWidget(_app(locale: const Locale('de')));
+    await tester.pumpAndSettle();
+    await _parse(tester, '3 bread');
+
+    expect(find.text('slice'), findsNothing);
+    expect(find.text(lookupS(const Locale('de')).servingLabel), findsOneWidget);
+  });
+
   testWidgets('and keeps "serving" when the record names no measure', (
     tester,
   ) async {

--- a/test/unit_test/portion_label_test.dart
+++ b/test/unit_test/portion_label_test.dart
@@ -5,46 +5,46 @@ void main() {
   group('householdPortionLabel', () {
     test('pulls the measure out of an FDC-style label', () {
       // What `MealEntity._spServingLabel` renders for a backend food.
-      expect(householdPortionLabel('1 slice (38 g)'), 'slice');
+      expect(householdPortionLabel('1 slice (38 g)', languageCode: 'en'), 'slice');
     });
 
     test('keeps a qualified measure whole, comma and all', () {
       // The backend's own schema comment names this exact shape, and the
       // comma is why the word may never reach the *stored* unit (#864).
-      expect(householdPortionLabel('1 cup, sliced (240 g)'), 'cup, sliced');
+      expect(householdPortionLabel('1 cup, sliced (240 g)', languageCode: 'en'), 'cup, sliced');
     });
 
     test('handles a description with no weight appended', () {
-      expect(householdPortionLabel('1 egg'), 'egg');
+      expect(householdPortionLabel('1 egg', languageCode: 'en'), 'egg');
     });
 
     test('a bare weight names no household measure', () {
       // OFF's common shape. Reducing "30 g" to "g" and showing it as a unit
       // would replace a correct word with a wrong one.
-      expect(householdPortionLabel('30 g'), isNull);
-      expect(householdPortionLabel('240ml'), isNull);
-      expect(householdPortionLabel('1.5 l'), isNull);
+      expect(householdPortionLabel('30 g', languageCode: 'en'), isNull);
+      expect(householdPortionLabel('240ml', languageCode: 'en'), isNull);
+      expect(householdPortionLabel('1.5 l', languageCode: 'en'), isNull);
     });
 
     test('a decimal or comma count is stripped like any other', () {
-      expect(householdPortionLabel('0.5 cup (120 g)'), 'cup');
-      expect(householdPortionLabel('1,5 slices'), 'slices');
+      expect(householdPortionLabel('0.5 cup (120 g)', languageCode: 'en'), 'cup');
+      expect(householdPortionLabel('1,5 slices', languageCode: 'en'), 'slices');
     });
 
     test('"portion" is the backend saying it has no household measure', () {
       // `food_summary` maps FDC's measure_unit 9999 ('undetermined') to the
       // word "portion". It says nothing the dropdown does not already say.
-      expect(householdPortionLabel('1 portion'), isNull);
-      expect(householdPortionLabel('serving'), isNull);
+      expect(householdPortionLabel('1 portion', languageCode: 'en'), isNull);
+      expect(householdPortionLabel('serving', languageCode: 'en'), isNull);
     });
 
     test('nothing usable gives null rather than an empty label', () {
-      expect(householdPortionLabel(null), isNull);
-      expect(householdPortionLabel(''), isNull);
-      expect(householdPortionLabel('   '), isNull);
-      expect(householdPortionLabel('1'), isNull);
-      expect(householdPortionLabel('1 (38 g)'), isNull);
-      expect(householdPortionLabel('---'), isNull);
+      expect(householdPortionLabel(null, languageCode: 'en'), isNull);
+      expect(householdPortionLabel('', languageCode: 'en'), isNull);
+      expect(householdPortionLabel('   ', languageCode: 'en'), isNull);
+      expect(householdPortionLabel('1', languageCode: 'en'), isNull);
+      expect(householdPortionLabel('1 (38 g)', languageCode: 'en'), isNull);
+      expect(householdPortionLabel('---', languageCode: 'en'), isNull);
     });
 
     test('a label too long for the row is refused, not truncated', () {
@@ -52,16 +52,39 @@ void main() {
       // already overflowed once (#824). "Serving" underneath is still
       // correct, so losing the word is the cheaper failure.
       final long = 'a' * (maxHouseholdPortionLabel + 1);
-      expect(householdPortionLabel('1 $long'), isNull);
+      expect(householdPortionLabel('1 $long', languageCode: 'en'), isNull);
       final atLimit = 'a' * maxHouseholdPortionLabel;
-      expect(householdPortionLabel('1 $atLimit'), atLimit);
+      expect(householdPortionLabel('1 $atLimit', languageCode: 'en'), atLimit);
+    });
+
+    test('nothing is offered outside English, because the data is English', () {
+      // #864. `food_summary.serving_size` comes straight from
+      // `food_portion.portion_description`; `food_portion_translation` is
+      // empty on the live backend — 0 rows against 36,682 portions — so this
+      // word is English for every locale the app ships. Showing it in the
+      // other eight put a raw dataset string in their UI, which #865 did.
+      for (final locale in ['de', 'cs', 'it', 'pl', 'sk', 'tr', 'uk', 'zh']) {
+        expect(
+          householdPortionLabel('1 slice (38 g)', languageCode: locale),
+          isNull,
+          reason: '$locale would have been shown the English word',
+        );
+      }
+    });
+
+    test('the gate is on the language, not the region', () {
+      // A country subtag never reaches this function — the caller passes
+      // `languageCode` — but pinning it means a future caller passing "en_US"
+      // fails here rather than silently going quiet in every English build.
+      expect(householdPortionLabel('1 slice', languageCode: 'en'), 'slice');
+      expect(householdPortionLabel('1 slice', languageCode: 'en_US'), isNull);
     });
 
     test('a non-Latin measure survives', () {
       // The backend translates portion descriptions per locale, so this
       // function must not assume the Latin script it was written against.
-      expect(householdPortionLabel('1 片 (38 g)'), '片');
-      expect(householdPortionLabel('1 Scheibe (38 g)'), 'Scheibe');
+      expect(householdPortionLabel('1 片 (38 g)', languageCode: 'en'), '片');
+      expect(householdPortionLabel('1 Scheibe (38 g)', languageCode: 'en'), 'Scheibe');
     });
   });
 }


### PR DESCRIPTION
[#865](https://github.com/simonoppowa/OpenNutriTracker/pull/865) taught the bulk-add row to say
**"3 slice"** where the food record names its portion. It never checked what language that word is
in, and the answer is always English — so it shipped a raw dataset string into all nine locales. A
German row read "3 slice".

This is a defect I introduced; found while scoping #864 phase 2.

## Why it is always English

`food_summary.serving_size` is built straight from `food_portion.portion_description`. **Nothing on
any path joins `food_portion_translation`** — not the view, not `food_summary_by_ids`, not
`search_food_translation`, which returns only `(food_id, description, source)` for a food's *name*.

Measured against the live backend rather than read off the schema:

| Table | Rows |
|---|---|
| `food_portion` | **36,682** |
| `food_portion_translation` | **0** |
| `measure_unit_translation` | **0** |
| `food_translation` (names) | 20,834 |

**That asymmetry is what made it easy to miss.** Food names *are* translated, so the German row
showed a German name beside an English unit and looked mostly right.

## The fix

The household word is offered only when the app is in English. Everything else falls back to the
localized "serving" — what those rows said before #865, which was never wrong, only less specific.

**One cost, stated rather than hidden:** an Open Food Facts product whose own `serving_size`
happens to be in the reader's language is suppressed too, because nothing here can tell which
language that field holds. Guessing the other way is exactly what put an English word in eight
other locales.

The gate lives inside `householdPortionLabel`, not at the call site, so the rule is unit-testable
and carries its reasoning where the next person will change it. It is also the first thing to
delete if `food_portion_translation` is ever populated.

## Checks

- `fvm flutter analyze` — `No issues found!`
- `fvm flutter test` — **1991 passed**
- New coverage: all eight non-English locales refused, `en` still works, and a screen-level test
  proving a German row shows "Portion" rather than "slice"

Three mutations, three caught:

| Mutation | |
|---|---|
| Remove the locale gate | caught |
| Invert it, so English is the one refused | caught |
| Loosen it to `startsWith('en')` | caught |

That third one is why there is a test pinning `en_US` as refused — a caller passing a full locale
tag instead of a language code would otherwise make the feature go quiet in every English build,
silently.

## What this means for #864 phase 2

Two of the issue's stated premises were wrong, and I will correct the issue separately:

- **No backend change is needed.** `food_portion` and `food_portion_translation` are already in the
  schema's `public read` RLS list; I read `food_portion` live with the anon key.
- **Localisation is not solved upstream.** Decision 6 rests on `food_portion_translation` supplying
  per-locale vocabulary without an app-side word list (the #600 objection). The column exists; the
  data does not.

Phase 2 now turns on a question that did not exist when the issue was written: whether to populate
`measure_unit` translations — a **closed 123-row vocabulary**, so 984 strings for eight locales,
held in the backend rather than in nine app files. That is materially different from the app-side
list #600 rejected, and it is a decision, not a task.
