### PR TITLE
feat(add-meal): let the word someone typed pick the portion

### DIFF
--- a/lib/features/add_meal/presentation/bloc/bulk_add_bloc.dart
+++ b/lib/features/add_meal/presentation/bloc/bulk_add_bloc.dart
@@ -7,6 +7,7 @@ import 'package:opennutritracker/features/add_meal/domain/usecase/read_meal_phot
 import 'package:opennutritracker/features/add_meal/domain/usecase/read_meal_text_usecase.dart';
 import 'package:opennutritracker/features/add_meal/domain/usecase/resolve_parsed_meals_usecase.dart';
 import 'package:opennutritracker/features/add_meal/util/meal_text_parser.dart';
+import 'package:opennutritracker/features/add_meal/util/portion_match.dart';
 import 'package:opennutritracker/features/add_meal/util/portion_unit.dart';
 import 'package:opennutritracker/features/meal_detail/presentation/bloc/meal_detail_bloc.dart';
 
@@ -401,6 +402,19 @@ class BulkAddBloc extends Bloc<BulkAddEvent, BulkAddState> {
         ? UnitDropdownItem.oz.toString()
         : UnitDropdownItem.gml.toString();
     if (meal == null) return fallback;
+
+    // The user named a portion, so their word decides which — "3 slices of
+    // bread" is slices, not the cup that happens to sort first. Above the
+    // bare-count rule below, because that rule cannot tell the two apart and
+    // would take the default.
+    //
+    // Only ever *narrows* the choice: no match leaves the preselection
+    // exactly as it was, which is decision 7 — nothing changes for anyone
+    // who did not name a portion.
+    if (parsed.quantity != null) {
+      final named = matchPortionToQuery(parsed.query, meal.portions);
+      if (named != null) return portionUnit(named);
+    }
 
     // A bare count means "N of them", and when the record's serving can be
     // scaled that is precisely what a serving is — so `2 eggs` is two

--- a/lib/features/add_meal/util/portion_match.dart
+++ b/lib/features/add_meal/util/portion_match.dart
@@ -1,0 +1,82 @@
+/// Works out which of a food's portions the user meant, from the words they
+/// typed.
+///
+/// "3 slices of bread" should pick the slice, not the cup. The parser cannot
+/// do it: it keys off unit *symbols* (`g`, `ml`, `oz`) because a vocabulary
+/// of words would grow with every locale, which is the objection that ruled
+/// out number-words in #600. So the word survives into the query text and is
+/// matched here instead — against the food's **own** portion labels, which
+/// arrive translated from the backend. The vocabulary lives in the data, per
+/// food, per language, and the app never holds a word list. #864.
+///
+/// Deliberately quiet about failure. No match means the row keeps the
+/// preselection it would have had, so a miss costs nothing and a false
+/// positive would cost a wrong portion on a plausible-looking row — which is
+/// the failure this whole issue exists to stop.
+library;
+
+import 'package:opennutritracker/features/add_meal/domain/entity/meal_portion_entity.dart';
+
+/// A parenthetical: "1 cup (8 fl oz)".
+final _parenthetical = RegExp(r'\([^)]*\)');
+
+/// Anything that is not a letter, for splitting both sides into words.
+final _nonLetter = RegExp(r'[^\p{L}]+', unicode: true);
+
+/// Below this a word is too short to match on. "oz" would otherwise hit
+/// "ozark", and two letters carry too little signal in any language.
+const _minTermLength = 3;
+
+/// How much longer an inflected form may be than the term it matches.
+///
+/// Two covers the endings that actually appear — slice/slices,
+/// Scheibe/Scheiben, plátek/plátky — without letting a term match an
+/// unrelated longer word. It is a bound, not a grammar: no per-language
+/// plural rules, which is the same reason this file holds no word list.
+const _maxInflection = 2;
+
+Set<String> _words(String text) => text
+    .toLowerCase()
+    .split(_nonLetter)
+    .where((w) => w.length >= _minTermLength)
+    .toSet();
+
+/// The words of a portion label that are worth matching on.
+/// The count needs no stripping: [_words] keeps only runs of letters, so the
+/// "1" in "1 slice" and the "1/2" in "1/2 bagel" never become terms.
+Set<String> _termsOf(String label) =>
+    _words(label.replaceAll(_parenthetical, ' '));
+
+/// True when [token] is [term], or either is the other with a short ending.
+bool _matches(String token, String term) {
+  if (token == term) return true;
+  if (token.startsWith(term) && token.length - term.length <= _maxInflection) {
+    return true;
+  }
+  return term.startsWith(token) && term.length - token.length <= _maxInflection;
+}
+
+/// Which portion [query] names, or null when it names none.
+///
+/// Scored by the length of the longest term that matched, so a query hitting
+/// both "1 large" and "1 large single serving bag" resolves to whichever
+/// matched on more word, and ties go to the earlier portion — the backend's
+/// order, whose first entry is the default the row would have taken anyway.
+int? matchPortionToQuery(String query, List<MealPortionEntity> portions) {
+  if (portions.isEmpty) return null;
+  final tokens = _words(query);
+  if (tokens.isEmpty) return null;
+
+  int? best;
+  var bestScore = 0;
+  for (var i = 0; i < portions.length; i++) {
+    for (final term in _termsOf(portions[i].label)) {
+      if (!tokens.any((t) => _matches(t, term))) continue;
+      if (term.length > bestScore) {
+        bestScore = term.length;
+        best = i;
+      }
+    }
+  }
+  return best;
+}

--- a/test/unit_test/bulk_add_bloc_test.dart
+++ b/test/unit_test/bulk_add_bloc_test.dart
@@ -9,6 +9,7 @@ import 'package:opennutritracker/features/add_meal/domain/usecase/read_meal_phot
 import 'package:opennutritracker/features/add_meal/domain/usecase/read_meal_text_usecase.dart';
 import 'package:opennutritracker/features/add_meal/domain/entity/meal_entity.dart';
 import 'package:opennutritracker/features/add_meal/domain/entity/meal_nutriments_entity.dart';
+import 'package:opennutritracker/features/add_meal/domain/entity/meal_portion_entity.dart';
 import 'package:opennutritracker/features/add_meal/domain/usecase/resolve_parsed_meals_usecase.dart';
 import 'package:opennutritracker/features/add_meal/domain/usecase/search_products_usecase.dart';
 import 'package:opennutritracker/features/add_meal/presentation/bloc/bulk_add_bloc.dart';
@@ -19,6 +20,7 @@ MealEntity meal(
   double? servingQuantity,
   String? servingUnit,
   String? servingSize,
+  List<MealPortionEntity> portions = const [],
 }) => MealEntity(
   code: name,
   name: name,
@@ -28,6 +30,7 @@ MealEntity meal(
   servingQuantity: servingQuantity,
   servingUnit: servingUnit,
   servingSize: servingSize,
+  portions: portions,
   source: MealSourceEntity.off,
   nutriments: MealNutrimentsEntity.empty(),
 );
@@ -862,6 +865,84 @@ void main() {
           );
         }
       }
