### PR TITLE
fix(settings): offer a way to confirm a switch to a keyed provider

### DIFF
--- a/lib/features/settings/presentation/widgets/ai_assist_dialog.dart
+++ b/lib/features/settings/presentation/widgets/ai_assist_dialog.dart
@@ -1056,14 +1056,30 @@ class _AiAssistDialogState extends State<AiAssistDialog> {
             child: Text(s.dialogCancelLabel),
           ),
         ),
-        // Offered whenever something on screen can still be typed into. For
-        // the hosted three that is exactly "before a key exists", which is
-        // what this used to say. A server the user runs keeps an address and
-        // a model name editable for as long as the dialog is open, and
-        // hanging OK off the credential left both fields rendered with no way
-        // to commit a change — the only exit was Remove, which discards the
-        // address as well.
-        if (!_loading && (!_hasKey || _provider == AiProvider.ownServer))
+        // Offered whenever something on screen can still be typed into, **or
+        // whenever there is already a change to confirm**. For the hosted
+        // three the first half is exactly "before a key exists", which is
+        // what this used to say on its own. A server the user runs keeps an
+        // address and a model name editable for as long as the dialog is
+        // open, and hanging OK off the credential left both fields rendered
+        // with no way to commit a change — the only exit was Remove, which
+        // discards the address as well.
+        //
+        // The second half is #979. Switching to a provider that already has
+        // a key is a change, and it had no way out that kept it: `_hasKey`
+        // is true for that provider, so OK was never rendered, while Cancel
+        // and the back button both run `_cancel` and restore the previous
+        // one. Every exit undid the switch, which made a second configured
+        // destination unreachable — the choice the four-destination design
+        // exists to offer. The test that covered "OK still switches" passed
+        // throughout, because its provider had no key and so was on the
+        // lucky side of this gate.
+        //
+        // `_changed` is the right question rather than `_provider != _providerOnOpen`:
+        // a model pick and the enabled toggle are also changes someone may
+        // want to keep, and they are already written by the time they set it.
+        if (!_loading &&
+            (!_hasKey || _provider == AiProvider.ownServer || _changed))
           Semantics(
             identifier: 'ai-assist-save-key',
             child: TextButton(onPressed: _save, child: Text(s.dialogOKLabel)),

--- a/test/features/settings/presentation/ai_assist_dialog_test.dart
+++ b/test/features/settings/presentation/ai_assist_dialog_test.dart
@@ -2757,6 +2757,69 @@ void main() {
       expect(await storage.activeProvider(), AiProvider.openai);
     });
 
