### PR TITLE
chore: bump to 2.2.0+63, and keep the feature/** trigger

### DIFF
--- a/.github/workflows/default_workflow.yml
+++ b/.github/workflows/default_workflow.yml
@@ -23,6 +23,14 @@ on:
       # This is scoped to `feature/**` rather than `**` on purpose: it should
       # cover deliberate integration branches without firing a full CI run on
       # every PR between two arbitrary topic branches.
+      #
+      # Kept after `feature/ai-assisted-meal-logging` merged, rather than
+      # removed as spent. It is not leftover config: it is what gave #975,
+      # #978, #980 and #981 any checks at all, and four of the five defects
+      # that branch surrendered were found after CI passed on exactly those
+      # PRs. The next long-lived branch will need it before anyone remembers
+      # to add it back, and the failure mode is silent — a retargeted PR
+      # still reports mergeable with no checks run.
       - 'feature/**'
   workflow_dispatch:
 

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -15,7 +15,7 @@ publish_to: 'none' # Remove this line if you wish to publish to pub.dev
 # In iOS, build-name is used as CFBundleShortVersionString while build-number is used as CFBundleVersion.
 # Read more about iOS versioning at
 # https://developer.apple.com/library/archive/documentation/General/Reference/InfoPlistKeyReference/Articles/CoreFoundationKeys.html
-version: 2.1.0+62
+version: 2.2.0+63
 
 environment:
   sdk: '>=3.11.0 <4.0.0'


### PR DESCRIPTION
Two release-readiness items, both small, ahead of a `develop` → `main` merge.

## 1. Version bump to 2.2.0+63

**Build 62 is spent.** `ios-deploy` succeeded on both of `main`'s last two pushes, so TestFlight holds 2.1.0 (62) — even though the release never completed. `android-deploy` failed on the Play health-declaration defect ([#942](https://github.com/simonoppowa/OpenNutriTracker/issues/942)) and `github-release` needs both deploys, so there is **no `v2.1.0` tag and no GitHub release**. Merging without a bump would offer Apple a versionCode it has already taken.

**2.2.0 rather than 2.1.0+63**, because the release this produces is not the one 2.1.0 was scoped as. It carries everything 2.1.0 never shipped — workout import, the crash-report and privacy-policy corrections, food search over POST — plus AI-assisted meal logging ([#599](https://github.com/simonoppowa/OpenNutriTracker/issues/599), [#648](https://github.com/simonoppowa/OpenNutriTracker/pull/648)).

That is a judgement call, and a cheap one to reverse: `2.1.0+63` is a one-line change if you would rather keep the planned name. Worth knowing either way — two comments name 2.1.0 as the milestone they wait on (`config_data_source.dart`'s legacy-tombstone drain, and a note in `ios_health_purpose_strings_test.dart`). Both mean "the next shipped release" rather than that number, so they are left alone.

**No changelog file is included, deliberately.** Nothing consumes one: the Fastfile sets `skip_upload_metadata: true`, so fastlane never uploads Play notes, and `github-release` uses `generate_release_notes: true`. The single `fastlane/metadata/android/en-US/changelogs/12.txt` is vestigial. Adding a `63.txt` would look like release notes and reach nobody.

## 2. The `feature/**` trigger stays

Comment only, no behaviour change. It was the outstanding decision from #648's pre-merge list.

With the branch merged the entry reads as spent configuration, which invites deleting it. It is what gave #975, #978, #980 and #981 any checks at all — and four of the five defects that branch surrendered were found *after* CI passed on exactly those PRs. The failure mode if it goes is silent: a PR retargeted onto a long-lived branch still reports mergeable with no checks run.

## What this does not fix

`main`'s release pipeline is still failing, and this PR does not change that — but the fix is already on `develop`. [#960](https://github.com/simonoppowa/OpenNutriTracker/issues/960) taught the workflow to tolerate the exact health-declaration error string, and that commit is **not an ancestor of `main`**. So the `develop` → `main` merge is what repairs it: `android-deploy` will warn and pass, `github-release` will run, and the Android bundle still needs uploading by hand, as #942 documents.

Still outstanding before that merge, and not addressed here: the Play Data safety question ([#816](https://github.com/simonoppowa/OpenNutriTracker/issues/816)), the encryption-in-transit declaration the own-server provider forces, and the three open privacy-policy issues ([#915](https://github.com/simonoppowa/OpenNutriTracker/issues/915), [#919](https://github.com/simonoppowa/OpenNutriTracker/issues/919), [#920](https://github.com/simonoppowa/OpenNutriTracker/issues/920)).