+    });
+  });
+
+
+  group('the typed word picks the portion (#864)', () {
+    const cup = MealPortionEntity(
+        label: '1 cup', gramWeight: 244, localized: false);
+    const slice = MealPortionEntity(
+        label: '1 slice', gramWeight: 38, localized: false);
+
+    test('"3 slices of bread" preselects the slice, not the cup', () async {
+      // The whole point. Without this the row takes the first portion and
+      // three slices log as three cups — 732 g of bread.
+      final bloc = blocWith({
+        'slices of bread': [
+          meal('Bread', servingQuantity: 244, portions: [cup, slice]),
+        ],
+      });
+
+      final row = (await parse(bloc, '3 slices of bread')).rows.single;
+
+      expect(row.unit, 'serving#1');
+      expect(row.amountText, '3');
+    });
+
+    test('naming no portion leaves the preselection exactly as it was',
+        () async {
+      // Decision 7: this only ever narrows. A bare count with no word still
+      // means the default portion, which is what the row did before.
+      final bloc = blocWith({
+        'bread': [meal('Bread', servingQuantity: 244, portions: [cup, slice])],
+      });
+
+      final row = (await parse(bloc, '3 bread')).rows.single;
+
+      expect(row.unit, 'serving');
+    });
+
+    test('a stated unit still wins over a named portion', () async {
+      // "100g toast" is grams whatever else the text says: the parser
+      // already resolved it, and second-guessing that would let a food name
+      // override an explicit measurement.
+      final bloc = blocWith({
+        'slices of bread': [
+          meal('Bread', servingQuantity: 244, portions: [cup, slice]),
+        ],
+      });
+
+      final row = (await parse(bloc, '100g slices of bread')).rows.single;
+
+      expect(row.unit, 'g');
+    });
+
+    test('naming a portion with no count does not preselect it', () async {
+      // The gate on a stated quantity is load-bearing, not tidiness.
+      // `_initialAmount` falls back to the *default* portion's weight, so
+      // preselecting the slice here would pair the slice's name with the
+      // cup's 244 g and the row would read "244 slice".
+      final bloc = blocWith({
+        'slices of bread': [
+          meal('Bread', servingQuantity: 244, portions: [cup, slice]),
+        ],
+      });
+
+      final row = (await parse(bloc, 'slices of bread')).rows.single;
+
+      expect(row.unit, isNot('serving#1'));
+      expect(row.amountText, '244');
+    });
+
+    test('a food with no portion list is untouched', () async {
+      final bloc = blocWith({
+        'slices of bread': [meal('Bread', servingQuantity: 30)],
+      });
+
+      final row = (await parse(bloc, '3 slices of bread')).rows.single;
+
+      expect(row.unit, 'serving');
     });
   });
 

