### PR TITLE
feat(add-meal): show a food's portion in the reader's language

### DIFF
--- a/lib/features/add_meal/data/data_sources/sp_food_data_source.dart
+++ b/lib/features/add_meal/data/data_sources/sp_food_data_source.dart
@@ -77,6 +77,41 @@ class SpFoodDataSource {
   /// Source codes the user allows in search results (Settings → Food
   /// databases), or null when everything is enabled and no filter is
   /// needed. An empty list means every backend source is disabled.
+  /// A verified portion label per food id, in the reader's language.
+  ///
+  /// Empty rather than throwing on anything unusual — no locale, no verified
+  /// translations, a backend that refused. The caller's fallback is the
+  /// English label it already has, which is what it shows today, so a failure
+  /// here costs nothing and must never cost a search.
+  ///
+  /// Resolves the locale here rather than taking one, because this class
+  /// already owns that decision for the search itself and two answers would
+  /// eventually disagree.
+  Future<Map<int, String>> fetchPortionLabels(List<int> foodIds) async {
+    if (foodIds.isEmpty) return const {};
+    final locale = SPConst.translationLocaleOf(
+      SupportedLanguage.fromCode(Platform.localeName),
+    );
+    // English needs no lookup: the stored description is already English.
+    if (locale == null) return const {};
+
+    try {
+      final rows = await _rpcRows(
+        locator<SupabaseClient>(),
+        SPConst.portionLabelsByFoodIdsFn,
+        {'ids': foodIds, 'loc': locale},
+      );
+      return {
+        for (final row in rows)
+          if (row['food_id'] is int && row['label'] is String)
+            row['food_id'] as int: row['label'] as String,
+      };
+    } catch (e) {
+      log.fine('No portion labels for $locale: $e');
+      return const {};
+    }
+  }
+
   Future<List<String>?> _enabledSources() async {
     final toggles = await locator<ConfigDataSource>().getFoodSourceToggles();
     if (toggles == null) return null;

--- a/lib/features/add_meal/data/dto/sp/sp_const.dart
+++ b/lib/features/add_meal/data/dto/sp/sp_const.dart
@@ -61,6 +61,12 @@ class SPConst {
   static const searchFoodTranslationFn = 'search_food_translation';
   static const foodSummaryByIdsFn = 'food_summary_by_ids';
 
+  /// A food's default portion label in the reader's language, and only
+  /// where a human has verified the translation. The `verified` filter is
+  /// server-side, so this app cannot show machine output by forgetting to
+  /// ask for it. #864.
+  static const portionLabelsByFoodIdsFn = 'portion_labels_by_food_ids';
+
   /// food_source.code prefix shared by the USDA FDC sources
   /// (fdc_foundation, fdc_sr_legacy, fdc_survey). Only these foods have a
   /// public detail page to link to.

--- a/lib/features/add_meal/data/repository/products_repository.dart
+++ b/lib/features/add_meal/data/repository/products_repository.dart
@@ -106,7 +106,27 @@ class ProductsRepository {
         .map((foodItem) => MealEntity.fromSpFood(foodItem))
         .where(_keepIfConsistent)
         .toList();
-    return products;
+
+    // The serving label a food record carries is English on every path, so a
+    // German row read "3 slice" until #966 gated it off. This puts the
+    // reader's own word back where a human has verified one. #864.
+    //
+    // After the consistency filter, so nothing is fetched for rows that were
+    // just dropped. One call for the whole page rather than one per row.
+    final ids = products
+        .map((meal) => int.tryParse(meal.code ?? ''))
+        .nonNulls
+        .toList();
+    final labels = await _spBackendDataSource.fetchPortionLabels(ids);
+    if (labels.isEmpty) return products;
+
+    return [
+      for (final meal in products)
+        if (labels[int.tryParse(meal.code ?? '')] case final label?)
+          meal.withServingLabel(label)
+        else
+          meal,
+    ];
   }
 
   Future<MealEntity> getOFFProductByBarcode(String barcode) async {

--- a/lib/features/add_meal/domain/entity/meal_entity.dart
+++ b/lib/features/add_meal/domain/entity/meal_entity.dart
@@ -85,6 +85,17 @@ class MealEntity extends Equatable {
   /// disclosure hint under the title for these.
   final bool machineTranslatedName;
 
+  /// True when [servingSize] holds a translation a human has verified, rather
+  /// than the English text every food record carries.
+  ///
+  /// Needed because the two are indistinguishable by inspection: "1 Scheibe"
+  /// and "1 slice" are both just strings on the entity, and showing the
+  /// second one to a German reader is the defect #966 had to gate against.
+  /// Only [withServingLabel] sets it, so it is false everywhere a label did
+  /// not come from the backend's verified set — including every meal read
+  /// back from the database, which stores no such provenance.
+  final bool servingSizeIsLocalized;
+
   /// Relative path (`meal_images/<code>.webp`) to a user-attached photo
   /// for a custom meal, or null if none is set. Resolved to an absolute
   /// path at render time via `MealImageStorage.absolutePath`. Always
@@ -123,9 +134,39 @@ class MealEntity extends Equatable {
     required this.source,
     this.backendSource,
     this.machineTranslatedName = false,
+    this.servingSizeIsLocalized = false,
     this.localImagePath,
     this.detailed = false,
   });
+
+  /// The same meal with a verified translation in place of the English
+  /// serving label.
+  ///
+  /// Deliberately narrow: it replaces the text and records where it came
+  /// from, and touches nothing else. [servingQuantity] in particular stays
+  /// as it was, because the backend picks the label and the gram weight from
+  /// the same portion row — swapping one without the other is how "1 slice"
+  /// ends up beside 240 g.
+  MealEntity withServingLabel(String label) => MealEntity(
+    code: code,
+    name: name,
+    brands: brands,
+    thumbnailImageUrl: thumbnailImageUrl,
+    mainImageUrl: mainImageUrl,
+    url: url,
+    mealQuantity: mealQuantity,
+    mealUnit: mealUnit,
+    servingQuantity: servingQuantity,
+    servingUnit: servingUnit,
+    servingSize: label,
+    nutriments: nutriments,
+    source: source,
+    backendSource: backendSource,
+    machineTranslatedName: machineTranslatedName,
+    servingSizeIsLocalized: true,
+    localImagePath: localImagePath,
+    detailed: detailed,
+  );
 
   factory MealEntity.empty() => MealEntity(
     code: IdGenerator.getUniqueID(),

--- a/lib/features/add_meal/presentation/screens/bulk_add_screen.dart
+++ b/lib/features/add_meal/presentation/screens/bulk_add_screen.dart
@@ -993,6 +993,7 @@ class _BulkAddScreenState extends State<BulkAddScreen> {
           householdPortionLabel(
             row.meal?.servingSize,
             languageCode: Localizations.localeOf(context).languageCode,
+            textIsLocalized: row.meal?.servingSizeIsLocalized ?? false,
           ) ??
               S.of(context).servingLabel,
       };

--- a/lib/features/add_meal/util/portion_label.dart
+++ b/lib/features/add_meal/util/portion_label.dart
@@ -66,12 +66,20 @@ const maxHouseholdPortionLabel = 16;
 /// was never wrong — only less specific. Guessing the other way puts an
 /// English word in eight other languages' UI.
 ///
-/// This is the gate to remove first if `food_portion_translation` is ever
-/// populated (#864).
+/// `food_portion_translation` is populated now, and `portion_labels_by_food_ids`
+/// serves only rows a human promoted to `verified` — so [textIsLocalized]
+/// opens this up per locale, with no app release, the moment a reviewer
+/// signs one off. The English path is unchanged: that text needs no
+/// translation to be in an English reader's language.
 String? householdPortionLabel(String? servingSize, {
   required String languageCode,
+  bool textIsLocalized = false,
 }) {
-  if (languageCode != 'en') return null;
+  // English, or a translation a human has verified. Both mean the same
+  // thing here — the text is in the reader's language — and nothing else
+  // does, because "1 Scheibe" and "1 slice" are indistinguishable as
+  // strings once they are on the entity.
+  if (!textIsLocalized && languageCode != 'en') return null;
   if (servingSize == null) return null;
 
   final withoutWeight = servingSize.replaceFirst(_trailingWeight, '');

--- a/test/features/add_meal/data/repository/products_repository_portion_label_test.dart
+++ b/test/features/add_meal/data/repository/products_repository_portion_label_test.dart
@@ -1,0 +1,123 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:opennutritracker/features/add_meal/data/data_sources/off_data_source.dart';
+import 'package:opennutritracker/features/add_meal/data/data_sources/sp_food_data_source.dart';
+import 'package:opennutritracker/features/add_meal/data/dto/off/off_product_dto.dart';
+import 'package:opennutritracker/features/add_meal/data/dto/off/off_word_response_dto.dart';
+import 'package:opennutritracker/features/add_meal/data/dto/sp/sp_food_dto.dart';
+import 'package:opennutritracker/features/add_meal/data/repository/products_repository.dart';
+
+SpFoodDTO _food(
+  int id,
+  String name, {
+  String? servingSize,
+  double carbs = 40,
+  double sugars = 5,
+}) => SpFoodDTO(
+  foodId: id,
+  source: 'fdc_survey',
+  sourceCode: '$id',
+  name: name,
+  servingGramWeight: 38,
+  servingSize: servingSize,
+  energyKcal100: 250,
+  carbohydrates100: carbs,
+  sugars100: sugars,
+  fat100: 4,
+  proteins100: 8,
+);
+
+class _FakeSp extends SpFoodDataSource {
+  _FakeSp(this.foods, this.labels);
+
+  final List<SpFoodDTO> foods;
+  final Map<int, String> labels;
+  List<int>? askedFor;
+
+  @override
+  Future<List<SpFoodDTO>> fetchSearchWordResults(String searchString) async =>
+      foods;
+
+  @override
+  Future<Map<int, String>> fetchPortionLabels(List<int> foodIds) async {
+    askedFor = foodIds;
+    return labels;
+  }
+}
+
+class _FakeOff extends OFFDataSource {
+  @override
+  Future<OFFWordResponseDTO> fetchSearchWordResults(String searchString) async =>
+      OFFWordResponseDTO(
+        count: 0, page: 1, page_count: 1, page_size: 0,
+        products: const <OFFProductDTO>[],
+      );
+}
+
+void main() {
+  group('a verified portion label reaches the meal (#864)', () {
+    test('replaces the English label and marks it localized', () async {
+      final sp = _FakeSp(
+        [_food(1, 'Bread', servingSize: '1 slice (38 g)')],
+        {1: '1 Scheibe (38 g)'},
+      );
+      final meals =
+          await ProductsRepository(_FakeOff(), sp).getSupabaseFoodsByString('bread');
+
+      expect(meals, hasLength(1));
+      expect(meals.single.servingSize, '1 Scheibe (38 g)');
+      expect(meals.single.servingSizeIsLocalized, isTrue);
+    });
+
+    test('a food with no verified label keeps the English one', () async {
+      // Partial coverage is the normal case: 109 seeded strings do not cover
+      // every food, so the two must be able to sit side by side in one page
+      // of results.
+      final sp = _FakeSp(
+        [
+          _food(1, 'Bread', servingSize: '1 slice (38 g)'),
+          _food(2, 'Cheese', servingSize: '1 cubic inch (17 g)'),
+        ],
+        {1: '1 Scheibe (38 g)'},
+      );
+      final meals =
+          await ProductsRepository(_FakeOff(), sp).getSupabaseFoodsByString('x');
+
+      final byName = {for (final m in meals) m.name: m};
+      expect(byName['Bread']!.servingSizeIsLocalized, isTrue);
+      expect(byName['Cheese']!.servingSize, '1 cubic inch (17 g)');
+      expect(byName['Cheese']!.servingSizeIsLocalized, isFalse);
+    });
+
+    test('asks only for the foods that survived the consistency filter',
+        () async {
+      // The lookup runs after filtering, so nothing is fetched for rows that
+      // were just dropped.
+      //
+      // The dropped food has to be genuinely implausible — more sugar than
+      // carbohydrate, which #222 rejects — or this passes whether the fetch
+      // happens before or after the filter, and pins nothing. An earlier
+      // version made exactly that mistake.
+      final sp = _FakeSp([
+        _food(7, 'Bread', servingSize: '1 slice'),
+        _food(8, 'Impossible', servingSize: '1 slice', carbs: 5, sugars: 40),
+      ], {});
+      final meals =
+          await ProductsRepository(_FakeOff(), sp).getSupabaseFoodsByString('b');
+
+      expect(meals.map((m) => m.name), ['Bread'],
+          reason: 'the implausible food should have been dropped');
+      expect(sp.askedFor, [7],
+          reason: 'a dropped food must not be looked up');
+    });
+
+    test('an empty label map changes nothing', () async {
+      // What every English build gets, and every locale nobody has reviewed:
+      // the lookup returns nothing and the results are exactly as before.
+      final sp = _FakeSp([_food(1, 'Bread', servingSize: '1 slice (38 g)')], {});
+      final meals =
+          await ProductsRepository(_FakeOff(), sp).getSupabaseFoodsByString('b');
+      expect(meals.single.servingSize, '1 slice (38 g)');
+      expect(meals.single.servingSizeIsLocalized, isFalse);
+    });
+  });
+}

--- a/test/unit_test/meal_entity_serving_label_test.dart
+++ b/test/unit_test/meal_entity_serving_label_test.dart
@@ -1,0 +1,55 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:opennutritracker/features/add_meal/domain/entity/meal_entity.dart';
+import 'package:opennutritracker/features/add_meal/domain/entity/meal_nutriments_entity.dart';
+
+MealEntity _meal({String? servingSize, double? servingQuantity}) => MealEntity(
+  code: '123',
+  name: 'Bread',
+  url: null,
+  mealQuantity: null,
+  mealUnit: 'g',
+  servingQuantity: servingQuantity,
+  servingUnit: 'g',
+  servingSize: servingSize,
+  source: MealSourceEntity.fdc,
+  nutriments: MealNutrimentsEntity.empty(),
+);
+
+void main() {
+  group('MealEntity.withServingLabel (#864)', () {
+    test('replaces the label and records that it is localized', () {
+      final meal = _meal(servingSize: '1 slice (38 g)', servingQuantity: 38);
+      expect(meal.servingSizeIsLocalized, isFalse);
+
+      final localized = meal.withServingLabel('1 Scheibe (38 g)');
+      expect(localized.servingSize, '1 Scheibe (38 g)');
+      expect(localized.servingSizeIsLocalized, isTrue);
+    });
+
+    test('leaves the gram weight alone', () {
+      // The backend picks the label and the weight from the same portion
+      // row, so swapping one without the other is how "1 slice" ends up
+      // beside a weight that belongs to a different portion.
+      final localized =
+          _meal(servingSize: '1 slice (38 g)', servingQuantity: 38)
+              .withServingLabel('1 Scheibe (38 g)');
+      expect(localized.servingQuantity, 38);
+      expect(localized.servingUnit, 'g');
+    });
+
+    test('carries the rest of the meal across unchanged', () {
+      final localized = _meal(servingSize: '1 slice', servingQuantity: 38)
+          .withServingLabel('1 Scheibe');
+      expect(localized.code, '123');
+      expect(localized.name, 'Bread');
+      expect(localized.source, MealSourceEntity.fdc);
+      expect(localized.mealUnit, 'g');
+    });
+
+    test('a meal read back from the database is never marked localized', () {
+      // Nothing persists this provenance, so a stored meal must report the
+      // conservative answer rather than inheriting a default of true.
+      expect(_meal(servingSize: '1 slice').servingSizeIsLocalized, isFalse);
+    });
+  });
+}

--- a/test/unit_test/portion_label_test.dart
+++ b/test/unit_test/portion_label_test.dart
@@ -80,6 +80,47 @@ void main() {
       expect(householdPortionLabel('1 slice', languageCode: 'en_US'), isNull);
     });
 
+    test('a verified translation is shown in its own locale', () {
+      // #864. `portion_labels_by_food_ids` serves only rows a human promoted
+      // to 'verified', so text that arrived that way is by construction in
+      // the reader's language — and opening this per locale needs no app
+      // release, only a reviewer signing one off.
+      expect(
+        householdPortionLabel('1 Scheibe (38 g)',
+            languageCode: 'de', textIsLocalized: true),
+        'Scheibe',
+      );
+      expect(
+        householdPortionLabel('1 片 (38 g)',
+            languageCode: 'zh', textIsLocalized: true),
+        '片',
+      );
+    });
+
+    test('but the same text unverified is still refused', () {
+      // The flag is the whole difference. Without it this is the English
+      // record text, and #966 gated it for exactly that reason.
+      expect(
+        householdPortionLabel('1 Scheibe (38 g)', languageCode: 'de'),
+        isNull,
+      );
+    });
+
+    test('being localized does not excuse a bare weight or a long label', () {
+      // The other rules still apply: a verified translation of "30 g" names
+      // no household measure, and one too long for the row is still too long.
+      expect(
+        householdPortionLabel('30 g', languageCode: 'de', textIsLocalized: true),
+        isNull,
+      );
+      final long = 'a' * (maxHouseholdPortionLabel + 1);
+      expect(
+        householdPortionLabel('1 $long',
+            languageCode: 'de', textIsLocalized: true),
+        isNull,
+      );
+    });
+
     test('a non-Latin measure survives', () {
       // The backend translates portion descriptions per locale, so this
       // function must not assume the Latin script it was written against.


### PR DESCRIPTION
The app half of [#864](https://github.com/simonoppowa/OpenNutriTracker/issues/864) phase 2.
**Depends on [Backend#6](https://github.com/simonoppowa/OpenNutriTracker-Backend/pull/6)** being
merged and applied — without it every lookup fails and falls back, which is also exactly what
happens today.

## What it does

[#966](https://github.com/simonoppowa/OpenNutriTracker/pull/966) gated the household word to
English because English was the only language it existed in. The translations exist now
([Backend#5](https://github.com/simonoppowa/OpenNutriTracker-Backend/pull/5), applied), so this
reaches them.

A search result's food ids go to `portion_labels_by_food_ids`, which returns a label **only where a
human has promoted that locale to `verified`**. The filter is server-side: this app cannot show
machine output by forgetting to ask, and a locale lights up the moment a reviewer signs it off —
**no app release required**.

## The gate now says what it always meant

From *"the locale is English"* to *"the text is in the reader's language"*. Both conditions satisfy
it and nothing else does — `1 Scheibe` and `1 slice` are indistinguishable as strings once they are
on the entity, so the entity has to carry where the text came from.

That is `servingSizeIsLocalized`, set only by `withServingLabel`. It is false everywhere else,
**including every meal read back from the database**, which stores no such provenance — the
conservative answer, not an inherited default.

## `withServingLabel` replaces the text and nothing else

The gram weight in particular stays put. The backend picks the label and the weight from the same
portion row, so swapping one without the other is how `1 slice` ends up beside a weight belonging
to a different portion. There is a test for exactly that.

## Failure is free

The lookup runs **after** the plausibility filter (nothing fetched for rows just dropped), **one
call per page** rather than per row, and returns an empty map for anything unusual — no locale, no
verified translations, a backend that refused. The fallback is the English label already in hand.

## Checks

- `fvm flutter analyze` — `No issues found!`
- `fvm flutter test` — **2002 passed**
- New coverage: the gate in both directions, the entity copy, and the repository wiring

**Eight mutations, eight caught — but one needed a better test first.** The "only asks for foods
that survived the filter" case originally used foods that *all* survived, so it passed whether the
fetch ran before or after the filter and pinned nothing. Rewritten around a food #222 rejects for
holding more sugar than carbohydrate. That is the second time in this issue a test looked like
coverage and was decoration; both were found by mutation, not by review.

## Nothing changes for anyone yet

No locale is `verified`, so every lookup returns empty and every row shows exactly what it shows
today. The first visible change happens when a German speaker completes
`review/portions_de.csv` and it is applied — at which point 4,119 foods gain a German portion word
with no further code.

## Still open in phase 2

This is the localized-label slice. Not included, and each is its own change:

- offering a food's **other** portions in `allowedUnits` (multi-portion picker)
- matching the user's leftover words against those descriptions
- adding `portion` to the model tool schema as a lookup key
