### PR TITLE
fix(add-meal): drop a unit the user never wrote

### DIFF
--- a/lib/features/add_meal/data/anthropic_meal_items_api.dart
+++ b/lib/features/add_meal/data/anthropic_meal_items_api.dart
@@ -103,7 +103,12 @@ class AnthropicMealItemsApi implements MealItemsApi {
       );
     }
 
-    return validateParsedMealItems(_itemsFrom(response.body));
+    return validateParsedMealItems(
+      _itemsFrom(response.body),
+      // Only the typed path corroborates: a photograph states no units at
+      // all, and its own counts-only filter already drops them.
+      statedIn: content is MealTextContent ? content.text : null,
+    );
   }
 
   /// What Anthropic's status codes mean here.

--- a/lib/features/add_meal/data/openai_compatible_meal_items_api.dart
+++ b/lib/features/add_meal/data/openai_compatible_meal_items_api.dart
@@ -319,7 +319,12 @@ class OpenAiCompatibleMealItemsApi implements MealItemsApi {
 
     _warnIfThePinDidNotHold(decoded);
 
-    return validateParsedMealItems(_itemsFrom(decoded));
+    return validateParsedMealItems(
+      _itemsFrom(decoded),
+      // Only the typed path corroborates: a photograph states no units at
+      // all, and its own counts-only filter already drops them.
+      statedIn: content is MealTextContent ? content.text : null,
+    );
   }
 
   /// Checks that the provider named in the app is the one that answered.

--- a/lib/features/add_meal/data/openai_meal_items_api.dart
+++ b/lib/features/add_meal/data/openai_meal_items_api.dart
@@ -130,7 +130,12 @@ class OpenAiMealItemsApi implements MealItemsApi {
       throw const MealInterpreterException('malformed response');
     }
 
-    return validateParsedMealItems(_itemsFrom(decoded));
+    return validateParsedMealItems(
+      _itemsFrom(decoded),
+      // Only the typed path corroborates: a photograph states no units at
+      // all, and its own counts-only filter already drops them.
+      statedIn: content is MealTextContent ? content.text : null,
+    );
   }
 
   /// Responses content. **Image before text**, matching the Anthropic client