+    testWidgets('a keyed provider can be switched to and confirmed (#979)', (
+      tester,
+    ) async {
+      // The state every real user is in once they configure a second
+      // destination, and the one this group never covered: the test above
+      // passes because its target provider has no key, which is the only
+      // reason OK was on screen for it.
+      //
+      // With keys stored, `_hasKey` is true, OK was not rendered at all, and
+      // Cancel and Back both restore the previous provider. Every exit undid
+      // the switch. Reported from a device as "the switch dialog does not
+      // have an OK button to confirm the change" — it did not.
+      await storage.writeApiKey('sk-or', provider: AiProvider.openrouter);
+      await storage.writeApiKey('sk-oa', provider: AiProvider.openai);
+      await storage.setActiveProvider(AiProvider.openrouter);
+      await tester.pumpWidget(_app(storage));
+      await tester.pumpAndSettle();
+
+      await choose(tester, AiProvider.openai);
+
+      expect(
+        find.bySemanticsIdentifier('ai-assist-save-key'),
+        findsOneWidget,
+        reason: 'a change with no way to confirm it is a change that cannot '
+            'be made',
+      );
+
+      await tester.tap(find.bySemanticsIdentifier('ai-assist-save-key'));
+      await tester.pumpAndSettle();
+
+      expect(await storage.activeProvider(), AiProvider.openai);
+    });
+
+    testWidgets('Cancel still reverts a keyed switch (#848 holds)', (
+      tester,
+    ) async {
+      // The half that must not regress while fixing the other one.
+      await storage.writeApiKey('sk-or', provider: AiProvider.openrouter);
+      await storage.writeApiKey('sk-oa', provider: AiProvider.openai);
+      await storage.setActiveProvider(AiProvider.openrouter);
+      await tester.pumpWidget(_app(storage));
+      await tester.pumpAndSettle();
+
+      await choose(tester, AiProvider.openai);
+      await cancel(tester);
+
+      expect(await storage.activeProvider(), AiProvider.openrouter);
+    });
+
+    testWidgets('an untouched dialog offers nothing to confirm', (
+      tester,
+    ) async {
+      // The gate is widened by "there is a change", not removed: opening the
+      // dialog on a configured provider and touching nothing still has no OK,
+      // which is what kept a no-op confirm off the screen in the first place.
+      await storage.writeApiKey('sk-ant', provider: AiProvider.anthropic);
+      await storage.setActiveProvider(AiProvider.anthropic);
+      await tester.pumpWidget(_app(storage));
+      await tester.pumpAndSettle();
+
+      expect(find.bySemanticsIdentifier('ai-assist-save-key'), findsNothing);
+    });
+
     testWidgets('the system back button puts it back too', (tester) async {
       // The exit that runs no handler of its own. Driven through the real
       // `show()` route, because a dialog embedded in a body has nothing to


### PR DESCRIPTION
Fixes [#979](https://github.com/simonoppowa/OpenNutriTracker/issues/979) — which will not auto-close from here, since `Closes` only fires on the default branch.

## The bug

Tapping a provider row writes it immediately. Then every exit from the dialog undid it:

| Exit | Behaviour |
| :-- | :-- |
| **OK** | Not rendered — gated on `!_hasKey`, true for any provider with a stored key |
| **ABBRECHEN** | `_cancel()` → `restoreActiveProviderTag(...)` |
| **Back** | `PopScope(canPop: false)` → the same `_cancel()` |
| **Outside** | `barrierDismissible: false` |

So with keys stored for two hosted providers — the ordinary state once someone configures a second — **no switch between them was possible.** That is the choice the four-destination design exists to offer.

Reported from a device as *"the switch dialog does not have an OK button to confirm the change"*. It did not.

## The change

OK is offered when something can still be typed into **or when there is already a change to confirm**:

```dart
if (!_loading &&
    (!_hasKey || _provider == AiProvider.ownServer || _changed))
```

`_changed` rather than comparing against the provider on open: a model pick and the enabled toggle are also changes someone may want to keep, and both are already written by the time they set it.

**Cancel and back still revert an unconfirmed switch** — [#848](https://github.com/simonoppowa/OpenNutriTracker/issues/848) is what makes tapping down the list to read each disclosure safe, and it holds. An untouched dialog still shows no OK, which is what kept a no-op confirm off the screen to begin with.

## Why CI never caught it

The `leaving without confirming (#848)` group already had a test named **`OK still switches, and still persists`**, and it passed throughout. Its provider has no key, so `_hasKey` is false and OK renders — the one side of the gate where the button exists. The whole defect lived in the precondition the test happened not to set.

The new test stores keys first, which is the state the report came from. `an untouched dialog offers nothing to confirm` pins the other edge, so the gate is widened rather than removed.

## Verified

- **2058 tests pass**, analyzer clean.
- **Mutation-checked**: restoring the `!_hasKey`-only gate fails `a keyed provider can be switched to and confirmed (#979)`.
- Both #848 directions re-pinned with keys stored — Cancel reverts, and now OK does not.

**Device verification is outstanding, and needs a person.** The build is installed on the Pixel 6 with all three keys present, but the AI Assist row cannot be driven over ADB ([#974](https://github.com/simonoppowa/OpenNutriTracker/issues/974)), so the four taps have to be done by hand: open the dialog, tap another provider, check **OK** is now on screen, tap it, and confirm the Settings row names the new provider. Until then this rests on the widget tests alone.

Worth noting the two provider switches earlier in the #830 pass only stuck because the app was force-stopped before the dialog could revert — an accident of the harness. After this, they should stick because the user confirmed them.
