### PR TITLE
feat(add-meal): let a row pick which portion it means

### DIFF
--- a/lib/features/add_meal/data/data_sources/sp_food_data_source.dart
+++ b/lib/features/add_meal/data/data_sources/sp_food_data_source.dart
@@ -8,6 +8,7 @@ import 'package:opennutritracker/core/utils/locator.dart';
 import 'package:opennutritracker/core/utils/retry_util.dart';
 import 'package:opennutritracker/core/utils/supported_language.dart';
 import 'package:opennutritracker/features/add_meal/data/dto/sp/sp_const.dart';
+import 'package:opennutritracker/features/add_meal/domain/entity/meal_portion_entity.dart';
 import 'package:opennutritracker/features/add_meal/data/dto/sp/sp_food_dto.dart';
 import 'package:opennutritracker/features/add_meal/util/meal_relevance_ranker.dart';
 import 'package:sentry_flutter/sentry_flutter.dart';
@@ -108,6 +109,56 @@ class SpFoodDataSource {
       };
     } catch (e) {
       log.fine('No portion labels for $locale: $e');
+      return const {};
+    }
+  }
+
+  /// Every usable portion per food id, in the backend's order.
+  ///
+  /// Same failure policy as [fetchPortionLabels]: empty for anything unusual,
+  /// because the caller's fallback is the single serving it already has, and
+  /// a portion list is not worth costing anyone a search.
+  ///
+  /// Unlike the label lookup this runs for English too — the choice between a
+  /// food's cup, slice and ounce is worth offering whether or not the words
+  /// needed translating.
+  Future<Map<int, List<MealPortionEntity>>> fetchPortions(
+    List<int> foodIds,
+  ) async {
+    if (foodIds.isEmpty) return const {};
+    final locale = SPConst.translationLocaleOf(
+      SupportedLanguage.fromCode(Platform.localeName),
+    );
+
+    try {
+      final rows = await _rpcRows(
+        locator<SupabaseClient>(),
+        SPConst.portionsByFoodIdsFn,
+        // English has no translations to look for, and the function treats an
+        // unmatched locale as "none verified", so passing 'en' asks the same
+        // question without a special case here.
+        {'ids': foodIds, 'loc': locale ?? 'en'},
+      );
+
+      final byFood = <int, List<MealPortionEntity>>{};
+      for (final row in rows) {
+        final id = row['food_id'];
+        final label = row['label'];
+        final grams = row['gram_weight'];
+        if (id is! int || label is! String || grams == null) continue;
+        final weight = grams is num ? grams.toDouble() : null;
+        if (weight == null || weight <= 0) continue;
+        byFood.putIfAbsent(id, () => []).add(
+          MealPortionEntity(
+            label: label,
+            gramWeight: weight,
+            localized: row['localized'] == true,
+          ),
+        );
+      }
+      return byFood;
+    } catch (e) {
+      log.fine('No portions fetched: $e');
       return const {};
     }
   }

