### PR TITLE
fix(add-meal): keep an amount the app cannot vouch for out of the batch

### DIFF
--- a/lib/features/add_meal/presentation/bloc/bulk_add_bloc.dart
+++ b/lib/features/add_meal/presentation/bloc/bulk_add_bloc.dart
@@ -82,9 +82,19 @@ class BulkAddRow extends Equatable {
   /// serving that becomes 3 g/ml, and looking only for a *missing* unit
   /// would let it through unmarked.
   ///
-  /// Either way the row still logs — both fields are editable — but it is
-  /// marked so the eye lands on the one row needing a decision rather than
-  /// on a plausible-looking wrong number.
+  /// Either way the row is **held back from the batch** until the user
+  /// settles it, and marked so the eye lands on the one row needing a
+  /// decision rather than on a plausible-looking wrong number.
+  ///
+  /// Marking alone used to be the whole remedy, and it was not enough. A
+  /// device pass typed `zwei Eier und drei Scheiben Brot`, got two flagged
+  /// rows reading 2 g/ml and 3 g/ml, and **Save all** wrote both: 11 kcal
+  /// for a breakfast. The flag was doing its job and the batch ignored it.
+  /// Worse, the control the flag points at cannot always answer — a record
+  /// with no portion offers only `g`, `oz`, `g/ml`, so there is no unit on
+  /// the dropdown that means *one egg*. A warning pointing at a control that
+  /// cannot resolve it, over a button that logs it anyway, is not a warning.
+  /// #973.
   ///
   /// Derived rather than stored, so picking a different candidate
   /// re-evaluates it against the food actually selected. A stored flag
@@ -183,7 +193,12 @@ class BulkAddRow extends Equatable {
       allowedUnits.contains(unit) ? unit : UnitDropdownItem.gml.toString();
 
   /// Rows that will actually be written when the user confirms.
-  bool get willBeLogged => isResolved && !skipped;
+  ///
+  /// [amountNeedsCheck] excludes rather than merely annotates: an amount the
+  /// app cannot vouch for is not written to the diary on the user's behalf.
+  /// Picking a unit clears the flag and the row rejoins the batch, so the
+  /// way out is one tap on the control the warning already points at. #973.
+  bool get willBeLogged => isResolved && !skipped && !amountNeedsCheck;
 
   BulkAddRow copyWith({
     int? selectedIndex,

--- a/test/features/add_meal/presentation/bulk_add_screen_test.dart
+++ b/test/features/add_meal/presentation/bulk_add_screen_test.dart
@@ -1155,7 +1155,10 @@ void main() {
   testWidgets('writes one intake per loggable row, in order', (tester) async {
     await _register({
       'toast': [_meal('Toast')],
-      'eggs': [_meal('Egg')],
+      // Countable, so the row stays in the batch: a bare count against a
+      // serving-less record is held back now (#973), which would quietly
+      // drop a row this test needs.
+      'eggs': [_meal('Egg', servingQuantity: 50)],
       'milk': [_meal('Milk')],
     });
     await tester.pumpWidget(_app());
@@ -1228,7 +1231,10 @@ void main() {
   testWidgets('a skipped row is not written', (tester) async {
     await _register({
       'toast': [_meal('Toast')],
-      'eggs': [_meal('Egg')],
+      // Countable, so the row stays in the batch: a bare count against a
+      // serving-less record is held back now (#973), which would quietly
+      // drop a row this test needs.
+      'eggs': [_meal('Egg', servingQuantity: 50)],
     });
     await tester.pumpWidget(_app());
     await _parse(tester, '100g toast, 2 eggs');
@@ -1266,6 +1272,50 @@ void main() {
     await _parse(tester, '2 eggs');
 
     expect(find.text(l10nEn.bulkAddCheckAmountLabel), findsOneWidget);
+  });
+
+  testWidgets('a flagged row is not written by Save all', (tester) async {
+    // #973. The flag existed and the batch wrote the row anyway. A device
+    // pass typed two eggs and three slices of bread against records with no
+    // portion, and logged 11 kcal for a breakfast — both rows warned, both
+    // rows written. Warning and writing are the same decision here.
+    await _register({
+      'toast': [_meal('Toast')],
+      'eggs': [_meal('Egg')],
+    });
+    await tester.pumpWidget(_app());
+    await _parse(tester, '100g toast, 2 eggs');
+
+    expect(find.text(l10nEn.bulkAddCheckAmountLabel), findsOneWidget);
+
+    await tester.tap(_submitButton());
+    await tester.pumpAndSettle();
+
+    expect(_mealDetailBloc.writes.map((w) => w.mealName), ['Toast']);
+  });
+
+  testWidgets('choosing a unit lets a flagged row be written', (
+    tester,
+  ) async {
+    // Excluding the row is only defensible because the way back is one tap
+    // on the control the warning already points at.
+    await _register({
+      'eggs': [_meal('Egg')],
+    });
+    await tester.pumpWidget(_app());
+    await _parse(tester, '2 eggs');
+
+    await tester.tap(find.byType(DropdownButton<String>).first);
+    await tester.pumpAndSettle();
+    await tester.tap(find.text('g').last);
+    await tester.pumpAndSettle();
+
+    expect(find.text(l10nEn.bulkAddCheckAmountLabel), findsNothing);
+
+    await tester.tap(_submitButton());
+    await tester.pumpAndSettle();
+
+    expect(_mealDetailBloc.writes.map((w) => w.mealName), ['Egg']);
   });
 
   testWidgets('a countable food shows no warning', (tester) async {
@@ -1368,7 +1418,10 @@ void main() {
   ) async {
     await _register({
       'toast': [_meal('Toast')],
-      'eggs': [_meal('Egg')],
+      // Countable, so the row stays in the batch: a bare count against a
+      // serving-less record is held back now (#973), which would quietly
+      // drop a row this test needs.
+      'eggs': [_meal('Egg', servingQuantity: 50)],
     }, failOnSecondWrite: true);
     await tester.pumpWidget(_app());
     await _parse(tester, '100g toast, 2 eggs');

--- a/test/unit_test/bulk_add_bloc_test.dart
+++ b/test/unit_test/bulk_add_bloc_test.dart
@@ -254,8 +254,8 @@ void main() {
     });
 
     test('flags a count when the food has no serving data', () async {
-      // Nothing to count, so the amount falls back to a weight. The row
-      // still logs — it is editable — but it is marked.
+      // Nothing to count, so the amount falls back to a weight. The row is
+      // marked, and held out of the batch until the user settles it.
       final bloc = blocWith({
         'eggs': [meal('Egg')],
       });
@@ -264,7 +264,67 @@ void main() {
 
       expect(row.amountText, '2');
       expect(row.amountNeedsCheck, isTrue);
-      expect(row.willBeLogged, isTrue);
+      expect(row.willBeLogged, isFalse);
+    });
+
+    test('a flagged count is kept out of the batch', () async {
+      // #973. Typing `zwei Eier und drei Scheiben Brot` on a device gave two
+      // flagged rows at 2 g/ml and 3 g/ml, and Save all wrote both — 11 kcal
+      // for a breakfast. The flag was right and the batch ignored it.
+      final bloc = blocWith({
+        'eggs': [meal('Egg')],
+        'bread': [meal('Bread')],
+      });
+
+      final state = await parse(bloc, '2 eggs, 3 bread');
+
+      expect(state.rows.length, 2);
+      expect(state.rows.every((r) => r.amountNeedsCheck), isTrue);
+      expect(state.loggableCount, 0);
+    });
+
+    test('picking a unit returns a flagged row to the batch', () async {
+      // The way out has to be reachable from the row itself, or excluding it
+      // just strands the user. Choosing a unit is the call the warning asks
+      // for, so it both clears the flag and restores the row.
+      final bloc = blocWith({
+        'eggs': [meal('Egg')],
+      });
+      await parse(bloc, '2 eggs');
+
+      bloc.add(const ChangeRowUnitEvent(0, 'g'));
+      final state = await bloc.stream.first as BulkAddLoadedState;
+
+      expect(state.rows.single.amountNeedsCheck, isFalse);
+      expect(state.rows.single.willBeLogged, isTrue);
+      expect(state.loggableCount, 1);
+    });
+
+    test('a countable food is unaffected and still logs in one pass', () async {
+      // The guard must not cost the case that already worked: a record with
+      // serving data counts as servings and goes straight into the batch.
+      final bloc = blocWith({
+        'eggs': [meal('Egg', servingQuantity: 50)],
+      });
+
+      final state = await parse(bloc, '2 eggs');
+
+      expect(state.rows.single.unit, 'serving');
+      expect(state.rows.single.amountNeedsCheck, isFalse);
+      expect(state.loggableCount, 1);
+    });
+
+    test('a stated weight is unaffected and still logs in one pass', () async {
+      // The deterministic path with an explicit unit is the common case and
+      // must be untouched by this.
+      final bloc = blocWith({
+        'toast': [meal('Toast', servingQuantity: 30)],
+      });
+
+      final state = await parse(bloc, '100g toast');
+
+      expect(state.rows.single.unit, 'g');
+      expect(state.loggableCount, 1);
     });
 
     test('a stated unit is never second-guessed', () async {


### PR DESCRIPTION
Closes [#973](https://github.com/simonoppowa/OpenNutriTracker/issues/973) — which will not auto-close from here, since `Closes` only fires on the default branch.

## The bug

A count the model reads **correctly** loses its unit when the matched record carries no portion. The number survives, `effectiveUnit` substitutes `g/ml`, and *two eggs* becomes *two grams*.

The row was already flagged for exactly this. It was flagged and written anyway. A device pass against this branch head typed `zwei Eier und drei Scheiben Brot` and logged:

| Row | Match | Amount | Energy |
| :-- | :-- | :-- | :-- |
| Eier | Classic, K-Classic, Kaufland | 2 g/ml | 3 kcal |
| Brot | Backerkronung | 3 g/ml | 8 kcal |

**11 kcal for a breakfast**, both rows amber, both rows in the diary. It reproduces identically on anthropic and openai, so the fault is after the model, not inside either interpreter.

It is not an edge case. Five of six ordinary breakfast foods hit it — `eine Banane, ein Apfel, zwei Eier, eine Scheibe Brot, ein Glas Milch, ein Becher Joghurt` saves as **124 kcal**, 117 of it from the one row that resolved a portion. An apple logs as **0 kcal**.

And the warning points at a control that cannot always answer it: a record with no portion offers `g`, `oz`, `g/ml` and nothing else, so there is no unit on the dropdown that means *one egg*. The user is asked to fix something the screen does not let them express.

## The change

One line of behaviour. `amountNeedsCheck` now **excludes** the row from the batch instead of only annotating it:

```dart
bool get willBeLogged => isResolved && !skipped && !amountNeedsCheck;
```

Picking a unit clears the flag and the row rejoins the batch, so the way out stays one tap on the control the warning already points at. Everything routes through `loggableRows`, so this is the single point.

Deliberately **not** in this PR: preferring a match that has a portion. It was the other candidate on the issue, and probing weakened it — `Banane Oaklands`, `la banane française`, `albi` and `Banane Banane` are all Open Food Facts records with per-100 g data and no count-based serving, so there may be nothing better to prefer. That is a quality change worth making on its own terms; this one closes the data-integrity hole without depending on it.

## Verified

- **2053 tests pass**, analyzer clean.
- **Mutation-checked**: restoring `willBeLogged` to `isResolved && !skipped` fails two named tests.
- **On the Pixel 6 that found it**: the same input now shows `0 Einträge speichern` instead of `2`; picking `g` on the Eier row clears its warning and the button reads `1 Einträge speichern`, with the Brot row still held back.

Three existing widget tests used `2 eggs` against a serving-less record as an incidental vehicle for testing ordering, skipping, and a mid-batch write failure. Their egg fixture is now countable so each keeps testing its actual subject, with a comment saying why. The test that exists *for* the flag keeps the serving-less record.

## Worth a follow-up, not done here

Nothing on screen says the row is being held back — the amber `Einheit für diese Menge prüfen` is unchanged, and the submit button simply reads `0`. Saying so plainly needs a new ARB key in all nine locales, and eight of those would be machine translations; that felt like a separate change rather than something to bundle into a data-integrity fix.