--- a/test/unit_test/portion_match_test.dart
+++ b/test/unit_test/portion_match_test.dart
@@ -1,0 +1,107 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:opennutritracker/features/add_meal/domain/entity/meal_portion_entity.dart';
+import 'package:opennutritracker/features/add_meal/util/portion_match.dart';
+
+MealPortionEntity _p(String label) =>
+    MealPortionEntity(label: label, gramWeight: 1, localized: false);
+
+void main() {
+  group('the word the user typed picks the portion (#864)', () {
+    final cupAndSlice = [_p('1 cup'), _p('1 slice')];
+
+    test('the case this exists for', () {
+      // "3 slices of bread" logged as three cups is the defect. The parser
+      // cannot catch it — it keys off unit symbols, not words — so the word
+      // survives into the query and is matched against the food's own labels.
+      expect(matchPortionToQuery('slices of bread', cupAndSlice), 1);
+    });
+
+    test('singular and plural both land, in either direction', () {
+      expect(matchPortionToQuery('slice of bread', cupAndSlice), 1);
+      expect(matchPortionToQuery('cups of rice', cupAndSlice), 0);
+      // The label may be the plural and the query the singular.
+      expect(matchPortionToQuery('slice', [_p('2 slices')]), 0);
+    });
+
+    test('a word nobody typed matches nothing', () {
+      expect(matchPortionToQuery('bread', cupAndSlice), isNull);
+      expect(matchPortionToQuery('', cupAndSlice), isNull);
+    });
+
+    test('no portions, no match', () {
+      expect(matchPortionToQuery('slices of bread', const []), isNull);
+    });
+
+    test('a short term does not match a longer unrelated word', () {
+      expect(matchPortionToQuery('ozark trail bar', [_p('1 oz')]), isNull);
+    });
+
+    test('a filler word inside a label is not a term', () {
+      // What the length floor is actually for. "1 large or thick slice"
+      // contains "or"; without a minimum, "a bowl or two" would match it and
+      // silently pick a portion the user never named. The previous example
+      // did not test this — the inflection bound caught it either way.
+      final portions = [_p('1 cup'), _p('1 large or thick slice')];
+      expect(matchPortionToQuery('a bowl or two', portions), isNull);
+    });
+
+    test('an inflection is bounded, not a prefix rule', () {
+      // "cup" must not match "cupboard": three letters longer is not an
+      // ending, it is a different word.
+      expect(matchPortionToQuery('cupboard sandwich', [_p('1 cup')]), isNull);
+      expect(matchPortionToQuery('cups', [_p('1 cup')]), 0);
+    });
+
+    test('a count is never a term, so it needs no stripping', () {
+      // Only runs of letters become terms, so "1" and "1/2" cannot match
+      // anything and there is no separate rule for them.
+      expect(matchPortionToQuery('a cup of tea', [_p('1 cup (8 fl oz)')]), 0);
+      expect(matchPortionToQuery('half bagel', [_p('1/2 bagel')]), 0);
+    });
+
+    test('a word inside a parenthetical is not a term', () {
+      // These are real labels. "1 fl oz (no ice)" would otherwise offer
+      // "ice", and "ice cream" would silently select a fluid-ounce portion
+      // the user never asked for. The previous example only had two-letter
+      // words in its brackets, which the length floor dropped anyway — so it
+      // passed whether parentheticals were stripped or not.
+      final portions = [_p('1 cup'), _p('1 fl oz (no ice)')];
+      expect(matchPortionToQuery('ice cream', portions), isNull);
+    });
+
+    test('the longer match wins over an earlier, shorter one', () {
+      // Both portions match "bag"; only the second also matches "large".
+      // Taking the first match instead of the longest would pick portion 0
+      // here, so the example has to make them disagree — an earlier version
+      // did not, and the rule was untested.
+      final portions = [_p('1 bag'), _p('1 large single serving bag')];
+      expect(matchPortionToQuery('large bag', portions), 1);
+    });
+
+    test('ties go to the earlier portion', () {
+      // The backend's order, whose first entry is the default the row would
+      // have taken anyway.
+      final portions = [_p('1 large'), _p('1 large single serving bag')];
+      expect(matchPortionToQuery('large eggs', portions), 0);
+    });
+
+    test('a qualifier after the comma is matchable too', () {
+      final portions = [_p('1 cup'), _p('1 cup, cooked')];
+      expect(matchPortionToQuery('cooked rice', portions), 1);
+    });
+
+    test('it works on a translated label, which is the point', () {
+      // The vocabulary is whatever the backend sent, so German portions match
+      // German words with no word list in the app. #600.
+      final de = [_p('1 Tasse'), _p('1 Scheibe')];
+      expect(matchPortionToQuery('Scheiben Brot', de), 1);
+      expect(matchPortionToQuery('Tasse Reis', de), 0);
+    });
+
+    test('and on a non-Latin one', () {
+      // Chinese has no spaces, so a label term will not appear as its own
+      // token — this must return null rather than mismatching.
+      expect(matchPortionToQuery('两片面包', [_p('1 片')]), isNull);
+    });
+  });
+}

