### PR TITLE
fix(settings): stop the embedded form being a viewport inside a viewport

### DIFF
--- a/lib/features/settings/settings_screen.dart
+++ b/lib/features/settings/settings_screen.dart
@@ -161,20 +161,25 @@ class _SettingsScreenState extends State<SettingsScreen> {
           final isDark = Theme.of(context).brightness == Brightness.dark;
           final palette = isDark ? AppPalette.dark : AppPalette.light;
           final error = Theme.of(context).colorScheme.error;
-          return ListView(
-            shrinkWrap: widget.embedded,
-            physics: widget.embedded
-                ? const NeverScrollableScrollPhysics()
-                : null,
-            padding: widget.embedded
-                ? EdgeInsets.zero
-                : const EdgeInsets.fromLTRB(
-                    Dimens.spacing16,
-                    Dimens.spacing16,
-                    Dimens.spacing16,
-                    Dimens.spacing32,
-                  ),
-            children: [
+          // Built once, then wrapped in one of two shapes — because the
+          // embedded form is not a scrollable and should not pretend to be.
+          //
+          // It used to be a `ListView` either way, `shrinkWrap` with
+          // `NeverScrollableScrollPhysics` when embedded: a viewport that
+          // cannot scroll, nested inside the You tab's viewport that can.
+          // Rows outside the outer viewport are marked `isHidden`, and which
+          // of them cleared was decided by that outer list's offset — flung,
+          // it moves in large non-overlapping jumps, and a band in the middle
+          // was never uncovered. Four rows (the food databases, Health
+          // Connect, AI Assist, custom food import) could not be reached by a
+          // screen reader at all. #974.
+          //
+          // A `Column` has no viewport, so nothing here hides anything and
+          // the outer list alone decides what is on screen, exactly as it
+          // does for every other row of the You tab. It renders the same: a
+          // shrink-wrapped, unscrollable list of fixed children *is* a
+          // Column, with a viewport in the way.
+          final children = <Widget>[
               _categoryHeader(
                 context,
                 palette,
@@ -576,7 +581,19 @@ class _SettingsScreenState extends State<SettingsScreen> {
               ),
               const SizedBox(height: Dimens.spacing24),
               AppBannerVersion(versionNumber: state.versionNumber),
-            ],
+          ];
+
+          if (widget.embedded) {
+            return Column(mainAxisSize: MainAxisSize.min, children: children);
+          }
+          return ListView(
+            padding: const EdgeInsets.fromLTRB(
+              Dimens.spacing16,
+              Dimens.spacing16,
+              Dimens.spacing16,
+              Dimens.spacing32,
+            ),
+            children: children,
           );
         }
         return const SizedBox();

--- a/test/features/settings/settings_screen_test.dart
+++ b/test/features/settings/settings_screen_test.dart
@@ -110,6 +110,63 @@ void main() {
   setUp(() => _register());
   tearDown(() async => locator.reset());
 
+  group('the embedded form is not a scrollable (#974)', () {
+    /// The You tab hosts the screen inside its own scrollable, so anything
+    /// scrollable here is a viewport nested in a viewport.
+    Widget embeddedIn(Widget child) => MaterialApp(
+      localizationsDelegates: const [
+        S.delegate,
+        GlobalMaterialLocalizations.delegate,
+        GlobalWidgetsLocalizations.delegate,
+        GlobalCupertinoLocalizations.delegate,
+      ],
+      supportedLocales: S.supportedLocales,
+      home: Scaffold(body: SingleChildScrollView(child: child)),
+    );
+
+    testWidgets('embedded, it creates no viewport of its own', (tester) async {
+      // The fix, stated as the thing that can be checked without a device.
+      //
+      // It used to be a `ListView` with `shrinkWrap` and
+      // `NeverScrollableScrollPhysics`: a viewport that cannot scroll,
+      // inside the You tab's viewport that can. Rows outside the outer
+      // viewport are flagged `isHidden`, and which of them cleared depended
+      // on the outer list's offset — flung, it jumps in large
+      // non-overlapping steps, and four rows in the middle were never
+      // uncovered for a screen reader.
+      //
+      // The device behaviour cannot be reproduced here: a widget test
+      // scrolls to a computed offset, which a fling never rests at. So this
+      // pins the structural property the fix rests on instead, and says so
+      // rather than implying wider cover.
+      await tester.pumpWidget(
+        embeddedIn(const SettingsScreen(embedded: true)),
+      );
+      await tester.pumpAndSettle();
+
+      final scrollables = tester.widgetList(find.byType(Scrollable));
+      expect(
+        scrollables,
+        hasLength(1),
+        reason: 'only the host scrollable — the embedded settings must add '
+            'none of its own',
+      );
+    });
+
+    testWidgets('pushed, it still scrolls itself', (tester) async {
+      // The other half: the standalone screen is the one that must keep its
+      // viewport, and it is the arrangement that was always reachable.
+      await tester.pumpWidget(_app());
+      await tester.pumpAndSettle();
+
+      expect(find.byType(Scrollable), findsWidgets);
+      expect(
+        tester.widget<ListView>(find.byType(ListView).first).physics,
+        isNot(isA<NeverScrollableScrollPhysics>()),
+      );
+    });
+  });
+
   testWidgets('the AI row is nowhere near the top of a plain Settings', (
     tester,
   ) async {


### PR DESCRIPTION
Fixes [#974](https://github.com/simonoppowa/OpenNutriTracker/issues/974) — which will not auto-close from a merge into `develop`.

**Targets `develop`, not the AI branch.** This is a Settings defect that predates the AI feature and affects `settings-food-sources`, `settings-health-sync` and `settings-import-custom-food` as much as `settings-ai-assist`. It ships today.

## The defect

Four rows of Settings cannot be reached by a screen reader. With TalkBack on the **You** tab, swiping right from `Tag beginnt um` jumps straight to *App-Daten exportieren*, skipping the food databases, Health Connect, AI Assist and custom food import. Confirmed by hand on a Pixel 6.

**The rows were never missing from the semantics tree.** All 17 are there; the ones outside the outer viewport carry `SemanticsFlag.isHidden`, and Android's accessibility bridge drops hidden nodes. Which ones cleared was decided by the You tab's scroll offset — and flung, that list moves in large non-overlapping jumps, so a band in the middle was never uncovered. Two disjoint windows, nothing between them.

## The change

The embedded form was a `ListView` with `shrinkWrap: true` and `NeverScrollableScrollPhysics` — a viewport that cannot scroll, nested inside one that can. It is now a `Column`, which has no viewport, so nothing here hides anything and the outer list alone decides what is on screen, exactly as it does for every other row of the tab.

It renders identically: a shrink-wrapped, unscrollable list of fixed children *is* a Column, with a viewport in the way.

**The pushed route is untouched** and keeps its own scrolling. That difference is what located this — driven the same way on the same build, the pushed screen's window moves gradually and covers every row, while the embedded one does not.

## Verified on a Pixel 6

| | before | after |
| :-- | :-- | :-- |
| window behaviour | two disjoint states | moves gradually, overlapping |
| `settings-food-sources` | never | reached |
| `settings-health-sync` | never | reached |
| `settings-ai-assist` | never | reached |
| `settings-import-custom-food` | never | reached |

The window now behaves exactly as the pushed screen's does.

- **2068 tests pass**, analyzer clean.
- **Mutation-checked**: restoring the nested `ListView` fails `embedded, it creates no viewport of its own`.

## What the test does and does not cover, stated plainly

**The device behaviour cannot be reproduced in a widget test.** A test scrolls the scrollable to a computed offset; a fling never rests at one. Four separate reproduction attempts passed against the broken build, which is why the earlier analysis on the issue went through three wrong hypotheses before a same-device comparison settled it.

So the test added here pins the **structural property** the fix rests on — embedded adds no scrollable of its own, pushed keeps one — rather than the symptom. That is worth knowing when reading it: it would not have caught the original bug, and it will catch a regression of this fix.

## One check still outstanding

TalkBack traversal on the device. The semantics window now matches the pushed screen, which is reachable, so the expectation is that swiping right walks the whole list — but that is inference from the window, and the original report came from a human finger. Worth one pass with TalkBack on before this is trusted.
