### PR TITLE
docs(ai): correct eight claims the code no longer supports

### DIFF
--- a/docs/ai-architecture.md
+++ b/docs/ai-architecture.md
@@ -64,6 +64,27 @@ The permitted fields are exactly four: `query` (the food name, in your language)
 model answering, it made the model map a litre onto `ml` and keep the number, turning 1.5 l of milk
 into 1.5 ml. A thousandfold undercount that nothing flagged, because a unit *had* been stated.
 
+Adding them opened the failure on the other side: a model answering with a unit nobody typed.
+*"ein Glas Milch"* states no amount at all — Anthropic answered `1 l`, OpenAI answered
+`unit: "Glas"`, and which of the two wrong answers hurt was decided by what the enum happened to
+spell. The litre was recognised, multiplied by a thousand, and logged as 470 kcal for a glass of
+milk; `Glas` was dropped as unrecognised and came out right.
+
+**So a unit in a reply is now corroborated against the text the model was given.**
+`textStatesAUnit` runs the parser's own segmentation and extraction over that text and asks
+whether any segment carries a number with a unit against it. If none does, every unit in the
+batch is dropped — before the kg/l conversion, because after it `1 l` is already 1000 ml and the
+number cannot be put back. The quantities survive, so each row arrives as a bare count, which the
+review screen resolves against the food's own serving: that is how the `Glas` answer reaches the
+right figure today, by being unrecognised rather than by being right.
+
+It reuses the parser rather than scanning for the symbols because `l` occurs inside `Glas`, so a
+substring test would report a unit in exactly the phrase this exists to catch. And it asks the
+question of the whole input rather than of each row, because a model's rows do not map onto the
+input's segments reliably enough to ask per row — *"100g Toast, 2 Eier"* states a unit, so nothing
+in that batch is touched. Only the typed path corroborates: a photograph states nothing, and the
+photo path's counts-only rule already drops every unit it gets.
+
 `portion` is a word, never a number — the schema says so in as many words: *"A word only, never a
 weight or a count."* It is a lookup key into the matched food's own portion list ("slice", "cup"),
 so the gram weight still comes from the database row, and a key matching nothing is ignored. It
@@ -110,13 +131,64 @@ saying *there is no food here*, which is an answer, not a failure — so it is h
 alternative was measured on a Pixel 6: the parser will turn any sentence into a search, and
 *"meine Steuererklärung und ein Tacker"* came back as a cheese-roll match the user had to dismiss.
 
-**Nothing the user typed is ever logged.** Failures are logged by reason, never with the input.
+**A reply with no usable items is not that answer.** Entries are read one at a time and one
+carrying no `query` is dropped, so a single bad entry does not cost the good ones. A reply where
+*every* entry drops is refused outright rather than passed on as an empty list — it would
+otherwise reach the screen wearing the same clothes as a deliberate "there is no food here", and
+the user would get neither the model's rows, which never existed, nor the parser's, which that
+judgement had suppressed.
+
+That refusal is transient, and so is a body that will not decode, an `items` that is not an array,
+and arguments that are not JSON: nothing about one garbled reply says the next one will be. A
+reply with no tool call in it at all is the exception and lands on `unsupported` instead, because
+a model that answers in prose will answer in prose again. On the typed path a transient failure
+means the parser's rows, with no notice and not even the read-by-AI banner — the screen the user
+would have had with the feature switched off. On the photo path there is nothing underneath, so
+it becomes the one line the screen has for it: *Couldn't read the photo. Check your connection and
+try again.* Right for the common cause of a transient failure, and wrong for this one.
+
+**Being cut off is not a case the app recognises.** The answer is capped at 1024 tokens, which is
+roomy for a short list of short strings and short enough that a runaway is stopped early, and no
+client reads the flag a provider sets when that cap is reached. A truncated reply is therefore
+judged only on whether what arrived still parses: losing a closing brace makes it malformed and
+lands it with everything above, while a partial list that parses is believed as though it were the
+whole answer.
+
+**None of the three clients puts what you typed, or your photograph, into a log or an error
+string.** A socket error can carry the request URL and, on some platforms, part of the payload,
+so the caught error is dropped and a fixed reason thrown in its place, and an ordinary failure
+reaches the log as a status code. One path above them is narrower: an interpreter that throws
+something no client constructs is a bug, and the use case logs that object and its stack trace
+before falling back to the parser.
 
 Not every failure is worth interrupting for. `auth`, `unsupported`, `billing`, `timeout` and
 `insecureDestination` produce a notice, because they are permanent until something changes — a
 mistyped key that fails silently forever is a bad afternoon, and it was found exactly that way on
 a device. A dropped connection or a rate limit produces nothing, because a notice that fires for
 blips is a notice people learn to ignore.
+
+**What travels with a request is a short list, and it is the same list every time.** The model id
+you picked; the system prompt; the line you typed, with the surrounding whitespace off; the tool —
+its name, its one-line description and the schema above — together with the instruction to call
+it; and the cap on the answer. That is the whole body. Two destinations add a field of their own
+and neither is about you: OpenAI is told `store: false`, and OpenRouter is given the routing block
+that pins the vendor and refuses providers that would train on what they are sent.
+
+The system prompt is about two hundred words, and it is rules rather than data: one entry per
+food, `query` is the food name alone in the language you wrote in, an amount only where you stated
+one, never converted between units, and an empty list when the input holds no food. Your app
+language is appended to it as a single sentence — *The user's app language is "de"* — and that is
+the bare language code, with no region and nothing else about the device it came from.
+
+**Nothing else is attached, and there is nowhere for it to be attached.** Not a diary entry, a
+past meal, a goal, a weight, an age or anything else from your profile; not an earlier request or
+its reply, since each one stands alone; and no identifier for you, your install or your device.
+Each client builds its body out of exactly two things it was handed, the prompt and what you are
+asking about, and the headers the app sets are the credential, the content type, and — depending
+on the destination — Anthropic's API version or OpenRouter's metadata opt-in. OpenRouter's
+attribution headers are deliberately not among them: they would put the app on a public
+leaderboard as a side effect of somebody saving a key. A photo request differs only where it has
+to, in its own prompt and a picture in place of the line.
 
 ## A photo, end to end
 
