### PR TITLE
docs(photo): the 1024px bound is on the shortest edge, not the longest

### DIFF
--- a/lib/core/utils/user_image_storage.dart
+++ b/lib/core/utils/user_image_storage.dart
@@ -31,8 +31,8 @@ enum UserImageKind {
 /// across app reinstalls and iOS sandbox refreshes, where the documents
 /// directory's parent prefix can change between launches.
 ///
-/// Photos are stored as WebP at quality 80, capped at 1024px on the
-/// longest edge — small enough that an export zip of a few dozen
+/// Photos are stored as WebP at quality 80, bounded at 1024px on the
+/// shortest edge — small enough that an export zip of a few dozen
 /// recipes and meals stays in the low-megabyte range, while still
 /// being plenty crisp for a list thumbnail and the detail-screen
 /// header. WebP roughly halves the bytes of an equivalent-quality JPEG
@@ -83,7 +83,7 @@ class UserImageStorage {
     return imagesDir;
   }
 
-  /// Reads `sourcePath`, re-encodes it to WebP (quality 80, longest
+  /// Reads `sourcePath`, re-encodes it to WebP (quality 80, shortest
   /// edge 1024px), writes the result to the matching images directory
   /// under `<ownerId>.webp`, and returns the relative slug to persist.
   /// The source file is left untouched.
@@ -185,9 +185,12 @@ class UserImageStorage {
         quality: 80,
         minWidth: 1024,
         minHeight: 1024,
-        // `minWidth`/`minHeight` are upper bounds for the *longest*
-        // edge when the source exceeds them; the compressor preserves
-        // aspect ratio. Shorter-edge images pass through untouched.
+        // `minWidth`/`minHeight` bound the *shortest* edge, not the longest.
+        // The compressor takes `min(width/minWidth, height/minHeight)` as its
+        // scale factor, so the smaller ratio wins and the edge that lands on
+        // 1024 is the short one: a 4080x3072 frame comes out 1360x1024, and a
+        // 16:9 frame wider still. Aspect ratio is preserved and an image
+        // already smaller than 1024 on both edges passes through untouched.
       );
     } catch (_) {
       return null;

--- a/lib/features/add_meal/util/meal_photo_encoder.dart
+++ b/lib/features/add_meal/util/meal_photo_encoder.dart
@@ -53,7 +53,7 @@ enum MealPhotoFormat {
 /// the documents directory is a photo the export zip picks up and the user
 /// never asked to keep.
 ///
-/// The encoding — quality 80, longest edge 1024 px — matches
+/// The encoding — quality 80, shortest edge 1024 px — matches
 /// `UserImageStorage` on purpose. It is the pipeline this app already trusts
 /// for food photography, and a 1024 px image is about 1400 visual tokens,
 /// which is what makes this cost fractions of a cent where anyone is charging
@@ -193,9 +193,12 @@ class MealPhotoEncoder {
         // the app promises it asks for no location. [PhotoMetadata] does the
         // same job on the fallback path below, where no encoder runs.
         keepExif: false,
-        // `minWidth`/`minHeight` are upper bounds for the *longest* edge
-        // when the source exceeds them; the compressor preserves aspect
-        // ratio. Shorter-edge images pass through untouched.
+        // `minWidth`/`minHeight` bound the *shortest* edge, not the longest.
+        // The compressor takes `min(width/minWidth, height/minHeight)` as its
+        // scale factor, so the smaller ratio wins and the edge that lands on
+        // 1024 is the short one: a 4080x3072 frame comes out 1360x1024, and a
+        // 16:9 frame wider still. Aspect ratio is preserved and an image
+        // already smaller than 1024 on both edges passes through untouched.
       );
     } catch (_) {
       return null;

--- a/lib/features/recipes/presentation/screens/recipe_builder_screen.dart
+++ b/lib/features/recipes/presentation/screens/recipe_builder_screen.dart
@@ -408,8 +408,8 @@ class _RecipeBuilderScreenState extends State<RecipeBuilderScreen> {
     try {
       final picker = ImagePicker();
       // Pick at full resolution — `UserImageStorage.importFrom` re-encodes
-      // to WebP at quality 80 with a 1024px longest-edge cap, so we don't
-      // need image_picker's own JPEG compression on top. Doing it in one
+      // to WebP at quality 80, bounding the shortest edge at 1024px, so we
+      // don't need image_picker's own JPEG compression on top. Doing it in one
       // place keeps the on-disk footprint consistent regardless of which
       // source (camera / gallery) the photo came from.
       final picked = await picker.pickImage(source: source);


### PR DESCRIPTION
Comment-only. The calls are unchanged and the behaviour was always this — what was wrong is what we told ourselves it was.

## The claim

Three places said `minWidth`/`minHeight` are *"upper bounds for the **longest** edge"*. They bound the **shortest** edge.

`flutter_image_compress` computes its scale factor as `max(1f, min(scaleW, scaleH))` where `scaleW = width/minWidth` and `scaleH = height/minHeight` (`BitmapCompressExt.kt:62-66`). Taking the **min** of the two ratios means the smaller downscale wins, so the edge that lands exactly on 1024 is the short one. iOS reaches the same result by a different route (`UIImage+scale.m:12-21`).

A 4080×3072 camera frame therefore comes out **1360×1024**, not 1024×768 — about 1.8× the pixels the comments promised, and more again for a 16:9 frame. I verified this in the pub cache rather than taking it from the review, since an assertion about a third-party library's scaling is exactly the kind of claim that produced the original error.

## Where it was

- `meal_photo_encoder.dart` — dartdoc summary and the call-site comment
- `user_image_storage.dart` — class dartdoc, method dartdoc, and the call-site comment
- `recipe_builder_screen.dart` — repeated it while explaining why it picks at full resolution

That third one was not in the review's scope; it turned up on a repo-wide grep after fixing the first two.

## Related

`docs/ai-architecture.md` stated the same thing in its photo diagram and is corrected in #996. This PR is the code half.

- [x] `flutter analyze` clean on all three files
- [x] `meal_photo_encoder_test.dart` passes