### PR TITLE
fix(add-meal): only hold back an amount that would actually be wrong

### DIFF
--- a/lib/features/add_meal/presentation/bloc/bulk_add_bloc.dart
+++ b/lib/features/add_meal/presentation/bloc/bulk_add_bloc.dart
@@ -10,6 +10,7 @@ import 'package:opennutritracker/features/add_meal/util/meal_text_parser.dart';
 import 'package:opennutritracker/features/add_meal/util/portion_match.dart';
 import 'package:opennutritracker/features/add_meal/util/portion_unit.dart';
 import 'package:opennutritracker/features/meal_detail/presentation/bloc/meal_detail_bloc.dart';
+import 'package:opennutritracker/features/meal_detail/util/meal_quantity_converter.dart';
 
 part 'bulk_add_event.dart';
 part 'bulk_add_state.dart';
@@ -192,13 +193,51 @@ class BulkAddRow extends Equatable {
   String get effectiveUnit =>
       allowedUnits.contains(unit) ? unit : UnitDropdownItem.gml.toString();
 
+  /// True when the row's number would reach the diary meaning something
+  /// other than what was asked for.
+  ///
+  /// **Narrower than [amountNeedsCheck], deliberately.** That flag fires on
+  /// every substituted unit, including substitutions that change nothing.
+  /// A record measured in grams offers no `ml`, so `200ml Milch` becomes
+  /// `200 g/ml` — same number, same base quantity, same energy, and a row
+  /// that was right all along. The guard added for #973 (#975) held those
+  /// back too, refusing an amount the user typed correctly and the app
+  /// understood correctly.
+  ///
+  /// Three ways a number does go wrong, and each is checked on its own terms
+  /// rather than inferred from the label:
+  ///
+  /// * **Nothing was stated** and the food cannot be counted, so the number
+  ///   is a count about to be read as a weight — `2 Eier` as two grams.
+  /// * **A serving the food cannot scale.** `3 serving` against a record
+  ///   with no scalable serving converts to a bare `3`, and so does
+  ///   `3 g/ml` — numerically identical, both meaningless, so comparing the
+  ///   two conversions cannot see it. Caught by asking what the unit *is*.
+  /// * **The conversion moves the number**, `4oz` against a record that
+  ///   cannot honour ounces being the plain case.
+  bool get amountWouldBeWrong {
+    if (!amountNeedsCheck) return false;
+    // Nothing to compare against: the count has no unit and no serving to
+    // land on.
+    if (resolved.parsed.unit == null) return true;
+    // A serving the food cannot honour. Checked before the conversion, not
+    // by it — see above.
+    if (isPortionUnit(unit)) return true;
+    final quantity = resolved.parsed.quantity;
+    final food = meal;
+    if (quantity == null || food == null) return true;
+    return convertQuantityToBaseUnit(quantity, unit, food) !=
+        convertQuantityToBaseUnit(quantity, effectiveUnit, food);
+  }
+
   /// Rows that will actually be written when the user confirms.
   ///
-  /// [amountNeedsCheck] excludes rather than merely annotates: an amount the
-  /// app cannot vouch for is not written to the diary on the user's behalf.
-  /// Picking a unit clears the flag and the row rejoins the batch, so the
-  /// way out is one tap on the control the warning already points at. #973.
-  bool get willBeLogged => isResolved && !skipped && !amountNeedsCheck;
+  /// [amountWouldBeWrong] excludes rather than merely annotates: an amount
+  /// that would land meaning something else is not written to the diary on
+  /// the user's behalf. Picking a unit clears it and the row rejoins the
+  /// batch, so the way out is one tap on the control the warning already
+  /// points at. #973.
+  bool get willBeLogged => isResolved && !skipped && !amountWouldBeWrong;
 
   BulkAddRow copyWith({
     int? selectedIndex,

--- a/test/unit_test/bulk_add_bloc_test.dart
+++ b/test/unit_test/bulk_add_bloc_test.dart
@@ -20,13 +20,14 @@ MealEntity meal(
   double? servingQuantity,
   String? servingUnit,
   String? servingSize,
+  String? mealUnit,
   List<MealPortionEntity> portions = const [],
 }) => MealEntity(
   code: name,
   name: name,
   url: null,
   mealQuantity: null,
-  mealUnit: null,
+  mealUnit: mealUnit,
   servingQuantity: servingQuantity,
   servingUnit: servingUnit,
   servingSize: servingSize,
@@ -265,6 +266,46 @@ void main() {
       expect(row.amountText, '2');
       expect(row.amountNeedsCheck, isTrue);
       expect(row.willBeLogged, isFalse);
+    });
+
+    test('a harmless substitution still logs', () async {
+      // A record measured in grams offers no `ml`, so a typed `200ml`
+      // becomes `200 g/ml` — same number, same base quantity, same energy.
+      // The #973 guard (#975) held these back too, refusing an amount the
+      // user had typed correctly and the app had understood correctly.
+      final bloc = blocWith({
+        'milk': [meal('Milk', mealUnit: 'g')],
+      });
+
+      final state = await parse(bloc, '200ml milk');
+
+      final row = state.rows.single;
+      expect(row.effectiveUnit, 'g/ml');
+      expect(row.amountText, '200');
+      expect(
+        row.amountNeedsCheck,
+        isTrue,
+        reason: 'the swap is still worth pointing at',
+      );
+      expect(
+        row.amountWouldBeWrong,
+        isFalse,
+        reason: 'but it does not move the number',
+      );
+      expect(state.loggableCount, 1);
+    });
+
+    test('a substitution that moves the number is kept out', () async {
+      // `4oz` against a record that cannot honour ounces becomes `4 g/ml`:
+      // a 28-fold under-count, and exactly the shape the guard is for.
+      final bloc = blocWith({
+        'steak': [meal('Steak', mealUnit: 'ml')],
+      });
+
+      final state = await parse(bloc, '4oz steak');
+
+      expect(state.rows.single.amountWouldBeWrong, isTrue);
+      expect(state.loggableCount, 0);
     });
 
     test('a flagged count is kept out of the batch', () async {


### PR DESCRIPTION
Follow-up to [#975](https://github.com/simonoppowa/OpenNutriTracker/pull/975), which fixed [#973](https://github.com/simonoppowa/OpenNutriTracker/issues/973) and over-reached doing it.

## The regression

#975 excluded every row carrying `amountNeedsCheck` from the batch. That flag fires on **any** substituted unit, including substitutions that change nothing — so it refused amounts that were right.

`200ml Milch`, on the merged branch, Pixel 6:

| Match | Amount | Energy | Button |
| :-- | :-- | :-- | :-- |
| Milch, Milbona | 200 g/ml | 94 kcal | **`0 Einträge speichern`** |

94 kcal is correct for 200 ml of milk. The record is measured in grams and its dropdown offers `Portion`, `g`, `oz`, `g/ml` — **no `ml`** — so the typed unit is swapped for `g/ml` and the row is flagged. Before #975 that row logged, correctly. After it, an explicit and unambiguous amount is declined.

This was my error in #975, not a gap in #973: the issue asked that a *model-reported count with no portion* be held back, and I implemented something broader. Every test I wrote used the count branch, so the suite stayed green and a device probe found it.

## The change

`amountWouldBeWrong` narrows the exclusion to the three ways a number actually goes wrong, each asked on its own terms rather than inferred from the label:

- **nothing stated and nothing to count** — `2 Eier` about to be read as two grams
- **a serving the food cannot scale** — `3 serving` converts to a bare `3`, and so does `3 g/ml`. Numerically identical, both meaningless, so comparing conversions is blind to it; caught by asking what the unit *is*
- **a conversion that moves the number** — `4oz` against a record that cannot honour ounces, a 28-fold under-count

Everything #973 was about still stays out of the diary. Only rows where the swap costs nothing are let back in.

**The warning is deliberately unchanged.** A swapped unit is still worth pointing at even when it changes no number — the app is treating a typed `ml` as `g`, which is right for milk and would not be for oil. `amountNeedsCheck` keeps its meaning; only the decision to *withhold* the row is narrowed.

## Verified

- **2055 tests pass**, analyzer clean.
- **Mutation-checked**: restoring `willBeLogged` to exclude on `amountNeedsCheck` fails the named harmless-substitution test.
- New tests both ways — a substitution that preserves the number logs; one that moves it does not.

**Device verification is outstanding.** The APK is built and installed, but the phone locked itself mid-run and I will not unlock it. The two checks to run are `200ml Milch` (must now read `1 Eintrag speichern`) and `zwei Eier und drei Scheiben Brot` (must still read `0`). I would rather say that plainly than let the merge imply a device pass that did not happen.