--- a/lib/features/add_meal/data/dto/sp/sp_const.dart
+++ b/lib/features/add_meal/data/dto/sp/sp_const.dart
@@ -67,6 +67,10 @@ class SPConst {
   /// ask for it. #864.
   static const portionLabelsByFoodIdsFn = 'portion_labels_by_food_ids';
 
+  /// Every usable portion a food has, so the unit dropdown can offer a
+  /// choice rather than the one `food_summary` picked. #864.
+  static const portionsByFoodIdsFn = 'portions_by_food_ids';
+
   /// food_source.code prefix shared by the USDA FDC sources
   /// (fdc_foundation, fdc_sr_legacy, fdc_survey). Only these foods have a
   /// public detail page to link to.

--- a/lib/features/add_meal/data/repository/products_repository.dart
+++ b/lib/features/add_meal/data/repository/products_repository.dart
@@ -5,6 +5,7 @@ import 'package:opennutritracker/core/utils/off_country.dart';
 import 'package:opennutritracker/features/add_meal/data/data_sources/off_data_source.dart';
 import 'package:opennutritracker/features/add_meal/data/data_sources/sp_food_data_source.dart';
 import 'package:opennutritracker/features/add_meal/domain/entity/meal_entity.dart';
+import 'package:opennutritracker/features/add_meal/domain/entity/meal_portion_entity.dart';
 import 'package:opennutritracker/features/add_meal/domain/entity/meal_nutriments_entity.dart';
 import 'package:sentry_flutter/sentry_flutter.dart';
 
@@ -117,16 +118,39 @@ class ProductsRepository {
         .map((meal) => int.tryParse(meal.code ?? ''))
         .nonNulls
         .toList();
-    final labels = await _spBackendDataSource.fetchPortionLabels(ids);
-    if (labels.isEmpty) return products;
+    // Both lookups in flight together: they answer different questions of the
+    // same page and neither depends on the other, so serialising them would
+    // just add a round trip to every search.
+    final (labels, portions) = await (
+      _spBackendDataSource.fetchPortionLabels(ids),
+      _spBackendDataSource.fetchPortions(ids),
+    ).wait;
+    if (labels.isEmpty && portions.isEmpty) return products;
 
     return [
       for (final meal in products)
-        if (labels[int.tryParse(meal.code ?? '')] case final label?)
-          meal.withServingLabel(label)
-        else
-          meal,
+        _decorate(meal, labels, portions),
     ];
+  }
+
+  /// Applies whichever of the two lookups had something for this meal.
+  ///
+  /// Either can be absent independently — a food may have a verified default
+  /// label and only one portion, or several portions and no translation — so
+  /// they are applied separately rather than as a pair.
+  MealEntity _decorate(
+    MealEntity meal,
+    Map<int, String> labels,
+    Map<int, List<MealPortionEntity>> portions,
+  ) {
+    final id = int.tryParse(meal.code ?? '');
+    if (id == null) return meal;
+    var result = meal;
+    if (labels[id] case final label?) result = result.withServingLabel(label);
+    if (portions[id] case final found? when found.isNotEmpty) {
+      result = result.withPortions(found);
+    }
+    return result;
   }
 
   Future<MealEntity> getOFFProductByBarcode(String barcode) async {

--- a/lib/features/add_meal/domain/entity/meal_entity.dart
+++ b/lib/features/add_meal/domain/entity/meal_entity.dart
@@ -1,6 +1,7 @@
 import 'dart:io';
 
 import 'package:equatable/equatable.dart';
+import 'package:opennutritracker/features/add_meal/domain/entity/meal_portion_entity.dart';
 import 'package:opennutritracker/core/data/dbo/meal_dbo.dart';
 import 'package:opennutritracker/core/utils/id_generator.dart';
 import 'package:opennutritracker/core/utils/supported_language.dart';
@@ -96,6 +97,15 @@ class MealEntity extends Equatable {
   /// back from the database, which stores no such provenance.
   final bool servingSizeIsLocalized;
 
+  /// Every way this food can be counted, in the backend's order, so the first
+  /// is the portion `food_summary` picked and a picker opens where the app
+  /// already stood.
+  ///
+  /// Empty for everything that is not a fresh backend search result — Open
+  /// Food Facts, custom meals, anything read back from the database — and the
+  /// row then behaves exactly as it did before portions existed.
+  final List<MealPortionEntity> portions;
+
   /// Relative path (`meal_images/<code>.webp`) to a user-attached photo
   /// for a custom meal, or null if none is set. Resolved to an absolute
   /// path at render time via `MealImageStorage.absolutePath`. Always
@@ -135,6 +145,7 @@ class MealEntity extends Equatable {
     this.backendSource,
     this.machineTranslatedName = false,
     this.servingSizeIsLocalized = false,
+    this.portions = const [],
     this.localImagePath,
     this.detailed = false,
   });
@@ -164,6 +175,34 @@ class MealEntity extends Equatable {
     backendSource: backendSource,
     machineTranslatedName: machineTranslatedName,
     servingSizeIsLocalized: true,
+    portions: portions,
+    localImagePath: localImagePath,
+    detailed: detailed,
+  );
+
+  /// The same meal knowing every portion it can be counted in.
+  ///
+  /// Separate from [withServingLabel] because the two arrive from different
+  /// calls and either can be absent: a food may have a verified default label
+  /// and no picker-worthy list, or several portions and no translation.
+  MealEntity withPortions(List<MealPortionEntity> found) => MealEntity(
+    code: code,
+    name: name,
+    brands: brands,
+    thumbnailImageUrl: thumbnailImageUrl,
+    mainImageUrl: mainImageUrl,
+    url: url,
+    mealQuantity: mealQuantity,
+    mealUnit: mealUnit,
+    servingQuantity: servingQuantity,
+    servingUnit: servingUnit,
+    servingSize: servingSize,
+    nutriments: nutriments,
+    source: source,
+    backendSource: backendSource,
+    machineTranslatedName: machineTranslatedName,
+    servingSizeIsLocalized: servingSizeIsLocalized,
+    portions: found,
     localImagePath: localImagePath,
     detailed: detailed,
   );

--- a/lib/features/add_meal/domain/entity/meal_portion_entity.dart
+++ b/lib/features/add_meal/domain/entity/meal_portion_entity.dart
@@ -1,0 +1,38 @@
+import 'package:equatable/equatable.dart';
+
+/// One way a food can be counted, with the weight that makes it scalable.
+///
+/// A food usually has several — 3,499 of the backend's foods carry two or
+/// more, up to fifteen — and the app showed exactly one until now: whichever
+/// `food_summary` picked, which is the lowest `seq_num`.
+///
+/// [label] is what the reader sees and [localized] says whether it is in
+/// their language or the English the record carries. The two are
+/// indistinguishable as strings, and showing the English one to a German
+/// reader is the defect #966 gated against, so the answer travels beside the
+/// text rather than being inferred from it.
+///
+/// Not persisted. A meal read back from the database has no portions, which
+/// is the honest answer: nothing stores them, and the amount was converted to
+/// grams before it was written.
+class MealPortionEntity extends Equatable {
+  const MealPortionEntity({
+    required this.label,
+    required this.gramWeight,
+    required this.localized,
+  });
+
+  /// As published, count and all — "1 cup", "1 Tasse", "1 cup, cooked".
+  final String label;
+
+  /// What one of these weighs. Always greater than zero: the backend drops
+  /// portions that cannot scale an amount, because offering one would put a
+  /// unit on the screen that multiplies to nothing.
+  final double gramWeight;
+
+  /// True when [label] came from a translation a human verified.
+  final bool localized;
+
+  @override
+  List<Object?> get props => [label, gramWeight, localized];
+}

--- a/lib/features/add_meal/presentation/bloc/bulk_add_bloc.dart
+++ b/lib/features/add_meal/presentation/bloc/bulk_add_bloc.dart
@@ -7,6 +7,7 @@ import 'package:opennutritracker/features/add_meal/domain/usecase/read_meal_phot
 import 'package:opennutritracker/features/add_meal/domain/usecase/read_meal_text_usecase.dart';
 import 'package:opennutritracker/features/add_meal/domain/usecase/resolve_parsed_meals_usecase.dart';
 import 'package:opennutritracker/features/add_meal/util/meal_text_parser.dart';
+import 'package:opennutritracker/features/add_meal/util/portion_unit.dart';
 import 'package:opennutritracker/features/meal_detail/presentation/bloc/meal_detail_bloc.dart';
 
 part 'bulk_add_event.dart';
@@ -145,13 +146,21 @@ class BulkAddRow extends Equatable {
       meal?.servingQuantity == null;
 
   List<String> get allowedUnits => [
+    // One entry per portion the food actually has — cup, slice, ounce —
+    // rather than the single one `food_summary` picked. The values are
+    // `serving`, `serving#1`, ...; `storedUnit` strips the suffix before
+    // anything is written, so the published unit vocabulary is unchanged.
+    // #864.
+    if (meal?.portions.isNotEmpty ?? false)
+      for (var i = 0; i < meal!.portions.length; i++) portionUnit(i)
     // Only when the serving can actually be scaled. `hasServingValues` is
     // also true for a record carrying nothing but `servingSize` text, and
     // `convertQuantityToBaseUnit` leaves those unscaled — so offering
     // `serving` there is a no-op dressed as a fix. Worse, it is the option
     // a user reaches for after reading `amountNeedsCheck`: picking it
     // relabels the row, clears the warning and logs the same wrong number.
-    if (meal?.servingQuantity != null) UnitDropdownItem.serving.toString(),
+    else if (meal?.servingQuantity != null)
+      UnitDropdownItem.serving.toString(),
     if (meal?.isSolid ?? false) ...[
       UnitDropdownItem.g.toString(),
       UnitDropdownItem.oz.toString(),

--- a/lib/features/add_meal/presentation/screens/bulk_add_screen.dart
+++ b/lib/features/add_meal/presentation/screens/bulk_add_screen.dart
@@ -17,6 +17,7 @@ import 'package:opennutritracker/features/add_meal/domain/usecase/read_meal_text
 import 'package:opennutritracker/features/add_meal/presentation/bloc/bulk_add_bloc.dart';
 import 'package:opennutritracker/features/add_meal/util/meal_photo_encoder.dart';
 import 'package:opennutritracker/features/add_meal/util/portion_label.dart';
+import 'package:opennutritracker/features/add_meal/util/portion_unit.dart';
 import 'package:opennutritracker/features/add_meal/util/meal_text_parser.dart';
 import 'package:opennutritracker/features/add_meal/presentation/widgets/quick_add_bottom_sheet.dart';
 import 'package:opennutritracker/features/diary/presentation/bloc/calendar_day_bloc.dart';
@@ -982,8 +983,29 @@ class _BulkAddScreenState extends State<BulkAddScreen> {
   /// Takes the row because one of the six units is not a fixed word: the
   /// food names its own portion, and "3 slice" says what "3 serving" only
   /// implies. Display only — the value behind it stays `serving` (#864).
-  String _unitLabel(BuildContext context, String unit, BulkAddRow row) =>
-      switch (UnitDropdownItem.g.fromString(unit)) {
+  String _unitLabel(BuildContext context, String unit, BulkAddRow row) {
+    // A named portion shows its own word — "slice", "cup" — which is the
+    // whole point of offering more than one. Only when the text is in the
+    // reader's language: the backend says per portion whether it is, and
+    // showing English to the other eight locales is what #966 gated.
+    final portions = row.meal?.portions ?? const [];
+    if (isPortionUnit(unit) && portions.isNotEmpty) {
+      final index = effectivePortionIndex(unit);
+      if (index < portions.length) {
+        final portion = portions[index];
+        final label = householdPortionLabel(
+          portion.label,
+          languageCode: Localizations.localeOf(context).languageCode,
+          textIsLocalized: portion.localized,
+        );
+        if (label != null) return label;
+      }
+    }
+    return _fixedUnitLabel(context, unit, row);
+  }
+
+  String _fixedUnitLabel(BuildContext context, String unit, BulkAddRow row) =>
+      switch (UnitDropdownItem.g.fromString(storedUnit(unit))) {
         UnitDropdownItem.g => S.of(context).gramUnit,
         UnitDropdownItem.ml => S.of(context).milliliterUnit,
         UnitDropdownItem.gml => S.of(context).gramMilliliterUnit,
@@ -1242,7 +1264,10 @@ class _BulkAddScreenState extends State<BulkAddScreen> {
       for (var i = 0; i < rows.length; i++) {
         await mealDetailBloc.addIntake(
           context,
-          rows[i].effectiveUnit,
+          // The suffix is a display device; the stored vocabulary stays
+          // the closed set the export format and QR payload were written
+          // against. #864 decision 3.
+          storedUnit(rows[i].effectiveUnit),
           amounts[i].toString(),
           _args.intakeTypeEntity,
           rows[i].meal!,

--- a/lib/features/add_meal/util/portion_unit.dart
+++ b/lib/features/add_meal/util/portion_unit.dart
@@ -1,0 +1,62 @@
+/// How one portion out of several is named in the unit dropdown, without that
+/// name ever reaching storage.
+///
+/// The dropdown's value is what `addIntake` writes to `IntakeDBO.unit`, and
+/// that column is published in `docs/export-format.md` and rides in a
+/// *positional* QR share array other builds parse. So a food's portion names
+/// — dataset prose, commas and all — may never be the value; #864 decision 3
+/// settled that and this file is how it holds while the dropdown still offers
+/// a choice.
+///
+/// The encoding is deliberately dull: `serving` for the first portion, then
+/// `serving#1`, `serving#2`. Everything before the `#` is exactly what the
+/// app stored before portions existed, so [storedUnit] is a suffix strip and
+/// an old row and a new one are the same row.
+library;
+
+import 'package:opennutritracker/features/meal_detail/presentation/bloc/meal_detail_bloc.dart';
+
+const _portionSeparator = '#';
+
+/// The dropdown value for the portion at [index].
+///
+/// Index 0 is the bare `serving`, so a food with one portion produces exactly
+/// the string it always did and nothing downstream can tell the difference.
+String portionUnit(int index) {
+  final serving = UnitDropdownItem.serving.toString();
+  return index == 0 ? serving : '$serving$_portionSeparator$index';
+}
+
+/// Which portion [unit] names, or null when it names none.
+///
+/// Null for `g`, `oz`, a bare `serving` — the first portion is index 0 but
+/// callers that ask "which portion is this" about an unadorned unit want "no
+/// answer", not "the first one". [effectivePortionIndex] is the one that
+/// defaults.
+int? portionIndexOf(String unit) {
+  final at = unit.indexOf(_portionSeparator);
+  if (at < 0) return null;
+  return int.tryParse(unit.substring(at + 1));
+}
+
+/// Which portion a serving-shaped [unit] scales by: the named one, or the
+/// first when none is named.
+///
+/// Exists so a row saved before portions existed, and a row that simply took
+/// the default, both resolve to the portion `food_summary` would have picked.
+int effectivePortionIndex(String unit) => portionIndexOf(unit) ?? 0;
+
+/// True when [unit] is any portion of a food, named or not.
+bool isPortionUnit(String unit) =>
+    storedUnit(unit) == UnitDropdownItem.serving.toString();
+
+/// What actually gets written down.
+///
+/// Strips the portion so the stored vocabulary stays the closed set the
+/// export format and the QR payload were written against. Anything without a
+/// separator passes through untouched, so this is safe to call on every unit
+/// rather than only the ones that might carry one.
+String storedUnit(String unit) {
+  final at = unit.indexOf(_portionSeparator);
+  return at < 0 ? unit : unit.substring(0, at);
+}

--- a/lib/features/meal_detail/util/meal_quantity_converter.dart
+++ b/lib/features/meal_detail/util/meal_quantity_converter.dart
@@ -1,4 +1,5 @@
 import 'package:opennutritracker/core/utils/calc/unit_calc.dart';
+import 'package:opennutritracker/features/add_meal/util/portion_unit.dart';
 import 'package:opennutritracker/features/add_meal/domain/entity/meal_entity.dart';
 import 'package:opennutritracker/features/meal_detail/presentation/bloc/meal_detail_bloc.dart';
 
@@ -20,7 +21,25 @@ double convertQuantityToBaseUnit(
   String unit,
   MealEntity meal,
 ) {
-  if (unit == UnitDropdownItem.serving.toString()) {
+  // A named portion scales by its own weight. Falls through to the old
+  // serving path when the food has no portion list — every meal that is not
+  // a fresh backend search result — so nothing that worked before changes.
+  if (isPortionUnit(unit) && meal.portions.isNotEmpty) {
+    final index = effectivePortionIndex(unit);
+    if (index < meal.portions.length) {
+      return quantity * meal.portions[index].gramWeight;
+    }
+    // An index past the end means the food changed under a chosen unit.
+    // Falling through is deliberate: the serving path below either scales by
+    // the record's own serving or leaves the amount alone, and both are
+    // better than multiplying by a portion that belongs to another food.
+  }
+
+  // `storedUnit`, not `unit`: an index past the end falls through to here
+  // still carrying its suffix, and comparing the raw string would miss the
+  // serving path entirely and hand back an unscaled amount — 2 instead of
+  // 2 x 30 g.
+  if (storedUnit(unit) == UnitDropdownItem.serving.toString()) {
     // `scalableServingQuantity`, not `servingQuantity` (#629): OFF often
     // leaves the numeric field empty while `serving_size` carries the figure
     // as text, and reading only the numeric one left this branch silently

--- a/test/features/add_meal/presentation/bulk_add_screen_test.dart
+++ b/test/features/add_meal/presentation/bulk_add_screen_test.dart
@@ -16,6 +16,7 @@ import 'package:opennutritracker/core/domain/entity/intake_type_entity.dart';
 import 'package:opennutritracker/core/utils/energy_unit_provider.dart';
 import 'package:opennutritracker/core/utils/navigation_options.dart';
 import 'package:opennutritracker/features/add_meal/domain/entity/meal_entity.dart';
+import 'package:opennutritracker/features/add_meal/domain/entity/meal_portion_entity.dart';
 import 'package:opennutritracker/features/add_meal/domain/entity/meal_nutriments_entity.dart';
 import 'package:opennutritracker/features/add_meal/domain/usecase/resolve_parsed_meals_usecase.dart';
 import 'package:opennutritracker/features/add_meal/domain/usecase/search_products_usecase.dart';
@@ -115,6 +116,7 @@ MealEntity _meal(
   String? servingSize,
   String? mealUnit,
   String? brands,
+  List<MealPortionEntity> portions = const [],
 }) =>
     MealEntity(
       code: name,
@@ -126,6 +128,7 @@ MealEntity _meal(
       servingQuantity: servingQuantity,
       servingUnit: null,
       servingSize: servingSize,
+      portions: portions,
       source: MealSourceEntity.off,
       nutriments: const MealNutrimentsEntity(
         energyKcal100: 100,
@@ -684,6 +687,41 @@ void main() {
       find.text(lookupS(const Locale('en')).bulkAddDefaultAmountLabel),
       findsNothing,
     );
+  });
+
+  testWidgets('a chosen portion is written as a plain serving', (
+    tester,
+  ) async {
+    // #864 decision 3. The dropdown offers "serving#1" so the row can name
+    // the slice, but `IntakeDBO.unit` is published in docs/export-format.md
+    // and rides in a positional QR array other builds parse, so what gets
+    // written has to stay inside the closed set.
+    await _register({
+      'bread': [
+        _meal('Bread', servingQuantity: 244, portions: const [
+          MealPortionEntity(label: '1 cup', gramWeight: 244, localized: false),
+          MealPortionEntity(label: '1 slice', gramWeight: 38, localized: false),
+        ]),
+      ],
+    });
+
+    await tester.pumpWidget(_app());
+    await _parse(tester, '3 bread');
+
+    // Pick the second portion, then log.
+    await tester.tap(find.byType(DropdownButton<String>).first);
+    await tester.pumpAndSettle();
+    await tester.tap(find.text('slice').last);
+    await tester.pumpAndSettle();
+
+    await tester.tap(_submitButton());
+    await tester.pumpAndSettle();
+
+    final write = _mealDetailBloc.writes.single;
+    expect(write.unit, 'serving',
+        reason: 'the portion suffix must never be written down');
+    expect(double.parse(write.amount), 114,
+        reason: '3 slices at 38 g, not 3 cups at 244 g');
   });
 
   testWidgets('the quantity box holds the largest amount at 2x', (

--- a/test/unit_test/portion_picker_test.dart
+++ b/test/unit_test/portion_picker_test.dart
@@ -1,0 +1,107 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:opennutritracker/features/add_meal/domain/entity/meal_entity.dart';
+import 'package:opennutritracker/features/add_meal/domain/entity/meal_nutriments_entity.dart';
+import 'package:opennutritracker/features/add_meal/domain/entity/meal_portion_entity.dart';
+import 'package:opennutritracker/features/add_meal/presentation/bloc/bulk_add_bloc.dart';
+import 'package:opennutritracker/features/add_meal/domain/usecase/resolve_parsed_meals_usecase.dart';
+import 'package:opennutritracker/features/add_meal/util/meal_text_parser.dart';
+import 'package:opennutritracker/features/add_meal/util/portion_unit.dart';
+import 'package:opennutritracker/features/meal_detail/util/meal_quantity_converter.dart';
+
+MealEntity _meal({
+  double? servingQuantity,
+  List<MealPortionEntity> portions = const [],
+}) => MealEntity(
+  code: '1',
+  name: 'Bread',
+  url: null,
+  mealQuantity: null,
+  mealUnit: 'g',
+  servingQuantity: servingQuantity,
+  servingUnit: 'g',
+  servingSize: null,
+  source: MealSourceEntity.fdc,
+  nutriments: MealNutrimentsEntity.empty(),
+  portions: portions,
+);
+
+const _cup = MealPortionEntity(label: '1 cup', gramWeight: 244, localized: false);
+const _slice = MealPortionEntity(label: '1 slice', gramWeight: 38, localized: false);
+const _ounce = MealPortionEntity(label: '1 oz', gramWeight: 28, localized: false);
+
+BulkAddRow _row(MealEntity meal, String unit) => BulkAddRow(
+  resolved: ResolvedMealItem(
+    parsed: const ParsedMealItem(query: 'bread'),
+    candidates: [meal],
+    selectedIndex: 0,
+    confidence: 0.9,
+  ),
+  selectedIndex: 0,
+  amountText: '2',
+  unit: unit,
+);
+
+void main() {
+  group('the unit dropdown offers every portion (#864)', () {
+    test('one entry per portion, in the backend order', () {
+      final row = _row(_meal(portions: [_cup, _slice, _ounce]), 'serving');
+      expect(
+        row.allowedUnits.where(isPortionUnit),
+        ['serving', 'serving#1', 'serving#2'],
+      );
+    });
+
+    test('a food with no portion list keeps the single serving entry', () {
+      // Everything that is not a fresh backend search result: Open Food
+      // Facts, custom meals, anything read back from the database.
+      final row = _row(_meal(servingQuantity: 30), 'serving');
+      expect(row.allowedUnits.where(isPortionUnit), ['serving']);
+    });
+
+    test('a food with neither offers no serving at all', () {
+      final row = _row(_meal(), 'g');
+      expect(row.allowedUnits.where(isPortionUnit), isEmpty);
+    });
+
+    test('weights and measures are still offered alongside', () {
+      final row = _row(_meal(portions: [_cup, _slice]), 'serving');
+      expect(row.allowedUnits, contains('g'));
+      expect(row.allowedUnits, contains('oz'));
+    });
+  });
+
+  group('an amount scales by the portion the user picked', () {
+    final meal = _meal(portions: [_cup, _slice, _ounce]);
+
+    test('the first portion, named or not', () {
+      expect(convertQuantityToBaseUnit(2, 'serving', meal), 488);
+      expect(convertQuantityToBaseUnit(2, 'serving#0', meal), 488);
+    });
+
+    test('a later portion scales by its own weight, not the first', () {
+      // The whole point: three slices is 114 g, not 732 g.
+      expect(convertQuantityToBaseUnit(3, 'serving#1', meal), 114);
+      expect(convertQuantityToBaseUnit(2, 'serving#2', meal), 56);
+    });
+
+    test('an index past the end does not multiply by another food', () {
+      // Reachable when the user picks a different candidate under a chosen
+      // unit. Falling back to the record's serving beats scaling by a
+      // portion that belongs to something else.
+      final short = _meal(servingQuantity: 30, portions: [_cup]);
+      expect(convertQuantityToBaseUnit(2, 'serving#9', short), 60);
+    });
+
+    test('a food with no portions behaves exactly as before', () {
+      expect(
+        convertQuantityToBaseUnit(2, 'serving', _meal(servingQuantity: 30)),
+        60,
+      );
+    });
+
+    test('grams and ounces are untouched by any of this', () {
+      expect(convertQuantityToBaseUnit(100, 'g', meal), 100);
+      expect(convertQuantityToBaseUnit(1, 'oz', meal), closeTo(28.35, 0.01));
+    });
+  });
+}

--- a/test/unit_test/portion_unit_test.dart
+++ b/test/unit_test/portion_unit_test.dart
@@ -1,0 +1,58 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:opennutritracker/features/add_meal/util/portion_unit.dart';
+
+void main() {
+  group('portion units never reach storage (#864)', () {
+    test('the first portion is the string the app always stored', () {
+      // A food with one portion has to produce exactly what it produced
+      // before portions existed, or every row written since becomes a
+      // different row.
+      expect(portionUnit(0), 'serving');
+      expect(storedUnit(portionUnit(0)), 'serving');
+    });
+
+    test('later portions are distinguishable but store the same', () {
+      expect(portionUnit(1), 'serving#1');
+      expect(portionUnit(7), 'serving#7');
+      expect(storedUnit('serving#1'), 'serving');
+      expect(storedUnit('serving#7'), 'serving');
+    });
+
+    test('storedUnit leaves every other unit alone', () {
+      // Safe to call on all of them, so no call site has to decide first.
+      for (final u in ['g', 'ml', 'g/ml', 'oz', 'fl.oz', 'serving']) {
+        expect(storedUnit(u), u);
+      }
+    });
+
+    test('an unadorned unit names no portion', () {
+      expect(portionIndexOf('serving'), isNull);
+      expect(portionIndexOf('g'), isNull);
+      expect(portionIndexOf('oz'), isNull);
+    });
+
+    test('but a serving-shaped unit still scales by one', () {
+      // A row saved before portions existed, and a row that took the
+      // default, both mean the portion food_summary would have picked.
+      expect(effectivePortionIndex('serving'), 0);
+      expect(effectivePortionIndex('serving#0'), 0);
+      expect(effectivePortionIndex('serving#3'), 3);
+    });
+
+    test('isPortionUnit recognises both spellings and nothing else', () {
+      expect(isPortionUnit('serving'), isTrue);
+      expect(isPortionUnit('serving#2'), isTrue);
+      expect(isPortionUnit('g'), isFalse);
+      expect(isPortionUnit('fl.oz'), isFalse);
+    });
+
+    test('a malformed suffix is not a portion, and still stores clean', () {
+      // Nothing writes these, but a unit read back from an older or newer
+      // build must not become an index by accident.
+      expect(portionIndexOf('serving#'), isNull);
+      expect(portionIndexOf('serving#x'), isNull);
+      expect(effectivePortionIndex('serving#x'), 0);
+      expect(storedUnit('serving#x'), 'serving');
+    });
+  });
+}


### PR DESCRIPTION
The multi-portion picker — [#864](https://github.com/simonoppowa/OpenNutriTracker/issues/864) phase
2. **Depends on [Backend#7](https://github.com/simonoppowa/OpenNutriTracker-Backend/pull/7)** being
merged and applied; without it every fetch returns empty and every row behaves exactly as today.

## The problem

A food usually has more than one way to be counted, and the row offered whichever sorted first:

| | |
|---|---|
| Foods with ≥1 usable portion | 5,375 |
| **Foods with ≥2** | **3,499** |
| Foods with ≥3 | 2,239 |
| Max | 15 |

A food measured in cups, slices and ounces gave you cups — so *three slices of bread* logged as
three cups.

## No portion name is ever written down

`addIntake` stores the dropdown's value **verbatim**, and `IntakeDBO.unit` is published in
`docs/export-format.md` and rides in a **positional** QR array that other builds parse. Dataset
prose — commas and all — may never be that value. Decision 3 settled this.

So the values are `serving`, `serving#1`, `serving#2`, and `storedUnit` strips the suffix at the
one place anything is written. **A food with one portion produces exactly the string it always
produced**, so nothing already stored becomes a different row.

There is an end-to-end widget test for this: pick the second portion, log, assert `write.unit ==
'serving'` and `write.amount == 114` (3 slices at 38 g, not 3 cups at 244 g).

## Labels

The dropdown shows the portion's own word, and only where the backend says that word is in the
reader's language. **Coverage is per portion, not per food** — one food returns `1 Tasse` and
`1 Flüssigunze` verified and `1 individual school container` not, and the third falls back alone.

## The defect the tests caught

An index past the end of the list — reachable by picking a different candidate under a chosen unit
— fell through to the serving path, which compared the raw `serving#9` against `serving`, missed,
and **returned the amount unscaled**: 2 instead of 2 × 30 g. The comparison is on the stripped unit
now, and the case has a test.

## Checks

- `fvm flutter analyze` — `No issues found!`
- `fvm flutter test` — **2019 passed** (+17)
- **Seven mutations, seven caught**, including writing the raw unit with its suffix, offering only
  the first portion, dropping the out-of-range guard, and reverting the fall-through fix

## Nothing changes yet

Backend#7 is unapplied, so `fetchPortions` returns empty and every row keeps its single serving.
After it lands, the picker appears for the 3,499 foods that have a choice — in English immediately,
and in German once `review/portions_de.csv` is reviewed and promoted.

## Still unbuilt in phase 2

Matching the user's typed words against portion descriptions, and adding `portion` to the model
tool schema as a lookup key.