--- a/lib/features/add_meal/util/meal_text_parser.dart
+++ b/lib/features/add_meal/util/meal_text_parser.dart
@@ -163,7 +163,54 @@ class MealTextParseResult {
 /// near-miss: `2 tbsp` becoming `2 g` is a thirteenfold under-count nobody
 /// is shown, whereas a bare `2` is a number the row already knows how to
 /// question.
-MealTextParseResult validateParsedMealItems(List<ParsedMealItem> candidates) {
+/// True when [input] actually carries a unit — a number with one of the
+/// [_unitSymbol] symbols against it, in any of its segments.
+///
+/// Asked of the text the *model* was given, so a unit in its reply can be
+/// checked against whether one was ever there to report. #977: for
+/// `ein Glas Milch` anthropic answered `1 l` and openai answered
+/// `unit: "Glas"`. Neither is in the input; the enum happened to contain
+/// one of them, so the app multiplied by a thousand and logged 470 kcal for
+/// a glass of milk, while the other was dropped as unrecognised and came out
+/// right. Which of two wrong answers is harmless should not be decided by
+/// what the enum happens to spell.
+///
+/// Reuses the parser's own segmentation and extraction rather than scanning
+/// for the symbols, and that is the whole point: `l` occurs inside `Glas`,
+/// so a substring test reports a unit in exactly the phrase this exists to
+/// catch. [_leadingQuantity] and [_trailingQuantity] only see a unit when a
+/// number is against it.
+bool textStatesAUnit(String input) => _segment(
+  input,
+).any((segment) => _extractQuantityAndUnit(segment).unit != null);
+
+MealTextParseResult validateParsedMealItems(
+  List<ParsedMealItem> candidates, {
+  String? statedIn,
+}) {
+  // A unit nobody wrote is a guess, and is dropped before the kg/l
+  // normalization below can act on it — after it, `1 l` is already 1000 ml
+  // and the number cannot be put back. Dropping leaves a bare count, which
+  // the review row already resolves against the food's own portion: that is
+  // how openai's `unit: "Glas"` arrives at the right figure today, by being
+  // unrecognised rather than by being right. #977.
+  //
+  // Whole-input rather than per-item: a model's rows do not map onto text
+  // segments reliably enough to ask the question per row, and `100g Toast,
+  // 2 Eier` states a unit, so nothing there changes. It is a narrowing of
+  // today's behaviour, not a replacement for it.
+  if (statedIn != null && !textStatesAUnit(statedIn)) {
+    candidates = [
+      for (final c in candidates)
+        ParsedMealItem(
+          query: c.query,
+          quantity: c.quantity,
+          unit: null,
+          portion: c.portion,
+        ),
+    ];
+  }
+
   final items = <ParsedMealItem>[];
   final errors = <MealTextParseError>[];
 

--- a/test/unit_test/meal_text_parser_test.dart
+++ b/test/unit_test/meal_text_parser_test.dart
@@ -459,6 +459,106 @@ void main() {
     );
   });
 
+  group('a unit nobody wrote (#977)', () {
+    // Every payload below was captured from the device, through the shipping
+    // client, with a real key. They are what the two providers actually
+    // answered — not what the schema asks for.
+
+    test('anthropic answering a litre for a glass is dropped', () {
+      // `ein Glas Milch` → `1 l`, normalised x1000 to 1000 ml, logged as
+      // 470 kcal for a glass of milk. The whole reason this rule exists.
+      final result = validateParsedMealItems(
+        const [ParsedMealItem(query: 'Milch', quantity: 1, unit: 'l')],
+        statedIn: 'ein Glas Milch',
+      );
+
+      expect(result.items.single.unit, isNull);
+      expect(
+        result.items.single.quantity,
+        1,
+        reason: 'dropped before the x1000, or the number cannot be put back',
+      );
+    });
+
+    test('the same phrase answered as a millilitre is dropped too', () {
+      // The other half of the coin flip: same input, same provider, `1 ml`.
+      final result = validateParsedMealItems(
+        const [ParsedMealItem(query: 'Milch', quantity: 1, unit: 'ml')],
+        statedIn: 'ein Glas Milch',
+      );
+
+      expect(result.items.single.unit, isNull);
+    });
+
+    test('`l` inside `Glas` is not a stated unit', () {
+      // A substring test reports a unit here, which would keep the litre and
+      // change nothing. The token test is the fix.
+      expect(textStatesAUnit('ein Glas Milch'), isFalse);
+    });
+
+    test('a stated unit is corroborated and kept', () {
+      final result = validateParsedMealItems(
+        const [ParsedMealItem(query: 'Milch', quantity: 200, unit: 'ml')],
+        statedIn: '200ml Milch',
+      );
+
+      expect(result.items.single.unit, 'ml');
+      expect(result.items.single.quantity, 200);
+    });
+
+    test('a stated litre still converts', () {
+      // The conversion this rule must not break: it exists because dropping
+      // a real litre silently logged 1.5 g/ml.
+      final result = validateParsedMealItems(
+        const [ParsedMealItem(query: 'Milch', quantity: 1.5, unit: 'l')],
+        statedIn: '1,5 l Milch',
+      );
+
+      expect(result.items.single.unit, 'ml');
+      expect(result.items.single.quantity, 1500);
+    });
+
+    test('a mixed line still states a unit, so nothing changes', () {
+      // Whole-input, so `100g Toast, 2 Eier` is untouched — the narrowing
+      // must not reach the ordinary case.
+      final result = validateParsedMealItems(
+        const [
+          ParsedMealItem(query: 'Toast', quantity: 100, unit: 'g'),
+          ParsedMealItem(query: 'Eier', quantity: 2),
+        ],
+        statedIn: '100g Toast, 2 Eier',
+      );
+
+      expect(result.items.first.unit, 'g');
+      expect(result.items.first.quantity, 100);
+    });
+
+    test('the portion key survives, since it is not a unit', () {
+      // Both providers answer `drei Scheiben Brot` correctly via `portion`,
+      // and that is the field the dropped unit should have been.
+      final result = validateParsedMealItems(
+        const [
+          ParsedMealItem(query: 'Brot', quantity: 3, portion: 'Scheiben'),
+        ],
+        statedIn: 'zwei Eier und drei Scheiben Brot',
+      );
+
+      expect(result.items.single.portion, 'Scheiben');
+      expect(result.items.single.quantity, 3);
+    });
+
+    test('without the text nothing is dropped', () {
+      // The photo path passes no text and has its own counts-only filter;
+      // omitting the argument must behave exactly as before.
+      final result = validateParsedMealItems(const [
+        ParsedMealItem(query: 'Milch', quantity: 1, unit: 'l'),
+      ]);
+
+      expect(result.items.single.unit, 'ml');
+      expect(result.items.single.quantity, 1000);
+    });
+  });
+
   group('validateParsedMealItems', () {
     // The gate every non-deterministic source passes through, so a model
     // can never reach the diary under looser rules than the regex does.

--- a/test/unit_test/openrouter_meal_items_api_test.dart
+++ b/test/unit_test/openrouter_meal_items_api_test.dart
@@ -453,7 +453,12 @@ void main() {
         ]),
       );
 
-      final result = await request(apiWith(client));
+      // The input has to state the unit the reply reports, or #977 drops it
+      // as invented. The default `'toast'` states none.
+      final result = await request(
+        apiWith(client),
+        content: const MealTextContent('100g toast, 2 eggs'),
+      );
 
       expect(result.items, hasLength(2));
       expect(result.items[0].unit, 'g');
@@ -502,7 +507,12 @@ void main() {
         ]),
       );
 
