### PR TITLE
feat(add-meal): let a model name a portion, as a key and not a number

### DIFF
--- a/lib/features/add_meal/domain/meal_items_api.dart
+++ b/lib/features/add_meal/domain/meal_items_api.dart
@@ -42,6 +42,14 @@ const mealItemsToolDescription = 'Record the food items found.';
 /// The schema every provider is held to. **No nutrition fields, by
 /// construction.**
 ///
+/// `portion` is not one, and the distinction is the whole design rather than
+/// a technicality. It is a **lookup key** into the food's own portions — the
+/// model says "slice" and the gram weight comes from the row that matched,
+/// which came from the food database. A key that matches nothing is ignored.
+/// So the model still names and the data still measures, and a wrong key
+/// costs a portion nobody selected rather than a number nobody can check.
+/// #864.
+///
 /// This is the provenance guarantee's enforcement point, and it is a
 /// top-level constant rather than a member of either client so that adding a
 /// provider cannot quietly add a second schema. Reviewing the guarantee stays
@@ -73,6 +81,13 @@ const mealItemsToolSchema = {
       'items': {
         'type': 'object',
         'properties': {
+          'portion': {
+            'type': 'string',
+            'description':
+                'How the food was portioned, if it was — '
+                'slice, cup, piece. A word only, never a weight or a '
+                'count. Omit when unsure.',
+          },
           'query': {
             'type': 'string',
             'description':
@@ -177,10 +192,17 @@ ParsedMealItem? _mealItemFrom(Map<dynamic, dynamic> raw) {
   };
 
   final rawUnit = raw['unit'];
+  final rawPortion = raw['portion'];
   return ParsedMealItem(
     query: query,
     quantity: quantity,
     unit: rawUnit is String ? rawUnit : null,
+    // A non-string is dropped rather than coerced: this is a key to look
+    // something up with, and a number here means the model misread the
+    // field, not that it meant 3.
+    portion: rawPortion is String && rawPortion.trim().isNotEmpty
+        ? rawPortion.trim()
+        : null,
   );
 }
 

--- a/lib/features/add_meal/presentation/bloc/bulk_add_bloc.dart
+++ b/lib/features/add_meal/presentation/bloc/bulk_add_bloc.dart
@@ -412,7 +412,13 @@ class BulkAddBloc extends Bloc<BulkAddEvent, BulkAddState> {
     // exactly as it was, which is decision 7 — nothing changes for anyone
     // who did not name a portion.
     if (parsed.quantity != null) {
-      final named = matchPortionToQuery(parsed.query, meal.portions);
+      // The model's own word first, then the user's. A photograph has no
+      // typed text to search, so `portion` is the only thing that can name a
+      // slice there; where both exist they usually agree, and the model saw
+      // the food.
+      final named =
+          matchPortionToQuery(parsed.portion ?? '', meal.portions) ??
+          matchPortionToQuery(parsed.query, meal.portions);
       if (named != null) return portionUnit(named);
     }
 

--- a/lib/features/add_meal/util/meal_text_parser.dart
+++ b/lib/features/add_meal/util/meal_text_parser.dart
@@ -19,11 +19,32 @@ class ParsedMealItem {
   final double? quantity;
   final String? unit;
 
-  const ParsedMealItem({required this.query, this.quantity, this.unit});
+  /// What the model called the portion — "slice", "cup" — as a **lookup key**
+  /// into the food's own portions, never a value.
+  ///
+  /// The deterministic parser never sets it: it keys off unit symbols and
+  /// leaves any household word in [query], where `matchPortionToQuery` finds
+  /// it. This is for the paths that have no typed text to search — a
+  /// photograph above all, where nobody wrote "slices" for anything to match.
+  ///
+  /// Nothing numeric arrives with it. The grams still come from the portion
+  /// the key resolves to, which came from the food database, so "every number
+  /// is cited" is untouched — the model names, the data measures. A key that
+  /// matches nothing is ignored, which is a far weaker failure than a wrong
+  /// number. #864.
+  final String? portion;
+
+  const ParsedMealItem({
+    required this.query,
+    this.quantity,
+    this.unit,
+    this.portion,
+  });
 
   @override
   String toString() =>
-      'ParsedMealItem(query: $query, quantity: $quantity, unit: $unit)';
+      'ParsedMealItem(query: $query, quantity: $quantity, unit: $unit, '
+      'portion: $portion)';
 }
 
 /// One rejected segment, identified by its position in the input.
@@ -210,7 +231,17 @@ MealTextParseResult validateParsedMealItems(List<ParsedMealItem> candidates) {
         ? unit
         : null;
 
-    items.add(ParsedMealItem(query: query, quantity: quantity, unit: keptUnit));
+    // `portion` is carried through untouched. Every model reply passes here,
+    // so dropping it would leave the key set and never used — the feature
+    // silently doing nothing, with no failure to notice.
+    items.add(
+      ParsedMealItem(
+        query: query,
+        quantity: quantity,
+        unit: keptUnit,
+        portion: candidate.portion,
+      ),
+    );
   }
 
   return MealTextParseResult(items: items, errors: errors);

--- a/test/unit_test/ai_endpoint_prober_test.dart
+++ b/test/unit_test/ai_endpoint_prober_test.dart
@@ -310,7 +310,12 @@ void main() {
           ((params['properties'] as Map)['items'] as Map)['items'] as Map;
       expect(
         (item['properties'] as Map).keys,
-        unorderedEquals(['query', 'quantity', 'unit']),
+      // `portion` joined the set in #864. It is a lookup key rather than a
+      // measurement — the model names a portion, the gram weight comes from
+      // the food's own record — so the provenance guarantee is unchanged.
+      // Kept exact rather than loosened to "contains no macros", because
+      // exact is what caught this addition and has to catch the next one.
+        unorderedEquals(['query', 'quantity', 'unit', 'portion']),
       );
     },
   );

--- a/test/unit_test/bulk_add_bloc_test.dart
+++ b/test/unit_test/bulk_add_bloc_test.dart
@@ -102,6 +102,39 @@ class _AlwaysFailsInterpreter implements MealTextInterpreter {
       throw failure;
 }
 
+/// A model that answers with exactly these items. The sibling of
+/// [readerFailingWith]: a key is stored, so the use case really takes the
+/// model path rather than falling back to the parser.
+ReadMealTextUseCase readerReturning(List<ParsedMealItem> items) =>
+    ReadMealTextUseCase(
+      AiCredentialStorage(
+        _MapStorage({
+          'AiApiKeyTag.anthropic': 'sk-test',
+          'AiAssistEnabledTag': 'true',
+        }),
+      ),
+      (_) => _FixedInterpreter(items),
+    );
+
+class _FixedInterpreter implements MealTextInterpreter {
+  final List<ParsedMealItem> items;
+
+  _FixedInterpreter(this.items);
+
+  @override
+  Future<MealTextParseResult> interpret(String input, {String? localeCode}) async =>
+      MealTextParseResult(items: items, errors: const []);
+}
+
+BulkAddBloc blocWithModelReply(
+  Map<String, List<MealEntity>> results,
+  List<ParsedMealItem> items,
+) => BulkAddBloc(
+  ResolveParsedMealsUseCase(_FakeSearch(results)),
+  readerReturning(items),
+  photoReaderWithoutKey(),
+);
+
 BulkAddBloc blocWithFailingReader(
   Map<String, List<MealEntity>> results,
   MealInterpreterException failure,
@@ -933,6 +966,33 @@ void main() {
 
       expect(row.unit, isNot('serving#1'));
       expect(row.amountText, '244');
+    });
+
+    test("the model's own word picks the portion", () async {
+      // A photograph has no typed text to search, so the key is the only
+      // thing that can name a slice on that path. Driven here through the
+      // text interpreter, which is the same ParsedMealItem either way.
+      final bloc = blocWithModelReply(
+        {'bread': [meal('Bread', servingQuantity: 244, portions: [cup, slice])]},
+        const [ParsedMealItem(query: 'bread', quantity: 3, portion: 'slice')],
+      );
+
+      final row = (await parse(bloc, 'bread')).rows.single;
+
+      expect(row.unit, 'serving#1');
+    });
+
+    test('a key that matches nothing leaves the row alone', () async {
+      // The weak failure this design chose: an unusable key is ignored, and
+      // the row keeps the preselection it would have had.
+      final bloc = blocWithModelReply(
+        {'bread': [meal('Bread', servingQuantity: 244, portions: [cup, slice])]},
+        const [ParsedMealItem(query: 'bread', quantity: 3, portion: 'thimble')],
+      );
+
+      final row = (await parse(bloc, 'bread')).rows.single;
+
+      expect(row.unit, 'serving');
     });
 
     test('a food with no portion list is untouched', () async {

--- a/test/unit_test/model_meal_text_interpreter_test.dart
+++ b/test/unit_test/model_meal_text_interpreter_test.dart
@@ -120,7 +120,7 @@ void main() {
     // The provenance guarantee for tier 1b is structural: the model has
     // nowhere to put a calorie. If someone adds a macro field to the tool
     // schema, this fails — which is the review question we want asked.
-    test('exposes only query, quantity and unit', () async {
+    test('exposes only query, quantity, unit and portion', () async {
       final client = FakeClient(body: toolReply(const []));
       await interpreterWith(client).interpret('toast');
 
@@ -131,10 +131,16 @@ void main() {
                   as Map)['items']
               as Map;
 
+      // `portion` joined the set in #864. It is a lookup key rather than a
+      // measurement — the model names a portion, the gram weight comes from
+      // the food's own record — so the provenance guarantee is unchanged.
+      // Kept exact rather than loosened to "contains no macros", because
+      // exact is what caught this addition and has to catch the next one.
       expect(((itemProps['properties']) as Map).keys.toSet(), {
         'query',
         'quantity',
         'unit',
+        'portion',
       });
       expect(itemProps['additionalProperties'], isFalse);
     });

--- a/test/unit_test/model_portion_key_test.dart
+++ b/test/unit_test/model_portion_key_test.dart
@@ -1,0 +1,70 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:opennutritracker/features/add_meal/domain/meal_items_api.dart';
+import 'package:opennutritracker/features/add_meal/util/meal_text_parser.dart';
+
+Map<String, dynamic> get _itemProps =>
+    ((mealItemsToolSchema['properties'] as Map)['items']
+            as Map)['items'] as Map<String, dynamic>;
+
+void main() {
+  group('the model may name a portion, never measure one (#864)', () {
+    test('the schema still has no nutrition field', () {
+      // The guarantee the whole feature rests on. `portion` is a lookup key;
+      // if this list ever grows a weight or an energy value, the model has
+      // started measuring.
+      final properties =
+          (_itemProps['properties'] as Map).keys.cast<String>().toSet();
+      expect(properties, {'query', 'quantity', 'unit', 'portion'});
+      expect(_itemProps['additionalProperties'], isFalse);
+    });
+
+    test('portion is a string, and only query is required', () {
+      final portion = (_itemProps['properties'] as Map)['portion'] as Map;
+      expect(portion['type'], 'string');
+      expect(_itemProps['required'], ['query']);
+    });
+
+    test('a portion in the reply survives to the item', () {
+      final items = mealItemsFromJson([
+        {'query': 'bread', 'quantity': 3, 'portion': 'slice'},
+      ]);
+      expect(items.single.portion, 'slice');
+    });
+
+    test('and survives validation, which rebuilds every item', () {
+      // The failure this nearly shipped as: `validateParsedMealItems`
+      // reconstructs each item, so a dropped field would leave the key set
+      // and never used — the feature doing nothing, with nothing to notice.
+      final result = validateParsedMealItems(
+        mealItemsFromJson([
+          {'query': 'bread', 'quantity': 3, 'portion': 'slice'},
+        ]),
+      );
+      expect(result.items.single.portion, 'slice');
+    });
+
+    test('a number where a name belongs is dropped, not coerced', () {
+      // A key is a word. A number here means the model misread the field,
+      // not that it meant three of something.
+      final items = mealItemsFromJson([
+        {'query': 'bread', 'quantity': 3, 'portion': 3},
+      ]);
+      expect(items.single.portion, isNull);
+    });
+
+    test('blank and whitespace are no key at all', () {
+      final items = mealItemsFromJson([
+        {'query': 'a', 'portion': ''},
+        {'query': 'b', 'portion': '   '},
+      ]);
+      expect(items.map((i) => i.portion), [isNull, isNull]);
+    });
+
+    test('the deterministic parser never sets one', () {
+      // It keys off unit symbols and leaves any household word in the query,
+      // where matchPortionToQuery finds it. Nothing offline invents a key.
+      final parsed = parseMealText('3 slices of bread');
+      expect(parsed.items.single.portion, isNull);
+    });
+  });
+}

--- a/test/unit_test/openai_compatible_endpoint_test.dart
+++ b/test/unit_test/openai_compatible_endpoint_test.dart
@@ -196,7 +196,12 @@ void main() {
         ((params['properties'] as Map)['items'] as Map)['items'] as Map;
     expect(
       (item['properties'] as Map).keys,
-      unorderedEquals(['query', 'quantity', 'unit']),
+      // `portion` joined the set in #864. It is a lookup key rather than a
+      // measurement — the model names a portion, the gram weight comes from
+      // the food's own record — so the provenance guarantee is unchanged.
+      // Kept exact rather than loosened to "contains no macros", because
+      // exact is what caught this addition and has to catch the next one.
+      unorderedEquals(['query', 'quantity', 'unit', 'portion']),
     );
   });
 

--- a/test/unit_test/openrouter_meal_items_api_test.dart
+++ b/test/unit_test/openrouter_meal_items_api_test.dart
@@ -380,7 +380,7 @@ void main() {
     // The same guarantee the Anthropic client is held to, asserted against
     // the bytes this client actually sends. A shared constant is only a
     // guarantee if every wire format really carries it.
-    test('exposes only query, quantity and unit', () async {
+    test('exposes only query, quantity, unit and portion', () async {
       final client = FakeClient(body: toolReply(const []));
       await request(apiWith(client));
 
@@ -389,10 +389,16 @@ void main() {
       final itemProps =
           (((parameters['properties'] as Map)['items'] as Map)['items']) as Map;
 
+      // `portion` joined the set in #864. It is a lookup key rather than a
+      // measurement — the model names a portion, the gram weight comes from
+      // the food's own record — so the provenance guarantee is unchanged.
+      // Kept exact rather than loosened to "contains no macros", because
+      // exact is what caught this addition and has to catch the next one.
       expect((itemProps['properties'] as Map).keys.toSet(), {
         'query',
         'quantity',
         'unit',
+        'portion',
       });
       expect(itemProps['additionalProperties'], isFalse);
     });


### PR DESCRIPTION
The last piece of [#864](https://github.com/simonoppowa/OpenNutriTracker/issues/864) phase 2.

## Why

[#969](https://github.com/simonoppowa/OpenNutriTracker/pull/969) made the typed word pick a
portion. **A photograph has no typed text** — nobody writes "slices" at a plate — so that path had
nothing to match and opened on whichever portion sorted first.

## A key, not a number

The schema gains `portion`: a word the model may supply — `slice`, `cup`, `piece` — used to look up
one of the **food's own** portions. The gram weight still comes from the row that matched, which
came from the food database.

The model names, the data measures. *Every number is cited* is exactly as true as before, and a key
that matches nothing is ignored — a far weaker failure than a wrong number. That distinction is
decision 6's whole basis, and it's now written into the schema's own docstring.

Preferred over the typed word where both exist: the model saw the food.

## Four guardrails fired, which is the design working

Adding one property broke **four existing tests on four separate wire paths**, each asserting the
schema's property set *exactly*:

| Test | Path |
|---|---|
| `model_meal_text_interpreter_test` | Anthropic |
| `openrouter_meal_items_api_test` | OpenRouter |
| `openai_compatible_endpoint_test` | own server |
| `ai_endpoint_prober_test` | the setup probe |

That's *"adding a provider cannot quietly add a second schema"* enforced by making any change to
that set fail in four places at once. **Each is widened, not loosened** — still an exact set rather
than a "contains no macros" check, because exact is what caught this and has to catch whatever
comes next.

## The near-miss

`validateParsedMealItems` rebuilds every item, and the first version **dropped `portion` on the way
through**. Every model reply passes there, so the key would have been set, carried, and never
used — the feature silently doing nothing, with no failure to notice. It has a test now, and the
test says why it exists.

## Checks

- `fvm flutter analyze` — `No issues found!`
- `fvm flutter test` — **2047 passed**
- **Five mutations, five caught**: schema drops the property, reader ignores it, reader coerces a
  number into a key, validator drops it, preselection ignores it

One process note worth recording: **the per-file runs were all green while the full suite had four
failures.** The guardrails live in files this change never touched, which is exactly the case a
targeted run cannot see.

## Phase 2 is complete after this

Localized labels, the multi-portion picker, typed-word matching, and now the model key. What
remains is not code: `review/portions_de.csv` needs a native speaker before any of it is visible
outside English.