--- a/test/unit_test/portion_picker_test.dart
+++ b/test/unit_test/portion_picker_test.dart
@@ -29,9 +29,10 @@ const _cup = MealPortionEntity(label: '1 cup', gramWeight: 244, localized: false
 const _slice = MealPortionEntity(label: '1 slice', gramWeight: 38, localized: false);
 const _ounce = MealPortionEntity(label: '1 oz', gramWeight: 28, localized: false);
 
-BulkAddRow _row(MealEntity meal, String unit) => BulkAddRow(
+BulkAddRow _row(MealEntity meal, String unit, {String query = 'bread'}) =>
+    BulkAddRow(
   resolved: ResolvedMealItem(
-    parsed: const ParsedMealItem(query: 'bread'),
+    parsed: ParsedMealItem(query: query),
     candidates: [meal],
     selectedIndex: 0,
     confidence: 0.9,


### PR DESCRIPTION
Third piece of [#864](https://github.com/simonoppowa/OpenNutriTracker/issues/864) phase 2, and the
one that makes the picker do its job unprompted.

## The problem it finishes

[#968](https://github.com/simonoppowa/OpenNutriTracker/pull/968) gave a row every portion a food
has. It still opened on whichever sorted first, so **"3 slices of bread" preselected the cup** and
three slices logged as 732 g.

## Why the parser can't do this

`meal_text_parser` keys off unit **symbols** — `g`, `ml`, `oz` — because a vocabulary of words would
grow with every locale, which is the objection that ruled out number-words in
[#600](https://github.com/simonoppowa/OpenNutriTracker/issues/600).

So the word survives into the query text, and is matched here against **the food's own portion
labels**, which arrive translated from the backend. The vocabulary lives in the data, per food and
per language — the app still holds no word list. That is why the German case works with no German
in this repo:

```dart
expect(matchPortionToQuery('Scheiben Brot', [_p('1 Tasse'), _p('1 Scheibe')]), 1);
```

## It only ever narrows

No match leaves the preselection exactly as it was — decision 7. A stated unit still wins:
`100g slices of bread` is grams, because the parser already resolved that and a food name must not
override a measurement.

**Gated on a stated quantity, and that gate is load-bearing.** `_initialAmount` falls back to the
*default* portion's weight, so preselecting the slice without a count would pair the slice's name
with the cup's 244 g — the row would read `244 slice`.

## Conservative by construction

Terms of three letters or more; endings bounded to two characters rather than per-language plural
rules; parentheticals ignored; longest match wins; ties to the earlier portion. Chinese returns
`null` — no word boundaries to tokenise — which is tested as a limitation rather than left to be
discovered.

## Checks

- `fvm flutter analyze` — `No issues found!`
- `fvm flutter test` — **2038 passed** (+19)

**Seven mutations. The first pass caught three, and the four misses were the interesting part** —
each was a test that looked like coverage:

| Test | Why it proved nothing |
|---|---|
| Length floor, via `oz`/`ozark` | the ending bound already rejected it. The floor's real job is stopping a filler word — `1 large or thick slice` offering `or` |
| Parenthetical rule, via `(8 fl oz)` | every word in those brackets is too short to be a term anyway. The real case is `1 fl oz (no ice)` matching `ice cream` |
| Longest-match-wins | only one portion matched at all, so first and longest agreed |
| Leading-count strip | **had no test because it does nothing** — `_words` keeps only runs of letters, so `1` and `1/2` were never terms |

All four now discriminate, and the dead regex is deleted rather than left as untested redundancy.

## Depends on nothing new

Backend#7 is already applied, so this works the moment it merges — in English now, in German once
`review/portions_de.csv` is promoted.

## Phase 2 after this

Only the model's `portion` lookup key remains.