@@ -170,6 +242,16 @@ whose format list has no WebP. All four common local runtimes decode JPEG, so ch
 server you run removes the incompatibility rather than detecting it. Quality and pixel size are
 identical either way.
 
+**What comes back from a photo may be a count, never a measurement.** The text path can carry
+`100 g` because you typed it; a photograph states nothing, so a gram figure read off a plate is
+an estimate wearing the shape of something measured. The prompt asks for counts only, and the
+interpreter drops any amount that came with a unit or is not a whole number — the number along
+with it. Keeping the bare number is the worse failure: an estimated `200 g` of rice stripped to
+`200` reads downstream as a count, and a count against a food whose serving can be scaled is
+logged as 200 servings. The row falls back to the amount an unquantified item gets, and you set
+it. The rule sits in the shared photo interpreter rather than in a client, so a provider added
+later inherits it.
+
 ## Where a request goes
 
 ```mermaid
@@ -189,9 +271,48 @@ to the vendor named beside it in Settings, with fallbacks off. Unpinned, a reque
 `anthropic/claude-haiku-4.5` was answered by Amazon Bedrock on every attempt of a three-run probe
 — a vendor the user never chose and the screen never named.
 
-Three of the four destinations are compiled-in `https://` URLs and cannot be redirected. Only the
-fourth is an address you supply, which makes it the only one where plaintext is possible at all —
-see [the guardrails](#the-guardrails).
+**What crosses on that path is more than the payload.** The disclosure shown before an OpenRouter
+key is stored says that OpenRouter forwards an account-level identity to the serving vendor on
+every request, and that this cannot be switched off — so the vendor sees a stable handle for your
+account next to the meal, not an anonymous request. That is OpenRouter's behaviour, not the app's:
+nothing here turns it off, and nothing here can check that it happens. It is in the consent text
+because it changes what "the vendor keeps what it receives" is worth.
+
+The app's own addition to that request is one header, and it is not an identity.
+`x-openrouter-metadata: enabled` opts the *reply* into naming the vendor that actually served the
+request — a per-request opt-in, so it has to ride on every call — and it is the only way the pin
+above can be checked at runtime instead of asserted. A mismatch is logged and nothing more: the
+reply is still a valid answer to the question asked, and losing someone's meal entry over a
+routing discrepancy would be the worse outcome.
+
+Three of the four destinations are compiled-in `https://` URLs and cannot be redirected. The
+fourth is an address you supply, and there plaintext is the ordinary case rather than an edge one:
+the field's own example is `http://192.168.1.5:11434`, and the dialog carries a separate
+disclosure sentence for an unencrypted address precisely because that is what people save. So the
+guard is not deciding *whether* plaintext happens but *where it may go* — see
+[the guardrails](#the-guardrails).
+
+**Two requests reach a server you run before any meal does.** One is the setup check described
+[below](#a-server-you-run-the-probe), which OK starts. The other is a `GET` to `/v1/models` on
+the address in the field, asked so the model box can offer a picker instead of a blank line.
+Exactly two things ask for it: committing a changed address — moving off the field, or the
+keyboard's own done key — and the *Load models* button. Opening the dialog asks nothing,
+switching to this provider asks nothing, no timer asks, and coming back to a configured server
+and leaving the address alone asks nothing.
+
+**The model list is the one request that goes out before you have agreed to anything.** The
+consent screen is reached from OK, on the path that writes a credential, and the fetch hangs
+off the address field instead — so on a first-time setup your server has already been asked
+what it serves by the time that screen appears. The request carries an `Authorization` header
+when a key is available, and a key typed into the dialog counts before OK commits it, because a
+reverse proxy in front of a local runtime will want one. The plaintext guard covers it like any
+other request, so a public `http://` address is refused rather than asked.
+
+The consent screen names both requests before you agree, and it is shown once for the whole
+feature — so someone who agreed while setting up a hosted provider does not see that paragraph
+again when they later point the app at a server of their own. The three hosted providers are
+sent nothing until you read a meal: their model lists are compiled in, so there is nothing to
+ask them for.
 
 Most of what each destination *keeps* is a policy question rather than a mechanism one, and it
 lives in the README's [Privacy](../README.md#privacy) section — but two of the four requests carry
@@ -201,6 +322,27 @@ Responses stores by default and silence there is not a no-op. The OpenRouter rou
 non-transiently ineligible to serve the request at all. Two things there are worth knowing before you
 read this page's diagrams as reassurance: being reached directly is not the same as keeping less,
 and on the broker path the two retention policies **stack**.
+
+### What the request itself asks for
+
+Two of the four requests carry a retention instruction of their own, and both are worth naming
+because in each case the provider's default is the opposite.
+
+**Every request to OpenAI carries `store: false`.** The Responses API stores by default, so the
+field is not a no-op — omitting it would leave each meal line, and each photograph, sitting in the
+account's stored responses.
+
+**Every request through OpenRouter carries `data_collection: 'deny'`** inside its routing block.
+OpenRouter's routing default is `allow`, which makes providers that store input non-transiently
+and may train on it eligible to serve the request. It is sent as a policy field rather than
+inferred from the model slug, because free *usage* is what triggers those clauses and not the
+`:free` suffix — a slug check would look like enforcement and would not be it.
+
+Anthropic gets no such field, and a server you run gets no routing block at all: asserting
+`data_collection: 'deny'` to a machine in your own house is a claim the app cannot mean.
+
+The app also **withholds OpenRouter's two attribution headers**. `HTTP-Referer` and `X-Title` put
+the app on OpenRouter's public leaderboard, and saving a key is not consent to being listed there.
 
 ## Choosing a provider
 
@@ -261,10 +403,22 @@ provider exists to serve.
 
 When you point the app at your own server, it cannot know what that server can do. So it asks — at
 setup, and again each time you confirm that dialog, because the address and the model can be
-identical and the machine behind them different — by sending a real meal line and a real photograph
+identical and the machine behind them different — by sending a fixed example line and a photograph that ships with the app
 through the shipping code path:
 the same prompts, the same schema, the same forcing mode, the same image encoder. A probe built
 from its own request would be testing a second implementation that nothing else uses.
+
+
+
+**Neither of those is yours.** The line is `two eggs and a slice of toast`, in English whatever
+your locale, because the bar is structural — did a parseable tool call come back with at least
+one item — and nothing about that depends on the words. The photograph is one of the demo
+images the app already ships for Try Demo: a sliced loaf on a board, one unambiguous food
+filling the frame, picked over the tempura bowl and the garnished yoghurt because either
+would make a correct answer look like a wrong one. It is written to a temporary file and run
+through the same encoder your own photo would go through, and deleted the same way. The consent
+screen puts it in those words before you agree: a fixed example line and a sample photograph of
+ours, never anything of yours.
 
 The verdict has three states, and the third is the interesting one.
 
@@ -274,8 +428,10 @@ stateDiagram-v2
     unknown --> passed: a parseable tool call with at least one item
     unknown --> failed: answered, but unusable
     unknown --> unknown: timeout, auth, billing, transient, refused plaintext
-    passed --> failed: a real request came back unsupported
+    passed --> failed: a photo came back unsupported
     passed --> unknown: endpoint or model changed
+
+    failed --> passed: a fresh check came back with items
     failed --> unknown: endpoint or model changed
 ```
 
@@ -289,12 +445,22 @@ one of these: nothing was sent, so nothing was learned, and it lands on `unknown
 
 A stored `passed` is a fact about one `(endpoint, model)` pair, and it can stop being true without
 the user touching anything — pull a different model under the same tag and the camera is still
-offered, still claims photos work, and fails on every photograph. So a live request that comes
-back `unsupported` retracts the stored pass. Only that one failure kind: the network, the load,
+offered, still claims photos work, and fails on every photograph. So a photo that comes back `unsupported` retracts the stored photo pass, and only that one. The
+text verdict is left where it stands: a photograph says nothing about whether a meal line
+still reads. The text path retracts nothing at all, in either row, because a typed meal that
+fails still has the offline parser underneath it and there is no capability to withdraw. Only that one failure kind: the network, the load,
 the credential and the bill say nothing about whether a model has eyes.
 
 Changing the address or the model discards the record entirely, so a stored verdict can only ever
 describe the configuration currently in place.
+
+
+
+**`failed` is not a dead end either.** *Check this server* re-runs both legs from Settings
+without a re-save, and a conclusive verdict overwrites a stored one in both directions — so
+pulling a model that can actually see, and checking again, turns the photo row back to a pass.
+Only a conclusive one: an inconclusive result leaves whatever was known alone, which is what
+stops a retry against a sleeping server revoking a pass that is still true.
 
 The probe runs its two legs **sequentially** — a local runtime serves one request at a time
 against one loaded model, so firing both at once would only queue them. That makes the worst case
@@ -310,12 +476,14 @@ Independent checks, not a sequence. Each one is pinned by a test that fails if i
 |---|---|---|---|
 | Schema with no nutrition fields | a model supplying a calorie count | [`meal_items_api.dart`](../lib/features/add_meal/domain/meal_items_api.dart) | [`openrouter_meal_items_api_test.dart`](../test/unit_test/openrouter_meal_items_api_test.dart) — *the schema exposes only query, quantity, unit and portion* |
 | Dart-side re-validation | a reply that ignored the schema | [`meal_text_parser.dart`](../lib/features/add_meal/util/meal_text_parser.dart) | [`meal_text_parser_test.dart`](../test/unit_test/meal_text_parser_test.dart) |
-| Payload never logged | the meal you typed, or a photo, reaching a log or an error string | all three clients | contract test — *a failing send puts the payload in neither the error nor the log*; *a photo never reaches the error or the log either* |
+| Counts only from a photo | an amount nobody stated arriving as if somebody had | [`model_meal_photo_interpreter.dart`](../lib/features/add_meal/data/model_meal_photo_interpreter.dart) | [`model_meal_photo_interpreter_test.dart`](../test/unit_test/model_meal_photo_interpreter_test.dart) — *a measured amount loses both its unit and its number*; *a fractional amount is not a count, so it goes too* |
+| Payload never logged by a client | the meal you typed, or a photo, reaching a log or an error string from a failed send | all three clients | contract test — *a failing send puts the payload in neither the error nor the log*; *a photo never reaches the error or the log either* |
 | Response body withheld on rejection | a provider's error text carrying your content back into a log | all three clients | contract test — *a rejected request does not carry the response body* |
-| Consent before storage | a credential written before you agreed to what leaving the device means | [`ai_assist_dialog.dart`](../lib/features/settings/presentation/widgets/ai_assist_dialog.dart), [`ai_consent_screen.dart`](../lib/features/settings/presentation/widgets/ai_consent_screen.dart) | [`ai_assist_dialog_test.dart`](../test/features/settings/presentation/ai_assist_dialog_test.dart) |
+| Consent before storage | a credential stored, or used, before you agreed to what leaving the device means | [`ai_assist_dialog.dart`](../lib/features/settings/presentation/widgets/ai_assist_dialog.dart), [`ai_consent_screen.dart`](../lib/features/settings/presentation/widgets/ai_consent_screen.dart), [`ai_credential_storage.dart`](../lib/core/utils/ai_credential_storage.dart) | [`ai_assist_dialog_test.dart`](../test/features/settings/presentation/ai_assist_dialog_test.dart), [`ai_credential_storage_test.dart`](../test/unit_test/ai_credential_storage_test.dart) — *a credential without an agreement is not usable* |
 | Plaintext destination guard | `http://` to anywhere that is not private | [`plaintext_destination_guard.dart`](../lib/core/utils/plaintext_destination_guard.dart) | [`plaintext_destination_guard_test.dart`](../test/unit_test/plaintext_destination_guard_test.dart) |
 | Address pinning after lookup | DNS answering differently the second time | same file | same test |
 | Vendor pin, fallbacks off | OpenRouter serving from a vendor the screen never named | [`meal_items_api_factory.dart`](../lib/features/add_meal/data/meal_items_api_factory.dart) | [`meal_items_api_factory_test.dart`](../test/unit_test/meal_items_api_factory_test.dart) |
+| Data collection denied on the broker path | OpenRouter routing to a vendor that may keep your meal and train on it | [`openai_compatible_meal_items_api.dart`](../lib/features/add_meal/data/openai_compatible_meal_items_api.dart) | [`openrouter_meal_items_api_test.dart`](../test/unit_test/openrouter_meal_items_api_test.dart) — *refuses providers that may keep and train on the input* |
 | Per-provider credential slots | a key reaching a provider it was not issued for | [`ai_credential_storage.dart`](../lib/core/utils/ai_credential_storage.dart) | [`ai_credential_storage_test.dart`](../test/unit_test/ai_credential_storage_test.dart) |
 | Unrecognised provider tag refuses to send | a downgraded build redirecting requests to a vendor you did not pick | same file | same test |
 | Connection budget | a request hanging indefinitely | all clients | contract test — *a stalled connection gives up instead of hanging* |
@@ -329,6 +497,12 @@ and it deliberately excludes carrier-grade NAT (`100.64.0.0/10`) — which is wh
 out, so a tailnet user must use `https://`. The app cannot tell a tailnet from an ISP's shared
 address space, and treating every `100.x` as private would quietly permit plaintext onto a
 carrier's network.
+
+That the platform does not enforce this was measured rather than assumed. `dart:io` opens BSD
+sockets, so a request never passes through NSURLSession or Android's HTTP stacks, and neither iOS
+App Transport Security nor Android's cleartext policy ever sees it. Which is why neither platform
+file says anything about it: there is no `usesCleartextTraffic` attribute in the manifest and no
+`NSAppTransportSecurity` dictionary in `Info.plist`, and adding either would change nothing.
 
 Both address families are checked. A measured dual-stack case shows why: a home server whose
 reverse lookup gave `192.168.1.46` had a **forward lookup returning only a public-scope IPv6
@@ -366,13 +540,14 @@ address**. An IPv4-only check would never have seen where the connection actuall
 | [`run_ai_endpoint_probe_usecase.dart`](../lib/features/add_meal/domain/usecase/run_ai_endpoint_probe_usecase.dart) | Probing and storing the verdict together |
 | [`meal_text_parser.dart`](../lib/features/add_meal/util/meal_text_parser.dart) | The deterministic parser, and the bounds every row is held to |
 | [`meal_photo_encoder.dart`](../lib/features/add_meal/util/meal_photo_encoder.dart) | 1024 px / q80 encoding, per-destination container, cache cleanup |
-| [`ai_credential_storage.dart`](../lib/core/utils/ai_credential_storage.dart) | Per-provider keys, addresses, model choice, probe records |
+| [`ai_credential_storage.dart`](../lib/core/utils/ai_credential_storage.dart) | Per-provider keys, addresses, model choice, probe records, and the recorded agreement |
 | [`ai_model_catalogue.dart`](../lib/core/utils/ai_model_catalogue.dart) | The curated lists and their vendor pins |
 | [`ai_model_list_api.dart`](../lib/core/utils/ai_model_list_api.dart) | Asking your own server which models it has |
 | [`plaintext_destination_guard.dart`](../lib/core/utils/plaintext_destination_guard.dart) | Whether an unencrypted request may leave, and to which address |
 | [`ai_assist_dialog.dart`](../lib/features/settings/presentation/widgets/ai_assist_dialog.dart) | The Settings surface: provider, credential, model, probe |
-| [`ai_consent_screen.dart`](../lib/features/settings/presentation/widgets/ai_consent_screen.dart) | The disclosure shown before anything is stored |
+| [`ai_consent_screen.dart`](../lib/features/settings/presentation/widgets/ai_consent_screen.dart) | The disclosure shown before a credential is stored |
 | [`ai_assist_summary.dart`](../lib/core/presentation/ai_assist_summary.dart) | The one-line state shown on the Settings tile |
+| [`onboarding_other_options_page_body.dart`](../lib/features/onboarding/presentation/widgets/onboarding_other_options_page_body.dart) | The same dialog during first-run onboarding, writing as it goes rather than when onboarding finishes |
 | [`bulk_add_screen.dart`](../lib/features/add_meal/presentation/screens/bulk_add_screen.dart) | Input, the review rows, and logging them |
 | [`bulk_add_bloc.dart`](../lib/features/add_meal/presentation/bloc/bulk_add_bloc.dart) | Screen state |
 | [`bulk_add_state.dart`](../lib/features/add_meal/presentation/bloc/bulk_add_state.dart) | Rows, flags, and what a row is missing |

--- a/docs/ai-architecture.md
+++ b/docs/ai-architecture.md
@@ -317,7 +317,8 @@ ask them for.
 Most of what each destination *keeps* is a policy question rather than a mechanism one, and it
 lives in the README's [Privacy](../README.md#privacy) section — but two of the four requests carry
 a retention instruction of their own. The direct OpenAI call sends `store: false`, because
-Responses stores by default and silence there is not a no-op. The OpenRouter routing block sends
+the Responses API retains request and response content by default, so saying nothing is not the
+same as opting out. The OpenRouter routing block sends
 `data_collection: "deny"` alongside the vendor pin, which makes a vendor that stores input
 non-transiently ineligible to serve the request at all. Two things there are worth knowing before you
 read this page's diagrams as reassurance: being reached directly is not the same as keeping less,

--- a/docs/ai-architecture.md
+++ b/docs/ai-architecture.md
@@ -58,11 +58,16 @@ decoding that would guarantee the reply matches the schema. The app does not rel
 guarantee is re-checked in Dart against a reply that ignored the schema entirely — because a
 guarantee you cannot verify locally is a guarantee held by somebody else.
 
-The permitted fields are exactly three: `query` (the food name, in your language), and optionally
-`quantity` and `unit` — the latter constrained to a fixed list. That list includes `l`, `kg` and
-`lb` for a measured reason recorded in the source: omitting them did not stop the model answering,
-it made the model map a litre onto `ml` and keep the number, turning 1.5 l of milk into 1.5 ml. A
-thousandfold undercount that nothing flagged, because a unit *had* been stated.
+The permitted fields are exactly four: `query` (the food name, in your language), and optionally
+`quantity`, `unit` — the latter constrained to a fixed list — and `portion`. That list includes
+`l`, `kg` and `lb` for a measured reason recorded in the source: omitting them did not stop the
+model answering, it made the model map a litre onto `ml` and keep the number, turning 1.5 l of milk
+into 1.5 ml. A thousandfold undercount that nothing flagged, because a unit *had* been stated.
+
+`portion` is a word, never a number — the schema says so in as many words: *"A word only, never a
+weight or a count."* It is a lookup key into the matched food's own portion list ("slice", "cup"),
+so the gram weight still comes from the database row, and a key matching nothing is ignored. It
+earns its place on the photo path, where there is no typed text for a portion word to be found in.
 
 ## A typed meal, end to end
 
@@ -81,7 +86,7 @@ sequenceDiagram
     opt a key or address is stored
         S->>I: the same text
         I->>M: forced tool call, schema with no nutrition fields
-        M-->>I: items — query, quantity, unit
+        M-->>I: items — query, quantity, unit, portion
         I-->>S: names and amounts only
     end
     S->>DB: search each name
@@ -115,17 +120,20 @@ blips is a notice people learn to ignore.
 
 ## A photo, end to end
 
-Reading a photo is the same feature with a camera instead of a keyboard, offered only once a key
-or address is enabled. What differs is that a photo has **nothing underneath it** — there is no
+Reading a photo is the same feature with a camera instead of a keyboard, offered once a key or
+address is enabled — and, for a server you run, only once the setup probe's photo leg has passed
+against the address and model currently configured. Nothing vouches for your own server the way a
+curated list vouches for a hosted one, so the app's own check stands in; a camera button missing
+here is that verdict, not a bug. What differs is that a photo has **nothing underneath it** — there is no
 offline way to turn a picture into food names — so a failure here is reported rather than
 absorbed.
 
 ```mermaid
 flowchart TD
-    Cam["Camera or picker"] --> Cache["Temporary copy in the app cache<br/>put there by image_picker, not by the app"]
-    Cache --> Enc{"Re-encode in memory<br/>longest edge 1024 px, quality 80"}
+    Cam["Camera"] --> Cache["Temporary copy in the app cache<br/>put there by image_picker, not by the app"]
+    Cache --> Enc{"Re-encode in memory<br/>shortest edge 1024 px, quality 80"}
     Enc -->|"succeeded"| Out["WebP to hosted providers<br/>JPEG to a server you run"]
-    Enc -->|"no usable encoder on this device"| Raw["The original file, unmodified<br/>only if its format is one the provider takes<br/>and only under 3 MB — otherwise nothing is sent"]
+    Enc -->|"no usable encoder on this device"| Raw["The original file at its own resolution<br/>metadata stripped first<br/>only if its format is one the provider takes,<br/>its metadata parses, and it is under 3 MB"]
     Out --> Send["base64, one request"]
     Raw --> Send
     Cache --> Del["Cache copy deleted, encoded or not<br/>best effort: if the delete fails, the OS clears it later"]
@@ -145,11 +153,13 @@ until the OS clears the cache. That is a narrower promise than "the file is gone
 request leaves", and the narrower one is the true one.
 
 **One branch sends more than the encoding above describes.** If the device has no usable encoder
-for the chosen container, the app falls back to sending the picked file *unmodified* rather than
-failing over an encoder the user has no way to install — so what leaves the device on that path is
-the camera's own output at its own resolution, not a 1024 px re-encode. Two conditions bound it:
-the file's format must be one the provider accepts, and it must be under 3 MB, or nothing is sent
-at all. The fallback is far rarer on the JPEG path than the WebP one, because JPEG encoders are
+for the chosen container, the app falls back to sending the picked file at its own resolution
+rather than failing over an encoder the user has no way to install — so what leaves the device on
+that path is the camera's own output, not a 1024 px re-encode. Its metadata is stripped first, EXIF
+above all: a phone geotags by default, and the app asks for no location permission. Three
+conditions bound it: the file's format must be one the provider accepts, its metadata blocks must
+parse — bytes the app cannot account for are refused rather than forwarded — and it must be under
+3 MB, or nothing is sent at all. The fallback is far rarer on the JPEG path than the WebP one, because JPEG encoders are
 universal where WebP's are not.
 
 The photo is never written to the documents directory, which is what the export zip reads — so a
@@ -183,8 +193,12 @@ Three of the four destinations are compiled-in `https://` URLs and cannot be red
 fourth is an address you supply, which makes it the only one where plaintext is possible at all —
 see [the guardrails](#the-guardrails).
 
-What each destination *keeps* is a policy question, not a mechanism one, and it lives in the
-README's [Privacy](../README.md#privacy) section. Two things there are worth knowing before you
+Most of what each destination *keeps* is a policy question rather than a mechanism one, and it
+lives in the README's [Privacy](../README.md#privacy) section — but two of the four requests carry
+a retention instruction of their own. The direct OpenAI call sends `store: false`, because
+Responses stores by default and silence there is not a no-op. The OpenRouter routing block sends
+`data_collection: "deny"` alongside the vendor pin, which makes a vendor that stores input
+non-transiently ineligible to serve the request at all. Two things there are worth knowing before you
 read this page's diagrams as reassurance: being reached directly is not the same as keeping less,
 and on the broker path the two retention policies **stack**.
 
@@ -245,8 +259,10 @@ provider exists to serve.
 
 ## A server you run: the probe
 
-When you point the app at your own server, it cannot know what that server can do. So it asks —
-once, at setup — by sending a real meal line and a real photograph through the shipping code path:
+When you point the app at your own server, it cannot know what that server can do. So it asks — at
+setup, and again each time you confirm that dialog, because the address and the model can be
+identical and the machine behind them different — by sending a real meal line and a real photograph
+through the shipping code path:
 the same prompts, the same schema, the same forcing mode, the same image encoder. A probe built
 from its own request would be testing a second implementation that nothing else uses.
 
@@ -267,7 +283,9 @@ stateDiagram-v2
 as `failed` would hide a working camera; recording an unproven guess as `passed` would offer a
 dead end. So every ambiguous outcome lands on `unknown`, and only two failure kinds are conclusive
 enough to close a capability: `unsupported` (nothing on the other end can serve this kind of
-request) and `rejected` (a guardrail refused it).
+request) and `rejected` (the provider refused the request itself — on the photo leg that means the
+picture, which will be refused again tomorrow). A refusal by the app's own plaintext guard is not
+one of these: nothing was sent, so nothing was learned, and it lands on `unknown` like a timeout.
 
 A stored `passed` is a fact about one `(endpoint, model)` pair, and it can stop being true without
 the user touching anything — pull a different model under the same tag and the camera is still
@@ -290,7 +308,7 @@ Independent checks, not a sequence. Each one is pinned by a test that fails if i
 
 | Gate | What it stops | Enforced in | Pinned by |
 |---|---|---|---|
-| Schema with no nutrition fields | a model supplying a calorie count | [`meal_items_api.dart`](../lib/features/add_meal/domain/meal_items_api.dart) | [`meal_items_api_contract_test.dart`](../test/unit_test/meal_items_api_contract_test.dart) — *output is held to the parser bounds, not the model* |
+| Schema with no nutrition fields | a model supplying a calorie count | [`meal_items_api.dart`](../lib/features/add_meal/domain/meal_items_api.dart) | [`openrouter_meal_items_api_test.dart`](../test/unit_test/openrouter_meal_items_api_test.dart) — *the schema exposes only query, quantity, unit and portion* |
 | Dart-side re-validation | a reply that ignored the schema | [`meal_text_parser.dart`](../lib/features/add_meal/util/meal_text_parser.dart) | [`meal_text_parser_test.dart`](../test/unit_test/meal_text_parser_test.dart) |
 | Payload never logged | the meal you typed, or a photo, reaching a log or an error string | all three clients | contract test — *a failing send puts the payload in neither the error nor the log*; *a photo never reaches the error or the log either* |
 | Response body withheld on rejection | a provider's error text carrying your content back into a log | all three clients | contract test — *a rejected request does not carry the response body* |

--- a/test/unit_test/ai_architecture_doc_test.dart
+++ b/test/unit_test/ai_architecture_doc_test.dart
@@ -41,8 +41,17 @@ void main() {
   /// catch, and this page quotes real source comments verbatim — so scanning
   /// one means failing the build over an accurate transcription. It also
   /// keeps a `# install` line in a shell block from registering as a heading.
+  /// Indented fences count. A fence inside a list item is indented by the
+  /// list's own margin, and anchoring at column 0 would read straight past it
+  /// — scanning the sample links and headings it contains as if they were the
+  /// page's own. Up to three spaces is what CommonMark allows before a fence
+  /// stops being a fence, and the closing run has to be allowed the same.
   String withoutFences(String markdown) => markdown.replaceAll(
-    RegExp(r'^(```|~~~)[^\n]*\n.*?^\1[^\n]*$', multiLine: true, dotAll: true),
+    RegExp(
+      r'^ {0,3}(```|~~~)[^\n]*\n.*?^ {0,3}\1[^\n]*$',
+      multiLine: true,
+      dotAll: true,
+    ),
     '',
   );
 

--- a/test/unit_test/ai_architecture_doc_test.dart
+++ b/test/unit_test/ai_architecture_doc_test.dart
@@ -20,32 +20,112 @@ void main() {
   final doc = File('docs/ai-architecture.md');
   final text = doc.readAsStringSync();
 
-  /// GitHub's heading slug: lowercased, punctuation dropped, spaces hyphened.
+  /// GitHub's heading slug, as GitHub actually computes it: lowercased,
+  /// punctuation dropped, and then every remaining space turned into a hyphen
+  /// one at a time rather than a run at a time. Underscores are word
+  /// characters and survive — which matters on a page whose headings name
+  /// files like `meal_text_parser.dart`. Both details are confirmed against
+  /// this repository's own rendered pages: the `food_summary` heading in
+  /// docs/supabase-self-hosting.md is served with the id
+  /// `food_summary--one-flat-row-per-food`, keeping the underscore and both
+  /// hyphens the em dash left behind. A slug that dropped either would call a
+  /// working link broken and a broken one fine.
   String slug(String heading) => heading
-      .toLowerCase()
-      .replaceAll(RegExp(r'[^a-z0-9 -]'), '')
       .trim()
-      .replaceAll(RegExp(r'\s+'), '-');
+      .toLowerCase()
+      .replaceAll(RegExp(r'[^\p{L}\p{N}_ -]', unicode: true), '')
+      .replaceAll(' ', '-');
 
+  /// Fenced blocks, removed before anything is scanned. A link inside a fence
+  /// is text on the rendered page and cannot be the 404 this test exists to
+  /// catch, and this page quotes real source comments verbatim — so scanning
+  /// one means failing the build over an accurate transcription. It also
+  /// keeps a `# install` line in a shell block from registering as a heading.
+  String withoutFences(String markdown) => markdown.replaceAll(
+    RegExp(r'^(```|~~~)[^\n]*\n.*?^\1[^\n]*$', multiLine: true, dotAll: true),
+    '',
+  );
+
+  /// The headings a link can land on. Repeated headings get a `-1` suffix on
+  /// GitHub and this does not model that; no page it reads has one.
   Set<String> anchorsIn(String markdown) => {
     for (final match in RegExp(
       r'^#{1,6}\s+(.+)$',
       multiLine: true,
-    ).allMatches(markdown))
-      slug(match.group(1)!.trim()),
+    ).allMatches(withoutFences(markdown)))
+      slug(match.group(1)!),
   };
 
-  // Links that climb out of docs/ — every reference into lib/, test/ or the
-  // README. Anything else on the page is an external URL and not ours to
-  // keep working.
-  final outward = RegExp(
-    r'\]\(\.\./([^)\s#]+)(#[^)\s]*)?\)',
-  ).allMatches(text).map((m) => (path: m.group(1)!, anchor: m.group(2)));
+  /// Every link target, in each form that renders as a link. Reading only
+  /// `](../path)` misses three that reach a reader just the same: a title
+  /// after the target, an angle-bracketed target, and a reference definition
+  /// on its own line. Missing them here is worse than it looks — the `sed` in
+  /// docs/RELEASING.md that publishes this page rewrites `](../` and nothing
+  /// else, so a form this scan does not catch is a form that arrives on the
+  /// wiki unrewritten, as a dead link.
+  Iterable<String> targetsIn(String markdown) sync* {
+    final body = withoutFences(markdown);
+    for (final match in RegExp(
+      r'\]\(\s*<?([^)\s>]+)>?[^)]*\)',
+    ).allMatches(body)) {
+      yield match.group(1)!;
+    }
+    for (final match in RegExp(
+      r'^ {0,3}\[[^\]]+\]:\s*<?([^\s>]+)>?',
+      multiLine: true,
+    ).allMatches(body)) {
+      yield match.group(1)!;
+    }
+  }
+
+  /// A target split into the file it names and the heading it jumps to.
+  ({String path, String? anchor}) parts(String target) {
+    final hash = target.indexOf('#');
+    if (hash < 0) return (path: target, anchor: null);
+    return (path: target.substring(0, hash), anchor: target.substring(hash));
+  }
+
+  /// Where a link written in docs/ lands, or null if it lands outside the
+  /// repository. `File('../x')` resolves against the working directory rather
+  /// than against docs/, so `](../../x)` was looked for *beside* the checkout
+  /// — and on a machine that happens to have something of that name there, it
+  /// is found and the link passes. GitHub serves it as a 404. A target
+  /// starting `/` is the same failure by another route: a reader's browser
+  /// resolves it against github.com, not against the repository.
+  String? insideRepo(String linkPath) {
+    if (linkPath.startsWith('/')) return null;
+    final segments = <String>[];
+    for (final segment in 'docs/$linkPath'.split('/')) {
+      if (segment.isEmpty || segment == '.') continue;
+      if (segment == '..') {
+        if (segments.isEmpty) return null;
+        segments.removeLast();
+      } else {
+        segments.add(segment);
+      }
+    }
+    return segments.join('/');
+  }
+
+  /// Somebody else's to keep working.
+  bool isExternal(String linkPath) =>
+      RegExp(r'^[a-zA-Z][a-zA-Z0-9+.-]*:|^//').hasMatch(linkPath);
+
+  final targets = targetsIn(text).map(parts).toList();
+
+  // Links into the repository — lib/, test/, the README, and a sibling page
+  // in docs/, which a scan that recognised a link only by its `../` never saw.
+  final outward = [
+    for (final target in targets)
+      if (target.path.isNotEmpty && !isExternal(target.path)) target,
+  ];
 
   // Links to a heading on the page itself — the table of contents, mostly.
-  final internal = RegExp(
-    r'\]\(#([^)\s]+)\)',
-  ).allMatches(text).map((m) => m.group(1)!).toSet();
+  final internal = {
+    for (final target in targets)
+      if (target.path.isEmpty && target.anchor != null)
+        target.anchor!.substring(1),
+  };
 
   group('docs/ai-architecture.md', () {
     test('the page is where this test thinks it is', () {
@@ -58,24 +138,46 @@ void main() {
 
     test('the link scan actually found links', () {
       // The canary. A regex that stops matching turns every check below into
-      // a loop over nothing, and a loop over nothing passes. The floor is
-      // deliberately well under the real count — this is here to catch a
-      // scan that broke, not to police how many files the page cites.
+      // a loop over nothing, and a loop over nothing passes. The floors sit
+      // just under the real counts — 49 outward links and 9 distinct anchors
+      // as this is written — so that losing one *kind* of link fails too: the
+      // code map alone is 24 rows, and a floor low enough to survive dropping
+      // it is a floor that catches nothing. A page that genuinely sheds links
+      // is an edit somebody made on purpose, and lowering these by hand is
+      // part of it.
       expect(
         outward.length,
-        greaterThan(25),
-        reason: 'the outward-link regex matched almost nothing, so the '
-            'checks below are running over an empty list and passing '
-            'vacuously — fix the scan, not the page',
+        greaterThan(40),
+        reason: 'the outward-link scan lost links, so the checks below are '
+            'running over a short list — or an empty one — and passing '
+            'vacuously; fix the scan, not the page',
       );
-      expect(internal, isNotEmpty);
+      expect(
+        internal.length,
+        greaterThan(6),
+        reason: 'the anchor scan lost links: the table of contents alone is '
+            'nine entries',
+      );
     });
 
     test('every file the page points at exists', () {
-      final missing = [
-        for (final link in outward)
-          if (!File(link.path).existsSync()) link.path,
-      ];
+      final missing = <String>[];
+      final escaping = <String>[];
+      for (final link in outward) {
+        final resolved = insideRepo(link.path);
+        if (resolved == null) {
+          escaping.add(link.path);
+        } else if (!File(resolved).existsSync() &&
+            !Directory(resolved).existsSync()) {
+          missing.add(link.path);
+        }
+      }
+      expect(
+        escaping,
+        isEmpty,
+        reason: 'the page cites a path that leaves the repository. Whatever '
+            'it finds on the machine running this, a reader gets a 404.',
+      );
       expect(
         missing,
         isEmpty,
@@ -104,10 +206,13 @@ void main() {
       // links honest; this keeps the one link *into* it honest, because a
       // page nothing references is a page nobody reads and a rename would
       // cost it its only inbound link without failing anything.
+      // The README's links resolve from the repository root, so the target
+      // is read as written — and read in every form, so that adding a title
+      // to the link does not read as the link having been removed.
       final readme = File('README.md').readAsStringSync();
       expect(
-        readme,
-        contains('](docs/ai-architecture.md)'),
+        targetsIn(readme).map((target) => parts(target).path),
+        contains('docs/ai-architecture.md'),
         reason: 'the README no longer links to the architecture page, so the '
             'only route a reader has to it is gone',
       );
@@ -121,8 +226,8 @@ void main() {
       // repo forever.
       final releasing = File('docs/RELEASING.md').readAsStringSync();
       expect(
-        releasing,
-        contains('](ai-architecture.md)'),
+        targetsIn(releasing).map((target) => parts(target).path),
+        contains('ai-architecture.md'),
         reason: 'docs/RELEASING.md no longer links to the architecture page, '
             'so the release step that publishes it has lost its target',
       );
@@ -133,9 +238,13 @@ void main() {
       for (final link in outward) {
         final anchor = link.anchor;
         if (anchor == null || !link.path.endsWith('.md')) continue;
-        final target = File(link.path);
+        final resolved = insideRepo(link.path);
+        if (resolved == null) continue; // already reported above
+        final target = File(resolved);
         if (!target.existsSync()) continue; // already reported above
-        if (!anchorsIn(target.readAsStringSync()).contains(anchor.substring(1))) {
+        if (!anchorsIn(
+          target.readAsStringSync(),
+        ).contains(anchor.substring(1))) {
           broken.add('${link.path}$anchor');
         }
       }


### PR DESCRIPTION
Five independent passes over [`docs/ai-architecture.md`](docs/ai-architecture.md), 164 claims checked against `origin/release/2.2.0`.

**The page's model of the feature is correct.** The schema-shaped guarantee, the routing, the timeouts, the probe taxonomy, the plaintext ranges and all 27 code-map rows survived. Eight sentences did not, and this PR fixes those.

Two of them are drift rather than error — the page landed 2026-08-27 07:24, metadata stripping (#914) at 19:18 the same day, `portion` (#864) three days later.

## The two that mattered

**"The permitted fields are exactly three" — there are four.** `portion` is in `mealItemsToolSchema` and the page's own excerpt elides the comment defending it. Three of five passes found this independently. It is not inert: `portion` is a lookup key into the matched food's own portion list, so the model's word chooses which portion row is preset. The grams still come from the database — the one rule holds — but a page that hands the reader an audit procedure ("did anyone add a field here?") has to state the right count.

**The encoder fallback said the file goes out "unmodified".** `meal_photo_encoder.dart` strips EXIF, XMP and IPTC — including the GPS block — and refuses a file it cannot parse. The page understated its own protection *and* asserted something false, in the one paragraph about the riskiest branch.

## The rest

- 1024 px bounds the **shortest** edge — a 4:3 frame leaves at ~1365×1024, not 1024×768
- "Camera or picker" implied a gallery source that does not exist
- The photo path has a second gate for a server you run: the probe's photo leg
- `store: false` and `data_collection: "deny"` are retention instructions on the wire, not policy deferred to the README
- The probe re-runs on every confirm, deliberately — not "once, at setup"
- `rejected` is the provider refusing, not a guardrail; a plaintext-guard refusal lands on `unknown`
- The schema row cited a test that would still pass if `calories` were added to the schema

## Not fixed here

- **`meal_photo_encoder.dart:196` and `user_image_storage.dart` repeat the shortest/longest-edge misreading.** Code comments, separate change.
- **The plaintext guard is not "the whole of the enforcement"** — redirects are followed inside `dart:io` without re-entering it. That is an OVERSTATED finding with a one-line code fix (`followRedirects = false`), not a documentation fix, so it is left for its own PR.
- Findings of kind GAP and OVERSTATED are not addressed; this PR is the factually-wrong set only.

## Test plan

- [x] `flutter test test/unit_test/ai_architecture_doc_test.dart` — passes; every link and anchor still resolves
- [x] The newly cited test exists and its name matches verbatim: `openrouter_meal_items_api_test.dart` → *exposes only query, quantity, unit and portion*
- [x] Each corrected claim re-verified by hand against `origin/release/2.2.0`, not taken from the review

**Worth reaching 2.2.0.** `RELEASING.md` says this page is published to the wiki on the first release shipping AI meal assistance — once it is over there, nothing runs against it.