-      final result = await request(apiWith(client));
+      // A litre the user actually wrote, which is the case that must still
+      // convert — #977 only drops one nobody wrote.
+      final result = await request(
+        apiWith(client),
+        content: const MealTextContent('1,5 l milk'),
+      );
 
       // Converted, not silently downgraded — the 1000x bug the unit enum
       // exists to prevent.


### PR DESCRIPTION
Fixes [#977](https://github.com/simonoppowa/OpenNutriTracker/issues/977) — which will not auto-close from here, since `Closes` only fires on the default branch.

## What the device actually returned

Captured through the shipping client with real credentials, at the shared `mealItemsFromJson`:

```
anthropic  ein Glas Milch  → [{"query":"Milch","quantity":1,"unit":"l"}]     x2
                           → [{"query":"Milch","quantity":1,"unit":"ml"}]
openai     ein Glas Milch  → [{"query":"Milch","quantity":1,"unit":"Glas"}]
both       200ml Milch     → [{"query":"Milch","quantity":200,"unit":"ml"}]
both       ...Scheiben Brot→ [{"query":"Brot","quantity":3,"portion":"Scheiben"}]
```

`ein Glas Milch` states no unit. Anthropic's `1 l` was normalised x1000 to 1000 ml — **470 kcal for a glass of milk** — and on the next identical call `1 ml` gave 0 kcal. OpenAI's `Glas` is not in the enum, so it was dropped, the row fell back to the food's own portion, and it came out right.

**Both providers misuse the same field in the same way.** Which of the two wrong answers was harmless got decided by what the enum happens to spell. That is the actual defect, and tuning one vendor's prompt would have left it in place.

## The change

A unit is corroborated against the text the model was given. No unit token in the input means any unit in the reply is invented, and it is dropped — exactly as an out-of-enum value already was. Dropping leaves a bare count, which the review row already resolves against the food's own portion; that is the path openai's answer has been taking all along.

Three things that are load-bearing rather than incidental:

- **Dropped before the kg/l normalisation.** After it, `1 l` is already 1000 ml and the number cannot be put back.
- **A token test, not a substring one.** `l` occurs inside `Glas`, so scanning for symbols reports a unit in precisely the phrase this exists to catch. It reuses `_segment` and `_extractQuantityAndUnit`, so the question is answered by the same code the deterministic path already trusts.
- **Whole-input, not per-item.** A model's rows do not map onto text segments reliably enough to ask per row, and `100g Toast, 2 Eier` states a unit, so the ordinary mixed line is untouched. A narrowing of today's behaviour, not a replacement for it.

Photo replies pass no text and are unaffected — that path has its own counts-only filter.

## Verified on the device, against the live models

| Input | Before | After |
| :-- | :-- | :-- |
| `ein Glas Milch` (anthropic) | 470 / 0 / 470 kcal, held back | **1 Portion, 117 kcal, loggable** — three consecutive runs |
| `200ml Milch` | 200 g/ml, 94 kcal | unchanged |
| `100g Toast, 2 Eier` | Toast logs, egg row held | unchanged |
| `zwei Eier und drei Scheiben Brot` | both held back | unchanged |

117 kcal is the figure openai and openrouter already produced, so all three providers now agree on this phrase.

- **2063 tests pass**, analyzer clean.
- **Mutation-checked**: disabling the drop fails both anthropic payload tests.
- The new tests use the payloads captured from the device verbatim, rather than invented ones.

## One test-harness correction

Two openrouter tests asserted conversion using replies claiming `g` and `l` while the harness sent the text `'toast'`, which states neither. That mismatch was harmless before and is meaningful now, so their input states what their reply reports. Their subject — decoding, and the bounds — is unchanged, and `1,5 l milk` still converts to 1500 ml.

## Note for #830

Case 10 fails on the current head for exactly this reason. It should pass on this branch; worth re-running before that box is ticked.
