### PR TITLE
fix(net): stop the plaintext guard being bypassed by a redirect

### DIFF
--- a/docs/ai-architecture.md
+++ b/docs/ai-architecture.md
@@ -492,7 +492,12 @@ Independent checks, not a sequence. Each one is pinned by a test that fails if i
 platform does not. `http://ollama.lan` is what people actually configure, and a name resolves
 wherever DNS says — possibly somewhere public, and possibly somewhere different today than when it
 was saved. Neither platform's transport-security policy reaches Dart's socket layer, so this check
-is the whole of the enforcement. It permits loopback, link-local, RFC 1918 and IPv6 unique-local,
+is the whole of the enforcement, and it stays whole because **a redirect is not followed**. A
+`Location` header is acted on inside `dart:io`, below where this check sits, so a second hop
+would be made on the strength of an approval granted to a different destination; instead a 30x
+comes back to the caller as the response it is. That holds for `https://` too, which the guard
+otherwise waves through: an encrypted first hop says nothing about where its `Location` points.
+The check permits loopback, link-local, RFC 1918 and IPv6 unique-local,
 and it deliberately excludes carrier-grade NAT (`100.64.0.0/10`) — which is what Tailscale hands
 out, so a tailnet user must use `https://`. The app cannot tell a tailnet from an ISP's shared
 address space, and treating every `100.x` as private would quietly permit plaintext onto a

--- a/docs/ai-architecture.md
+++ b/docs/ai-architecture.md
@@ -64,6 +64,27 @@ The permitted fields are exactly four: `query` (the food name, in your language)
 model answering, it made the model map a litre onto `ml` and keep the number, turning 1.5 l of milk
 into 1.5 ml. A thousandfold undercount that nothing flagged, because a unit *had* been stated.
 
+Adding them opened the failure on the other side: a model answering with a unit nobody typed.
+*"ein Glas Milch"* states no amount at all — Anthropic answered `1 l`, OpenAI answered
+`unit: "Glas"`, and which of the two wrong answers hurt was decided by what the enum happened to
+spell. The litre was recognised, multiplied by a thousand, and logged as 470 kcal for a glass of
+milk; `Glas` was dropped as unrecognised and came out right.
+
+**So a unit in a reply is now corroborated against the text the model was given.**
+`textStatesAUnit` runs the parser's own segmentation and extraction over that text and asks
+whether any segment carries a number with a unit against it. If none does, every unit in the
+batch is dropped — before the kg/l conversion, because after it `1 l` is already 1000 ml and the
+number cannot be put back. The quantities survive, so each row arrives as a bare count, which the
+review screen resolves against the food's own serving: that is how the `Glas` answer reaches the
+right figure today, by being unrecognised rather than by being right.
+
+It reuses the parser rather than scanning for the symbols because `l` occurs inside `Glas`, so a
+substring test would report a unit in exactly the phrase this exists to catch. And it asks the
+question of the whole input rather than of each row, because a model's rows do not map onto the
+input's segments reliably enough to ask per row — *"100g Toast, 2 Eier"* states a unit, so nothing
+in that batch is touched. Only the typed path corroborates: a photograph states nothing, and the
+photo path's counts-only rule already drops every unit it gets.
+
 `portion` is a word, never a number — the schema says so in as many words: *"A word only, never a
 weight or a count."* It is a lookup key into the matched food's own portion list ("slice", "cup"),
 so the gram weight still comes from the database row, and a key matching nothing is ignored. It
@@ -110,13 +131,64 @@ saying *there is no food here*, which is an answer, not a failure — so it is h
 alternative was measured on a Pixel 6: the parser will turn any sentence into a search, and
 *"meine Steuererklärung und ein Tacker"* came back as a cheese-roll match the user had to dismiss.
 
-**Nothing the user typed is ever logged.** Failures are logged by reason, never with the input.
+**A reply with no usable items is not that answer.** Entries are read one at a time and one
+carrying no `query` is dropped, so a single bad entry does not cost the good ones. A reply where
+*every* entry drops is refused outright rather than passed on as an empty list — it would
+otherwise reach the screen wearing the same clothes as a deliberate "there is no food here", and
+the user would get neither the model's rows, which never existed, nor the parser's, which that
+judgement had suppressed.
+
+That refusal is transient, and so is a body that will not decode, an `items` that is not an array,
+and arguments that are not JSON: nothing about one garbled reply says the next one will be. A
+reply with no tool call in it at all is the exception and lands on `unsupported` instead, because
+a model that answers in prose will answer in prose again. On the typed path a transient failure
+means the parser's rows, with no notice and not even the read-by-AI banner — the screen the user
+would have had with the feature switched off. On the photo path there is nothing underneath, so
+it becomes the one line the screen has for it: *Couldn't read the photo. Check your connection and
+try again.* Right for the common cause of a transient failure, and wrong for this one.
+
+**Being cut off is not a case the app recognises.** The answer is capped at 1024 tokens, which is
+roomy for a short list of short strings and short enough that a runaway is stopped early, and no
+client reads the flag a provider sets when that cap is reached. A truncated reply is therefore
+judged only on whether what arrived still parses: losing a closing brace makes it malformed and
+lands it with everything above, while a partial list that parses is believed as though it were the
+whole answer.
+
+**None of the three clients puts what you typed, or your photograph, into a log or an error
+string.** A socket error can carry the request URL and, on some platforms, part of the payload,
+so the caught error is dropped and a fixed reason thrown in its place, and an ordinary failure
+reaches the log as a status code. One path above them is narrower: an interpreter that throws
+something no client constructs is a bug, and the use case logs that object and its stack trace
+before falling back to the parser.
 
 Not every failure is worth interrupting for. `auth`, `unsupported`, `billing`, `timeout` and
 `insecureDestination` produce a notice, because they are permanent until something changes — a
 mistyped key that fails silently forever is a bad afternoon, and it was found exactly that way on
 a device. A dropped connection or a rate limit produces nothing, because a notice that fires for
 blips is a notice people learn to ignore.
+
+**What travels with a request is a short list, and it is the same list every time.** The model id
+you picked; the system prompt; the line you typed, with the surrounding whitespace off; the tool —
+its name, its one-line description and the schema above — together with the instruction to call
+it; and the cap on the answer. That is the whole body. Two destinations add a field of their own
+and neither is about you: OpenAI is told `store: false`, and OpenRouter is given the routing block
+that pins the vendor and refuses providers that would train on what they are sent.
+
+The system prompt is about two hundred words, and it is rules rather than data: one entry per
+food, `query` is the food name alone in the language you wrote in, an amount only where you stated
+one, never converted between units, and an empty list when the input holds no food. Your app
+language is appended to it as a single sentence — *The user's app language is "de"* — and that is
+the bare language code, with no region and nothing else about the device it came from.
+
+**Nothing else is attached, and there is nowhere for it to be attached.** Not a diary entry, a
+past meal, a goal, a weight, an age or anything else from your profile; not an earlier request or
+its reply, since each one stands alone; and no identifier for you, your install or your device.
+Each client builds its body out of exactly two things it was handed, the prompt and what you are
+asking about, and the headers the app sets are the credential, the content type, and — depending
+on the destination — Anthropic's API version or OpenRouter's metadata opt-in. OpenRouter's
+attribution headers are deliberately not among them: they would put the app on a public
+leaderboard as a side effect of somebody saving a key. A photo request differs only where it has
+to, in its own prompt and a picture in place of the line.
 
 ## A photo, end to end
 
@@ -170,6 +242,16 @@ whose format list has no WebP. All four common local runtimes decode JPEG, so ch
 server you run removes the incompatibility rather than detecting it. Quality and pixel size are
 identical either way.
 
+**What comes back from a photo may be a count, never a measurement.** The text path can carry
+`100 g` because you typed it; a photograph states nothing, so a gram figure read off a plate is
+an estimate wearing the shape of something measured. The prompt asks for counts only, and the
+interpreter drops any amount that came with a unit or is not a whole number — the number along
+with it. Keeping the bare number is the worse failure: an estimated `200 g` of rice stripped to
+`200` reads downstream as a count, and a count against a food whose serving can be scaled is
+logged as 200 servings. The row falls back to the amount an unquantified item gets, and you set
+it. The rule sits in the shared photo interpreter rather than in a client, so a provider added
+later inherits it.
+
 ## Where a request goes
 
 ```mermaid
@@ -189,9 +271,48 @@ to the vendor named beside it in Settings, with fallbacks off. Unpinned, a reque
 `anthropic/claude-haiku-4.5` was answered by Amazon Bedrock on every attempt of a three-run probe
 — a vendor the user never chose and the screen never named.
 
-Three of the four destinations are compiled-in `https://` URLs and cannot be redirected. Only the
-fourth is an address you supply, which makes it the only one where plaintext is possible at all —
-see [the guardrails](#the-guardrails).
+**What crosses on that path is more than the payload.** The disclosure shown before an OpenRouter
+key is stored says that OpenRouter forwards an account-level identity to the serving vendor on
+every request, and that this cannot be switched off — so the vendor sees a stable handle for your
+account next to the meal, not an anonymous request. That is OpenRouter's behaviour, not the app's:
+nothing here turns it off, and nothing here can check that it happens. It is in the consent text
+because it changes what "the vendor keeps what it receives" is worth.
+
+The app's own addition to that request is one header, and it is not an identity.
+`x-openrouter-metadata: enabled` opts the *reply* into naming the vendor that actually served the
+request — a per-request opt-in, so it has to ride on every call — and it is the only way the pin
+above can be checked at runtime instead of asserted. A mismatch is logged and nothing more: the
+reply is still a valid answer to the question asked, and losing someone's meal entry over a
+routing discrepancy would be the worse outcome.
+
+Three of the four destinations are compiled-in `https://` URLs and cannot be redirected. The
+fourth is an address you supply, and there plaintext is the ordinary case rather than an edge one:
+the field's own example is `http://192.168.1.5:11434`, and the dialog carries a separate
+disclosure sentence for an unencrypted address precisely because that is what people save. So the
+guard is not deciding *whether* plaintext happens but *where it may go* — see
+[the guardrails](#the-guardrails).
+
+**Two requests reach a server you run before any meal does.** One is the setup check described
+[below](#a-server-you-run-the-probe), which OK starts. The other is a `GET` to `/v1/models` on
+the address in the field, asked so the model box can offer a picker instead of a blank line.
+Exactly two things ask for it: committing a changed address — moving off the field, or the
+keyboard's own done key — and the *Load models* button. Opening the dialog asks nothing,
+switching to this provider asks nothing, no timer asks, and coming back to a configured server
+and leaving the address alone asks nothing.
+
+**The model list is the one request that goes out before you have agreed to anything.** The
+consent screen is reached from OK, on the path that writes a credential, and the fetch hangs
+off the address field instead — so on a first-time setup your server has already been asked
+what it serves by the time that screen appears. The request carries an `Authorization` header
+when a key is available, and a key typed into the dialog counts before OK commits it, because a
+reverse proxy in front of a local runtime will want one. The plaintext guard covers it like any
+other request, so a public `http://` address is refused rather than asked.
+
+The consent screen names both requests before you agree, and it is shown once for the whole
+feature — so someone who agreed while setting up a hosted provider does not see that paragraph
+again when they later point the app at a server of their own. The three hosted providers are
+sent nothing until you read a meal: their model lists are compiled in, so there is nothing to
+ask them for.
 
 Most of what each destination *keeps* is a policy question rather than a mechanism one, and it
 lives in the README's [Privacy](../README.md#privacy) section — but two of the four requests carry
@@ -201,6 +322,27 @@ Responses stores by default and silence there is not a no-op. The OpenRouter rou
 non-transiently ineligible to serve the request at all. Two things there are worth knowing before you
 read this page's diagrams as reassurance: being reached directly is not the same as keeping less,
 and on the broker path the two retention policies **stack**.
+
+### What the request itself asks for
+
+Two of the four requests carry a retention instruction of their own, and both are worth naming
+because in each case the provider's default is the opposite.
+
+**Every request to OpenAI carries `store: false`.** The Responses API stores by default, so the
+field is not a no-op — omitting it would leave each meal line, and each photograph, sitting in the
+account's stored responses.
+
+**Every request through OpenRouter carries `data_collection: 'deny'`** inside its routing block.
+OpenRouter's routing default is `allow`, which makes providers that store input non-transiently
+and may train on it eligible to serve the request. It is sent as a policy field rather than
+inferred from the model slug, because free *usage* is what triggers those clauses and not the
+`:free` suffix — a slug check would look like enforcement and would not be it.
+
+Anthropic gets no such field, and a server you run gets no routing block at all: asserting
+`data_collection: 'deny'` to a machine in your own house is a claim the app cannot mean.
+
+The app also **withholds OpenRouter's two attribution headers**. `HTTP-Referer` and `X-Title` put
+the app on OpenRouter's public leaderboard, and saving a key is not consent to being listed there.
 
 ## Choosing a provider
 
@@ -261,10 +403,22 @@ provider exists to serve.
 
 When you point the app at your own server, it cannot know what that server can do. So it asks — at
 setup, and again each time you confirm that dialog, because the address and the model can be
-identical and the machine behind them different — by sending a real meal line and a real photograph
+identical and the machine behind them different — by sending a fixed example line and a photograph that ships with the app
 through the shipping code path:
 the same prompts, the same schema, the same forcing mode, the same image encoder. A probe built
 from its own request would be testing a second implementation that nothing else uses.
+
+
+
+**Neither of those is yours.** The line is `two eggs and a slice of toast`, in English whatever
+your locale, because the bar is structural — did a parseable tool call come back with at least
+one item — and nothing about that depends on the words. The photograph is one of the demo
+images the app already ships for Try Demo: a sliced loaf on a board, one unambiguous food
+filling the frame, picked over the tempura bowl and the garnished yoghurt because either
+would make a correct answer look like a wrong one. It is written to a temporary file and run
+through the same encoder your own photo would go through, and deleted the same way. The consent
+screen puts it in those words before you agree: a fixed example line and a sample photograph of
+ours, never anything of yours.
 
 The verdict has three states, and the third is the interesting one.
 
@@ -274,8 +428,10 @@ stateDiagram-v2
     unknown --> passed: a parseable tool call with at least one item
     unknown --> failed: answered, but unusable
     unknown --> unknown: timeout, auth, billing, transient, refused plaintext
-    passed --> failed: a real request came back unsupported
+    passed --> failed: a photo came back unsupported
     passed --> unknown: endpoint or model changed
+
+    failed --> passed: a fresh check came back with items
     failed --> unknown: endpoint or model changed
 ```
 
@@ -289,12 +445,22 @@ one of these: nothing was sent, so nothing was learned, and it lands on `unknown
 
 A stored `passed` is a fact about one `(endpoint, model)` pair, and it can stop being true without
 the user touching anything — pull a different model under the same tag and the camera is still
-offered, still claims photos work, and fails on every photograph. So a live request that comes
-back `unsupported` retracts the stored pass. Only that one failure kind: the network, the load,
+offered, still claims photos work, and fails on every photograph. So a photo that comes back `unsupported` retracts the stored photo pass, and only that one. The
+text verdict is left where it stands: a photograph says nothing about whether a meal line
+still reads. The text path retracts nothing at all, in either row, because a typed meal that
+fails still has the offline parser underneath it and there is no capability to withdraw. Only that one failure kind: the network, the load,
 the credential and the bill say nothing about whether a model has eyes.
 
 Changing the address or the model discards the record entirely, so a stored verdict can only ever
 describe the configuration currently in place.
+
+
+
+**`failed` is not a dead end either.** *Check this server* re-runs both legs from Settings
+without a re-save, and a conclusive verdict overwrites a stored one in both directions — so
+pulling a model that can actually see, and checking again, turns the photo row back to a pass.
+Only a conclusive one: an inconclusive result leaves whatever was known alone, which is what
+stops a retry against a sleeping server revoking a pass that is still true.
 
 The probe runs its two legs **sequentially** — a local runtime serves one request at a time
 against one loaded model, so firing both at once would only queue them. That makes the worst case
@@ -310,12 +476,14 @@ Independent checks, not a sequence. Each one is pinned by a test that fails if i
 |---|---|---|---|
 | Schema with no nutrition fields | a model supplying a calorie count | [`meal_items_api.dart`](../lib/features/add_meal/domain/meal_items_api.dart) | [`openrouter_meal_items_api_test.dart`](../test/unit_test/openrouter_meal_items_api_test.dart) — *the schema exposes only query, quantity, unit and portion* |
 | Dart-side re-validation | a reply that ignored the schema | [`meal_text_parser.dart`](../lib/features/add_meal/util/meal_text_parser.dart) | [`meal_text_parser_test.dart`](../test/unit_test/meal_text_parser_test.dart) |
-| Payload never logged | the meal you typed, or a photo, reaching a log or an error string | all three clients | contract test — *a failing send puts the payload in neither the error nor the log*; *a photo never reaches the error or the log either* |
+| Counts only from a photo | an amount nobody stated arriving as if somebody had | [`model_meal_photo_interpreter.dart`](../lib/features/add_meal/data/model_meal_photo_interpreter.dart) | [`model_meal_photo_interpreter_test.dart`](../test/unit_test/model_meal_photo_interpreter_test.dart) — *a measured amount loses both its unit and its number*; *a fractional amount is not a count, so it goes too* |
+| Payload never logged by a client | the meal you typed, or a photo, reaching a log or an error string from a failed send | all three clients | contract test — *a failing send puts the payload in neither the error nor the log*; *a photo never reaches the error or the log either* |
 | Response body withheld on rejection | a provider's error text carrying your content back into a log | all three clients | contract test — *a rejected request does not carry the response body* |
-| Consent before storage | a credential written before you agreed to what leaving the device means | [`ai_assist_dialog.dart`](../lib/features/settings/presentation/widgets/ai_assist_dialog.dart), [`ai_consent_screen.dart`](../lib/features/settings/presentation/widgets/ai_consent_screen.dart) | [`ai_assist_dialog_test.dart`](../test/features/settings/presentation/ai_assist_dialog_test.dart) |
+| Consent before storage | a credential stored, or used, before you agreed to what leaving the device means | [`ai_assist_dialog.dart`](../lib/features/settings/presentation/widgets/ai_assist_dialog.dart), [`ai_consent_screen.dart`](../lib/features/settings/presentation/widgets/ai_consent_screen.dart), [`ai_credential_storage.dart`](../lib/core/utils/ai_credential_storage.dart) | [`ai_assist_dialog_test.dart`](../test/features/settings/presentation/ai_assist_dialog_test.dart), [`ai_credential_storage_test.dart`](../test/unit_test/ai_credential_storage_test.dart) — *a credential without an agreement is not usable* |
 | Plaintext destination guard | `http://` to anywhere that is not private | [`plaintext_destination_guard.dart`](../lib/core/utils/plaintext_destination_guard.dart) | [`plaintext_destination_guard_test.dart`](../test/unit_test/plaintext_destination_guard_test.dart) |
 | Address pinning after lookup | DNS answering differently the second time | same file | same test |
 | Vendor pin, fallbacks off | OpenRouter serving from a vendor the screen never named | [`meal_items_api_factory.dart`](../lib/features/add_meal/data/meal_items_api_factory.dart) | [`meal_items_api_factory_test.dart`](../test/unit_test/meal_items_api_factory_test.dart) |
+| Data collection denied on the broker path | OpenRouter routing to a vendor that may keep your meal and train on it | [`openai_compatible_meal_items_api.dart`](../lib/features/add_meal/data/openai_compatible_meal_items_api.dart) | [`openrouter_meal_items_api_test.dart`](../test/unit_test/openrouter_meal_items_api_test.dart) — *refuses providers that may keep and train on the input* |
 | Per-provider credential slots | a key reaching a provider it was not issued for | [`ai_credential_storage.dart`](../lib/core/utils/ai_credential_storage.dart) | [`ai_credential_storage_test.dart`](../test/unit_test/ai_credential_storage_test.dart) |
 | Unrecognised provider tag refuses to send | a downgraded build redirecting requests to a vendor you did not pick | same file | same test |
 | Connection budget | a request hanging indefinitely | all clients | contract test — *a stalled connection gives up instead of hanging* |
@@ -329,6 +497,12 @@ and it deliberately excludes carrier-grade NAT (`100.64.0.0/10`) — which is wh
 out, so a tailnet user must use `https://`. The app cannot tell a tailnet from an ISP's shared
 address space, and treating every `100.x` as private would quietly permit plaintext onto a
 carrier's network.
+
+That the platform does not enforce this was measured rather than assumed. `dart:io` opens BSD
+sockets, so a request never passes through NSURLSession or Android's HTTP stacks, and neither iOS
+App Transport Security nor Android's cleartext policy ever sees it. Which is why neither platform
+file says anything about it: there is no `usesCleartextTraffic` attribute in the manifest and no
+`NSAppTransportSecurity` dictionary in `Info.plist`, and adding either would change nothing.
 
 Both address families are checked. A measured dual-stack case shows why: a home server whose
 reverse lookup gave `192.168.1.46` had a **forward lookup returning only a public-scope IPv6
@@ -366,13 +540,14 @@ address**. An IPv4-only check would never have seen where the connection actuall
 | [`run_ai_endpoint_probe_usecase.dart`](../lib/features/add_meal/domain/usecase/run_ai_endpoint_probe_usecase.dart) | Probing and storing the verdict together |
 | [`meal_text_parser.dart`](../lib/features/add_meal/util/meal_text_parser.dart) | The deterministic parser, and the bounds every row is held to |
 | [`meal_photo_encoder.dart`](../lib/features/add_meal/util/meal_photo_encoder.dart) | 1024 px / q80 encoding, per-destination container, cache cleanup |
-| [`ai_credential_storage.dart`](../lib/core/utils/ai_credential_storage.dart) | Per-provider keys, addresses, model choice, probe records |
+| [`ai_credential_storage.dart`](../lib/core/utils/ai_credential_storage.dart) | Per-provider keys, addresses, model choice, probe records, and the recorded agreement |
 | [`ai_model_catalogue.dart`](../lib/core/utils/ai_model_catalogue.dart) | The curated lists and their vendor pins |
 | [`ai_model_list_api.dart`](../lib/core/utils/ai_model_list_api.dart) | Asking your own server which models it has |
 | [`plaintext_destination_guard.dart`](../lib/core/utils/plaintext_destination_guard.dart) | Whether an unencrypted request may leave, and to which address |
 | [`ai_assist_dialog.dart`](../lib/features/settings/presentation/widgets/ai_assist_dialog.dart) | The Settings surface: provider, credential, model, probe |
-| [`ai_consent_screen.dart`](../lib/features/settings/presentation/widgets/ai_consent_screen.dart) | The disclosure shown before anything is stored |
+| [`ai_consent_screen.dart`](../lib/features/settings/presentation/widgets/ai_consent_screen.dart) | The disclosure shown before a credential is stored |
 | [`ai_assist_summary.dart`](../lib/core/presentation/ai_assist_summary.dart) | The one-line state shown on the Settings tile |
+| [`onboarding_other_options_page_body.dart`](../lib/features/onboarding/presentation/widgets/onboarding_other_options_page_body.dart) | The same dialog during first-run onboarding, writing as it goes rather than when onboarding finishes |
 | [`bulk_add_screen.dart`](../lib/features/add_meal/presentation/screens/bulk_add_screen.dart) | Input, the review rows, and logging them |
 | [`bulk_add_bloc.dart`](../lib/features/add_meal/presentation/bloc/bulk_add_bloc.dart) | Screen state |
 | [`bulk_add_state.dart`](../lib/features/add_meal/presentation/bloc/bulk_add_state.dart) | Rows, flags, and what a row is missing |

--- a/docs/ai-architecture.md
+++ b/docs/ai-architecture.md
@@ -317,7 +317,8 @@ ask them for.
 Most of what each destination *keeps* is a policy question rather than a mechanism one, and it
 lives in the README's [Privacy](../README.md#privacy) section — but two of the four requests carry
 a retention instruction of their own. The direct OpenAI call sends `store: false`, because
-Responses stores by default and silence there is not a no-op. The OpenRouter routing block sends
+the Responses API retains request and response content by default, so saying nothing is not the
+same as opting out. The OpenRouter routing block sends
 `data_collection: "deny"` alongside the vendor pin, which makes a vendor that stores input
 non-transiently ineligible to serve the request at all. Two things there are worth knowing before you
 read this page's diagrams as reassurance: being reached directly is not the same as keeping less,

--- a/docs/ai-architecture.md
+++ b/docs/ai-architecture.md
@@ -58,11 +58,16 @@ decoding that would guarantee the reply matches the schema. The app does not rel
 guarantee is re-checked in Dart against a reply that ignored the schema entirely — because a
 guarantee you cannot verify locally is a guarantee held by somebody else.
 
-The permitted fields are exactly three: `query` (the food name, in your language), and optionally
-`quantity` and `unit` — the latter constrained to a fixed list. That list includes `l`, `kg` and
-`lb` for a measured reason recorded in the source: omitting them did not stop the model answering,
-it made the model map a litre onto `ml` and keep the number, turning 1.5 l of milk into 1.5 ml. A
-thousandfold undercount that nothing flagged, because a unit *had* been stated.
+The permitted fields are exactly four: `query` (the food name, in your language), and optionally
+`quantity`, `unit` — the latter constrained to a fixed list — and `portion`. That list includes
+`l`, `kg` and `lb` for a measured reason recorded in the source: omitting them did not stop the
+model answering, it made the model map a litre onto `ml` and keep the number, turning 1.5 l of milk
+into 1.5 ml. A thousandfold undercount that nothing flagged, because a unit *had* been stated.
+
+`portion` is a word, never a number — the schema says so in as many words: *"A word only, never a
+weight or a count."* It is a lookup key into the matched food's own portion list ("slice", "cup"),
+so the gram weight still comes from the database row, and a key matching nothing is ignored. It
+earns its place on the photo path, where there is no typed text for a portion word to be found in.
 
 ## A typed meal, end to end
 
@@ -81,7 +86,7 @@ sequenceDiagram
     opt a key or address is stored
         S->>I: the same text
         I->>M: forced tool call, schema with no nutrition fields
-        M-->>I: items — query, quantity, unit
+        M-->>I: items — query, quantity, unit, portion
         I-->>S: names and amounts only
     end
     S->>DB: search each name
@@ -115,17 +120,20 @@ blips is a notice people learn to ignore.
 
 ## A photo, end to end
 
-Reading a photo is the same feature with a camera instead of a keyboard, offered only once a key
-or address is enabled. What differs is that a photo has **nothing underneath it** — there is no
+Reading a photo is the same feature with a camera instead of a keyboard, offered once a key or
+address is enabled — and, for a server you run, only once the setup probe's photo leg has passed
+against the address and model currently configured. Nothing vouches for your own server the way a
+curated list vouches for a hosted one, so the app's own check stands in; a camera button missing
+here is that verdict, not a bug. What differs is that a photo has **nothing underneath it** — there is no
 offline way to turn a picture into food names — so a failure here is reported rather than
 absorbed.
 
 ```mermaid
 flowchart TD
-    Cam["Camera or picker"] --> Cache["Temporary copy in the app cache<br/>put there by image_picker, not by the app"]
-    Cache --> Enc{"Re-encode in memory<br/>longest edge 1024 px, quality 80"}
+    Cam["Camera"] --> Cache["Temporary copy in the app cache<br/>put there by image_picker, not by the app"]
+    Cache --> Enc{"Re-encode in memory<br/>shortest edge 1024 px, quality 80"}
     Enc -->|"succeeded"| Out["WebP to hosted providers<br/>JPEG to a server you run"]
-    Enc -->|"no usable encoder on this device"| Raw["The original file, unmodified<br/>only if its format is one the provider takes<br/>and only under 3 MB — otherwise nothing is sent"]
+    Enc -->|"no usable encoder on this device"| Raw["The original file at its own resolution<br/>metadata stripped first<br/>only if its format is one the provider takes,<br/>its metadata parses, and it is under 3 MB"]
     Out --> Send["base64, one request"]
     Raw --> Send
     Cache --> Del["Cache copy deleted, encoded or not<br/>best effort: if the delete fails, the OS clears it later"]
@@ -145,11 +153,13 @@ until the OS clears the cache. That is a narrower promise than "the file is gone
 request leaves", and the narrower one is the true one.
 
 **One branch sends more than the encoding above describes.** If the device has no usable encoder
-for the chosen container, the app falls back to sending the picked file *unmodified* rather than
-failing over an encoder the user has no way to install — so what leaves the device on that path is
-the camera's own output at its own resolution, not a 1024 px re-encode. Two conditions bound it:
-the file's format must be one the provider accepts, and it must be under 3 MB, or nothing is sent
-at all. The fallback is far rarer on the JPEG path than the WebP one, because JPEG encoders are
+for the chosen container, the app falls back to sending the picked file at its own resolution
+rather than failing over an encoder the user has no way to install — so what leaves the device on
+that path is the camera's own output, not a 1024 px re-encode. Its metadata is stripped first, EXIF
+above all: a phone geotags by default, and the app asks for no location permission. Three
+conditions bound it: the file's format must be one the provider accepts, its metadata blocks must
+parse — bytes the app cannot account for are refused rather than forwarded — and it must be under
+3 MB, or nothing is sent at all. The fallback is far rarer on the JPEG path than the WebP one, because JPEG encoders are
 universal where WebP's are not.
 
 The photo is never written to the documents directory, which is what the export zip reads — so a
@@ -183,8 +193,12 @@ Three of the four destinations are compiled-in `https://` URLs and cannot be red
 fourth is an address you supply, which makes it the only one where plaintext is possible at all —
 see [the guardrails](#the-guardrails).
 
-What each destination *keeps* is a policy question, not a mechanism one, and it lives in the
-README's [Privacy](../README.md#privacy) section. Two things there are worth knowing before you
+Most of what each destination *keeps* is a policy question rather than a mechanism one, and it
+lives in the README's [Privacy](../README.md#privacy) section — but two of the four requests carry
+a retention instruction of their own. The direct OpenAI call sends `store: false`, because
+Responses stores by default and silence there is not a no-op. The OpenRouter routing block sends
+`data_collection: "deny"` alongside the vendor pin, which makes a vendor that stores input
+non-transiently ineligible to serve the request at all. Two things there are worth knowing before you
 read this page's diagrams as reassurance: being reached directly is not the same as keeping less,
 and on the broker path the two retention policies **stack**.
 
@@ -245,8 +259,10 @@ provider exists to serve.
 
 ## A server you run: the probe
 
-When you point the app at your own server, it cannot know what that server can do. So it asks —
-once, at setup — by sending a real meal line and a real photograph through the shipping code path:
+When you point the app at your own server, it cannot know what that server can do. So it asks — at
+setup, and again each time you confirm that dialog, because the address and the model can be
+identical and the machine behind them different — by sending a real meal line and a real photograph
+through the shipping code path:
 the same prompts, the same schema, the same forcing mode, the same image encoder. A probe built
 from its own request would be testing a second implementation that nothing else uses.
 
@@ -267,7 +283,9 @@ stateDiagram-v2
 as `failed` would hide a working camera; recording an unproven guess as `passed` would offer a
 dead end. So every ambiguous outcome lands on `unknown`, and only two failure kinds are conclusive
 enough to close a capability: `unsupported` (nothing on the other end can serve this kind of
-request) and `rejected` (a guardrail refused it).
+request) and `rejected` (the provider refused the request itself — on the photo leg that means the
+picture, which will be refused again tomorrow). A refusal by the app's own plaintext guard is not
+one of these: nothing was sent, so nothing was learned, and it lands on `unknown` like a timeout.
 
 A stored `passed` is a fact about one `(endpoint, model)` pair, and it can stop being true without
 the user touching anything — pull a different model under the same tag and the camera is still
@@ -290,7 +308,7 @@ Independent checks, not a sequence. Each one is pinned by a test that fails if i
 
 | Gate | What it stops | Enforced in | Pinned by |
 |---|---|---|---|
-| Schema with no nutrition fields | a model supplying a calorie count | [`meal_items_api.dart`](../lib/features/add_meal/domain/meal_items_api.dart) | [`meal_items_api_contract_test.dart`](../test/unit_test/meal_items_api_contract_test.dart) — *output is held to the parser bounds, not the model* |
+| Schema with no nutrition fields | a model supplying a calorie count | [`meal_items_api.dart`](../lib/features/add_meal/domain/meal_items_api.dart) | [`openrouter_meal_items_api_test.dart`](../test/unit_test/openrouter_meal_items_api_test.dart) — *the schema exposes only query, quantity, unit and portion* |
 | Dart-side re-validation | a reply that ignored the schema | [`meal_text_parser.dart`](../lib/features/add_meal/util/meal_text_parser.dart) | [`meal_text_parser_test.dart`](../test/unit_test/meal_text_parser_test.dart) |
 | Payload never logged | the meal you typed, or a photo, reaching a log or an error string | all three clients | contract test — *a failing send puts the payload in neither the error nor the log*; *a photo never reaches the error or the log either* |
 | Response body withheld on rejection | a provider's error text carrying your content back into a log | all three clients | contract test — *a rejected request does not carry the response body* |

--- a/docs/ai-billing-status-codes.md
+++ b/docs/ai-billing-status-codes.md
@@ -1,0 +1,310 @@
+# Do Anthropic or OpenRouter distinguish exhausted credit from a rate limit?
+
+**Verdict: yes — both, and by HTTP status alone.** Each provider answers
+**402** when the account cannot pay and **429** when the account is going too
+fast. No message-string parsing is required, and no body inspection is
+required. The `billing` meaning can therefore be produced by both providers the
+app already ships, today. It does not have to wait for OpenAI.
+
+**The 402 belief about OpenRouter is confirmed, from OpenRouter's own error
+documentation** — *"Your account or API key has insufficient credits. Add more
+credits and retry the request."* listed against 402, and again in a typed table
+as `payment_required`. It was not taken from a search summary; the quote was
+grep-verified against the downloaded page.
+
+|  | Anthropic | OpenRouter |
+| --- | --- | --- |
+| No credit / insufficient balance | **402** `billing_error` | **402** `payment_required` |
+| Ordinary rate limit | **429** `rate_limit_error` | **429** `rate_limit_exceeded` |
+| **Separable by status alone?** | **yes** | **yes** |
+| Named code in the body | `error.type` | `error.metadata.error_type` |
+| Arrives inside a 200? | no | **no** — explicitly excluded (see [B3](#b3-billing-never-arrives-inside-a-200)) |
+
+Three things qualify this, none of which changes the verdict:
+
+1. **Anthropic never writes "insufficient credits → 402" in one place.** Its 402
+   is documented as *"There's an issue with your billing or payment
+   information"*; the fact that an empty balance stops API calls is stated in a
+   separate help-centre article that does not mention a status code. The join is
+   an inference. It is a well-corroborated one — see [A2](#a2-the-join-anthropic-does-not-make).
+2. **On OpenRouter, 402 is sufficient but not exhaustive.** A credit-based cap
+   can also surface as **400** `token_limit_exceeded`, and a free-model daily
+   quota surfaces as **429**. Details in [C](#c-the-third-case-quota-and-spend-caps).
+3. **Today both clients map 402 to `transient`**, via the `_ =>` default in
+   `_failureFor`. A user out of credit is currently told to try again later,
+   forever — the exact loop the `billing` decision was written to prevent.
+
+## How this was read
+
+Primary sources only, all read on **2026-08-17**. No live call was made and no
+key was used.
+
+Anthropic's docs publish a Markdown twin at `…​.md`; both Anthropic pages were
+downloaded that way and every quote below was **grep-verified verbatim against
+the downloaded file**, not transcribed from a rendering or a summary.
+OpenRouter's docs are client-rendered, so the pages were downloaded as HTML and
+quotes verified against the raw markup — including the JSX payload, because
+**the "HTTP Status" column of OpenRouter's typed-error tables renders empty in
+the served HTML**; the statuses live in `HTTPStatus.S402_Payment_Required`-style
+constants that are resolved in the browser. Every status in section B was read
+out of those constants.
+
+One search summary was checked against its source and **held up**: the
+help-centre sentence quoted in [A2](#a2-the-join-anthropic-does-not-make) is
+real and on the page attributed. The same check found that the article contains
+no occurrence of the string `402` at all, which is why this note treats the
+link as inference rather than documentation.
+
+| Page read | URL | Date shown |
+| --- | --- | --- |
+| Claude API errors | [`/docs/en/api/errors`](https://platform.claude.com/docs/en/api/errors) | none |
+| Claude API rate limits | [`/docs/en/api/rate-limits`](https://platform.claude.com/docs/en/api/rate-limits) | none |
+| How do I pay for my API usage? | [`support.anthropic.com/…/8977456`](https://support.anthropic.com/en/articles/8977456-how-do-i-pay-for-my-api-usage) | none |
+| OpenRouter — Errors and Debugging | [`/docs/api-reference/errors`](https://openrouter.ai/docs/api-reference/errors) | `dateModified` **2026-08-14** |
+| OpenRouter — Limits | [`/docs/api-reference/limits`](https://openrouter.ai/docs/api-reference/limits) | `dateModified` **2026-08-08** |
+
+## A. Anthropic
+
+### A1. The two codes
+
+From the error list, verbatim:
+
+> * 402 - `billing_error`: There's an issue with your billing or payment information. Check your payment details in the [Claude Console](https://platform.claude.com), or in AWS Marketplace if you're using Claude Platform on AWS.
+
+> * 429 - `rate_limit_error`: Your account has hit a rate limit.
+
+Distinct statuses, distinct `type` strings. The body shape is a top-level
+`error` object that *"always includes a `type` and `message` value"*, so the
+string is available too if a client wants belt and braces — but it is not
+needed to separate these two.
+
+Note 403 is **not** the billing case here: it is `permission_error`, *"Your API
+key does not have permission to use the specified resource."* The app's current
+`401 || 403 => auth` mapping is right for Anthropic.
+
+### A2. The join Anthropic does not make
+
+The errors page says 402 is about *"billing or payment information"*. It does
+not say "empty credit balance". The help-centre article says, verbatim and
+verified:
+
+> If you run out of credits, you will no longer be able to call the API or use Workbench.
+
+That article never mentions a status code. So "zero balance ⇒ 402" is an
+inference from two pages, not a documented statement on either.
+
+Two things corroborate it. Anthropic's 402 is the only documented status in the
+billing family, and 429 is documented narrowly as *"hit a rate limit"* with no
+mention of money. And **OpenRouter, which implements an Anthropic-compatible
+skin, maps its own `payment_required` (defined as insufficient credits) onto
+Anthropic's `billing_error`** — a third party's reading of which Anthropic-native
+code means "out of credit". That is corroboration, not Anthropic's word.
+
+The rate-limits page contains no occurrence of `402` or `billing_error` in an
+error context (checked by grep): the two concerns are documented apart, which is
+consistent with them being separate statuses.
+
+## B. OpenRouter
+
+### B1. The two codes
+
+From the `Error codes` list, verbatim:
+
+> **402**: Your account or API key has insufficient credits. Add more credits and retry the request.
+
+> **429**: You are being rate limited
+
+And from the typed-error tables — `payment_required`, status **402**:
+
+> The account or API key has insufficient credits. Add credits and retry.
+
+`rate_limit_exceeded`, status **429**:
+
+> Request- or token-level rate limit hit. Respect the `Retry-After` header before retrying.
+
+The Limits page states the same split structurally: a two-row table whose
+"Credit limits" row (*"How much you can spend (account balance and per-key
+credit caps)"*) carries **402** in its "Error on exceeding" column, and whose
+"Rate limits" row carries 429.
+
+### B2. There is also a stable named code — and it is an enum, not prose
+
+OpenRouter tags every error with a canonical string:
+
+> When a provider error reaches your application, OpenRouter tags it with a canonical `error_type` string — both on the non-streaming response body and on mid-stream SSE events. Use this value, not the HTTP status code alone, to programmatically distinguish error categories. It is stable across all three API skins even when the native protocol code is lossy.
+
+This is worth reading carefully, because it looks like it contradicts the
+verdict and does not. OpenRouter is warning that **its status codes are lossy in
+aggregate** — of the 27 documented `error_type` values, **13 share status 400**,
+and two each share 404 and 500. But **402 and 429 each map to exactly one
+`error_type`**, `payment_required` and `rate_limit_exceeded`. For the pair this
+note is about the status is therefore sufficient. `error_type` is available as a
+refinement, and it is a **closed enum**, not a message string, so consuming it
+would not be the unstable thing the project is trying to avoid.
+
+On the Chat Completions skin the app uses, it appears at
+`error.metadata.error_type`. The Limits page shows it in a real 429 body:
+
+```json
+{ "error": { "code": 429, "message": "Rate limit exceeded",
+             "metadata": { "error_type": "rate_limit_exceeded" } } }
+```
+
+### B3. Billing never arrives inside a 200
+
+This matters because `openrouter_meal_items_api.dart` already carries a second
+failure path for a 200 that is not a success. Billing does not use it:
+
+> The HTTP Response will have the same status code as `error.code`, forming a request error if:
+> * Your original request is invalid
+> * **Your API key/account is out of credits**
+
+Out-of-credit is named in the class that gets a real status line. Corroborated
+by the pre-stream section — auth and rate-limit checks are applied *"before any
+work begins"*, and mid-stream errors are listed as provider disconnect, provider
+timeout, token limit during generation, output content filter, provider
+overload. No billing case among them.
+
+So the 402 will reach `_failureFor(response.statusCode)` on the status line, and
+`_throwIfFailedGeneration` does not need to learn about billing.
+
+### B4. One alarming-looking thing that does not apply here
+
+OpenRouter documents a transformation turning certain limit errors into
+*successes*: `context_length_exceeded`, `max_tokens_exceeded`,
+**`token_limit_exceeded`** and `string_too_long` are each *"Transformed To"*
+`Success` with finish reason `length`, so that limit errors are handled
+*"without treating them as failures"*.
+
+**That table sits under the Responses API skin (`/api/v1/responses`), not Chat
+Completions** — confirmed structurally: it is an `h4` nested inside the `h3` for
+`Responses API`, and the `Chat Completions (/api/v1/chat/completions)` section
+above it has no such table. The app calls `/api/v1/chat/completions`, so a
+credit-based cap will not silently arrive as a successful `length` completion.
+
+## C. The third case: quota and spend caps
+
+There is a distinct third case on both providers, and it is the messiest part of
+the answer.
+
+**Anthropic — monthly spend cap.** Documented as a real thing:
+
+> Each of the Start, Build, and Scale tiers carries a monthly spend cap, which is the maximum your organization can spend on the API each calendar month. Once you reach your tier's spend cap, API usage pauses until the next month unless you request a higher limit.
+
+Users can also set their own limit below the tier cap. **The status returned
+when usage "pauses" is not documented on either page.** Either 402 or 429 is
+plausible and neither is stated. This is listed under
+[Not established](#not-established).
+
+**OpenRouter — four sub-cases, and they do not share a status:**
+
+| Case | Status | Notes |
+| --- | --- | --- |
+| Account balance at or below zero | **402** | *"If your account has a negative credit balance, you may see errors, including for free models."* |
+| Per-key credit cap exhausted | **402** | Handled under the page's own *"Handling 402 errors"* heading: *"If `limit_remaining` on the key is exhausted, raise the key's credit limit or wait for it to reset"*. Resettable, but still 402. |
+| Free-model daily/minute request cap | **429** | A quota that presents as a rate limit. |
+| `token_limit_exceeded` | **400** | *"A token budget enforced by OpenRouter (e.g. credit-based cap) was exceeded."* |
+
+The last two are the wrinkles.
+
+A **free-model daily cap** is a 429, so "try again later" is technically correct
+advice but "later" means tomorrow, not in sixty seconds. Nothing in the status
+distinguishes it from a per-minute limit; `X-RateLimit-Reset` on the response
+would, and `error_type` would not (both are `rate_limit_exceeded`).
+
+**`token_limit_exceeded` is a 400 that is partly a billing condition** — its own
+description names a credit-based cap. The app currently maps `400 => rejected`,
+which for the photo path means telling the user something is wrong with their
+image. This is the one case where status alone gives the wrong answer on
+OpenRouter, and the only one where reading `error.metadata.error_type` buys
+something real.
+
+## D. Retryability
+
+Both providers publish guidance, and both put billing outside the retryable set.
+
+**Anthropic**, verbatim:
+
+> The official SDKs automatically retry transient failures (such as connection errors, rate limits, and 5xx server errors) with exponential backoff, twice by default, honoring the `retry-after` header when present.
+
+Rate limits are named as retryable. 402 is not in the list. A 429 carries a
+`retry-after` header *"indicating how long to wait"*, plus `anthropic-ratelimit-*`
+headers giving remaining quota and an RFC 3339 reset time.
+
+**OpenRouter**, from the Limits page: for 429, *"Retry with exponential backoff.
+Rate limits are transient; wait and retry rather than immediately re-sending.
+Honor the `Retry-After` header when present."* For 402 the resolution steps are
+all user actions — add credits, raise the key's cap, or wait for its reset.
+`Retry-After` is documented on 429 and 503 only.
+
+So the shape the `billing` meaning wants — *fatal until the user acts, retrying
+will not help* — is what both providers' own guidance describes for 402.
+
+## What this means for the two clients
+
+Both `_failureFor` switches currently read:
+
+```dart
+401 || 403 => MealInterpreterFailure.auth,
+400 || 422 => MealInterpreterFailure.rejected,
+404 => MealInterpreterFailure.unsupported,
+_   => MealInterpreterFailure.transient,
+```
+
+402 falls through to `transient` on both. Adding `402 => billing` is a one-line
+change per client, needs no body parsing, and is justified by each provider's
+own documentation rather than by OpenAI's. Whether to also catch OpenRouter's
+`token_limit_exceeded` is a separate and much smaller question, and it does
+require reading the body.
+
+Noticed in passing and out of scope: OpenRouter's **403** is documented as
+*"Forbidden (insufficient permissions, guardrail block, or moderation flag)"*,
+so the current `403 => auth` mapping tells a user whose photo tripped a
+moderation filter to go check their API key. Anthropic's 403 has no such
+overload.
+
+## Not established
+
+- **What status Anthropic returns when a monthly spend cap or a self-set spend
+  limit is reached.** The behaviour is documented ("usage pauses until the next
+  month"); the status is not, on either page read. Not inferable — the case sits
+  between 402 and 429 on the published descriptions.
+- **Whether an empty Anthropic credit balance returns 402 specifically.** Argued
+  in [A2](#a2-the-join-anthropic-does-not-make) as a strong inference from two
+  pages plus OpenRouter's mapping. Not a documented sentence.
+- **Whether OpenRouter's pre-stream 402 body carries
+  `error.metadata.error_type`.** The typed-code section describes Chat
+  Completions `error_type` as appearing on mid-stream chunks and on non-streaming
+  responses *"when a provider error interrupts generation"*; the only pre-stream
+  example body shown is a 429. Immaterial to the verdict, which rests on the
+  status line.
+- **OpenRouter's free-model request-per-minute and per-day numbers.** Rendered
+  from client-side constants (`FREE_MODEL_RATE_LIMIT_RPM`,
+  `FREE_MODEL_NO_CREDITS_RPD`) that the served HTML does not resolve.
+- **Whether either provider's 402 is ever transient in practice.** Documentation
+  says the user must act. Only a live account with a drained balance would
+  confirm it, and this note made no calls.
+- **Anthropic page dates.** Neither doc page displays a last-updated date, so
+  the only guarantee offered is the read date, 2026-08-17. The OpenRouter dates
+  in the table above come from `dateModified` in the pages' own structured data.
+
+## Sources
+
+Anthropic:
+[Claude API errors](https://platform.claude.com/docs/en/api/errors) ·
+[Rate limits](https://platform.claude.com/docs/en/api/rate-limits) ·
+[How do I pay for my API usage?](https://support.anthropic.com/en/articles/8977456-how-do-i-pay-for-my-api-usage)
+
+OpenRouter:
+[Errors and Debugging](https://openrouter.ai/docs/api-reference/errors) ·
+[Limits](https://openrouter.ai/docs/api-reference/limits)
+
+Related notes in this repo:
+[`ai-openai-wire-format.md`](ai-openai-wire-format.md) ·
+[`ai-model-candidates.md`](ai-model-candidates.md) ·
+[`ai-open-research-questions.md`](ai-open-research-questions.md)
+
+In-repo files cited:
+[`lib/features/add_meal/domain/meal_interpreter_exception.dart`](../lib/features/add_meal/domain/meal_interpreter_exception.dart) ·
+[`lib/features/add_meal/data/anthropic_meal_items_api.dart`](../lib/features/add_meal/data/anthropic_meal_items_api.dart) ·
+[`lib/features/add_meal/data/openrouter_meal_items_api.dart`](../lib/features/add_meal/data/openrouter_meal_items_api.dart)

--- a/docs/ai-cleartext-http-policy.md
+++ b/docs/ai-cleartext-http-policy.md
@@ -1,0 +1,963 @@
+# What permitting cleartext HTTP would cost, and whether it can be scoped
+
+Research notes gathered 2026-08-20 against primary sources only —
+`developer.android.com`, `developer.apple.com`, and F-Droid's own documentation.
+Apple's documentation pages are client-rendered and returned nothing but a
+`<title>` to automated fetching, so every Apple quote below was taken from
+Apple's own DocC JSON endpoints under `developer.apple.com/tutorials/data/…`,
+which are the documents that back the rendered pages. Where a page would not
+yield its content by either route it is named in
+[Not verified](#not-verified) rather than replaced with a secondary source.
+Nothing here rests on a tutorial, a forum thread or a Stack Overflow answer.
+
+Written to answer one question for
+[#734](https://github.com/simonoppowa/OpenNutriTracker/issues/734) on map
+[#732](https://github.com/simonoppowa/OpenNutriTracker/issues/732): **what does
+it cost this app to permit cleartext HTTP, and can that permission be scoped
+narrowly instead of granted globally?** The motivating address is
+`http://192.168.1.5:11434` — Ollama on a desktop, the overwhelmingly common
+shape of a self-hosted LLM endpoint. This document states what each option
+costs. It does not pick one.
+
+## Bottom line up front
+
+**Scoping is expressible on iOS and is not expressible on Android**, and that
+asymmetry is the whole answer. Everything else is secondary.
+
+1. **Android cannot express "any private address."** A `<domain-config>` matches
+   a literal string, optionally with DNS-suffix matching via
+   `includeSubdomains`. The documentation describes no wildcard, no CIDR, and no
+   range. Worse, the matching that does exist is right-anchored (a suffix rule)
+   while an address range is left-anchored (a network prefix), so even a
+   generous reading of suffix matching over IP-shaped strings would point the
+   wrong way. And the config is a compiled build-time resource, while the
+   address is runtime user input — so the one form that *is* expressible, an
+   exact literal host, is exactly the thing the app cannot know in advance.
+2. **iOS can express it exactly.** `NSExceptionDomains` accepts IPv4 and IPv6
+   literals *and* CIDR ranges as of iOS 17, in Apple's own words: *"You can also
+   use a classless inter-domain routing (CIDR) range."* So
+   `10.0.0.0/8`, `172.16.0.0/12`, `192.168.0.0/16` and friends are a literal,
+   checkable expression of "private ranges only." Option B is achievable on
+   iOS and only approximable on Android.
+3. **On iOS the narrow option costs an App Store justification and the looser
+   one does not.** Apple lists five exceptions that require justification at
+   review; `NSExceptionAllowsInsecureHTTPLoads` — which the CIDR form needs — is
+   one of them. `NSAllowsLocalNetworking` is **not** on that list. So the
+   cheaper-at-review path is the *broader* one, which permits cleartext to any
+   IP literal (public ones included), any unqualified name, and any `.local`
+   name. Narrower scope, higher review cost. That inversion is the iOS decision.
+4. **The cleartext gate may not be the gate that is actually stopping this
+   app.** Both vendors document that their cleartext enforcement is
+   layer-specific. Android: *"there's no expectation that the `Socket` API
+   honors this flag."* Apple: *"ATS doesn't apply to calls your app makes to
+   lower-level networking interfaces."* This app reaches the network through
+   `package:http` → `dart:io` `HttpClient`, which is built on `SecureSocket` /
+   raw sockets, not on `HttpsURLConnection` or `URLSession`. A string search of
+   the Flutter engine binary pinned by [`.fvmrc`](../.fvmrc) finds no reference
+   to `NetworkSecurityPolicy` or `isCleartextTrafficPermitted`, and no such
+   check exists anywhere in the pinned Dart SDK, the `http` package, or the
+   Flutter framework. **The premise that the platform refuses the request
+   before the app sees it is plausible but unverified for this stack, and a
+   ten-minute device test would settle it.** See [Section F](#f-does-any-of-this-reach-this-apps-http-client).
+5. **The gate that certainly does bite is the local-network permission, and it
+   is on both platforms.** It is unrelated to cleartext — it would apply to
+   `https://192.168.1.5` too. iOS has had it since iOS 14 and an outgoing TCP
+   connection to a LAN address triggers it. Android 17 introduces
+   `ACCESS_LOCAL_NETWORK`, mandatory for apps targeting API 37, and Android
+   documents it as enforced *"deep in the networking stack, and thus they apply
+   to all networking APIs"* — the opposite of the best-effort language attached
+   to cleartext. Whatever this decision picks, LAN access is a runtime
+   permission prompt on both platforms within about two target-SDK cycles.
+6. **F-Droid does not care.** Its ten anti-features are Ads, Disabled Algorithm,
+   Known Vulnerability, Non-Free Addons, Non-Free Assets, Non-Free
+   Dependencies, Non-Free Network Services, No Source Since, Tethered Network
+   Services and Tracking. None concerns cleartext, transport encryption, or
+   network configuration. The Inclusion Policy says nothing about it either.
+   Permitting cleartext adds no anti-feature and no metadata obligation to
+   [#575](https://github.com/simonoppowa/OpenNutriTracker/issues/575).
+7. **Loopback is nearly free, and about to be free outright on Android.** From
+   Android 17, if no configuration is defined for localhost an implicit one is
+   included that *"allows cleartext traffic."* Below Android 17 a one-line
+   `<domain>localhost</domain>` config covers it. On iOS, loopback is not a
+   local network address under Apple's definition (a local network requires a
+   *"broadcast-capable network interface"*), so the permission prompt should not
+   apply — see the caveat in [Not verified](#not-verified).
+
+Two operational findings that hold regardless of which option is chosen:
+
+- **`android:usesCleartextTraffic` has a shelf life and is unnecessary here
+  anyway.** Google's own words: *"This attribute is getting deprecated and will
+  be ignored for apps targeting API levels 38 and above."* The app's `minSdk`
+  is 24 (Flutter 3.44.6's `minSdkVersionInt`), and a network security config
+  needs API 24, so the manifest flag buys nothing this app needs. Any
+  implementation should be a network security config, not the attribute.
+- **The README already carries a sentence this decision touches**, and so does
+  [`ai-legal-constraints.md`](ai-legal-constraints.md), which asserts at the
+  Data safety analysis that *"The 'Encryption in transit' declaration remains
+  true — HTTPS to whatever endpoint."* Permitting cleartext makes that claim
+  conditional on what the user typed. It is one sentence in two files, but it
+  is a sentence that currently says something false-once-shipped.
+
+## A. What the repo declares today
+
+Confirmed by reading, not by assumption:
+
+- [`android/app/src/main/AndroidManifest.xml`](../android/app/src/main/AndroidManifest.xml)
+  declares **neither** `android:usesCleartextTraffic` **nor**
+  `android:networkSecurityConfig`. A repo-wide grep for either string across
+  `android/` returns nothing. `android/app/src/main/res/xml/` contains only
+  `data_extraction_rules.xml` — there is no `network_security_config.xml` to
+  edit, so an implementation creates a file rather than changing one.
+- [`android/app/build.gradle`](../android/app/build.gradle) sets
+  `compileSdkVersion 36` and `targetSdkVersion 36`. `minSdkVersion` is
+  `flutter.minSdkVersion`, which in the pinned Flutter 3.44.6 is **24**.
+- [`ios/Runner/Info.plist`](../ios/Runner/Info.plist) contains **no**
+  `NSAppTransportSecurity` dictionary, no `NSLocalNetworkUsageDescription`, and
+  no `NSBonjourServices`. A grep for every ATS key across `ios/` returns
+  nothing.
+- [`ios/Podfile`](../ios/Podfile) pins `platform :ios, '15.5'`, and the Runner
+  target's `IPHONEOS_DEPLOYMENT_TARGET` is `15.5`. **This matters**: iOS 15.5
+  and 16 sit inside the version band where ATS permits IP-literal destinations
+  by default, and iOS 17 is where that stops. The app therefore straddles the
+  change.
+- The AI clients
+  ([`anthropic_meal_items_api.dart`](../lib/features/add_meal/data/anthropic_meal_items_api.dart),
+  [`openai_meal_items_api.dart`](../lib/features/add_meal/data/openai_meal_items_api.dart),
+  [`openrouter_meal_items_api.dart`](../lib/features/add_meal/data/openrouter_meal_items_api.dart))
+  all import `package:http/http.dart`. [`pubspec.yaml`](../pubspec.yaml) pins
+  `http: ^1.6.0`. There is no `cupertino_http`, no `cronet_http`, and no `dio`.
+- [`README.md`](../README.md) publishes a **"What leaves your device"** table
+  introduced as *"These destinations, nothing else"*, plus a per-destination
+  retention analysis. That is a falsifiable claim, which is why permitting
+  cleartext is a decision and not a config tweak.
+
+## B. Android — what is blocked, and how narrowly it can be told not to be
+
+### B1. The default, and the two switches
+
+The default is documented on the Network security configuration page:
+
+> Up to Android 8.1 (API level 27), cleartext support is enabled by default.
+> Applications can opt out of cleartext traffic for additional security.
+>
+> Starting with Android 9 (API level 28), cleartext support is disabled by
+> default. Applications that require cleartext traffic can opt in to cleartext
+> traffic.
+
+The Android 9 behaviour-changes page states the same thing in terms of the API
+the platform stacks consult:
+
+> If your app targets Android 9 or higher, the `isCleartextTrafficPermitted()`
+> method returns `false` by default. If your app needs to enable cleartext for
+> specific domains, you must explicitly set `cleartextTrafficPermitted` to
+> `true` for those domains in your app's Network Security Configuration.
+
+There are two switches, and only one of them has a future.
+
+**`android:usesCleartextTraffic`** — a single global boolean on `<application>`:
+
+> Indicates whether the app intends to use cleartext network traffic, such as
+> cleartext HTTP. The default value for apps that target API level 27 or lower
+> is `"true"`. Apps that target API level 28 or higher default to `"false"`.
+
+with two notes that between them retire it for this app:
+
+> This attribute is getting deprecated and will be ignored for apps targeting
+> API levels 38 and above. Specify a Network Security Configuration to control
+> cleartext traffic for API levels 24 and above. If your app targets API levels
+> 23 and below, you must specify `android:usesCleartextTraffic` in addition to
+> a Network Security Config.
+
+> This flag is ignored on Android 7.0 (API level 24) and above if an Android
+> Network Security Config is present.
+
+Android 17's all-apps behaviour-changes page repeats the plan:
+
+> In a future release, we plan to deprecate the `usesCleartextTraffic` element.
+> Apps that need to make unencrypted (HTTP) connections should migrate to using
+> a network security configuration file, which lets you specify which domains
+> your app needs to make cleartext connections to.
+
+This app's `minSdk` is 24, so the attribute is redundant today and ignored
+tomorrow. Any Android implementation of any option below is a
+`res/xml/network_security_config.xml` plus one manifest attribute.
+
+**The network security config** is the other switch, and it is the one that can
+in principle be scoped. `<base-config>` sets the app-wide default;
+`<domain-config>` overrides it per destination. The documented default
+`<base-config>` for API 28 and above is:
+
+```xml
+<base-config cleartextTrafficPermitted="false">
+    <trust-anchors>
+        <certificates src="system" />
+    </trust-anchors>
+</base-config>
+```
+
+and the documented shape of a per-destination permit, using the page's own
+example domain, is:
+
+```xml
+<domain-config cleartextTrafficPermitted="true">
+    <domain includeSubdomains="true">insecure.example.com</domain>
+</domain-config>
+```
+
+### B2. What a `domain-config` can actually match — the crux
+
+This is the question the map hangs on, and the documentation answers it
+narrowly. The `<domain>` element is:
+
+```xml
+<domain includeSubdomains=["true" | "false"]>example.com</domain>
+```
+
+with exactly one attribute:
+
+> `includeSubdomains`: If `"true"`, then this domain rule matches the domain and
+> all subdomains, including subdomains of subdomains. Otherwise, the rule only
+> applies to exact matches.
+
+and one resolution rule between competing configs:
+
+> Note that if multiple `domain-config` elements cover a destination, the
+> configuration with the most specific (longest) matching domain rule is used.
+
+That is the entire matching vocabulary. Reading the page for wildcards, CIDR
+notation, address ranges, port numbers or negation returns nothing — none of
+those words appear.
+
+**IP literals are legal `<domain>` values.** The page does not say so in the
+`<domain>` reference, but it says so unavoidably in the localhost section,
+which defines a configuration as targeting localhost when its domain is
+`localhost`, `ip6-localhost`, or:
+
+> a numerical IP address and `InetAddress.isLoopback()` is `true` (for example,
+> `127.0.0.1` or `[::1]`)
+
+A rule that inspects whether the numerical IP address in a `<domain>` element is
+a loopback address presupposes that a numerical IP address is a valid
+`<domain>` element. So *one* address can be permitted. **A range cannot.**
+
+Three reasons this is not a technicality:
+
+1. **No range syntax exists.** There is no documented CIDR form, no wildcard,
+   no prefix form. The only generalising operator is `includeSubdomains`.
+2. **The one generalising operator points the wrong way.** `includeSubdomains`
+   is a DNS-suffix rule: it extends a match leftward across label boundaries,
+   matching `X.example.com` from `example.com`. An IPv4 range is a *prefix*:
+   `192.168.0.0/16` constrains the leftmost 16 bits. Suffix matching over
+   IP-shaped strings, if it happens at all, would generalise `1.5` to
+   `192.168.1.5` — the host part, not the network part. Whether the matcher
+   even applies suffix logic to IP-shaped strings is undocumented and is in
+   [Not verified](#not-verified); either way it is the wrong axis.
+3. **Enumeration is not a workaround.** The RFC1918 space is
+   `10.0.0.0/8` + `172.16.0.0/12` + `192.168.0.0/16` ≈ 17.9 million addresses.
+   That is not a resource file.
+
+And even if a range were expressible, there is a second, independent blocker:
+**the network security config is a compiled resource, read by the platform,
+fixed at build time.** The address in question is typed by the user into a
+settings field at runtime. The app cannot ship a `<domain>` element for a host
+it will not learn about until after it is installed. The only literal hosts a
+build can know are ones the project chooses — `localhost` being the realistic
+member of that set.
+
+**So option B is not expressible on Android.** What is available instead is an
+approximation with the enforcement moved: `<base-config
+cleartextTrafficPermitted="true">` — a global permit — combined with the app
+itself refusing, in Dart, to build a request to any `http://` host that does not
+parse as an RFC1918, loopback or link-local literal. That is a real restriction
+and it is testable in the repo's own test suite. It is not a *platform*
+restriction, and the difference is the whole residual exposure: nothing outside
+the app checks, the check is defeated by any other code path in the app or in
+any dependency that makes its own HTTP calls, and a reader auditing the APK
+sees `cleartextTrafficPermitted="true"` with no indication of the narrowing.
+
+### B3. The localhost special case
+
+Loopback is treated differently, and increasingly so.
+
+From Android 17 (API level 37), the Network security configuration page
+documents an implicit configuration:
+
+> From Android 17 (API level 37) and higher, if no configuration has been
+> defined for localhost, an implicit configuration is included.
+
+which, by default:
+
+> - Allows cleartext traffic.
+> - Doesn't enforce certificate transparency (CT).
+> - Doesn't enforce certificate pinning.
+> - Delegates to `<base-config>` for trust anchors.
+
+The rationale the page gives is that enforcing these features for localhost
+connections is generally unnecessary.
+
+Below Android 17 there is no special case: a user running the server on the
+phone itself hits the same API 28 default as anyone else, and needs an explicit
+`<domain>localhost</domain>` (and, for the numeric form, `127.0.0.1` and
+`[::1]` — Android's localhost definition covers numeric loopback literals, but
+only inside an implicit-configuration rule that does not exist before API 37).
+
+Whether the Android 17 implicit config keys off the *device* version or the
+*target* SDK is ambiguous in the page's wording and is in
+[Not verified](#not-verified). If it keys off the target SDK, this app gets it
+when it targets 37 and not before.
+
+## C. Android 17 adds a second gate, and scoping does not avoid it
+
+This is the finding most likely to be missed, because it is filed under privacy
+rather than security and it has nothing to do with cleartext.
+
+Android 17 introduces `ACCESS_LOCAL_NETWORK`, a runtime permission:
+
+> Android 17 introduces the `ACCESS_LOCAL_NETWORK` runtime permission to protect
+> users from unauthorized local network access… Apps targeting Android 17 (API
+> level 37) or higher now have two paths to maintain communication with LAN
+> devices: Adopt system-mediated, privacy-preserving device pickers to skip the
+> permission prompt, or explicitly request this new permission at runtime to
+> maintain local network communication.
+
+Enforcement is by target SDK:
+
+> In Android 16, apps could opt in to local network permissions. Beginning with
+> Android 17, enforcement is mandatory for apps that target Android 17 (API
+> level 37) or higher.
+
+with a grace period this app currently sits inside:
+
+> Apps with INTERNET permission receive an implicit permission grant for
+> `ACCESS_LOCAL_NETWORK`, allowing them to retain access. This is temporary and
+> will be blocked by default once app bumps target SDK to 37.
+
+> Don't request `ACCESS_LOCAL_NETWORK` at runtime prior to targeting SDK 37.
+
+Three things make this consequential:
+
+**It applies to every networking API, unlike cleartext.** Android's own
+description is categorical where the cleartext language is hedged:
+
+> These restrictions are implemented deep in the networking stack, and thus they
+> apply to all networking APIs. This includes sockets created in the platform or
+> managed code, networking libraries like Cronet and OkHttp, and any APIs
+> implemented on top of those.
+
+"Sockets created in the platform or managed code" reaches `dart:io`. So even if
+the cleartext policy turns out not to touch this app's HTTP client
+([Section F](#f-does-any-of-this-reach-this-apps-http-client)), this will.
+
+**Android names the exact ranges Apple's CIDR list would name.** The Local
+network definition page defines a local network as *"an IP network that
+utilizes a broadcast-capable network interface, such as Wi-Fi or Ethernet, but
+excludes cellular (WWAN) or VPN connections"*, and enumerates:
+
+| Family | Ranges named |
+| :-- | :-- |
+| IPv4 | `169.254.0.0/16` (link-local), `100.64.0.0/10` (CGNAT), `10.0.0.0/8`, `172.16.0.0/12`, `192.168.0.0/16` |
+| IPv6 | link-local, directly-connected routes, stub networks such as Thread, multiple-subnets |
+| Special | multicast `224.0.0.0/4` and `ff00::/8`, IPv4 broadcast `255.255.255.255` |
+
+Loopback appears nowhere on that list, which is consistent with the
+broadcast-capable-interface definition excluding it, but the page does not say
+so — see [Not verified](#not-verified).
+
+**The timing is close.** Google Play's target API requirements page, read on
+2026-08-20, requires new apps and updates to target **API 36 or higher as of
+31 August 2026** (extensions available to 1 November 2026). The app is already
+at 36. On the annual cadence that page describes, the API 37 requirement
+follows in the 2027 cycle, at which point `ACCESS_LOCAL_NETWORK` becomes a
+runtime prompt this feature must handle. Costed properly, the LAN feature
+carries a permission-request flow on Android regardless of which cleartext
+option is picked.
+
+The user-facing surface: the permission sits in the `NEARBY_DEVICES` group, and
+the documentation notes that *"If a user has already granted another permission
+in this group (such as Bluetooth permissions), they won't be re-prompted for
+local network access."* Denial is not an exception the app can catch cleanly —
+TCP typically surfaces as a timeout.
+
+## D. iOS — App Transport Security, and where scoping is genuinely expressible
+
+### D1. What ATS blocks, and which of the app's traffic it covers
+
+Apple's framing:
+
+> On Apple platforms, a networking security feature called App Transport
+> Security (ATS) improves privacy and data integrity for all apps and app
+> extensions. It does this by requiring that network connections made by your
+> app are secured by the Transport Layer Security (TLS) protocol using reliable
+> certificates and ciphers. ATS blocks connections that don't meet minimum
+> security requirements.
+
+> ATS operates by default for apps linked against the iOS 9.0 or macOS 10.11
+> SDKs or later.
+
+and the scope sentence that matters most for a Flutter app:
+
+> The system enforces ATS when you use the standard URL Loading System.
+
+> ATS doesn't apply to calls your app makes to lower-level networking
+> interfaces like the Network framework or CFNetwork. In these cases, you take
+> responsibility for ensuring the security of the connection.
+
+When it does apply, the failure is a console message rather than a nice error:
+
+> App Transport Security has blocked a cleartext HTTP (http://) resource load
+> since it is insecure. Temporary exceptions can be configured via your app's
+> Info.plist file.
+
+### D2. The global keys, and what each actually permits
+
+`NSAppTransportSecurity` is a dictionary of optional keys, all defaulting to
+values Apple describes as suitable for most apps. Three matter here.
+
+**`NSAllowsArbitraryLoads`** (Boolean, default `NO`, iOS 9.0+) —
+
+> Set this key's value to `YES` to disable App Transport Security (ATS)
+> restrictions for all domains not specified in the `NSExceptionDomains`
+> dictionary.
+
+It is broader than "allow HTTP": it also drops the extended checks on HTTPS
+connections, including the TLS 1.2 minimum and forward secrecy. Apple attaches
+a justification requirement to it (see D3), and notes that from iOS 10 it is
+**ignored** — treated as `NO` — if `NSAllowsArbitraryLoadsForMedia`,
+`NSAllowsArbitraryLoadsInWebContent` or `NSAllowsLocalNetworking` is present.
+
+**`NSAllowsLocalNetworking`** (Boolean, default `NO`, iOS 10.0+) — the key with
+the confusing name, because it predates and is unrelated to the local-network
+*permission* in [Section E](#e-ios-local-network-permission). Verbatim:
+
+> The `NSAllowsLocalNetworking` key controls whether App Transport Security
+> (ATS) allows your app to connect to unqualified domains, `.local` domains, and
+> IP addresses using IPv4 or IPv6.
+
+> In iOS 10 through iOS 16, iPadOS 13.1 through iPadOS 16, and macOS 10.12
+> through macOS 13, ATS allows all three of these connections by default, so you
+> no longer need an exception for any of them. However, if you need to maintain
+> compatibility with older versions of the OS, set both of the
+> `NSAllowsArbitraryLoads` and `NSAllowsLocalNetworking` keys to `YES`.
+
+> In iOS 17, iPadOS 17, and macOS 14, ATS no longer allows connections to IP
+> addresses by default. Add individual IP addresses and classless inter-domain
+> routing (CIDR) ranges in the `NSExceptionDomains` dictionary.
+
+> The local networking exception tells newer versions of the OS to ignore the
+> arbitrary loads key, and enable access to unqualified domains, `.local`
+> domains, and IP addresses that they would otherwise restrict.
+
+Two consequences, and one unresolved tension.
+
+- **On iOS 15.5 and 16 — inside this app's deployment band — ATS already
+  permits `http://192.168.1.5:11434` with no plist entry at all**, because IP
+  literals are one of the three destination classes ATS allows by default in
+  that version range. The problem starts at iOS 17.
+- **`NSAllowsLocalNetworking` is not RFC1918-scoped.** It covers *any* IP
+  literal, public ones included, plus every unqualified name and every `.local`
+  name. It is narrower than `NSAllowsArbitraryLoads` — it does not touch the
+  HTTPS extended checks for named hosts — but it is not "private ranges only."
+- **The tension:** the third paragraph says newer OS versions must add IPs and
+  CIDR ranges to `NSExceptionDomains`; the fourth says the local networking
+  exception itself enables IP addresses newer OS versions "would otherwise
+  restrict." Apple does not reconcile these. Which one governs iOS 17+ decides
+  whether `NSAllowsLocalNetworking` alone is sufficient there. It is in
+  [Not verified](#not-verified) and it is the single most testable open
+  question on the iOS side.
+
+Apple also suggests declaring intent even where the default is permissive:
+
+> While ATS doesn't block local loads by default in newer versions of the OS,
+> consider setting `NSAllowsLocalNetworking` to `YES` as a declaration of
+> intent, if appropriate, even if you don't support older OS versions.
+
+### D3. `NSExceptionDomains` — the only place a range is expressible
+
+The domain-keyed dictionary is where iOS diverges from Android decisively:
+
+> The value for this key is a dictionary with keys that name specific domains,
+> IP addresses, or IP address ranges for which you want to set exceptions.
+
+with explicit rules, of which the second is the finding:
+
+> **Use a DNS domain name, IP address, or range of IP addresses** — In iOS 17,
+> iPadOS 17, and macOS 14, you can use an IPv4 address, for example
+> `192.168.42.63`, or an IPv6 address, for example `2001:db8:12::34`. You can
+> also use a classless inter-domain routing (CIDR) range, for example
+> `2001:db8:12::/48`.
+
+> **Don't include a port number** — Use `example.com`, not `example.com:443`.
+
+> **Don't use wildcard domains** — Don't use `*.example.com`. Instead, use
+> `example.com` and set `NSIncludesSubdomains` to `YES`.
+
+and a note that matters for a settings field where the user might type either a
+name or an address:
+
+> If you exclude a DNS domain name and your app contacts a host by IP address,
+> the ATS exclusion for the domain name doesn't apply to the connection even if
+> a DNS query for the domain name would resolve to the IP address. If you
+> exclude an IP address and your app contacts a host by DNS name that resolves
+> to that IP address, the ATS exclusion for the IP address doesn't apply to the
+> connection.
+
+Read plainly: a CIDR exception for `192.168.0.0/16` covers
+`http://192.168.1.5:11434` and does **not** cover `http://ollama.lan:11434`,
+even if `ollama.lan` resolves into that range. A user who types a hostname
+instead of an address falls outside the exception. Whatever B looks like on
+iOS, it is an address-based permission, and a hostname-based local setup needs
+either `NSAllowsLocalNetworking` (which covers unqualified names and `.local`)
+or a separate named exception.
+
+One more interaction, which reverses the usual precedence:
+
+> If you specify an exception domain dictionary, ATS ignores any global
+> configuration keys, like `NSAllowsArbitraryLoads`, for that domain. This is
+> true even if you leave the domain-specific dictionary empty and rely entirely
+> on its keys' default values.
+
+So the CIDR entries cannot lean on a global key; each needs
+`NSExceptionAllowsInsecureHTTPLoads` set on it:
+
+> Set the value for this key to `YES` to allow insecure HTTP loads for the given
+> domain, or to be able to loosen the server trust evaluation requirements for
+> HTTPS connections to the domain.
+
+### D4. What Apple documents about App Store review
+
+Apple documents the review consequence explicitly, and the list is the finding:
+
+> Adding certain ATS exceptions to your app's Information Property List file
+> requires you to provide justification, and might trigger additional App Store
+> review for your app. Exceptions that require justification are:
+>
+> - Arbitrary connection exceptions (`NSAllowsArbitraryLoads`)
+> - Media streaming exceptions (`NSAllowsArbitraryLoadsForMedia`)
+> - Web content loads (`NSAllowsArbitraryLoadsInWebContent`)
+> - Per-domain nonsecure connections (`NSExceptionAllowsInsecureHTTPLoads`)
+> - Per-domain minimum TLS version (`NSExceptionMinimumTLSVersion`)
+
+`NSAllowsLocalNetworking` is absent from that list, and unlike
+`NSAllowsArbitraryLoads` and `NSExceptionAllowsInsecureHTTPLoads` its
+documentation page carries no "You must supply a justification" note.
+
+Apple also lists example justifications, one of which describes this feature
+almost exactly:
+
+> - The app must connect to a server managed by another entity that doesn't
+>   support secure connections.
+> - The app must support connecting to devices that cannot be upgraded to use
+>   secure connections, and that must be accessed using public host names.
+
+The first fits a user-run Ollama server. Note the qualifier on the second —
+*"public host names"* — which does not fit a LAN address. And the closing
+instruction:
+
+> When submitting your app to the App Store, provide sufficient information for
+> the App Store to determine why your app cannot make secure connections by
+> default.
+
+> Always look for a way to avoid using exceptions as a first recourse. If you
+> must use an exception, make it as limited in scope as possible.
+
+**The inversion is worth stating once more.** The exception that most limits
+scope — CIDR ranges confined to RFC1918 — is the one Apple requires a
+justification for. The looser `NSAllowsLocalNetworking` is free at review.
+Following Apple's "as limited in scope as possible" instruction costs a review
+conversation; ignoring it does not.
+
+## E. iOS local network permission
+
+This is a separate mechanism from ATS, on a separate timeline, and it applies
+whether or not the connection is encrypted.
+
+**Availability** (from Apple's technote on local network privacy): iOS 14+,
+iPadOS 14+, visionOS 1+, macOS 15+. Not supported on tvOS or watchOS.
+
+**What counts as local:**
+
+> A local network is an IP network associated with a broadcast-capable network
+> interface. Such interfaces include Wi-Fi and Ethernet, but not cellular (WWAN)
+> or VPN. A local network address is any address on a local network. Traffic to
+> a local network address goes directly; it's not forwarded by a router.
+
+> In addition, all multicast addresses (224.0.0.0/4, ff00::/8) and the IPv4
+> broadcast address (255.255.255.255) are local network addresses.
+
+**Does it apply to a plain HTTP client hitting a LAN IP, as opposed to Bonjour
+discovery? Yes.** The technote's operations table lists *making an outgoing TCP
+connection* as requiring local network access — alongside sending UDP unicast,
+multicast and broadcast, and resolving a `.local` DNS name. Bonjour registration,
+browsing and resolution require it too, but they are not the only trigger. A
+`URLSession` (or any TCP client) opening a connection to `192.168.1.5:11434`
+requires it. Notably:
+
+- **The multicast entitlement is not needed.** `com.apple.developer.networking.multicast`
+  is documented as required for sending or receiving UDP multicast/broadcast and
+  for arbitrary Bonjour service types. A unicast TCP connection needs none of
+  that.
+- **`NSBonjourServices` is not needed** either, since the app registers and
+  browses nothing.
+- **`NSLocalNetworkUsageDescription` is needed.** Apple: *"Any app that uses the
+  local network, directly or indirectly, should include this description. This
+  includes apps that use Bonjour and services implemented with Bonjour, as well
+  as direct unicast or multicast connections to local hosts."* Available iOS
+  14.0+, macOS 11.0+.
+
+**What the user sees.** The privilege has three states — undetermined, allowed,
+denied. On the first local network operation the system presents an alert
+carrying the `NSLocalNetworkUsageDescription` string, and records the choice.
+Users change it later in *Settings > Privacy & Security > Local Network*. Two
+behaviours worth designing around:
+
+> If an iOS app is in the background and performs a local network operation
+> while its Local Network privilege is undetermined, the system denies that
+> operation without presenting the local network alert.
+
+and the technote's exclusions — traffic via `WKWebView`, `SFSafariViewController`
+and Safari does not require it, nor does traffic to a DNS server or proxy that
+happens to sit on the local network.
+
+**This is a user-visible sentence the project writes.** The
+`NSLocalNetworkUsageDescription` string is displayed verbatim in a system alert.
+It joins `NSCameraUsageDescription` and `NSPhotoLibraryUsageDescription` in
+[`Info.plist`](../ios/Runner/Info.plist), and it is read by more users than the
+README is.
+
+## F. Does any of this reach this app's HTTP client?
+
+Both vendors document that their cleartext enforcement lives at a particular
+layer, and both say so unprompted.
+
+Android, in the `usesCleartextTraffic` reference:
+
+> This flag is honored on a best-effort basis because it's impossible to prevent
+> all cleartext traffic from Android applications given the level of access
+> provided to them. For example, there's no expectation that the `Socket` API
+> honors this flag, because it can't determine whether its traffic is in
+> cleartext.
+
+> However, most network traffic from applications is handled by higher-level
+> network stacks and components, which can honor this flag by either reading it
+> from `ApplicationInfo.flags` or
+> `NetworkSecurityPolicy.isCleartextTrafficPermitted()`.
+
+Apple, in *Preventing Insecure Network Connections*:
+
+> ATS doesn't apply to calls your app makes to lower-level networking interfaces
+> like the Network framework or CFNetwork.
+
+Both mechanisms are opt-in from the client's side: the client must ask the
+policy, or route through a stack that asks on its behalf.
+
+**This app's client does not obviously ask.** The AI clients use
+`package:http`, which on mobile resolves to `dart:io`'s `HttpClient`, which
+opens `Socket`/`SecureSocket` connections directly. Three observations against
+the pinned toolchain (Flutter 3.44.6 per [`.fvmrc`](../.fvmrc)):
+
+- Searching the Dart SDK's `_http` and `io` libraries, the Flutter framework,
+  and the `http` package for `cleartext`, `Insecure HTTP`, or
+  `isInsecureConnectionAllowed` returns nothing.
+- A `strings` scan of the Flutter Android engine binary finds no
+  `NetworkSecurityPolicy`, no `isCleartextTrafficPermitted`, and no JNI class
+  path for either. (Matches are Skia's `clearTextureSupport` and an unrelated
+  media string.)
+- The Flutter Android embedding jar contains no network-security classes.
+
+**The honest conclusion is a question, not an answer.** These are observations
+about the shipped toolchain, not platform documentation, and they were not
+confirmed by running the app. If they hold, the premise in
+[#734](https://github.com/simonoppowa/OpenNutriTracker/issues/734) — that
+`http://192.168.1.5:11434` is *"refused by the platform before the app sees
+it"* — is false for this stack on both platforms today, and options A/B/C are
+about declared posture rather than about whether the request succeeds. That
+would change what each option buys quite a lot: in particular **option A,
+"require HTTPS", would have to be enforced by the app in Dart**, because
+neither platform would be enforcing it on the app's behalf.
+
+The test is small and decisive: build a debug APK and an iOS build with no
+config changes, point the client at an `http://` LAN address, and see whether
+the request completes. Do that before costing anything below. It is filed in
+[Not verified](#not-verified) because it was not run here.
+
+## G. F-Droid
+
+F-Droid's own [Anti-Features](https://f-droid.org/en/docs/Anti-Features/) page
+documents ten labels, and the complete list is the answer:
+
+| Anti-feature | F-Droid's description |
+| :-- | :-- |
+| Ads | advertising |
+| Disabled Algorithm | signed using an unsafe algorithm |
+| Known Vulnerability | known security vulnerability |
+| Non-Free Addons | promotes other non-libre apps or plugins |
+| Non-Free Assets | non-libre media in things that are not code |
+| Non-Free Dependencies | needs a non-libre app to work |
+| Non-Free Network Services | promotes or depends entirely on a non-free network service |
+| No Source Since | source code no longer available |
+| Tethered Network Services | depends entirely on a service which is impossible (or not easy) to replace |
+| Tracking | tracks and/or reports your activity to somewhere |
+
+**None concerns cleartext, transport encryption, TLS, or network
+configuration.** The two that sound closest are scoped elsewhere:
+*Disabled Algorithm* is *"applied to apps that were signed using a signature
+algorithm that is considered outdated or unsafe"* — app signing, not transport;
+*Known Vulnerability* is *"applied to apps with a known security vulnerability,
+found by one of the scanners in fdroidserver"* — scanner output over
+dependencies, with nothing on the page extending it to application
+configuration.
+
+The [Inclusion Policy](https://f-droid.org/en/docs/Inclusion_Policy/) contains
+nothing about network security, encryption, cleartext, HTTP versus HTTPS, or
+user-configurable endpoints. Its relevant machinery is the disclosure rule —
+apps that *"contain undisclosed anti-features will receive a rejection"* — which
+bites only where an anti-feature applies, and none does here. And anti-features
+are labels rather than bars: they *"serve as warning indicators about user
+freedom, privacy or etc. without necessarily disqualifying applications from
+inclusion."* Only `Tracking` hides an app by default in the client.
+
+**So permitting cleartext costs
+[#575](https://github.com/simonoppowa/OpenNutriTracker/issues/575) nothing** — no
+anti-feature, no metadata field, no hidden listing. This is entirely separate
+from the `NonFreeNet` question that
+[`fdroid-submission-feasibility.md`](fdroid-submission-feasibility.md) and
+[`ai-legal-constraints.md`](ai-legal-constraints.md) already work through, which
+is about *which* services the app promotes and is unaffected either way.
+
+One second-order note: `ACCESS_LOCAL_NETWORK` would appear in the app's
+permission list, and F-Droid renders permissions on its app pages. That is a new
+line on the listing whenever the app targets API 37 — but again, it follows from
+LAN access, not from cleartext.
+
+## H. Is it user-visible?
+
+Yes, on five surfaces, three of which a stranger can check without trusting the
+project.
+
+1. **The repo.** GPL-3.0, public. A new
+   `android/app/src/main/res/xml/network_security_config.xml` and a new
+   `NSAppTransportSecurity` dictionary in
+   [`Info.plist`](../ios/Runner/Info.plist) are both diffs anyone can read,
+   which is the strongest form of the README's existing "you can check this"
+   posture.
+2. **The shipped artifacts.** The merged manifest ships inside the APK and the
+   `Info.plist` ships inside the app bundle; both are readable from a downloaded
+   build. The README already teaches APK verification with `apksigner`, so this
+   audience exists.
+3. **The iOS system alert.** If the app reaches a LAN address, iOS shows the
+   local-network prompt carrying the project's own
+   `NSLocalNetworkUsageDescription` sentence. That is the most-read sentence in
+   this entire decision, and it is written by the project.
+4. **The Android permission list**, once the app targets API 37 and declares
+   `ACCESS_LOCAL_NETWORK` — visible in Play, in F-Droid, and in system settings
+   under *Nearby devices*.
+5. **Google Play's Data safety section.** Developers must declare whether user
+   data collected by the app is encrypted in transit. Permitting cleartext makes
+   that answer depend on an address the project does not control.
+   [`ai-legal-constraints.md`](ai-legal-constraints.md) currently records
+   *"The 'Encryption in transit' declaration remains true — HTTPS to whatever
+   endpoint."* Whichever option is chosen, that line needs revisiting; under B
+   or C it is no longer unconditionally true. The Data safety guidance lives on
+   `support.google.com` rather than `developer.android.com`, and the exact
+   question wording could not be extracted — see
+   [Not verified](#not-verified).
+
+Apple's privacy nutrition labels have no encryption-in-transit field, so there
+is no App Store listing equivalent to (5).
+
+**The README consequence.** The *"These destinations, nothing else"* table
+cannot enumerate an address the app does not know — a problem
+[#732](https://github.com/simonoppowa/OpenNutriTracker/issues/732) already
+names for the provider itself. Cleartext adds a second, smaller sentence on top
+of it: not only *where* the data goes but *how* it travels. Under B that
+sentence is checkable and bounded ("plain HTTP, and only to addresses on your
+own network"). Under C it is checkable and unbounded. Under A there is no
+sentence to write, which is A's main non-obvious benefit.
+
+## The three options
+
+Costs below assume [Section F](#f-does-any-of-this-reach-this-apps-http-client)
+resolves the ordinary way — that the platform gates do apply. If it resolves the
+other way, every row marked *platform-enforced* becomes *app-enforced* and A in
+particular gets more expensive rather than free.
+
+| | **A. Require HTTPS** | **B. Private/loopback only** | **C. Permit broadly** |
+| :-- | :-- | :-- | :-- |
+| **Android config** | none | **not expressible.** Closest: `base-config cleartextTrafficPermitted="true"` + a Dart-side RFC1918/loopback host check | `base-config cleartextTrafficPermitted="true"` in a network security config (not the deprecated attribute) |
+| **iOS config** | none | `NSExceptionDomains` with RFC1918/loopback/link-local CIDR entries, each `NSExceptionAllowsInsecureHTTPLoads=YES`; or the looser `NSAllowsLocalNetworking=YES` | `NSAllowsArbitraryLoads=YES` |
+| **Scoping achievable?** | n/a | **iOS yes, Android no** | n/a |
+| **App Store justification** | none | **yes** for the CIDR form; **none** for `NSAllowsLocalNetworking` | **yes** — and it also drops TLS-version and forward-secrecy checks on HTTPS |
+| **F-Droid** | none | none | none |
+| **Local-network permission** | still required if the endpoint is a LAN address | required | required |
+| **README / Data safety** | no change; every existing claim stands | one bounded sentence; Data safety "encrypted in transit" becomes conditional | one unbounded sentence; same Data safety change |
+| **Who enforces the narrowing** | platform | iOS: platform. Android: **the app's own Dart code, and nothing else** | nobody |
+| **Residual exposure** | none new | Android: any code path in the app or any dependency can speak cleartext anywhere, and no auditor of the APK can see the intended limit | any cleartext to any host from any code path, plus weakened HTTPS on iOS |
+| **What it costs users** | most self-hosted setups fail; the user must front Ollama with a reverse proxy holding a certificate the device trusts | works for the common `http://192.168.1.5:11434` case; **fails for a hostname** like `ollama.lan` under the iOS CIDR form; fails for a remote box the user rents | works everywhere the user points it |
+
+Three asymmetries worth carrying into the decision:
+
+- **B is not one option, it is two.** On iOS the CIDR form and the
+  `NSAllowsLocalNetworking` form differ in scope *and* in review cost, in
+  opposite directions. On Android there is only the approximation.
+- **A is not free either.** [#732](https://github.com/simonoppowa/OpenNutriTracker/issues/732)
+  scopes this feature at a user-run server; requiring HTTPS means requiring a
+  reverse proxy and a trusted certificate in front of Ollama, which is a
+  materially different feature from the one the map describes. It is the only
+  option with nothing to write in the README, and the only one where the
+  platform keeps enforcing the property the README claims.
+- **C's real cost is not the config line, it is the loss of the check.** Under
+  A and B a reader can verify the transport claim from the shipped artifact.
+  Under C the artifact says only "anything, anywhere," and the claim moves back
+  into prose the reader has to trust.
+
+## Not verified
+
+- **Whether Android's cleartext policy or Apple's ATS applies to this app's HTTP
+  client at all.** The vendor sentences quoted in
+  [Section F](#f-does-any-of-this-reach-this-apps-http-client) are documented;
+  the conclusion drawn from them for `package:http` → `dart:io` is an inference
+  from the pinned SDK's source and binaries, not from platform documentation and
+  not from a device test. **This is the highest-value open item in the
+  document** and it invalidates or confirms the framing of the whole question.
+- **Whether `<domain includeSubdomains="true">` does anything at all when its
+  value is IP-shaped.** Undocumented on the Network security configuration page.
+  Section B2's argument does not depend on the answer — suffix matching is the
+  wrong axis for a network prefix either way — but the behaviour itself is
+  unestablished.
+- **Whether `NSAllowsLocalNetworking=YES` alone restores IP-literal access on
+  iOS 17+.** Apple's page says both that iOS 17 requires `NSExceptionDomains`
+  entries for IP addresses *and* that the local networking exception enables
+  "IP addresses that they would otherwise restrict." The two paragraphs are in
+  tension and Apple does not reconcile them. Testable on a device in minutes;
+  it decides whether the justification-free iOS path exists at all.
+- **`NetworkSecurityPolicy` API reference.** Both the Java and Kotlin reference
+  pages returned only navigation to automated fetching, so
+  `isCleartextTrafficPermitted(String hostname)` was not read at its own page.
+  Per-host evaluation is established indirectly, from the "most specific
+  (longest) matching domain rule" sentence and from the method's own signature
+  as cited on other pages.
+- **`Manifest.permission#ACCESS_LOCAL_NETWORK`.** Same problem — the reference
+  page would not render. The permission's protection level and the exact
+  constant string were not read at the reference; the manifest form
+  `android.permission.ACCESS_LOCAL_NETWORK` comes from the Local network
+  permission guide.
+- **The literal text of the Android local-network prompt**, and of the iOS local
+  network alert beyond the fact that it carries
+  `NSLocalNetworkUsageDescription`. Neither page reproduces the alert copy.
+- **Whether the Android 17 implicit localhost configuration keys off the device
+  version or the app's target SDK.** The page's phrasing — "From Android 17 (API
+  level 37) and higher" — reads as a platform-version statement, but the
+  surrounding section concerns target-SDK-gated behaviour and a second reading
+  of the same page returned "apps targeting API 37 or higher." Not settled.
+- **Whether loopback is exempt from the local-network permission** on either
+  platform. Neither Apple's technote nor Android's local network definition
+  mentions loopback at all. Exemption is inferred from both definitions
+  requiring a broadcast-capable interface, which loopback is not. Inference,
+  not documentation.
+- **Google Play's Data safety question wording.** The Play Console Help page
+  did not yield the form's verbatim text to automated fetching, and it lives on
+  `support.google.com`, outside the source set this document was scoped to. The
+  claim in Section H rests on the paraphrase there plus the existing analysis in
+  [`ai-legal-constraints.md`](ai-legal-constraints.md).
+- **Whether Google Play has any *policy* against cleartext**, as opposed to the
+  advisory "Cleartext communications" risk page on `developer.android.com`.
+  Nothing policy-shaped was found on `developer.android.com`; the Play Developer
+  Program Policies were not read.
+- **The App Store Review Guidelines' own text on ATS.** Only the developer
+  documentation article was read. Apple's justification requirements are quoted
+  from *Preventing Insecure Network Connections* and from the two key pages that
+  carry the note; the Guidelines document itself was not consulted.
+- **When Google Play will require API 37.** The target API requirements page as
+  read on 2026-08-20 names API 36 with a 31 August 2026 date and an extension to
+  1 November 2026. No API 37 date is published there yet; the 2027 estimate in
+  Section C is extrapolation from the annual cadence, not a published deadline.
+- **Whether F-Droid's `fdroidserver` scanners inspect the network security
+  config.** Only the Anti-Features and Inclusion Policy pages were read; the
+  scanner source was not.
+- **macOS, tvOS, watchOS and visionOS.** Availability strings are reported where
+  Apple gave them, but this app ships iOS and Android and no other platform was
+  analysed.
+- **Whether a server running on the phone itself is reachable in practice** —
+  process lifetime, background execution and battery are separate questions this
+  document does not touch. Only the transport policy for loopback was
+  established.
+
+## Sources
+
+Android (all `developer.android.com`):
+[Network security configuration](https://developer.android.com/privacy-and-security/security-config) —
+defaults per API level, `base-config` / `domain-config` / `domain` element
+reference, `includeSubdomains`, longest-match rule, the Android 17 implicit
+localhost configuration ·
+[`<application>` manifest element](https://developer.android.com/guide/topics/manifest/application-element) —
+`usesCleartextTraffic` description, defaults, best-effort/`Socket` caveat, the
+API 38 deprecation note, `networkSecurityConfig` attribute ·
+[Behavior changes: Android 9 (API 28)](https://developer.android.com/about/versions/pie/android-9.0-changes-28) —
+`isCleartextTrafficPermitted()` returning `false` by default ·
+[Behavior changes: all apps (Android 17)](https://developer.android.com/about/versions/17/behavior-changes-all) —
+the `usesCleartextTraffic` deprecation plan, cross-profile loopback ·
+[Behavior changes: apps targeting Android 17](https://developer.android.com/about/versions/17/behavior-changes-17) —
+`ACCESS_LOCAL_NETWORK` introduction and mandatory enforcement, certificate
+transparency default ·
+[Local network permission](https://developer.android.com/privacy-and-security/local-network-permission) —
+manifest and runtime request, `NEARBY_DEVICES` group, "all networking APIs"
+statement, the implicit grant for apps below target 37 ·
+[Local network definition](https://developer.android.com/privacy-and-security/local-network-definition) —
+the enumerated IPv4/IPv6 ranges and the broadcast-capable-interface definition ·
+[Cleartext communications](https://developer.android.com/privacy-and-security/risks/cleartext-communications) —
+Google's stated risk and its scoping note ·
+[Target API level requirements for Google Play](https://developer.android.com/google/play/requirements/target-sdk) —
+the API 36 deadline and extension window.
+
+Apple (all `developer.apple.com`; read via the DocC JSON endpoints under
+`/tutorials/data/` because the rendered pages returned no body to automated
+fetching):
+[Preventing Insecure Network Connections](https://developer.apple.com/documentation/security/preventing-insecure-network-connections) —
+ATS requirements, the URL Loading System scope and the lower-level-interfaces
+carve-out, the exception dictionary structure, the justification list and
+example justifications ·
+[NSAppTransportSecurity](https://developer.apple.com/documentation/bundleresources/information-property-list/nsapptransportsecurity) —
+child keys, defaults, availability, the iOS 9 versus iOS 10+ versioning rule ·
+[NSAllowsArbitraryLoads](https://developer.apple.com/documentation/bundleresources/information-property-list/nsapptransportsecurity/nsallowsarbitraryloads) —
+what it disables, the justification note, the iOS 10+ ignore rule ·
+[NSAllowsLocalNetworking](https://developer.apple.com/documentation/bundleresources/information-property-list/nsapptransportsecurity/nsallowslocalnetworking) —
+what it covers, the iOS 9 / iOS 10–16 / iOS 17+ version bands, the
+declaration-of-intent note ·
+[NSExceptionDomains](https://developer.apple.com/documentation/bundleresources/information-property-list/nsapptransportsecurity/nsexceptiondomains) —
+domain string rules, IPv4/IPv6/CIDR support, no ports, no wildcards, the
+DNS-name-versus-IP non-equivalence note, the global-key override rule ·
+[NSExceptionAllowsInsecureHTTPLoads](https://developer.apple.com/documentation/bundleresources/information-property-list/nsexceptionallowsinsecurehttploads) —
+what it permits and its justification requirement ·
+[NSLocalNetworkUsageDescription](https://developer.apple.com/documentation/bundleresources/information-property-list/nslocalnetworkusagedescription) —
+when it is required, availability ·
+[TN3179: Understanding local network privacy](https://developer.apple.com/documentation/technotes/tn3179-understanding-local-network-privacy) —
+platform availability, the local network definition, the operations table
+(outgoing TCP requires access), the multicast entitlement scope, background
+denial, the Settings location.
+
+F-Droid (all `f-droid.org`):
+[Anti-Features](https://f-droid.org/en/docs/Anti-Features/) — the complete list
+of ten and each description, `Disabled Algorithm` and `Known Vulnerability`
+scope, `Tracking` as the only default-hidden flag ·
+[Inclusion Policy](https://f-droid.org/en/docs/Inclusion_Policy/) — anti-features
+as labels rather than bars, the undisclosed-anti-feature rejection rule, and the
+absence of any network-security clause.
+
+Google Play (outside the primary source set, used only where noted and flagged
+in Not verified):
+[Provide information for Google Play's Data safety section](https://support.google.com/googleplay/android-developer/answer/10787469).
+
+Repo files read to establish current state:
+[`android/app/src/main/AndroidManifest.xml`](../android/app/src/main/AndroidManifest.xml) ·
+[`android/app/build.gradle`](../android/app/build.gradle) ·
+[`ios/Runner/Info.plist`](../ios/Runner/Info.plist) ·
+[`ios/Podfile`](../ios/Podfile) ·
+[`pubspec.yaml`](../pubspec.yaml) ·
+[`.fvmrc`](../.fvmrc) ·
+[`README.md`](../README.md) ·
+[`lib/features/add_meal/data/anthropic_meal_items_api.dart`](../lib/features/add_meal/data/anthropic_meal_items_api.dart)
+
+Related notes in this repo:
+[`ai-legal-constraints.md`](ai-legal-constraints.md) ·
+[`fdroid-submission-feasibility.md`](fdroid-submission-feasibility.md) ·
+[`ai-model-candidates.md`](ai-model-candidates.md)

--- a/docs/ai-cohort-restrictions.md
+++ b/docs/ai-cohort-restrictions.md
@@ -1,0 +1,829 @@
+# Restrictions the cohort's experience places on our AI plan
+
+Research notes gathered 2026-08-02 against primary sources — the cohort
+projects' own `LICENSE` files and source, pub.dev's own licence pages, F-Droid's
+own docs and the `fdroiddata` metadata repository, providers' own legal pages,
+and the GPLv3 text in this repo's `LICENSE`. Written as the follow-up to
+[`ai-in-open-source-nutrition-trackers.md`](ai-in-open-source-nutrition-trackers.md)
+and [`ai-legal-constraints.md`](ai-legal-constraints.md), against the design
+recorded in [#599](https://github.com/simonoppowa/OpenNutriTracker/issues/599)
+as revised on 2026-08-02 and the tier-0 sub-issues
+[#600](https://github.com/simonoppowa/OpenNutriTracker/issues/600) /
+[#601](https://github.com/simonoppowa/OpenNutriTracker/issues/601) /
+[#602](https://github.com/simonoppowa/OpenNutriTracker/issues/602).
+
+The two earlier documents answer *what other projects did* and *what the law
+says*. This one answers a narrower question: **what is this project not allowed
+to do, or blocked from doing, that our current documents assume it can?**
+
+Every finding is labelled:
+
+- **Restriction** — a rule that forbids something. Compliance is not optional.
+- **Risk** — something that might go wrong or might be ruled against us.
+- **Cost** — permitted, but it costs time, money or capability.
+
+Design decisions already settled in #599's comments are taken as given and are
+not re-litigated. Where a document of ours is simply correct, that is recorded
+too — a clean bill of health on a specific point saves the next person the
+lookup. Things I could not verify are in [Not verified](#not-verified) rather
+than stated.
+
+## Bottom line up front
+
+Three restrictions actually change what gets built.
+
+1. **Google ML Kit is already in the APK, and it blocks F-Droid inclusion
+   outright** — not as an anti-feature label but under the Free Software
+   Requirement. `ai-legal-constraints.md` treats F-Droid as a labelling question
+   that a build flavour could tidy up later; it is a *blocking* question that
+   exists today, before any AI work.
+2. **Anthropic's Usage Policy prohibits disordered-eating and body-image
+   content in its Universal Usage Standards**, not only in the High-Risk
+   section. #599's decision table cites that prohibition as an OpenAI-specific
+   reason to prefer Anthropic. Both providers have it; Anthropic's is broader.
+3. **A local endpoint needs a request timeout in the minutes, and our documents
+   specify none.** Revision 2's whole reach argument rests on Ollama and
+   LM Studio, and the one cohort project that shipped that path measured 54–100
+   second responses and had to raise its client timeout to a 180-second default.
+
+Everything else is either a smaller restriction, an attribution obligation, or —
+in several places worth knowing — confirmation that what we wrote is right.
+
+## Restrictions that bind
+
+| # | Restriction | Type | Source | Affects | Consequence |
+| :-- | :-- | :-- | :-- | :-- | :-- |
+| C1 | Bundled Google ML Kit (via `mobile_scanner`) is proprietary; F-Droid requires every binary dependency to be freely licensed | Restriction | [F-Droid Inclusion Policy](https://f-droid.org/en/docs/Inclusion_Policy/); [ML Kit Terms](https://developers.google.com/ml-kit/terms) | RFP [#2540](https://gitlab.com/fdroid/rfp/-/issues/2540), not an AI issue | An `fdroid` flavour is needed regardless of the AI feature — swap the scanner, as Open Food Facts did |
+| D2 | Anthropic AUP forbids facilitating "disordered eating" and promoting "unhealthy or unattainable body image", in Universal Usage Standards | Restriction | [Anthropic Usage Policy](https://www.anthropic.com/legal/aup) | #599 decision #7 rationale; tier-1 prompt design | Never put weight, goal or body metrics in the prompt; never ask the model to comment on an intake pattern |
+| E1 | A user-supplied local endpoint needs a client timeout measured in minutes | Restriction | [fud-ai#147](https://github.com/apoorvdarshan/fud-ai/issues/147) | #599 revision 2 (endpoint field) | Configurable timeout, ~180 s default. Without it the Ollama/LM Studio story does not work at all |
+| C3 | A build flavour does **not** by itself avoid `NonFreeNet` | Restriction | [fdroiddata `com.inspiredandroid.kai.yml`](https://gitlab.com/fdroid/fdroiddata/-/raw/master/metadata/com.inspiredandroid.kai.yml) | `ai-legal-constraints.md` F-Droid section | The flavour must remove the prefilled commercial endpoint, not just proprietary libraries |
+| A3–A6 | NutriTrace (AGPL-3.0), Tandoor (AGPL + Commons Clause), MacroShot (FSL-1.1), SparkyFitness (non-commercial) cannot be copied into this repo | Restriction | Their `LICENSE` files; GPLv3 §5(c), §7, §10, §13 in this repo's `LICENSE` | #599 tier-1 checklist items lifted from those projects | Re-implement the ideas; do not lift the code |
+| A2 | MIT cohort code (Fud AI, Scranbook, EatWise) may be copied in, but the copyright and permission notice must ship with it | Restriction | Their `LICENSE` files | #599 checklist "Keystore corruption on reinstall" | Carry the notice, or write it fresh (and see E5 — you probably need neither) |
+| E2 | Image `media_type` must be sniffed from the bytes, not derived from the `.webp` filename | Restriction | [`user_image_storage.dart:91-108`](../lib/core/utils/user_image_storage.dart); [Anthropic vision docs](https://platform.claude.com/docs/en/build-with-claude/vision) | Tier 2; the plan's "no transcode" claim | Our own fallback path copies source bytes under a `.webp` name — HEIC would be rejected |
+| C5 | Bundled Unsplash demo photos are under a licence that restricts selling; F-Droid's `NonFreeAssets` names exactly that | Restriction | [Unsplash License](https://unsplash.com/license); [F-Droid Anti-Features](https://f-droid.org/en/docs/Anti-Features/) | `assets/demo/`, not an AI issue | Expect `NonFreeAssets` on any future F-Droid listing, or replace the 12 images |
+| D9 | LM Studio is proprietary software; naming it in the UI is promotion of a non-free app | Restriction | [LM Studio Terms](https://lmstudio.ai/terms); F-Droid `NonFreeAdd` | Tier-1 settings copy | If one local option is named, name Ollama (MIT) |
+| D7 | OpenAI prohibits "automation of high-stakes decisions in sensitive areas without human review", medical included | Restriction | OpenAI Usage Policies (stale mirror — see [Not verified](#not-verified)) | #602 | The confirm-before-log screen is a compliance artefact; removing it is not a UX-only change |
+| F2 | #600 segments on `,` and also accepts `,` as a decimal separator, with no stated precedence | Restriction (spec) | [#600](https://github.com/simonoppowa/OpenNutriTracker/issues/600) body vs its own test list | #600 | `1,5 l milk` cannot both segment and parse. Decide the order before writing the parser |
+
+---
+
+## A. Licence restrictions on reuse
+
+Our repo is GPL-3.0 (`LICENSE` is the unmodified GPLv3 text). The rules that
+govern reuse are in that file, and they are the primary source that actually
+binds us:
+
+- **§5(b)–(c)**: "The work must carry prominent notices stating that it is
+  released under this License and any conditions added under section 7" and
+  "You must license the entire work, as a whole, under this License … This
+  License gives no permission to license the work in any other way."
+- **§7**: "All other non-permissive additional terms are considered 'further
+  restrictions' within the meaning of section 10."
+- **§10**: "You may not impose any further restrictions on the exercise of the
+  rights granted or affirmed under this License."
+- **§13**: "you have permission to link or combine any covered work with a work
+  licensed under version 3 of the GNU Affero General Public License into a
+  single combined work … but the special requirements of the GNU Affero General
+  Public License, section 13, concerning interaction through a network will
+  apply to the combination as such."
+
+Read against the cohort:
+
+| Project | Actual licence (read from the repo) | May we copy code in? |
+| :-- | :-- | :-- |
+| [Train Libre](https://github.com/rfivesix/train-libre/blob/main/LICENSE) | GPL-3.0 (full GPLv3 text) | **Yes**, with §5(a)/(b) notices |
+| [Fud AI](https://github.com/apoorvdarshan/fud-ai/blob/main/LICENSE) | MIT — "Copyright (c) 2026 Apoorv Darshan" | **Yes**, notice must ship |
+| [Scranbook](https://github.com/taugr/scranbook/blob/main/LICENSE) | MIT — "Copyright (c) 2026-present Tom Auger" | **Yes**, notice must ship |
+| [EatWise](https://github.com/zkwi/EatWise/blob/main/LICENSE) | MIT — "Copyright (c) 2026 zkwi" | **Yes**, notice must ship |
+| [NutriTrace](https://github.com/TraceApps/nutritrace/blob/main/LICENSE) | AGPL-3.0 | **No** — see A3 |
+| [Tandoor](https://github.com/TandoorRecipes/recipes/blob/develop/LICENSE.md) | AGPL-3.0 **plus Commons Clause v1.0** | **No** |
+| [MacroShot](https://github.com/anirudhtopiwala/macroshot/blob/main/LICENSE.md) | FSL-1.1-Apache-2.0 | **No** (until each version's Change Date) |
+| [SparkyFitness](https://github.com/CodeWithCJ/SparkyFitness/blob/main/LICENSE) | Custom non-commercial | **No** |
+| [smooth-app](https://github.com/openfoodfacts/smooth-app/blob/develop/LICENSE) | Apache-2.0 | **Yes**, one-way, with NOTICE preserved |
+| [Robotoff](https://github.com/openfoodfacts/robotoff) | AGPL-3.0 (`LICENCE`, British spelling) | **No** — see A3 |
+| [NutriTracker (cdz-hy)](https://github.com/cdz-hy/NutriTracker/blob/main/LICENSE) | GPL-3.0 | **Yes** |
+| [Waistline](https://github.com/davidhealey/waistline) | GPLv3, at `www/LICENSE.txt` — see A8 | **Yes** |
+| [Food You](https://github.com/maksimowiczm/FoodYou/blob/main/LICENSE) | GPL-3.0; fdroiddata records `GPL-3.0-or-later` | **Yes** |
+
+**A1 — "Model on" Train Libre is fine; "mirror" its prompt is copying.
+Restriction (mild).** #599's second comment offers "adopting the Train Libre
+posture (model names foods, database supplies numbers)" as a way to re-settle
+decision #5. Adopting a design posture is not copying — ideas and architectural
+approaches are not the subject of the licence. But
+[`documentation/features/byok_ai_validation.md`](https://github.com/rfivesix/train-libre/blob/main/documentation/features/byok_ai_validation.md)
+is a file in a GPL-3.0 repository, so its system-prompt text, its Jaro-Winkler
+thresholds table (0.95 / 0.78 / 0.55) and its plausibility rules are covered
+expression. Lifting them verbatim is a copy, and GPLv3 §5(a) then requires
+"prominent notices stating that you modified it, and giving a relevant date".
+Since we are GPL-3.0 too this is cheap — but it is not nothing, and it should be
+done deliberately rather than by paste.
+
+**A2 — MIT does not mean "no strings". Restriction.** All three MIT cohort
+projects carry the standard clause: "The above copyright notice and this
+permission notice shall be included in all copies or substantial portions of the
+Software." #599's tier-1 checklist says the Keystore recovery path "Needs a
+catch-wipe-rebuild path", and the survey points at Fud AI's `KeyStore.kt` as the
+reference. If that code is transcribed, `Copyright (c) 2026 Apoorv Darshan` plus
+the MIT text has to ship in the repo and in any about/licences screen. See **E5**
+— the pinned `flutter_secure_storage` version already does this, so the cheapest
+answer is to copy nothing.
+
+**A3 — AGPL-3.0 code cannot be absorbed without changing what this app is.
+Restriction.** GPLv3 §13 permits *combining*, but the combination then carries
+AGPL §13's network-interaction requirement, and §5(c) forbids licensing the whole
+work any other way. Practically: for an app that runs no server, AGPL §13 is
+close to inert (as `ai-legal-constraints.md` already establishes), but the
+combination is no longer a plain GPL-3.0 work, downstream redistributors inherit
+the condition, and F-Droid's `License:` field would have to change. This bites on
+exactly one #599 checklist item — "Put wire-shape adaptation at the boundary",
+whose reference implementation is NutriTrace's
+[`server/routes/ai.js`](https://github.com/TraceApps/nutritrace/blob/main/server/routes/ai.js).
+Write the OpenAI-shape image normalisation from the wire format, not from their
+source.
+
+**A4 — Tandoor is not open source and cannot be copied at all. Restriction.**
+`LICENSE.md` opens with the Commons Clause: "the grant of rights under the
+License will not include, and the License does not grant to you, the right to
+Sell the Software", where "Sell" reaches "a product or service whose value
+derives, entirely or substantially, from the functionality of the Software". That
+is a non-permissive additional term — a "further restriction" under GPLv3 §7,
+which §10 forbids us from imposing on our recipients. The #599 checklist item
+"Cap request size and retry count even though the user pays" is modelled on
+Tandoor's `AiLog` credit ceiling and NutriTrace's caps; both must be
+re-implemented rather than adapted.
+
+**A5 — MacroShot is time-delayed, not open. Restriction.** FSL-1.1-Apache-2.0
+grants use "provided that you do not use the Licensed Work for a Competing Use",
+with a "Change Date: Two years from the date the Licensed Work is published" and
+a Change License of Apache-2.0. A use restriction is a further restriction. The
+first versions convert in 2028.
+
+**A6 — SparkyFitness is non-commercial and assigns contributions. Restriction.**
+"the Software may not be used, directly or indirectly, in any product, service,
+or project primarily intended for or resulting in commercial advantage" and
+"By submitting any code … you hereby assign **all** right, title" — both are
+incompatible with GPL-3.0 and with F-Droid's Free Software Requirement.
+
+**A7 — Apache-2.0 is safe and one-way. Clean.** smooth-app's
+[`main_fdroid.dart`](https://github.com/openfoodfacts/smooth-app/blob/develop/packages/smooth_app/lib/entrypoints/android/main_fdroid.dart)
+entry-point pattern — the single most directly useful piece of cohort code for
+us, given **C1** — is Apache-2.0 and may be adapted into a GPL-3.0 work provided
+Apache §4's notice and NOTICE-file obligations are honoured. The reverse
+direction is not available; nothing we write can go back to them under GPL.
+
+**A8 — Do not trust GitHub's licence badge. Risk (process).** `GET
+/repos/davidhealey/waistline/license` returns HTTP 404 — GitHub's detector finds
+nothing, because the licence lives at `www/LICENSE.txt` (35,149 bytes, the full
+GPLv3 text) and the README explains "The full license file is in the www
+sub-folder and the license notice is placed at the top of every source file". A
+"no licence file means all rights reserved" check run against the API alone would
+have got this exactly backwards. Read the tree. Of the fourteen cohort repos
+checked, **every one has a licence file**; the four that GitHub reports as
+`NOASSERTION` (SparkyFitness, Tandoor, MacroShot, Daily Dozen) are the four where
+reading the file actually matters.
+
+**A9 — Our own licence has no version qualifier. Restriction (procedural).**
+`LICENSE` is the bare GPLv3 text; there are no per-file headers, and the README
+badge says only "GPLv3". GPLv3 §14 governs what that means, and F-Droid metadata
+for peers is explicit either way — Food You is `GPL-3.0-or-later`, Daily Dozen
+and Translate You are `GPL-3.0-only`. If OpenNutriTracker is ever accepted into
+`fdroiddata`, a value has to be chosen. Worth deciding before someone else
+decides it for us, and worth deciding before absorbing GPL-3.0-only code from a
+peer, which would force the combination to `-only`.
+
+---
+
+## B. Dependency licence restrictions
+
+Checked against pub.dev's own licence page for each package.
+
+| Package | In pubspec today | Licence | GPL-3.0 compatible | F-Droid |
+| :-- | :-- | :-- | :-- | :-- |
+| [`flutter_secure_storage`](https://pub.dev/packages/flutter_secure_storage/license) | ✅ `^10.0.0` | BSD 3-Clause ("Copyright 2017 German Saprykin") | Yes | Fine |
+| [`http`](https://pub.dev/packages/http) | ✅ `^1.6.0` | BSD-3-Clause (Dart team) | Yes | Fine |
+| [`flutter_image_compress`](https://pub.dev/packages/flutter_image_compress) | ✅ `^2.4.0` | MIT | Yes | Fine |
+| [`image_picker`](https://pub.dev/packages/image_picker) | ✅ `^1.1.2` | BSD-3-Clause (Flutter team) | Yes | Fine |
+| [`sentry_flutter`](https://pub.dev/packages/sentry_flutter/license) | ✅ `^9.19.0` | MIT ("Copyright (c) 2019 Sentry") | Yes | Licence fine; **service** is the problem — see C6 |
+| [`mobile_scanner`](https://pub.dev/packages/mobile_scanner) | ✅ `^7.2.0` | BSD-3-Clause **package**, proprietary **ML Kit** binary | Package yes | **Blocks inclusion** — see C1 |
+| [`openai_dart`](https://pub.dev/packages/openai_dart) | ❌ (candidate) | MIT, v8.0.0, supports a custom `baseUrl` | Yes | Fine |
+| [`anthropic_sdk_dart`](https://pub.dev/packages/anthropic_sdk_dart) | ❌ (candidate) | MIT, v7.0.0, publisher `davidmiguel.com` | Yes | Fine |
+
+**B1 — No licence blocker exists in the dependency path tier 1 would need.
+Clean.** Every package the design implies is BSD-3, MIT or Apache-2.0, all of
+which are one-way compatible with GPL-3.0. There is no equivalent here of the
+licence skew the survey found at the project level.
+
+**B2 — And no new dependency is actually required. Clean.** `http ^1.6.0` is
+already in `pubspec.yaml`. #599's revision 2 settles on "three fields — endpoint,
+API key, model — speaking the OpenAI chat-completions shape", and revision 3
+settles on treating every response as untrusted text to be parsed by hand. Both
+of those decisions remove the reason to add `openai_dart`: a typed client whose
+guarantees you then discard is a dependency for nothing, and a typed client
+cannot help with an arbitrary user endpoint. This is worth stating positively
+because the plan's Scope-boundary promise of "no new dependency" can hold for
+tier 1 as well as tier 0.
+
+**B3 — WebP encoding is slower on iOS. Cost.** pub.dev's platform matrix for
+`flutter_image_compress`: WebP on Android "uses the system encoder, which is
+fast"; on iOS it is "encoded via SDWebImageWebPCoder. Functional, but noticeably
+slower than the other formats"; on macOS "not supported". HEIC is "iOS 11+ only"
+and on Android "API 28+ only, and requires a working hardware encoder". This is
+already the app's shipped pipeline so it is not new — but it is the mechanism
+behind **E2**.
+
+---
+
+## C. F-Droid restrictions
+
+Primary sources: the [Inclusion Policy](https://f-droid.org/en/docs/Inclusion_Policy/),
+the [Anti-Features page](https://f-droid.org/en/docs/Anti-Features/), the
+canonical definitions in
+[`fdroiddata/config/antiFeatures.yml`](https://gitlab.com/fdroid/fdroiddata/-/raw/master/config/antiFeatures.yml),
+and the per-app metadata YAML in `fdroiddata`.
+
+The canonical anti-feature strings, verbatim from `antiFeatures.yml`:
+
+| Key | Definition |
+| :-- | :-- |
+| `NonFreeNet` | "This app promotes or depends entirely on a non-free network service" |
+| `NonFreeDep` | "This app depends on other non-free apps" |
+| `NonFreeAdd` | "This app promotes non-free add-ons" |
+| `NonFreeAssets` | "This app contains non-free assets" |
+| `TetheredNet` | "This app depends entirely on a certain instance of a network service" |
+| `Tracking` | "This app tracks and reports your activity" |
+
+**C1 — ML Kit blocks inclusion today, and this has nothing to do with AI.
+Restriction.** This is the biggest finding in the document and it is
+present-tense.
+
+`pubspec.yaml` pins `mobile_scanner: ^7.2.0`, used in five screens. Its own
+documentation: "This package uses by default the **bundled version** of MLKit
+Barcode-scanning for Android." Google's
+[ML Kit Terms](https://developers.google.com/ml-kit/terms) state "you may not
+reverse engineer or attempt to extract the source code or any related software"
+— i.e. proprietary — and that the APIs "send metrics about the performance and
+utilization of the APIs in your app to Google". `android/gradle.properties`
+contains no `dev.steenbakker.mobile_scanner.useUnbundled=true`, and switching to
+the unbundled variant would only trade a bundled proprietary blob for a runtime
+Play Services dependency.
+
+The Inclusion Policy's Free Software Requirement is unambiguous:
+
+> All binary dependencies including JAR files must originate either from source
+> compilation or Debian repository downloads. … Applications can download
+> prebuilt FLOSS binaries with specific conditions from trusted Maven
+> repositories. … **Those binaries must still be freely licensed, simply being
+> included in one of those repositories is not enough.**
+
+and
+
+> Upstream developers must implement either a FLOSS alternative or **a build
+> flavour that does not require these dependencies** when such features become
+> necessary.
+
+`ai-legal-constraints.md` concludes that F-Droid is a labelling question —
+"`NonFreeNet` is a label, not a bar" — and offers the build flavour as an
+optional nicety "if the project cared to". That is right about the network
+service and wrong about the whole picture. The build flavour is required for
+[RFP #2540](https://gitlab.com/fdroid/rfp/-/issues/2540) to succeed at all, and
+the exemplar is Open Food Facts' `main_fdroid.dart` swapping ML Kit for ZXing.
+The good news is that `android/app/build.gradle` already declares
+`flavorDimensions "version"` with `develop` and `full`, so a third flavour is
+cheap.
+
+**C2 — "Optional and off by default" does not clear `NonFreeNet`. Restriction.**
+The definition is disjunctive: "promotes **or** depends entirely on". Our design
+comfortably fails the "depends entirely" limb — the app is fully usable with the
+feature off — but #599 revision 2 prefills "Anthropic's URL and a sensible model
+… as the default", and a prefilled commercial endpoint is promotion.
+
+**C3 — A build flavour does not by itself avoid the flag. Restriction, and this
+corrects `ai-legal-constraints.md`.** Kai 9000 is the decisive case:
+[`com.inspiredandroid.kai.yml`](https://gitlab.com/fdroid/fdroiddata/-/raw/master/metadata/com.inspiredandroid.kai.yml)
+selects `gradle: [foss]` in 49 of its 55 build entries **and still carries**
+`NonFreeNet: "Rely on Gemini and Groq"`. Compare
+[`org.breezyweather.yml`](https://gitlab.com/fdroid/fdroiddata/-/raw/master/metadata/org.breezyweather.yml),
+which selects `gradle: [freenet]` in 20 of 21 entries and carries no
+anti-features at all. The difference is not the existence of a flavour; it is
+what the flavour removes. A `foss` flavour that strips Google libraries but
+leaves the provider list intact earns the label anyway. The flavour has to remove
+the prefilled commercial endpoint.
+
+**C4 — the Translate You precedent in `ai-legal-constraints.md` is stale.
+Correction.** That document states Translate You "builds `gradle: [libre]`".
+[`com.bnyro.translate.yml`](https://gitlab.com/fdroid/fdroiddata/-/raw/master/metadata/com.bnyro.translate.yml)
+uses `libre` in only 3 build entries and `yes` in the 15 most recent, and the app
+carries **no `AntiFeatures:` block at all** while still supporting DeepL. So
+Translate You is not currently an example of the flavour pattern; Breezy Weather
+is. This weakens rather than strengthens the "you must have a flavour" reading,
+and suggests F-Droid's application of the "promotes" limb is not perfectly
+consistent — which is a reason to ask rather than to assume.
+
+**C5 — Bundled Unsplash photos are non-free assets. Restriction.**
+`pubspec.yaml` ships `assets/demo/alex_demo_avatar.jpg` and eleven JPEGs in
+`assets/demo/meals/`. The [Unsplash License](https://unsplash.com/license)
+states images "cannot be **sold** without significant modification" and does not
+grant "the right to compile images from Unsplash to replicate a similar or
+competing service". F-Droid's `NonFreeAssets` definition names precisely this
+shape: "apps using artwork … under a license that restricts commercial usage or
+making derivative works". The Inclusion Policy adds that non-functional assets
+"must allow redistribution when using non-commercial licenses". The comment in
+`unsplash_attribution.dart` correctly reasons about *attribution* — the general
+Licence does not require it — but attribution and freeness are different
+questions. Unrelated to AI; worth an issue of its own.
+
+**C6 — Sentry is the closest precedent we have, and it went against a peer.
+Risk.** The legacy Open Food Facts app's metadata carries `Tracking: "Analytics
+are opt-in but the app connects to sentry.io from the start, and connects even if
+rejected"` alongside `NonFreeNet` naming sentry.io among its servers. `Tracking`
+is the one anti-feature the F-Droid client hides by default. Our Sentry is opt-in
+and initialises only in release builds (`main.dart`), which is a materially
+better posture than the one that earned the label — but the label was earned on
+connection behaviour, not on the toggle, so the posture needs to be demonstrable
+rather than asserted.
+
+**C7 — F-Droid can build a Flutter app, in one specific shape. Restriction
+(build).** [`com.danemadsen.maid.yml`](https://gitlab.com/fdroid/fdroiddata/-/raw/master/metadata/com.danemadsen.maid.yml)
+is the working precedent: `submodules: true` with the Flutter SDK vendored into
+the repo and invoked as `packages/flutter/bin/flutter`, `flutter config
+--no-analytics` in `prebuild`, `scanignore: [packages/flutter/bin/cache]`,
+`scandelete: [.pub-cache, packages/flutter]`, `flutter build apk --release
+--split-per-abi`, and **one metadata entry per ABI** with a distinct
+`versionCode`. The Inclusion Policy separately permits this: "The Android SDK,
+Flutter SDK and Hermes have permission to use official prebuilt binaries until
+Debian provides alternative solutions." Our current release flow builds an AAB
+for Play; F-Droid needs per-ABI APKs from a vendored SDK.
+
+**C8 — F-Droid does permit shipping a client for a proprietary network service.
+Clean.** Inclusion Policy: anti-features "serve as warning indicators about user
+freedom, privacy or etc. **without necessarily disqualifying applications from
+inclusion**", and only `Tracking` is hidden by default. maid, oxproxion and Kai
+9000 are all in the main repository. There is no rule against the AI feature as
+such.
+
+**C9 — Never ship a project key. Clean, satisfied by construction.** "F-Droid
+does not sign up for any API keys. Even if provided by a third party, we include
+them in both binary and source code releases." BYO-key satisfies this by design.
+
+**C10 — If a local model is ever bundled or downloaded, it needs an explicit
+opt-in. Restriction (future).** "Applications must not download additional
+executable binary files (e.g. add-ons, auto-updates, etc.) without explicit user
+consent. Consent means it needs to be opt-in … and structured in a way that
+clearly explains to users that they're choosing to bypass F-Droid's checks."
+Nothing in the current design does this. It would bite immediately if #250's
+reopening conditions are ever met and an on-device model lands.
+
+---
+
+## D. Provider terms that bind the developer, not the user
+
+Our design is BYO-key and device-to-endpoint. The question is whether any of
+these terms reach *us* anyway.
+
+**D1 — Anthropic's Usage Policy scope clause reaches passthrough clients.
+Risk.** The AUP opens: "Our Usage Policy applies to anyone who can submit inputs
+to Anthropic's products and/or services, **including via any authorized resellers
+or passthrough access**, all of whom we refer to as 'users.'" That is a broader
+scope clause than "our customers". It does not obviously make a client-app
+developer a "user" — the developer never submits an input; the end user does, on
+their own device, with their own key. But the drafting anticipates the
+intermediary pattern, so the comfortable position that the AUP is purely the
+user's contract is not free. Treat AUP compliance as a design constraint on the
+prompt we ship, not as someone else's problem.
+
+**D2 — Anthropic prohibits disordered-eating and body-image content in its
+*universal* standards, and #599's provider rationale reads as though it does not.
+Restriction.** Under **Universal Usage Standards → "Do Not Create
+Psychologically or Emotionally Harmful Content"**:
+
+> Facilitate, promote, or glamorize any form of suicide or self-harm, including
+> disordered eating and unhealthy or compulsive exercise
+
+> Engage in behaviors that promote unhealthy or unattainable body image or
+> beauty standards, such as using the model to critique anyone's body shape or
+> size
+
+#599's decision table rejects OpenAI in part because "the usage policy prohibits
+*'disordered eating promotion or facilitation'*", implying a contrast. There is
+none: Anthropic has the same prohibition and adds a body-image limb that OpenAI's
+universal section does not. This does not unsettle decision #7 — the other three
+reasons for Anthropic (the nutrition carve-out from High-Risk, ephemeral image
+handling, structured outputs) stand — but it does impose a concrete constraint on
+the prompt:
+
+- do not include the user's weight, weight goal, BMI, TDEE or calorie deficit in
+  the request; the model does not need them to name a food;
+- do not add any feature that asks the model to comment on, summarise or judge
+  the user's intake pattern, body or progress. That is the "critique anyone's
+  body shape or size" limb, and it is where a "coach" feature would land.
+
+The app already ships a low-kcal warning and an intermittent-fasting content
+gate. Those instincts are correct and should extend to the prompt.
+
+**D3 — The High-Risk disclosure and human-review duties do *not* attach to this
+feature. Clean.** The AUP's structure is three sections: Universal Usage
+Standards, High-Risk Use Case Requirements, Additional Use Case Guidelines. The
+per-session disclosure — "If model outputs are presented directly to individuals
+or consumers, you must disclose to them that you are using AI to help produce
+your advice, decisions, or recommendations. This disclosure must be provided at a
+minimum at the beginning of each session" — sits in **High-Risk Use Case
+Requirements**, alongside "A qualified professional in that field must review the
+content or decision prior to dissemination or finalization." The High-Risk
+categories are Legal, Healthcare, Insurance, Finance, Employment and housing,
+Academic testing/accreditation/admissions, and Media or professional journalistic
+content — and Healthcare expressly excludes us: "Wellness advice (e.g., advice on
+sleep, stress, nutrition, exercise, etc.) does not fall under this category."
+
+So Anthropic imposes **no** attribution or per-session AI-disclosure duty on
+meal logging. The in-app disclosure `ai-legal-constraints.md` calls for is driven
+by Apple 5.1.2(i) and Google Play, not by Anthropic. The caution is the mirror
+image of D2: any drift toward advice flips the classification and switches on a
+*qualified-professional review* requirement that a solo project cannot satisfy.
+
+**D4 — The Commercial Terms bind the account holder, who is the user. Clean.**
+"Subject to these Terms, Anthropic gives Customer permission to use the Services,
+including to power products and services Customer makes available to its own
+customers and end users"; "Customer is responsible for all activity under its
+account"; "Customer and its Users may only use the Services in compliance with
+these Terms". Under BYO-key the user is Customer. Two clauses were checked
+specifically and do not bite:
+
+- **Resale.** "Customer may not and must not attempt to … resell the Services
+  except as expressly approved by Anthropic." The project charges nothing and
+  intermediates nothing.
+- **Credentials.** No clause was found forbidding a Customer from entering their
+  own key into third-party software running on their own device. The
+  confidentiality provisions run between the parties, not to the user's own
+  tooling.
+- **Age.** No minimum-age requirement appears in the Commercial Terms or the
+  AUP.
+
+**D5 — Anthropic will not name people in images, and says so in the docs.
+Clean.** The vision documentation lists under Limitations: "**People
+identification:** Claude [cannot be used](https://www.anthropic.com/legal/aup) to
+name people in images and refuses to do so." That matches
+`ai-legal-constraints.md`'s advice to never ask the model about people in the
+frame, and means the tier-2 photo path cannot accidentally acquire a biometric
+character through the model's own behaviour.
+
+**D6 — And it disclaims healthcare use. Clean, reinforcing.** Same page:
+"Although Claude can analyze general medical images, it is not designed to
+interpret complex diagnostic scans … Claude's outputs should not be considered a
+substitute for professional medical advice or diagnosis."
+
+**D7 — OpenAI's human-review clause makes #602 load-bearing. Restriction (source
+quality weak — see [Not verified](#not-verified)).** From the Usage Policies:
+
+> automation of high-stakes decisions in sensitive areas without human review …
+> medical
+
+> provision of tailored advice that requires a license, such as legal or medical
+> advice, without appropriate involvement by a licensed professional
+
+> suicide, self-harm, or disordered eating promotion or facilitation
+
+> promoting unhealthy dieting or exercise behavior to minors
+
+The confirm-before-log review screen in #602 is what keeps an OpenAI endpoint on
+the right side of the first clause, exactly as #599's third comment already
+argues it may be under AI Act Article 50(4). That is now two independent regimes
+resting on the same screen. It should be recorded in #602 that the screen is not
+purely a UX affordance.
+
+The "promoting unhealthy dieting … to minors" clause is worth a note because the
+app is not age-gated. Nothing in the current design targets minors or generates
+diet advice, so it does not attach — but a "coach" feature in an
+all-ages-rated app would.
+
+**D8 — Ollama is the only endpoint with no terms at all in the loop. Clean, and
+useful.** The Ollama binary is [MIT](https://github.com/ollama/ollama/blob/main/LICENSE)
+("Copyright (c) Ollama"). [ollama.com's Terms of Service](https://ollama.com/terms)
+govern the hosted service — they require account holders to be at least 18, cover
+registration and prohibited activities — and contain no clause about the local
+server API or third-party clients, because the local binary needs no account.
+Pointing the app at `http://localhost:11434` therefore engages no third-party
+terms, no age gate, and no data-handling question. That is a genuine argument for
+naming Ollama specifically in the settings copy.
+
+**D9 — LM Studio is proprietary, and that has an F-Droid consequence.
+Restriction.** [LM Studio's Terms](https://lmstudio.ai/terms) grant "a
+non-exclusive, non-transferable license to use the Software solely for Your
+personal and / or internal business purposes" and forbid, among other things:
+
+> (a) modify, adapt, alter, translate, or create derivative works from the
+> Software … (b) integrate the Software with other software other than through
+> Element Labs published interfaces made available with the Software … (c) use
+> any open source products with the Software in a manner that imposes … a
+> requirement … that the Software or any part thereof: (i) be disclosed or
+> distributed in source code for[m] … (e) reverse engineer, decompile,
+> disassemble
+
+Two consequences. First, a client speaking LM Studio's documented
+OpenAI-compatible local server *is* going "through Element Labs published
+interfaces", so the integration itself is permitted, and clause (c) is not
+triggered by an HTTP request — the FSF's socket analysis in
+`ai-legal-constraints.md` covers this. Second, and more practically: LM Studio is
+**non-free software**, so a settings screen that names it or prefills its port is
+promoting a non-free app, which is what F-Droid's `NonFreeAdd` covers ("This app
+promotes non-free add-ons") and adjacent to `NonFreeDep` ("This app depends on
+other non-free apps"). If the UI names exactly one local option — and it should,
+because "run a local server" is meaningless to most users — name Ollama.
+
+---
+
+## E. Technical restrictions the cohort hit that our documents do not account for
+
+The four already recorded in #599 (Keystore `AEADBadTagException`, key-regex
+validation, truncation vs malformed output, and the Anthropic image content-part
+shape) are not repeated. These are the ones that are not in our documents.
+
+**E1 — There is no timeout in our design, and a local endpoint needs a big one.
+Restriction — this is a hard blocker, not a bug.**
+[fud-ai#147](https://github.com/apoorvdarshan/fud-ai/issues/147) is the only
+cohort report from someone actually running the architecture #599 revision 2
+describes: a self-hosted Ollama with `qwen3-vl:4b` on a GTX 1660 Super, reached
+through the app's OpenAI-compatible custom-provider field.
+
+> Photo-based food logging consistently fails with a "network error: timeout" in
+> the app, even though the server-side request *does* complete successfully —
+> confirmed via server logs showing `HTTP 200` after ~54-100 seconds
+
+The maintainer's fix, in the same thread: "Ollama and Custom OpenAI-compatible
+request timeouts are now configurable from **30–600 seconds**, with a
+**180-second default**", plus downscaling analysis images to 1600 px before
+upload.
+
+Revision 2's central argument is that the endpoint field "removes the constraint
+that most weakened this feature" by making local inference viable. That argument
+does not survive a default HTTP timeout. Neither the plan nor #599 nor #601 nor
+#602 mentions a timeout at all. Concretely: whichever issue scopes the tier-1
+client must specify a configurable timeout with a default in the low hundreds of
+seconds, and the review screen must show progress rather than appearing hung —
+a 90-second wait with no feedback reads as a crash.
+
+**E2 — Our `.webp` filenames are not a guarantee, and Anthropic validates
+`media_type`. Restriction.** The plan and #599 both assert that "the existing
+1024 px q80 pipeline in `user_image_storage.dart` feeds the API with no
+transcode". Our own code says otherwise on the fallback path
+([`user_image_storage.dart:91-108`](../lib/core/utils/user_image_storage.dart)):
+
+> If the on-device WebP encoder is unavailable for some reason (very old
+> hardware, simulator quirks), `FlutterImageCompress` returns `null` and we fall
+> back to copying the source bytes verbatim — **the file extension stays
+> `.webp` either way** so callers don't have to branch on it.
+
+Anthropic's vision documentation: "Claude supports JPEG, PNG, GIF, and WebP
+images (`image/jpeg`, `image/png`, `image/gif`, `image/webp`)." HEIC is not on
+that list, and iOS `image_picker` can hand back HEIC. So a stored
+`meal_images/<code>.webp` that is actually HEIC bytes, sent with a `media_type`
+derived from its extension, is a request Anthropic rejects — and the failure
+would be a rare, device-specific, unreproducible bug report. The tier-2 client
+must sniff the format from the leading bytes and re-encode or refuse, not read
+the extension. This is a small change made much cheaper by knowing about it
+first.
+
+**E3 — Anthropic's hard image limits, sourced. Clean, with the numbers now
+written down.** From the vision docs, none of which our documents record:
+
+- maximum dimensions **8000×8000 px**;
+- maximum size per image **10 MB base64** on the Claude API (5 MB on Bedrock and
+  Google Cloud);
+- **32 MB request-size limit** for standard endpoints;
+- **≤20 image/document blocks per request**, above which "a stricter per-image
+  dimension limit applies" and oversize images are rejected with an
+  `invalid_request_error` referencing "many-image requests";
+- standard-tier models downscale anything with a long edge above **1568 px**
+  (high-resolution tier, Claude 4.7+, is 2576 px);
+- images cost `⌈width / 28⌉ × ⌈height / 28⌉` visual tokens.
+
+Our 1024 px q80 WebP is comfortably inside every one of these, single-image
+requests are far under the block limit, and the plan's arithmetic checks out:
+⌈1024/28⌉² = 37² = **1369 visual tokens**, exactly as stated. The lossy-compression
+warning the plan flags is verbatim from the same page. This is a clean bill of
+health for the tier-2 sizing decisions.
+
+**E4 — The cohort's only measured accuracy datum supports #601's database-first
+rule. Confirming.** [fud-ai#157](https://github.com/apoorvdarshan/fud-ai/issues/157),
+a feature request asking Fud AI to consult Open Food Facts before trusting the
+model:
+
+> I tested the exact same meal 10 times via text input with identical quantities
+> and brand names, and the reported calories varied by about 900 ± 300 kcal.
+> That's too inconsistent for reliable calorie tracking.
+
+The reporter also asks for "A small icon showing the source (🗄️ Database / 🤖 AI)".
+That is #601's database-first policy and #599 revision 1's `estimated` marker,
+independently arrived at by a user of the app that did not do it. The survey
+notes that no cohort project publishes measured accuracy; this is the closest
+thing, and it is a run-to-run *variance* figure rather than an error figure,
+which is arguably worse. It is a good argument to keep in #601.
+
+**E5 — The Keystore recovery path is already handled by the version we pin.
+Clean; a checklist item can be closed.** #599's tier-1 checklist opens with
+"Keystore corruption on reinstall … Needs a catch-wipe-rebuild path". The
+[`flutter_secure_storage` 10.0.0 changelog](https://pub.dev/packages/flutter_secure_storage/changelog)
+states:
+
+> ResetOnError will now automatically be true, because most errors are
+> unrecoverable due to key storage problems
+
+along with `encryptedSharedPreferences` being deprecated "due to Jetpack Crypto
+package deprecation", default ciphers moving to
+`RSA_ECB_OAEPwithSHA_256andMGF1Padding` and `AES_GCM_NoPadding`, and minimum
+Android SDK rising from 19 to 23. `pubspec.yaml` pins `^10.0.0`, so the
+catch-wipe-rebuild behaviour Fud AI had to write by hand in Kotlin is now the
+library default for us. Two follow-ons: the checklist item should be rewritten as
+"verify `resetOnError` is on and that losing the key on reinstall is surfaced to
+the user, not silently swallowed", and there is now no reason to transcribe
+`KeyStore.kt` (removing the **A2** attribution obligation entirely). minSdk 23 is
+below #599's stated floor of 24, so nothing is lost there.
+
+**E6 — One real store-review restriction in the cohort, and it is not about AI.
+Cost.** [train-libre#480](https://github.com/rfivesix/train-libre/issues/480) —
+"fix(ios): Restrict app deployment to iPhone only to bypass iPad screenshot
+requirements". The nearest neighbour project by construction hit an App Store
+submission requirement and solved it by narrowing device support. No cohort
+project shows an App Store or Play rejection caused by an AI feature; the survey's
+finding that "nobody was removed from F-Droid over AI" has a store-side
+equivalent. Absence of evidence, but the search was reasonably thorough.
+
+---
+
+## F. What our documents assume away
+
+**F1 — The plan's Scope boundary holds. Clean.** "Deterministic text parser" /
+"Any model, local or remote"; "Resolution against existing search" / "Network
+calls to any new destination"; "no new dependency". Verified against the repo:
+`resolve_parsed_meals_usecase.dart` reuses `SearchProductsUseCase`, which reaches
+only Open Food Facts and the Supabase backend — both already in the README's
+destination table — and the parser needs nothing that is not already in
+`pubspec.yaml`. Tier 0 changes nothing about the privacy table, and no restriction
+found in this document attaches to it. #600, #601 and #602 can proceed on the
+licence, F-Droid and provider-terms axes without further work.
+
+**F2 — #600 contradicts itself on the comma, and the cohort's own worked example
+is the failing case. Restriction (spec).** The issue body says "**Segment** the
+input on `,`, `;`, newline, and `+`" and then "Accept `.` or `,` as the decimal
+separator". Its own test checklist asks for both "Comma decimal (`1,5 l milk`)"
+and "Each separator: `,` `;` newline `+`". These cannot both hold under a
+naive left-to-right segmentation: `1,5 l milk` becomes `1` and `5 l milk`.
+
+This is not a nitpick, because it is exactly the case the cohort raised.
+[fud-ai#130](https://github.com/apoorvdarshan/fud-ai/issues/130) — the issue #599
+cites approvingly as validating #600's locale-independence — proposed a German
+quick-parser whose worked example was `1 EL Öl`, and German writes `1,5 l Milch`.
+Seven of the nine shipped locales use the comma as the decimal separator
+(`cs`, `de`, `it`, `pl`, `sk`, `tr`, `uk`); only `en` and `zh` do not. The
+parser needs a stated
+precedence rule (the obvious one: a comma flanked by digits on both sides is a
+decimal point, everything else is a separator), and #600's acceptance tests need
+a case that exercises both in one input, e.g. `1,5 l milk, 2 eggs`.
+
+**F3 — The Anthropic-versus-OpenAI rationale in #599 overstates the difference.
+Correction.** Covered at **D2**. The decision stands; the reasoning has one leg
+fewer than it appears to.
+
+**F4 — Revision 2's local-endpoint story carries two restrictions the comment
+does not.** The timeout (**E1**) and LM Studio's non-free status versus Ollama's
+MIT (**D9**). Both belong in whichever issue scopes tier 1.
+
+**F5 — `ai-legal-constraints.md`'s F-Droid section needs two corrections and one
+enlargement.** The build-flavour conclusion is too optimistic (**C3**), the
+Translate You citation is stale (**C4**), and the framing of F-Droid as a
+label-only question is wrong in two places that have nothing to do with AI —
+ML Kit (**C1**) and the Unsplash assets (**C5**). The net effect is that
+"F-Droid work" is a larger, earlier and more separable piece of work than that
+document implies, and it should not be bundled into the AI feature.
+
+**F6 — #602's review screen is now load-bearing under three regimes. Confirming,
+and worth recording in the issue.** AI Act Article 50(4)'s human-editorial-review
+exception (already noted in #599's third comment, flagged there as a reading
+rather than a verified position); OpenAI's prohibition on "automation of
+high-stakes decisions in sensitive areas without human review" (**D7**); and
+Anthropic's High-Risk human-in-the-loop requirement should the feature ever drift
+into advice (**D3**). #602 currently describes the screen purely as UX. A one-line
+note that removing or auto-confirming it has consequences beyond usability would
+be cheap insurance against a future "just log it automatically" optimisation.
+
+**F7 — A small drift worth fixing while nearby.** The plan and #599 both quote
+the README as promising *"these four destinations, nothing else"*. `README.md`
+line 131 says "**Three** destinations, nothing else" and lists Open Food Facts,
+the Supabase backend and Sentry. Not a restriction, but the sentence is the one
+the plan says "is the product", so it is worth quoting accurately.
+
+---
+
+## Not verified
+
+- **OpenAI's Services Agreement / Business Terms §2.2 and §3.3(g)** — the
+  clauses #599 cites as explicitly blessing BYO-key. `openai.com` returned
+  HTTP 403 to every attempt (WebFetch and `curl` with a browser user-agent, on
+  `/policies/services-agreement/`, `/policies/business-terms/` and the `en-GB`
+  variants). The BYO-key blessing remains unverified.
+- **OpenAI's current Usage Policies.** The text quoted at **D7** comes from a
+  Microsoft-hosted PDF copy
+  (`learn.microsoft.com/.../usage-policies-openai.pdf`) printed 2025-11-07 and
+  marked "Effective: October 29, 2025" — a mirror, and roughly nine months stale
+  as of today. The quotes are verbatim from that copy; they should be re-checked
+  against openai.com before being relied on.
+- **gnu.org's licence list and GPL FAQ.** Repeated HTTP 429 and a connection
+  reset; `curl` was served a 199-byte stub. Every GPL-compatibility conclusion in
+  section A is therefore drawn from the GPLv3 text in this repo's own `LICENSE`
+  (§5, §7, §10, §13, §14) rather than from the FSF's commentary. That is arguably
+  the better source for our purposes, but it means the FSF's own characterisation
+  of AGPLv3-versus-GPLv3 compatibility is not quoted here.
+- **What Kai 9000's `foss` flavour actually removes.** `fdroiddata` selects
+  `gradle: [foss]`, which is a fact from the metadata. I could not find a
+  `productFlavors` block in `composeApp/build.gradle.kts` on `main`, so the
+  inference at **C3** — that the flavour strips Google libraries but not the
+  provider list — is reasoning from the outcome, not from the build file.
+- **Whether F-Droid would in fact apply `NonFreeAssets` to the Unsplash demo
+  photos.** The definition fits the Unsplash Licence's no-sale clause, but no
+  ruling on Unsplash-licensed assets specifically was found in `fdroiddata` or
+  the F-Droid docs.
+- **Whether `ollama.com`'s Terms reach a locally-run `ollama serve`.** The Terms
+  describe an account-based hosted service and are silent on the local binary,
+  which is MIT and needs no account. Silence is not the same as an exclusion.
+- **Whether the ML Kit dependency can be swapped without losing barcode
+  formats.** `mobile_scanner` offers bundled and unbundled ML Kit; it does not
+  offer a free-software backend on Android. Open Food Facts used ZXing. Whether
+  ZXing covers every symbology the app relies on was not checked.
+- **Our current Play content rating and App Store age rating.** Neither is in the
+  repo — both live in the consoles — so the interaction between an all-ages
+  rating and OpenAI's "promoting unhealthy dieting … to minors" clause could not
+  be assessed.
+- **Whether `flutter.minSdkVersion` currently resolves to 24.**
+  `android/app/build.gradle` defers to the Flutter default rather than pinning a
+  number, so #599's "runs down to minSdk 24" claim was taken at face value.
+  `flutter_secure_storage` 10 requires 23, so the conclusion at **E5** holds
+  either way.
+- **Any App Store or Play rejection caused by an AI feature.** None found across
+  the cohort's issue trackers. That is an absence of evidence from a
+  keyword-driven search, not evidence of absence.
+
+## Sources
+
+Cohort licences, read from the repositories:
+[Train Libre](https://github.com/rfivesix/train-libre/blob/main/LICENSE) ·
+[Fud AI](https://github.com/apoorvdarshan/fud-ai/blob/main/LICENSE) ·
+[Scranbook](https://github.com/taugr/scranbook/blob/main/LICENSE) ·
+[EatWise](https://github.com/zkwi/EatWise/blob/main/LICENSE) ·
+[NutriTrace](https://github.com/TraceApps/nutritrace/blob/main/LICENSE) ·
+[Tandoor](https://github.com/TandoorRecipes/recipes/blob/develop/LICENSE.md) ·
+[MacroShot](https://github.com/anirudhtopiwala/macroshot/blob/main/LICENSE.md) ·
+[SparkyFitness](https://github.com/CodeWithCJ/SparkyFitness/blob/main/LICENSE) ·
+[smooth-app](https://github.com/openfoodfacts/smooth-app/blob/develop/LICENSE) ·
+[Waistline `www/LICENSE.txt`](https://github.com/davidhealey/waistline/tree/master/www) ·
+[Food You](https://github.com/maksimowiczm/FoodYou/blob/main/LICENSE) ·
+[NutriTracker (cdz-hy)](https://github.com/cdz-hy/NutriTracker/blob/main/LICENSE)
+
+Our own licence text: [`LICENSE`](../LICENSE) (GPLv3 §5, §7, §10, §13, §14).
+
+Package licences, from pub.dev's own licence pages:
+[flutter_secure_storage](https://pub.dev/packages/flutter_secure_storage/license) ·
+[sentry_flutter](https://pub.dev/packages/sentry_flutter/license) ·
+[flutter_image_compress](https://pub.dev/packages/flutter_image_compress) ·
+[mobile_scanner](https://pub.dev/packages/mobile_scanner) ·
+[openai_dart](https://pub.dev/packages/openai_dart) ·
+[anthropic_sdk_dart](https://pub.dev/packages/anthropic_sdk_dart) ·
+[flutter_secure_storage changelog](https://pub.dev/packages/flutter_secure_storage/changelog)
+
+F-Droid:
+[Inclusion Policy](https://f-droid.org/en/docs/Inclusion_Policy/) ·
+[Anti-Features](https://f-droid.org/en/docs/Anti-Features/) ·
+[`config/antiFeatures.yml`](https://gitlab.com/fdroid/fdroiddata/-/raw/master/config/antiFeatures.yml) ·
+[`com.inspiredandroid.kai.yml`](https://gitlab.com/fdroid/fdroiddata/-/raw/master/metadata/com.inspiredandroid.kai.yml) ·
+[`io.github.stardomains3.oxproxion.yml`](https://gitlab.com/fdroid/fdroiddata/-/raw/master/metadata/io.github.stardomains3.oxproxion.yml) ·
+[`com.danemadsen.maid.yml`](https://gitlab.com/fdroid/fdroiddata/-/raw/master/metadata/com.danemadsen.maid.yml) ·
+[`org.breezyweather.yml`](https://gitlab.com/fdroid/fdroiddata/-/raw/master/metadata/org.breezyweather.yml) ·
+[`com.bnyro.translate.yml`](https://gitlab.com/fdroid/fdroiddata/-/raw/master/metadata/com.bnyro.translate.yml) ·
+[`com.maksimowiczm.foodyou.yml`](https://gitlab.com/fdroid/fdroiddata/-/raw/master/metadata/com.maksimowiczm.foodyou.yml) ·
+[`openfoodfacts.github.scrachx.openfood.yml`](https://gitlab.com/fdroid/fdroiddata/-/raw/master/metadata/openfoodfacts.github.scrachx.openfood.yml) ·
+[RFP #2540](https://gitlab.com/fdroid/rfp/-/issues/2540)
+
+Provider terms:
+[Anthropic Usage Policy](https://www.anthropic.com/legal/aup) ·
+[Anthropic Commercial Terms of Service](https://www.anthropic.com/legal/commercial-terms) ·
+[Anthropic Service Specific Terms](https://www.anthropic.com/legal/service-specific-terms) ·
+[Anthropic vision documentation](https://platform.claude.com/docs/en/build-with-claude/vision) ·
+OpenAI Usage Policies (mirror, see [Not verified](#not-verified)) ·
+[Ollama Terms of Service](https://ollama.com/terms) ·
+[Ollama LICENSE](https://github.com/ollama/ollama/blob/main/LICENSE) ·
+[LM Studio Terms](https://lmstudio.ai/terms) ·
+[Google ML Kit Terms](https://developers.google.com/ml-kit/terms) ·
+[Unsplash License](https://unsplash.com/license)
+
+Cohort issue threads:
+[fud-ai#147](https://github.com/apoorvdarshan/fud-ai/issues/147) ·
+[fud-ai#157](https://github.com/apoorvdarshan/fud-ai/issues/157) ·
+[fud-ai#130](https://github.com/apoorvdarshan/fud-ai/issues/130) ·
+[train-libre#480](https://github.com/rfivesix/train-libre/issues/480)
+
+In-repo files cited:
+[`LICENSE`](../LICENSE) ·
+[`pubspec.yaml`](../pubspec.yaml) ·
+[`android/app/build.gradle`](../android/app/build.gradle) ·
+[`android/gradle.properties`](../android/gradle.properties) ·
+[`lib/core/utils/user_image_storage.dart`](../lib/core/utils/user_image_storage.dart) ·
+[`lib/core/utils/demo/unsplash_attribution.dart`](../lib/core/utils/demo/unsplash_attribution.dart) ·
+[`README.md`](../README.md)

--- a/docs/ai-in-open-source-nutrition-trackers.md
+++ b/docs/ai-in-open-source-nutrition-trackers.md
@@ -1,0 +1,599 @@
+# AI features in other open-source nutrition trackers
+
+Research notes gathered 2026-08-02 against primary sources — repositories,
+source files, dependency manifests, project docs, and issue threads. Written to
+inform issue [#599](https://github.com/simonoppowa/OpenNutriTracker/issues/599),
+which scoped AI-assisted meal logging for this app as a deterministic local
+parser for everyone plus an opt-in bring-your-own-key tier using Anthropic.
+
+Every factual claim below links to the file or issue it came from. Star counts
+and "last pushed" dates are as of 2026-08-02. Things I could not confirm are
+listed at the end rather than guessed at.
+
+> **Read alongside [`ai-cohort-restrictions.md`](ai-cohort-restrictions.md).**
+> This document answers *what other projects did*. That one answers *what we
+> are allowed to copy* — several of the projects surveyed here are under
+> licences (AGPL-3.0, FSL-1.1, Commons Clause, non-commercial) that this
+> repo's GPL-3.0 cannot take code from. Treat everything below as
+> read-for-ideas unless that document says otherwise.
+
+## Summary
+
+The landscape splits cleanly along a line that is not the one you would expect.
+The strictly-free, F-Droid-distributed calorie trackers with real user
+bases — [Waistline](https://github.com/davidhealey/waistline),
+[Food You](https://github.com/maksimowiczm/FoodYou),
+[FitBook](https://github.com/brandonp2412/FitBook) — have **no AI code at all**,
+not behind a flag and not in a branch; their dependency manifests contain no
+model runtime and no provider SDK. Everything that does ship AI is either
+self-hosted server software under a source-available or non-commercial licence
+([Tandoor](https://github.com/TandoorRecipes/recipes),
+[SparkyFitness](https://github.com/CodeWithCJ/SparkyFitness),
+[MacroShot](https://github.com/anirudhtopiwala/macroshot)), or a small
+mobile app that ships **bring-your-own-key and nothing else** — no bundled
+credential, no project-operated proxy
+([Fud AI](https://github.com/apoorvdarshan/fud-ai),
+[Train Libre](https://github.com/rfivesix/train-libre),
+[EatWise](https://github.com/zkwi/EatWise),
+[Scranbook](https://github.com/taugr/scranbook)). BYO-key is therefore the
+conventional choice, not a novel one; the two design decisions where
+OpenNutriTracker's plan is genuinely unusual are hardcoding a *single* provider
+(everyone else is multi-provider or OpenAI-compatible from day one) and letting
+the model emit macros at all (the closest comparator forbids it outright).
+Open Food Facts is the outlier in the other direction: it runs its ML
+server-side on self-hosted fine-tuned open weights and deliberately disables the
+one on-device ML dependency it has in its F-Droid build.
+
+## Comparison table
+
+| Project | Licence | AI feature | Where inference runs | Provider(s) | BYO key? | Shipped? |
+| :-- | :-- | :-- | :-- | :-- | :-- | :-- |
+| [Fud AI](https://github.com/apoorvdarshan/fud-ai) | MIT | Photo→meal (up to 10 images), text, voice, coach chat, nutrient-goal estimation | Device → provider, direct. Apple Intelligence on-device as last fallback | 13, incl. Anthropic, OpenAI, Gemini, Ollama, custom OpenAI-compatible | Yes, only | Yes — App Store + Play |
+| [Train Libre](https://github.com/rfivesix/train-libre) | GPL-3.0 | Photo + text meal capture; LLM forbidden from emitting numbers | Device → provider, direct; no intermediate server | OpenAI, Gemini, Anthropic, Mistral, xAI | Yes, only | Yes (beta) — App Store, Obtainium, own F-Droid repo |
+| [NutriTrace](https://github.com/TraceApps/nutritrace) | AGPL-3.0 | Conversational assistant with 16 tools, Smart Log text/voice, photo `propose_food`, Scan Label OCR | Self-hosted server (proxy mode) or browser → provider | Claude, OpenAI, Gemini, any OpenAI-compatible incl. Ollama | Yes (per-instance or admin env) | Yes |
+| [SparkyFitness](https://github.com/CodeWithCJ/SparkyFitness) | Non-commercial (custom) | "SparkyAI" chat logging, food-image logging | Self-hosted server | Anthropic, OpenAI, Gemini, Ollama, OpenAI-compatible | Yes (admin-configured) | Yes (beta) |
+| [Tandoor Recipes](https://github.com/TandoorRecipes/recipes) | AGPL + Commons Clause | Recipe import from image/PDF/text, step sorting, food + recipe property (nutrition) extraction | Self-hosted server, via LiteLLM | Anything LiteLLM routes | Yes, per space | Yes, since Tandoor 2 |
+| [Open Food Facts](https://github.com/openfoodfacts/robotoff) (Robotoff) | AGPL-3.0 | Category/brand/label prediction, nutrition-table extraction, ingredient spellcheck, logo ANN | Project's own servers (Triton) | Self-hosted fine-tuned Mistral-7B + custom models | No | Yes |
+| [Open Food Facts](https://github.com/openfoodfacts/smooth-app) (Smoothie app) | Apache-2.0 | On-device OCR/classification via ML Kit; on-device LLM exploratory only | On-device (non-F-Droid builds only) | Google ML Kit | No | Partly — **disabled in the F-Droid build** |
+| [MacroShot](https://github.com/anirudhtopiwala/macroshot) | FSL-1.1-Apache-2.0 (source-available) | Photo/text/barcode logging, MCP coach with 23 tools | Self-hosted server or author's hosted instance | Gemini (single, required env var) | No — operator supplies | Yes (open beta) |
+| [Scranbook](https://github.com/taugr/scranbook) | MIT | Photo→dish + label transcription; **macros computed locally** from bundled composition data | Browser → user's OpenAI-compatible endpoint | LM Studio default, any OpenAI-compatible | Yes, only | Yes (small) |
+| [EatWise](https://github.com/zkwi/EatWise) | MIT | Photo meal analysis, ranges only | Device → user's endpoint | OpenRouter default, any OpenAI-compatible | Yes, only | Yes (GitHub releases) |
+| [NutriTracker (cdz-hy)](https://github.com/cdz-hy/NutriTracker) | GPL-3.0 | Photo food recognition, weight + nutrient estimation | Device → user's endpoint | Any OpenAI-compatible multimodal | Yes, only | Yes (GitHub releases) |
+
+Projects with a comparable user base and **no AI**: Waistline (728★),
+Food You (515★), FitBook (157★), kcal (350★),
+[PANTS](https://github.com/dylanleigh/PriceAndNutritionTrackingSystem) (131★),
+[Daily Dozen](https://github.com/nutritionfactsorg/daily-dozen-android) (294★).
+
+## Fud AI — the closest shipped comparator
+
+[`apoorvdarshan/fud-ai`](https://github.com/apoorvdarshan/fud-ai), MIT, Kotlin
+(Compose) + Swift (SwiftUI), 299★, last pushed 2026-07-25. Ships on the
+[App Store](https://apps.apple.com/us/app/fud-ai-calorie-tracker/id6758935726)
+and [Google Play](https://play.google.com/store/apps/details?id=com.apoorvdarshan.calorietracker).
+The README contains no F-Droid reference.
+
+This is the app OpenNutriTracker's tier 1 + tier 2 would resemble if both
+shipped, and it is worth reading in full because it has already absorbed a
+year of BYO-key support load.
+
+**Provider surface.** Thirteen providers, enumerated in
+[`android/app/src/main/java/com/apoorvdarshan/calorietracker/models/AIProvider.kt`](https://github.com/apoorvdarshan/fud-ai/blob/main/android/app/src/main/java/com/apoorvdarshan/calorietracker/models/AIProvider.kt)
+as a Kotlin enum carrying a `baseUrl` and a curated `models` list per provider,
+mirrored by `ios/calorietracker/Models/AIProvider.swift`. Nine of the thirteen
+are just "OpenAI-compatible with a different base URL"; only Gemini and
+Anthropic need bespoke wire formats. Ollama and a free-form "Custom
+(OpenAI-compatible)" entry give local inference for free. There is a fallback
+provider setting: if the primary returns 429/503, the app silently retries
+against a second configured provider.
+
+**Key storage.**
+[`data/KeyStore.kt`](https://github.com/apoorvdarshan/fud-ai/blob/main/android/app/src/main/java/com/apoorvdarshan/calorietracker/data/KeyStore.kt)
+uses `EncryptedSharedPreferences` (AES-256, AndroidKeystore-backed), one entry
+per provider under an `apikey_` prefix; iOS uses `KeychainHelper`. This is the
+same substrate `flutter_secure_storage` sits on. That file also carries a
+comment worth reading before we write ours:
+
+> On Android 14/15 (and occasionally older), the AndroidKeystore master-key
+> alias survives `pm uninstall` but the encrypted prefs file does not — so a
+> reinstall […] hits an `AEADBadTagException` on the first read […] Without
+> this, the app crashes on `Application.onCreate` before showing any UI.
+
+Their recovery path catches the failure, deletes both the prefs file and the
+Keystore alias, and rebuilds.
+
+**No bundled key, and a hosted proxy they killed.** The README states plainly
+that requests "go directly from your device to the provider you configure", and
+that "The optional Fud AI Premium proxy from earlier iOS versions has been
+discontinued." A project of this size tried operating a paid proxy and stopped.
+[`SECURITY.md`](https://github.com/apoorvdarshan/fud-ai/blob/main/SECURITY.md)
+puts "Denial-of-service against the user's own AI provider via API quota
+exhaustion" explicitly out of scope as "a user-controlled cost, not a security
+boundary".
+
+**What BYO-key actually costs in support.** The issue tracker is the most
+valuable artefact here:
+
+- [#139](https://github.com/apoorvdarshan/fud-ai/issues/139) — Claude Sonnet
+  returns responses the app cannot parse ("Could not understand the AI
+  response"), while the Anthropic dashboard confirms the requests landed. The
+  community workaround was to tell users to add `Response Format: **1024
+  tokens**` to their custom instructions.
+- [#145](https://github.com/apoorvdarshan/fud-ai/issues/145) — the user raises
+  "Max response tokens" to 2048 to work around #139 and the app becomes
+  unstable and crashes. Fixed by handling "truncated and reasoning-only
+  responses safely".
+- [#105](https://github.com/apoorvdarshan/fud-ai/issues/105) — `unexpected char
+  0x0a at 15 in Authorization value`: the pasted key carried a trailing
+  newline.
+- [#140](https://github.com/apoorvdarshan/fud-ai/issues/140) — Google's new
+  `AQ.`-prefixed Gemini keys were rejected by the app's own key validation even
+  though they worked against Google's curl example.
+- [#106](https://github.com/apoorvdarshan/fud-ai/issues/106) — "What does it
+  mean api limit it reached?" drew a several-hundred-word maintainer reply
+  walking the user through three different free tiers.
+- [#63](https://github.com/apoorvdarshan/fud-ai/issues/63),
+  [#170](https://github.com/apoorvdarshan/fud-ai/issues/170) — keys that "don't
+  work", and a key entered during onboarding not showing up in settings.
+
+**Two declines worth noting.**
+[#36](https://github.com/apoorvdarshan/fud-ai/issues/36) asked for on-device
+Gemma via Google AI Edge Gallery; the maintainer kept it open as research but
+said current phone models are "weaker and slower" for "accurate structured
+nutrition JSON, image/label understanding, and serving estimates".
+[#130](https://github.com/apoorvdarshan/fud-ai/issues/130) proposed exactly the
+kind of deterministic local work OpenNutriTracker's tier 0 describes — a local
+correction-memory table and a German quick-parser for `1 EL Öl` — and was
+**closed as not planned**, on the grounds that a language-specific parser "would
+add language-specific behavior that would need to be maintained across all
+supported languages".
+
+## Train Libre — the same stack, the opposite call on estimates
+
+[`rfivesix/train-libre`](https://github.com/rfivesix/train-libre), GPL-3.0,
+Flutter/Dart, 5★, in beta since 2026-07-22 (currently `v1.0.0-beta.7`).
+Distributed via the Apple App Store, Obtainium, and **its own F-Droid
+repository**, not the main F-Droid catalogue.
+
+Technically this is the nearest neighbour we have: same language, same licence,
+same offline-first pitch, same `flutter_secure_storage`. Its design document
+[`documentation/features/byok_ai_validation.md`](https://github.com/rfivesix/train-libre/blob/main/documentation/features/byok_ai_validation.md)
+is the single most useful file found in this survey.
+
+**Key storage** is per-provider under `ai_api_key_openai`, `ai_api_key_gemini`,
+`ai_api_key_anthropic`, `ai_api_key_mistral`, `ai_api_key_xai`, via
+`FlutterSecureStorage`. "Train Libre does not deploy intermediate servers to
+handle AI requests."
+
+**The model is banned from producing numbers.** From the system-prompt rules:
+
+> **Macro/Calorie Ban**: The AI is strictly prohibited from estimating,
+> guessing, or returning any nutritional numbers (calories, protein, carbs,
+> fat). Nutritional calculations are resolved deterministically by Train Libre
+> using its local database.
+
+Instead the model is required to decompose a meal into atomic, generically-named
+ingredients ("Spaghetti Bolognese" → spaghetti, beef mince, tomatoes, onions,
+garlic, olive oil, parmesan), consolidate duplicates, and return grams plus a
+`mealContext` block containing an `expectedKcalRange`, a `cookingState`, and an
+`expectedMacroProfile`. Those anchors exist purely so a local engine can
+cross-check the database matches it produced.
+
+**The local validation engine** then fuzzy-matches each ingredient against the
+app's SQLite food database (Jaro-Winkler, thresholds at 0.95 / 0.78 / 0.55),
+applies plausibility rules (`grams > 3000` is a hard error, `< 5g` a warning),
+and runs four cross-checks against the anchors: total kcal deviation >25% warns
+and >50% errors; macro-profile deviation >15% warns; raw-vs-cooked state
+mismatch errors if caloric density differs by >30%; portion density outside
+0.5–2× the database default warns.
+
+**When validation fails, the model is demoted to a selector.** The engine pulls
+the top 5–10 fuzzy candidates from the local database, re-ranks them by cooking
+state, injects them into the repair prompt as a `CANDIDATES` block, and asks the
+LLM to pick — "The LLM acts as a semantic selector rather than an estimator."
+The loop runs at most three passes; a candidate passes only at score ≥70 with
+zero critical errors.
+
+This is the same problem OpenNutriTracker faces, solved by never letting the
+provenance chain break in the first place.
+
+## NutriTrace — self-hosted, and the only one with a documented proxy mode
+
+[`TraceApps/nutritrace`](https://github.com/TraceApps/nutritrace), AGPL-3.0,
+Svelte + Node, 162★, actively developed. Single Docker container, PWA plus a
+Capacitor Android build.
+
+"Trace AI" is a tool-using assistant (16 tools) that can read the diary,
+wellness data and fasting state, and propose foods and diary entries for
+confirmation. Providers are `claude | openai | gemini | oai-compat`, set via
+[`.env.example`](https://github.com/TraceApps/nutritrace/blob/main/.env.example)
+or the Settings UI.
+
+Two implementation details are relevant to us:
+
+- **Env vars lock the UI.** [`server/ai.js`](https://github.com/TraceApps/nutritrace/blob/main/server/ai.js)
+  seeds `ai_provider`, `ai_api_key`, `ai_model`, `ai_base_url` into an
+  `app_config` table and sets `ai_env_locked`; when locked, calls are proxied
+  server-side so "The API key never leaves the server". The key is stored as a
+  plain row in SQLite.
+- **The proxy is hardened against its own users.**
+  [`server/routes/ai.js`](https://github.com/TraceApps/nutritrace/blob/main/server/routes/ai.js)
+  caps requests at `AI_MAX_MESSAGES = 60` and `AI_MAX_BYTES = 8_000_000`, and
+  rate-limits to 30/minute, with the stated reason of bounding "a misbehaving
+  client (or compromised account) from burning through the admin's AI API
+  budget with one giant request".
+
+It also documents a wire-format bug worth knowing: the proxy normalises every
+image part to the OpenAI `{type:'image_url', image_url:{url:'data:...'}}` shape
+because an OpenAI-compatible gateway "would reject Anthropic-shaped image parts
+with `invalid content type=image`" (fixes their #114). Anthropic's native
+`{type:'image', source:{type:'base64', ...}}` shape is not portable.
+
+On privacy, the docs state that for voice logging "only the transcript reaches
+your configured LLM; the audio stays on-device", and the README carries a long
+medical disclaimer naming eating disorders, diabetes and pregnancy explicitly,
+ending "Trace AI answers can be incorrect or incomplete".
+
+## Tandoor Recipes — the largest shipped AI feature, and the Anthropic bug
+
+[`TandoorRecipes/recipes`](https://github.com/TandoorRecipes/recipes), 8501★,
+AGPL plus a Commons Clause rider (so not OSI-free). Recipe parsing is the close
+cousin of our text parsing, and Tandoor 2 shipped it.
+
+[`docs/features/ai.md`](https://github.com/TandoorRecipes/recipes/blob/develop/docs/features/ai.md)
+documents the design: everything routes through **LiteLLM**, so any provider it
+supports works; AI providers are configured per space (or globally by a
+superuser) with name, model, API key and optional base URL; and there is a
+**default spending limit of roughly 1 USD per month per space**, enforced by
+[`cookbook/helper/ai_helper.py`](https://github.com/TandoorRecipes/recipes/blob/develop/cookbook/helper/ai_helper.py)
+via an `AiLog` table that records input/output tokens and credit cost on both
+success and failure. `AI_RATELIMIT` defaults to `60/hour`.
+
+The API key is stored unencrypted: `api_key = models.CharField(max_length=2048)`
+on the `AiProvider` model in `cookbook/models.py`.
+
+Their documented troubleshooting list reads like a checklist of BYO-key failure
+modes: JSON mode is required and models that ignore `response_format` will
+error; vision support is required for image/PDF import; AI calls are synchronous
+so slow models hit reverse-proxy timeouts; cost tracking silently degrades if
+the provider does not return usage data. There is also an explicit warning that
+"AI import sends the entire file as base64 inside the request. Large files can
+exceed provider limits or reverse proxy limits."
+
+**The Anthropic-specific bug** is
+[#4659](https://github.com/TandoorRecipes/recipes/issues/4659), still open. The
+`aiproperties` endpoint 500s with `JSONDecodeError: Expecting value: line 1
+column 1 (char 0)` for any Claude model, because:
+
+> Although `response_format={"type": "json_object"}` is passed to LiteLLM, the
+> Anthropic backend in LiteLLM does *not* enforce JSON mode the way OpenAI does
+> — Claude is free to return JSON wrapped in a Markdown code fence.
+
+The reporter's own recommendation is to stop relying on the OpenAI-shaped
+`response_format` and "switch to Anthropic's structured outputs / tool-use
+schema enforcement". This is worth reading as a validation of #599's choice of
+constrained decoding rather than as a warning against Anthropic — but it also
+shows how easy it is to end up on the fence-stripping path by accident when you
+go through an abstraction layer.
+
+## Open Food Facts — server-side by design, and F-Droid-aware
+
+We already consume their API, so their posture matters.
+
+**Robotoff** ([`openfoodfacts/robotoff`](https://github.com/openfoodfacts/robotoff),
+AGPL-3.0, 113★) is a batch and real-time prediction service that turns product
+data into "insights" — category, brand and label prediction, nutrition-table
+extraction, logo ANN, image quality. Inference runs on their infrastructure
+behind a Triton inference server; high-confidence insights are auto-applied,
+lower-confidence ones go to human validation.
+
+Their [ingredients spellcheck](https://openfoodfacts.github.io/robotoff/references/ingredients-spellcheck/)
+is the clearest statement of philosophy: the production model is a **self-hosted
+fine-tune of Mistral-7B-Base**, benchmarked against GPT-4o, Gemini-1.5-flash and
+Claude 3 Sonnet and beating them on correction precision. A closed model
+(GPT-3.5-Turbo) was used only to *generate synthetic training data*, which was
+then reviewed in Argilla. Third-party APIs are a tool for building the model,
+not a runtime dependency.
+
+**On-device is treated as speculative and F-Droid-hostile.** The app-side
+tracker [smooth-app#4027](https://github.com/openfoodfacts/smooth-app/issues/4027)
+contains the line that matters most for us:
+
+> Add optional offline ingredient extraction using MLKIT (**disabled on the
+> F-Droid build**)
+
+and the same for packaging extraction. The mechanism is visible in the source:
+[`packages/smooth_app/lib/entrypoints/android/main_fdroid.dart`](https://github.com/openfoodfacts/smooth-app/blob/develop/packages/smooth_app/lib/entrypoints/android/main_fdroid.dart)
+is a separate entry point that swaps Google ML Kit for ZXing, tagged
+`ScannerLabel.ZXing` and `StoreLabel.FDroid`.
+[smooth-app#5009](https://github.com/openfoodfacts/smooth-app/issues/5009),
+"Explore using the on-device LLM for various tasks", has been open since January
+2024 and opens with "this is highly speculative"; food-intake journaling is
+listed under *speculative* use cases, and the caveats are battery drain and
+device availability.
+
+Their one concrete multimodal-LLM proposal,
+[openfoodfacts-ai#341](https://github.com/openfoodfacts/openfoodfacts-ai/issues/341),
+extracts a product name and brand from a photo — and gates it on
+"the user requests it (with a button?)".
+
+## Smaller projects, and one structural variant
+
+**Scranbook** ([`taugr/scranbook`](https://github.com/taugr/scranbook), MIT) is
+a local-first PWA whose README describes a split we should consider: the vision
+model identifies the dish and ingredients, but "Editable calorie and macro
+estimates calculated locally from bundled official food-composition data" —
+the model never produces the numbers. It also states "No external nutrition API
+and no medical, allergy, or food-safety claims", defaults to LM Studio with
+`google/gemma-4-e4b`, and requires "Response mode: Strict JSON schema".
+
+**EatWise** ([`zkwi/EatWise`](https://github.com/zkwi/EatWise), MIT, Kotlin)
+takes the presentation route instead: it ships model estimates, but the README
+says calories, macros and fibre are shown **only as wide ranges**, vegetable
+quantity is qualitative, and the result explicitly "does not count as a weighed
+record". Base URL defaults to OpenRouter; key, base URL, model and dietary goal
+are all user-supplied.
+
+**NutriTracker** ([`cdz-hy/NutriTracker`](https://github.com/cdz-hy/NutriTracker),
+GPL-3.0, Kotlin) is directly downstream of us — its README credits
+OpenNutriTracker as the origin of "灵感和部分程序思路" (inspiration and part of the
+program design), and it reproduces our IOM 2005 TDEE, WHO BMI and MET
+calculations. It adds photo recognition and states "应用不内置 AI 服务" — the app
+bundles no AI service; the user configures API key, base URL and model, and the
+settings screen offers a connection test that verifies multimodal capability.
+
+**A structural variant: expose the tracker, don't embed the model.** A visible
+cluster of projects skips in-app AI entirely and ships an MCP server so the
+user's own agent does the logging —
+[`akutishevsky/nutrition-mcp`](https://github.com/akutishevsky/nutrition-mcp)
+(30★), [`rockitdev/macro-engine`](https://github.com/rockitdev/macro-engine),
+[`neonwatty/food-tracker-mcp`](https://github.com/neonwatty/food-tracker-mcp),
+[`RenierM26/calorie-tracker`](https://github.com/RenierM26/calorie-tracker).
+Fud AI was asked for exactly this in
+[#110](https://github.com/apoorvdarshan/fud-ai/issues/110) and declined it —
+"there's no backend, no account, and no cloud sync, so there's no server for an
+external tool like Claude to connect to" — offering JSON/CSV/Markdown export
+instead. That answer applies verbatim to us.
+
+## Projects that considered AI and declined
+
+**Grocy** ([`grocy/grocy`](https://github.com/grocy/grocy), 9337★) has declined
+every AI request it has received. On
+[#917 "AI vision"](https://github.com/grocy/grocy/issues/917), asking for ML Kit
+object detection, the maintainer closed with: "This is more something for native
+companion apps or other external add-ons."
+[#2486](https://github.com/grocy/grocy/issues/2486) (fridge camera with object
+recognition) and [#2927](https://github.com/grocy/grocy/issues/2927) (AI
+recipes) were both closed as duplicates without engagement. The consistent
+position is that AI belongs outside the core.
+
+**Food You** ([`maksimowiczm/FoodYou`](https://github.com/maksimowiczm/FoodYou),
+515★, GPL-3.0, on F-Droid with no anti-features) has an open request that is
+almost exactly #599's tier 1:
+[#419 "Natural Language AI Food Logging"](https://github.com/maksimowiczm/FoodYou/issues/419),
+opened 2026-05-25. The reporter even anticipates the architecture — "to maintain
+the app's open-source nature and avoid server costs for the developer, this
+could be implemented by allowing users to simply input their own API key (e.g.
+OpenAI, Gemini, Anthropic, or even a local AI endpoint)". Nine months on there
+is **no maintainer response**, and one community comment suggesting LiteRT /
+Google AI Edge for on-device Gemma. `gradle/libs.versions.toml` contains no AI,
+ML Kit, TFLite or LiteRT dependency. This is a decline by silence rather than by
+argument, but the outcome is the same.
+
+**Waistline** ([`davidhealey/waistline`](https://github.com/davidhealey/waistline),
+728★, GPL-3.0-only, on F-Droid with no anti-features) has no AI code and no AI
+discussion beyond [#923 "Pantry Wizard"](https://github.com/davidhealey/waistline/issues/923),
+an unanswered request for LLM-generated recipes. Its `package.json` lists only
+Cordova plugins — camera, barcode, TTS — no model runtime.
+
+**FitBook** ([`brandonp2412/FitBook`](https://github.com/brandonp2412/FitBook),
+157★, MIT, Flutter, on F-Droid) is the other Dart tracker; its `pubspec.yaml`
+contains `openfoodfacts`, `barcode_scan2` and nothing model-related. Its
+description is "Track your calories - Completely offline!".
+
+**kcal** ([`kcal-app/kcal`](https://github.com/kcal-app/kcal), 350★, MPL-2.0)
+declines even *food database APIs*, on the grounds that large community datasets
+are "daunting" to search and "can be inaccurate and counter-productive for users
+with calorie and/or macro goals".
+
+**OpenNutriTracker itself.** Issue
+[#250](https://github.com/simonoppowa/OpenNutriTracker/issues/250), "Ask AI to
+fill out custom dish information", was closed on 2026-05-15 as
+"researched, not shipping for now" after a documented spike: twelve small
+models, eight reference foods plus three multi-food prompts, run on a Pixel 8.
+The write-up rejects the on-device path on accuracy (the best phone-viable
+model, Qwen 2.5 1.5B, landed 25–45% high on an unseen freeform prompt) — and
+then **rejects the BYO-key path separately**, on four grounds: maintenance
+surface (key entry, secure storage, billing communication, model-deprecation
+drift), single-digit adoption, the privacy regression of dish descriptions
+leaving the device, and store-review provenance expectations for health apps.
+Its central claim is that "wrapping it in confidence flags doesn't add
+provenance, it adds a warning". Issue #599 reaches the opposite conclusion on
+the BYO-key question and does not reference #250.
+
+## Licensing and F-Droid consequences
+
+**Adding AI has skewed projects away from free licences.** Of the shipped
+server-side AI trackers, SparkyFitness is non-commercial-only, Tandoor carries a
+Commons Clause, and MacroShot uses FSL-1.1-Apache-2.0. None of the three would
+be accepted by F-Droid or be GPL-compatible. The AI-shipping projects that *are*
+OSI-free are all small mobile BYO-key apps (Fud AI MIT, Train Libre GPL-3.0,
+NutriTrace AGPL-3.0, EatWise/Scranbook MIT, cdz-hy GPL-3.0).
+
+**F-Droid's anti-features.** The catalogue currently defines ten
+([docs](https://f-droid.org/docs/Anti-Features/)); the relevant ones are
+*Non-Free Network Services* ("promotes or depends entirely on a proprietary
+network service"), *Non-Free Dependencies* ("requires things that are not Free
+Software in order to run"), and *Tethered Network Services*. NonFreeNet was
+narrowed in July 2024 when Tethered was split out of it
+([TWIF, 2024-07-25](https://f-droid.org/2024/07/25/twif.html)); 819 apps
+currently carry NonFreeNet.
+
+**Precedent for a BYO-key LLM app.** Two are directly on point:
+
+- [Kai 9000](https://f-droid.org/packages/com.inspiredandroid.kai/) (Apache-2.0),
+  a multi-provider LLM chat app, carries **Non-Free Network Services** —
+  "This app promotes or depends entirely on a non-free network service.
+  Specifically, the app relies on Gemini and Groq services."
+- [oxproxion](https://f-droid.org/packages/io.github.stardomains3.oxproxion/)
+  (Apache-2.0) supports Ollama, LM Studio, llama.cpp and MLX LM alongside
+  OpenRouter, and still carries **Non-Free Network Services** — "Depends on
+  OpenRouter API servers."
+
+So the presence of a local-inference option did not spare oxproxion. Both apps
+are *primarily* LLM clients, which is not our case; I could not find an app
+where AI is an optional secondary feature and F-Droid ruled on it either way.
+
+**What the food apps carry today.** Food You and Waistline have no anti-features
+listed. The legacy Open Food Facts Android app carries **Non-Free Network
+Services** ("depends on openfoodfacts.net/.org, openproductfacts.org,
+openstreetmap.org and sentry.io servers") and **Tracking** ("Analytics are
+opt-in but the app connects to sentry.io from the start, and connects even if
+rejected"). That second one is worth staring at: OpenNutriTracker also ships
+opt-in Sentry.
+
+**Nobody was removed from F-Droid over AI.** I found no case of an app being
+delisted for adding an AI feature. The observed responses are (a) build a
+separate F-Droid flavour with the proprietary bit removed — Open Food Facts
+swapping ML Kit for ZXing in `main_fdroid.dart`; or (b) skip the main catalogue
+and self-host a repo — Train Libre publishes its own
+[F-Droid repo](https://rfivesix.github.io/train-libre/fdroid/repo).
+
+**Our own status.** OpenNutriTracker is not in the main F-Droid catalogue;
+[RFP #2540](https://gitlab.com/fdroid/rfp/-/issues/2540) is outstanding and the
+README says "from F-Droid once the app is published there". Any AI work lands
+before that listing is decided, not after.
+
+## Privacy posture — what these projects tell users
+
+- **Fud AI**: "Requests go directly from your device to the provider you
+  configure." Marketing site carries a privacy page; the security policy scopes
+  API-key handling and names the exact storage mechanism per platform.
+- **Train Libre**: "User-Controlled AI: Optional AI features require your own
+  API key; no data is sent to providers without opt-in", plus "Train Libre does
+  not deploy intermediate servers to handle AI requests." It ships a clinical
+  disclaimer naming diabetes.
+- **NutriTrace**: per-feature statements ("only the transcript reaches your
+  configured LLM; the audio stays on-device"; label photos go to the provider as
+  base64 under a 12 MB body limit) and a long medical disclaimer.
+- **Scranbook**: "There are no Scranbook accounts, analytics, Worker code, or
+  server-side diary APIs", and the photo goes to the user's endpoint only "when
+  the user explicitly chooses to analyse a photo".
+- **EatWise**: privacy-first framing, and screenshots deliberately generated
+  from synthetic records so no real photo, key or dietary goal appears.
+- **Open Food Facts**: nothing runs on-device that isn't disabled in the F-Droid
+  build; server-side inference is documented publicly per model.
+
+The pattern: the credible ones make a *mechanical* claim ("no intermediate
+server", "audio stays on-device") rather than a values claim. That is the same
+move as our README's destination table.
+
+## What this means for OpenNutriTracker
+
+**Where our design is conventional.**
+
+- BYO-key with no bundled credential is the norm, not a novelty. Every shipped
+  free-licence mobile tracker with AI does this, and the one project that tried
+  operating its own proxy (Fud AI Premium) discontinued it.
+- Secure-storage choice matches exactly. Train Libre uses
+  `flutter_secure_storage` with one key per provider; Fud AI uses the native
+  equivalents directly.
+- Resolving model output against the existing food database rather than trusting
+  it is what the two most careful projects do (Train Libre, Scranbook).
+- Refusing to call the local tier "AI" is unusual but defensible; nobody else
+  ships a deterministic parser to compare against.
+
+**Where our design is unusual, and worth re-examining.**
+
+1. **One hardcoded provider.** Every shipped comparator is multi-provider from
+   v1, and most get there cheaply because nine of Fud AI's thirteen providers
+   are just a base-URL swap. Anthropic-only means no Ollama/LM Studio story at
+   all — which is the first thing the privacy-focused audience asks for
+   (Food You #419 asks for "even a local AI endpoint"; Fud AI #36 asks for
+   on-device Gemma). A single `baseUrl` text field behind the provider
+   interface would buy local inference and OpenRouter for near-zero cost.
+2. **Letting the model emit macros at all.** Decision #5 in #599 is the loosest
+   posture in the entire cohort. Train Libre bans it outright; Scranbook
+   computes macros locally from bundled composition data; EatWise ships only
+   wide ranges and qualitative portions. Our "every number is cited" claim is
+   stronger than any of theirs, and #599's answer — a new `MealSourceEntity`
+   value plus an "estimated" marker — is the *warning* approach that our own
+   #250 spike argued does not substitute for provenance.
+3. **Text first, photo deferred.** The cohort is the other way round: photo is
+   the headline feature and text is secondary. That is not obviously wrong (it
+   is the cheaper, more testable path) but it means tier 1 alone will not read
+   as competitive with Fud AI or Train Libre.
+4. **No free tier to fall back on.** #599 already notes this. Fud AI's #106 is
+   what it looks like in practice, and Fud AI could at least redirect users to
+   free Gemini, Groq and OpenRouter tiers. Anthropic-only removes that valve
+   and makes every support thread about billing end in "add a card".
+
+**Concrete pitfalls other projects hit that #599 does not cover.**
+
+- **Keystore corruption on reinstall.** Fud AI's `KeyStore.kt` documents an
+  `AEADBadTagException` on Android 14/15 where the Keystore master-key alias
+  outlives the encrypted prefs file, crashing in `Application.onCreate` before
+  any UI. `flutter_secure_storage` sits on the same substrate. We need the
+  equivalent catch-wipe-rebuild path, and losing the key on reinstall is the
+  correct behaviour.
+- **Never validate the shape of a pasted key.** Fud AI #140 rejected valid
+  Gemini keys because Google changed the prefix from `AIza` to `AQ.`, and #105
+  was a trailing newline in a paste. Trim aggressively, validate with a live
+  ping, never with a regex.
+- **Truncation is a distinct failure from malformed output.** Constrained
+  decoding solves the Tandoor #4659 problem (Claude fencing its JSON), but not
+  Fud AI #139/#145, where the response was cut off by the token budget and
+  raising the budget destabilised the app. Handle `stop_reason: "max_tokens"`
+  explicitly and cap the retry loop.
+- **Anthropic's image content-part shape is not portable.** NutriTrace had to
+  normalise `{type:'image', source:{...}}` to the OpenAI `image_url` shape
+  because gateways reject the Anthropic form. If the provider interface is meant
+  to admit more providers later, put the wire-shape adaptation at the boundary
+  now rather than leaking Anthropic's shape through it.
+- **Cap request size and retries even when the user pays.** Tandoor enforces a
+  ~$1/month per-space credit ceiling and logs every call; NutriTrace caps at 60
+  messages / 8 MB and rate-limits to 30/min. BYO-key moves the cost to the user
+  but does not make a runaway loop harmless.
+- **Base64 payload limits are a real failure mode.** Tandoor's docs warn that
+  base64-in-request "can exceed provider limits or reverse proxy limits".
+  Relevant to tier 2's WebP path.
+- **A per-locale parser is a maintenance argument, not just a code one.**
+  Fud AI closed #130 — which proposed exactly a local quick-parser — because
+  language-specific parsing "would need to be maintained across all supported
+  languages". We ship 9 locales. Tier 0 needs an explicit answer: either
+  language-neutral heuristics, or a stated English-first scope.
+- **#250 and #599 disagree and both are live.** Our own tracker now contains a
+  closed issue arguing the BYO-key path is not worth maintaining, and an open
+  umbrella issue adopting it. Whoever picks up tier 1 will find #250 first.
+  Reconciling them — particularly the store-review provenance argument, which
+  is independent of who runs the model — should happen before tier 1 is scoped.
+
+## What I could not verify
+
+- Whether Fud AI is distributed on F-Droid. Its README links only App Store,
+  Play and its own site, and contains no F-Droid reference; I did not search the
+  `fdroiddata` metadata repository directly.
+- The date, terms, or reason for the discontinuation of the "Fud AI Premium
+  proxy". The only source is one sentence in the current README.
+- Whether Kai 9000 ships a bundled free tier (which would explain its NonFreeNet
+  label more simply than BYO-key access does). That claim came from a search
+  result summary, not the repository.
+- Whether F-Droid has ever ruled on an app where AI is an *optional secondary*
+  feature. Both precedents found are apps whose primary purpose is LLM chat.
+- Whether Tandoor encrypts the provider API key anywhere outside the
+  `AiProvider.api_key` `CharField`; I read the model definition only.
+- Whether NutriTrace's AI configuration is genuinely per-user. The docs say
+  "per-user in Settings → AI Assistant", but `server/ai.js` stores it in an
+  instance-wide `app_config` table.
+- SparkyFitness's AI key scoping and whether its licence has changed; GitHub
+  reports no recognised licence and `LICENSE` reads as a custom
+  non-commercial grant.
+- Detail beyond metadata and one config file for MacroShot,
+  [Luma](https://github.com/d3mocide/Luma) and
+  [OpenFoodJournal](https://github.com/kvn8888/OpenFoodJournal); all three claim
+  AI features but were not read in depth.
+- Whether any project has published measured accuracy for cloud-model nutrition
+  estimation. None of the shipped projects publish evaluation numbers; the only
+  measured data found is our own #250 spike, and that covers on-device models.
+- Download or install counts for any of these apps. GitHub stars are a proxy
+  only.

--- a/docs/ai-local-runtime-apis.md
+++ b/docs/ai-local-runtime-apis.md
@@ -1,0 +1,728 @@
+# What Ollama, LM Studio, llama.cpp's server and vLLM actually expose
+
+Research notes gathered 2026-08-20 against each project's own documentation and,
+where the documentation was silent or ambiguous, against its own source. For
+Ollama that meant `docs/api/openai-compatibility.mdx` plus `openai/openai.go`,
+`middleware/openai.go`, `server/routes.go`, `server/images.go` and
+`api/types.go`. For llama.cpp, `tools/server/README.md` plus
+`tools/server/server.cpp`, `server-common.cpp/.h`, `server-http.cpp` and
+`tools/mtmd/mtmd-helper.cpp`. For vLLM, `docs.vllm.ai` plus
+`vllm/entrypoints/openai/**` and `vllm/multimodal/media/image.py`. LM Studio's
+server is closed source, so it is documentation only — its docs site is
+client-rendered, so every LM Studio quote below was taken from the Markdown
+source in `github.com/lmstudio-ai/docs`, which is the same text the site
+renders.
+
+Nothing here rests on a blog post, a tutorial or a Stack Overflow answer. **No
+server was installed, started or called.** Everything that needs a running
+server to answer is in [Not verified](#not-verified) rather than guessed at, and
+that section is deliberately long: three of the four runtimes leave at least one
+question the docs simply do not address.
+
+Written to answer [#733](https://github.com/simonoppowa/OpenNutriTracker/issues/733)
+on map [#732](https://github.com/simonoppowa/OpenNutriTracker/issues/732). The
+thing being matched against is the request
+[`OpenRouterMealItemsApi`](../lib/features/add_meal/data/openrouter_meal_items_api.dart)
+already puts on the wire, and the schema in
+[`meal_items_api.dart`](../lib/features/add_meal/domain/meal_items_api.dart) —
+`query` required, `quantity` and `unit` optional, `additionalProperties: false`,
+no `strict` field.
+
+## Bottom line up front
+
+1. **Nothing rejects the extra fields, so the routing block is not the reason to
+   fork the client.** All four accept unknown top-level keys and ignore them.
+   vLLM says so in a code comment — *"OpenAI API does allow extra fields"* — and
+   sets `extra="allow"`, logging ignored keys at **debug** level only. Ollama
+   binds into a Go struct that has no `provider` field, using gin's
+   `ShouldBindJSON`; neither `DisallowUnknownFields` nor
+   `EnableDecoderDisallowUnknownFields` appears anywhere in `ollama/ollama`.
+   llama.cpp reads named keys with a `json_value` helper and then **copies every
+   remaining top-level property through** into its internal params object, where
+   unknown keys are inert. LM Studio's docs say *"All parameters recognized by
+   `/v1/chat/completions` will be honored"* and nothing about unrecognised ones
+   — that is the one gap ([Not verified](#not-verified)). So `provider`,
+   `require_parameters`, `data_collection` and `allow_fallbacks` are dead weight
+   on a local server, not a 400.
+2. **The thing that actually diverges is the forced `tool_choice`, and only
+   vLLM honours it.** This is the finding that costs something, because the
+   forced call is how the app gets a parseable answer at all.
+   - **vLLM**: full support, in exactly the bytes the app sends. Validated
+     against `tools`, then enforced by the structured-outputs backend — *"You
+     are guaranteed a validly-parsable function call - not a high-quality
+     one."*
+   - **llama.cpp**: `tool_choice` is parsed as a **string**, and an object is
+     **silently downgraded to `"auto"`**. `json_value` catches the type error
+     and returns the default with a server-side log line. No 400, no 500 — the
+     request succeeds with the forcing quietly discarded.
+   - **Ollama**: `tool_choice` is not supported at all. The compatibility doc
+     lists it as an unchecked box, and `ChatCompletionRequest` in
+     `openai/openai.go` has no such field. Dropped on the floor.
+   - **LM Studio**: documented values are `"auto"`, `"none"` and `"required"`
+     only. A named-function object appears nowhere in its documentation, and
+     `"required"` is annotated *"(llama.cpp only)"* — i.e. not on the MLX
+     engine.
+   With one tool defined, `tool_choice: "required"` is semantically what the app
+   wants and is available on vLLM, llama.cpp (with `--jinja`) and LM Studio's
+   llama.cpp engine. On Ollama there is no forcing of any kind, and the app is
+   back to prompt-and-hope with `_itemsFrom` raising
+   `'response has no tool call'` when the model answers in prose. That is a
+   handled failure, not a wrong number — the guarantee in
+   [#683](https://github.com/simonoppowa/OpenNutriTracker/issues/683) holds —
+   but it is a *usefulness* cliff on the most popular of the four runtimes.
+3. **The photo path has a format problem, and it is llama.cpp's.**
+   `MealPhotoEncoder` produces `image/webp` on the normal path. llama.cpp
+   decodes images with `stbi_load_from_memory` from `stb_image.h`, whose
+   documented format list the server README repeats as *"jpeg, png, tga, bmp,
+   gif, ..."* — **no WebP**. llama.cpp's own web UI ships
+   `tools/ui/src/lib/utils/webp-to-png.ts`, which converts WebP to PNG in the
+   browser before sending, which is about as clear a confirmation as a source
+   tree can give. Ollama is the mirror image: `decodeImageURL` accepts exactly
+   `jpeg`, `jpg`, `png`, `webp` and rejects everything else with `400 invalid
+   image input` — so WebP is fine and the encoder's **GIF fallback is not**.
+   vLLM decodes with Pillow's `Image.open` and ignores the declared media type
+   entirely.
+4. **No schema rewrite is needed anywhere.** Nothing here has OpenAI's
+   strict-mode rule that every key in `properties` must also appear in
+   `required`. LM Studio's own tool-calling example uses a schema with
+   `"required": ["query"]`, two optional properties and
+   `additionalProperties: false` — structurally identical to
+   `mealItemsToolSchema`. vLLM feeds the schema straight to a JSON-Schema
+   constrained-decoding backend; its docs *recommend* the OpenAI strict style
+   *"For best compatibility with strict schema enforcement"* but explicitly do
+   not require it for named or `"required"` tool choice. `strict` itself is
+   accepted by vLLM (it changes behaviour only for `tool_choice: "auto"`) and
+   silently dropped by Ollama and llama.cpp, which have no such field.
+5. **Auth is optional on all four, and a bearer token sent to a keyless server
+   is ignored rather than refused.** Ollama documents *"No authentication is
+   required when accessing Ollama's API locally"* and its own example passes
+   `api_key='ollama',  # required but ignored`. llama.cpp's middleware opens
+   with *"If API key is not set, skip validation"*. vLLM only registers its
+   authentication middleware when a key is configured. LM Studio: *"By default,
+   LM Studio does not require authentication for API requests."* So the app can
+   send the header unconditionally without breaking a keyless server — but it
+   should not, because on a LAN address that is a credential leaked to whatever
+   answered.
+6. **`/v1/models` is enough to populate a picker on three of the four, and
+   useless for capability on all four.** Ollama returns `{id, object, created,
+   owned_by}` for every pulled model and nothing else. vLLM returns `{id,
+   object, created, owned_by, root, parent, max_model_len, permission}` for the
+   model it was started with. LM Studio returns *"the models visible to the
+   server"*, which *"may include all downloaded models when Just-In-Time loading
+   is enabled"*. llama.cpp in single-model mode returns *"one single element"* —
+   the `-m` path, or `--alias` if set — so there is nothing to pick from.
+   **Neither vision nor tool support is on any of those four responses.** Both
+   flags exist, but on non-OpenAI paths: LM Studio's `GET /api/v1/models`
+   carries `capabilities.vision` and `capabilities.trained_for_tool_use`;
+   Ollama's `POST /api/show` carries `capabilities: ["completion", "vision"]`;
+   llama-server **in router mode** puts `architecture.input_modalities:
+   ["text","image"]` on the same handler that serves `/v1/models`. vLLM
+   publishes nothing equivalent.
+7. **Only vLLM and llama.cpp can serve TLS, and neither does by default.** vLLM
+   takes `--ssl-keyfile`/`--ssl-certfile`. llama.cpp takes
+   `--ssl-key-file`/`--ssl-cert-file` and needs a build with
+   `-DLLAMA_OPENSSL=ON`, otherwise it logs *"the server is built without SSL
+   support"*. Ollama has no TLS at all — `ListenAndServeTLS`, `tls.Config` and
+   `OLLAMA_TLS` return **zero** hits across the whole repository, and the FAQ's
+   answer to exposing it is *"can be exposed using a proxy server such as
+   Nginx"*. LM Studio's documentation contains no TLS or HTTPS server option;
+   its own answer to leaving localhost is `lms server start --bind 0.0.0.0` plus
+   a recommendation to turn authentication on. **Plain HTTP is the default
+   everywhere and the only option on two of the four.**
+8. **The failure taxonomy does not survive the port.** Three concrete
+   divergences, all measured against `_failureFor`: a **404 means "model not
+   found"** on Ollama and vLLM — not "no endpoint supports this capability", and
+   `MealInterpreterFailure.unsupported` is roughly the right bucket by accident
+   rather than by design. **llama.cpp answers 500 for a capability problem**:
+   sending `tools` to a server started without `--jinja` throws a
+   `std::runtime_error`, and its `ex_wrapper` maps `std::invalid_argument` to
+   400 and *everything else* to 500. The app would call that transient and tell
+   the user to check their network forever. And llama.cpp has a **501**
+   (`not_supported_error`) that no current provider emits.
+
+## The four at a glance
+
+| | Ollama | LM Studio | llama.cpp `llama-server` | vLLM |
+| --- | --- | --- | --- | --- |
+| Default bind | `127.0.0.1:11434` | `localhost:1234` | `127.0.0.1:8080` | port `8000` |
+| Chat path | `/v1/chat/completions` | `/v1/chat/completions` | `/v1/chat/completions` **and** `/chat/completions` | `/v1/chat/completions` |
+| `/v1/models` exists | yes | yes | yes | yes |
+| …fields | `id, object, created, owned_by` | not enumerated in docs | `id, object, created, owned_by, meta{n_ctx_train, n_params, …}` | `id, object, created, owned_by, root, parent, max_model_len, permission` |
+| …lists more than one model | yes, every pulled model | yes (all downloaded, if JIT on) | **no** — one element, unless in router mode | the served model(s) |
+| …flags vision | no (`/api/show` does) | no (`/api/v1/models` does) | only in router mode | no |
+| …flags tool support | no | no (`/api/v1/models` does) | no | no |
+| Accepts OpenAI `tools[]` | yes | yes | **only with `--jinja`** | yes |
+| Forced `tool_choice` by name | **no field at all** | **undocumented**; `auto`/`none`/`required` only | **silently downgraded to `auto`** | **yes, enforced** |
+| `tool_choice: "required"` | no | yes, *"llama.cpp only"* | yes | yes, enforced |
+| Optional properties in schema | fine | fine (own example does it) | fine | fine |
+| `strict` on a tool | ignored (no field) | not documented | ignored (no field) | accepted; matters only for `auto` |
+| `image_url: {"url": "data:…"}` | **yes** (bare string too) | **undocumented** | **yes** | **yes** |
+| Image formats | `jpeg`, `jpg`, `png`, `webp` only | undocumented | stb_image set — **no WebP** | whatever Pillow opens |
+| Remote image URL | **refused** | undocumented | accepted | accepted (5 s fetch timeout) |
+| API key | none locally | optional toggle + tokens | optional `--api-key` | optional `--api-key` |
+| Bearer sent to keyless server | ignored | ignored (docs imply) | ignored (explicit in source) | ignored (middleware not mounted) |
+| Unknown top-level fields | ignored | *not established* | copied through, inert | ignored, logged at debug |
+| HTTPS | **none** | **none documented** | `--ssl-*`, needs OpenSSL build | `--ssl-keyfile`/`--ssl-certfile` |
+| Model not pulled/loaded | 404 | *not established* | 404 (router) / n/a | 404 `NotFoundError` |
+| Tools to an incapable model | **400** `"…does not support tools"` | falls back to a prompt shim | **500** without `--jinja` | *not established* |
+
+## A. What the existing client sends, field by field
+
+Read against
+[`openrouter_meal_items_api.dart`](../lib/features/add_meal/data/openrouter_meal_items_api.dart).
+"Survives" means the exact bytes it already builds are accepted and mean the
+same thing.
+
+| What it sends | Survives? | Note |
+| --- | --- | --- |
+| `model` | yes, everywhere | the *value* is a local identifier — a pulled tag, a GGUF path, an alias, a HF repo id |
+| `max_tokens: 1024` | yes, everywhere | Ollama and LM Studio document it; llama.cpp aliases it to `n_predict`; vLLM accepts it but marks it *"deprecated in favor of the max_completion_tokens field"* |
+| `messages[0]` as `role: "system"` | yes, everywhere | |
+| text part `{"type":"text","text":…}` | yes on Ollama, llama.cpp, vLLM; undocumented on LM Studio | Ollama's source accepts exactly `text`, `image_url` and `input_audio` and returns `invalid message format` for anything else |
+| image part `{"type":"image_url","image_url":{"url":"data:…"}}` | yes on Ollama, llama.cpp, vLLM | see [Section E](#e-vision) |
+| text **before** image | yes | none of the four documents an ordering requirement |
+| `tools[]` with the `function` wrapper | yes on Ollama, LM Studio, vLLM; llama.cpp needs `--jinja` | |
+| no `strict` key | correct on all four | nothing here normalises an absent `strict` into strict mode the way OpenAI's Responses API does |
+| `tool_choice` named object | **vLLM only** | see [Section D](#d-tool-calling) |
+| `provider{require_parameters, data_collection, only, allow_fallbacks}` | inert on all four | see [Section C](#c-the-extra-fields) |
+| `authorization: Bearer …` header | harmless but wrong | see [Section F](#f-auth) |
+| `x-openrouter-metadata: enabled` header | inert | there is nothing to name; `_warnIfThePinDidNotHold` has no input |
+| reading `choices[0].message.tool_calls[].function.arguments` as a **JSON string** | yes, everywhere | all four emit the OpenAI Chat Completions envelope; Ollama marshals `arguments` back to a string explicitly in `ToToolCalls` |
+| treating `finish_reason: "error"` as a failed generation | harmless | that value is an OpenRouter extension; none of the four produces it, so `_throwIfFailedGeneration` is simply never entered |
+
+**The conclusion this table points at:** the *body* generalises almost perfectly.
+What does not generalise is a short, enumerable list — the endpoint, the
+`tool_choice` shape, the `provider` block, the auth header, the metadata header
+and the status-code table. See [Section I](#i-so-does-this-need-a-fourth-client).
+
+## B. Base URLs, ports and paths
+
+**Ollama.** `http://localhost:11434/v1/`, and the FAQ is explicit: *"Ollama
+binds 127.0.0.1 port 11434 by default. Change the bind address with the
+`OLLAMA_HOST` environment variable."* The OpenAI-compatible surface is a real
+`/v1` prefix served by middleware in front of the native handlers —
+`r.POST("/v1/chat/completions", …, middleware.ChatMiddleware(), s.ChatHandler)`.
+`/v1/models`, `/v1/models/{model}`, `/v1/completions`, `/v1/embeddings` and (as
+of v0.13.3) `/v1/responses` are also served.
+
+**LM Studio.** `http://localhost:1234/v1`. The overview page says *"Note: The
+following examples assume the server port is `1234`"* and the port is a
+configurable server setting. Supported OpenAI-compatible endpoints are
+`/v1/models`, `/v1/responses`, `/v1/chat/completions`, `/v1/embeddings`,
+`/v1/completions`. Two other surfaces exist alongside: the legacy `/api/v0/*`
+REST API and the current `/api/v1/*` REST API, both of which return richer model
+metadata than `/v1/models` does.
+
+**llama.cpp.** *"by default listens on `127.0.0.1:8080`"*, `--host` and `--port`
+to change it. Both prefixed and unprefixed paths are registered for most
+endpoints — `/v1/chat/completions` **and** `/chat/completions`, `/v1/models`
+**and** `/models` — so a base URL with or without `/v1` reaches the same
+handler. Only `/health` and `/v1/health` skip the API-key check.
+
+**vLLM.** Port `8000` by default. `vllm serve` examples use
+`base_url="http://localhost:8000/v1"`. One warning from vLLM's own page is worth
+carrying into any UI copy, because it bears on the privacy claim rather than on
+compatibility:
+
+> The `--api-key` option (or `VLLM_API_KEY` environment variable) only
+> authenticates requests to endpoints under the `/v1`, `/v2`, and `/inference`
+> path prefixes. Other endpoints on the same HTTP server are **not**
+> authenticated — most notably `/invocations`, which exposes the same inference
+> capabilities as the `/v1` endpoints.
+
+## C. The extra fields
+
+This is the item that decides the client architecture, so it is answered from
+source in every case where source exists.
+
+**vLLM — accepted and ignored, by design.** `OpenAIBaseModel`, which every
+request model inherits from:
+
+```python
+class OpenAIBaseModel(BaseModel):
+    # OpenAI API does allow extra fields
+    model_config = ConfigDict(extra="allow")
+```
+
+and a `__log_extra_fields__` validator whose entire effect is one
+`logger.debug("The following fields were present in the request but ignored: %s", …)`.
+Not a warning, not an error.
+
+**Ollama — dropped at the struct boundary.** `ChatMiddleware` calls
+`c.ShouldBindJSON(&req)` into `openai.ChatCompletionRequest`, whose fields are
+`model`, `messages`, `stream`, `stream_options`, `max_tokens`, `seed`, `stop`,
+`temperature`, `frequency_penalty`, `presence_penalty`, `top_p`,
+`response_format`, `tools`, `reasoning`, `reasoning_effort`, `logprobs`,
+`top_logprobs` and an internal `_debug_render_only`. Gin's default JSON binding
+does not disallow unknown fields, and a search of `ollama/ollama` for
+`DisallowUnknownFields` and `EnableDecoderDisallowUnknownFields` returns zero
+hits for both, against four hits for `ShouldBindJSON`. Anything not in that list
+— `provider`, `tool_choice`, `strict`, `user`, `n` — is discarded silently.
+
+**llama.cpp — copied through and then ignored.** After reading the keys it knows
+about, `oaicompat_chat_params_parse` ends with:
+
+```cpp
+// Copy remaining properties to llama_params
+// This allows user to use llama.cpp-specific params like "mirostat", ... via OAI endpoint.
+for (const auto & item : body.items()) {
+    if (!llama_params.contains(item.key()) || item.key() == "n_predict") {
+        llama_params[item.key()] = item.value();
+    }
+}
+```
+
+so a `provider` object lands in the internal params blob and is never read. The
+only fields llama.cpp actively *refuses* are `best_of` and `suffix` — *"Params
+supported by OAI but unsupported by llama.cpp"* — plus `echo` set to true. None
+of those is anything the app sends.
+
+**LM Studio — not established.** The closest its documentation comes is *"All
+parameters recognized by `/v1/chat/completions` will be honored"*, on the tool
+use page. That says what happens to recognised parameters and nothing about the
+rest, and the server is closed source. See [Not verified](#not-verified).
+
+## D. Tool calling
+
+### D1. Does a forced `tool_choice` work?
+
+**vLLM — yes, and it is the only unambiguous yes.** The request model types it
+as `Literal["none"] | Literal["auto"] | Literal["required"] |
+ChatCompletionNamedToolChoiceParam | None`, and a `check_tool_usage` validator
+runs before anything else: it rejects a missing `tools`, rejects a value that is
+neither `"auto"`/`"required"` nor an object, rejects an object without a
+`function` dict or without a string `name`, and rejects a name that *"does not
+match any of the specified `tools`"*. All of those raise `VLLMValidationError`,
+which maps to **400** with `param` set to `tool_choice`. Once past validation,
+enforcement is real:
+
+> vLLM supports named function calling in the chat completion API by default.
+> … You are guaranteed a validly-parsable function call - not a high-quality
+> one.
+
+and from the constrained-decoding table, for a named function: *"Arguments are
+guaranteed to be valid JSON conforming to the function's parameter schema."*
+
+**llama.cpp — no, and it fails in the worst available way.** The parser takes a
+string:
+
+```cpp
+common_chat_tool_choice common_chat_tool_choice_parse_oaicompat(const std::string & tool_choice) {
+    if (tool_choice == "auto")     { return COMMON_CHAT_TOOL_CHOICE_AUTO; }
+    if (tool_choice == "none")     { return COMMON_CHAT_TOOL_CHOICE_NONE; }
+    if (tool_choice == "required") { return COMMON_CHAT_TOOL_CHOICE_REQUIRED; }
+    throw std::invalid_argument("Invalid tool_choice: " + tool_choice);
+}
+```
+
+but that `throw` is unreachable for an object, because the value is read as
+`json_value(body, "tool_choice", std::string("auto"))` and `json_value` is:
+
+```cpp
+try {
+    return body.at(key);
+} catch (NLOHMANN_JSON_NAMESPACE::detail::type_error const & err) {
+    LOG_WRN("Wrong type supplied for parameter '%s'. Expected '%s', using default value: %s\n", …);
+    return default_value;
+}
+```
+
+So `{"type":"function","function":{"name":"log_meal_items"}}` becomes `"auto"`,
+the request succeeds, and the only trace is a warning in the server operator's
+terminal. A client cannot detect this from the response. **If the app targets
+llama.cpp it must send the string `"required"`**, which llama.cpp does enforce:
+`COMMON_CHAT_TOOL_CHOICE_REQUIRED` sets the grammar's minimum tool-call count to
+1 and switches off lazy grammar triggering across every template handler.
+
+**Ollama — no.** The compatibility doc's supported-fields list for
+`/v1/chat/completions` has `- [ ] tool_choice`, and the struct confirms it. The
+practical consequence: with `tools` present, a capable model *may* emit a tool
+call and Ollama will parse it, but nothing obliges it to.
+
+**LM Studio — string values only, per its own changelog.** From the 0.3.15
+entry, *"Improved Tool Use API Support"*:
+
+> `"tool_choice": "none"` — Model will not call tools
+> `"tool_choice": "auto"` — Model decides
+> `"tool_choice": "required"` — Model must call tools (llama.cpp only)
+
+A named-function object is not among them, and the parenthesis matters: LM
+Studio runs GGUF models on llama.cpp and MLX models on its own `mlx-engine`, and
+`"required"` is only claimed for the former.
+
+### D2. Does the schema's optional properties cause trouble?
+
+No, and this is the least eventful answer in the note. None of the four
+implements OpenAI's strict-mode requirement that every key in `properties` also
+appear in `required`.
+
+- **LM Studio** publishes a worked `curl` example whose tool schema is
+  `"required": ["query"]` with `category` and `max_price` optional and
+  `"additionalProperties": false` — the same shape as `mealItemsToolSchema`,
+  down to the required key being called `query`.
+- **vLLM** hands the schema to a structured-outputs backend, which speaks JSON
+  Schema. Its *Strict Mode* section recommends the OpenAI style — *"Set
+  `additionalProperties` to `false`… Mark all fields in `properties` as
+  required… Represent optional fields by allowing `null`"* — but prefixes it
+  with *"For best compatibility with strict schema enforcement"*, and the table
+  above it says constrained decoding applies to named and `"required"` choices
+  **regardless of the `strict` field**.
+- **Ollama** unmarshals `parameters` into `ToolFunctionParameters{Type, $defs,
+  Items, Required, Properties}` where each property is a `ToolProperty{anyOf,
+  type, items, description, enum, properties, required}`. Nested objects,
+  arrays, enums and per-object `required` all survive. `additionalProperties`
+  has no field and is dropped — which is consistent with the schema's own
+  comment that it is *"documentation of intent rather than a defence"*.
+- **llama.cpp** builds a grammar from the tool schema. Its only schema-adjacent
+  refusal is *"Cannot use custom grammar constraints with tools."* — a
+  `std::invalid_argument`, so 400 — which fires when a request carries both
+  `tools` and a top-level `grammar`. The app sends no `grammar`.
+
+Sending `strict` either way changes nothing on Ollama and llama.cpp (no such
+field) and, on vLLM, changes nothing for a named or `"required"` choice. LM
+Studio does document `strict` — but on `response_format.json_schema`, which is a
+different feature from tool calling.
+
+### D3. What a client gets back
+
+All four return the OpenAI Chat Completions envelope with
+`choices[0].message.tool_calls[]`, each carrying `function.name` and
+`function.arguments` **as a JSON string**. Ollama's `ToToolCalls` marshals the
+arguments map back to a string explicitly. LM Studio documents the same shape
+and adds that *"The `finish_reason` field of the top-level response object will
+also be populated with `"tool_calls"`."* `_itemsFrom` and `_argumentsFrom`
+transfer unchanged.
+
+## E. Vision
+
+**Ollama — the data-URI object form works, and the format list is short.**
+`FromChatRequest` accepts `image_url` as **either** an object with a `url` key
+**or** a bare string, so the exact part the app builds today is fine. (Ollama's
+own examples use the bare-string form, which is not OpenAI-shaped; the object
+form is handled first in the source.) Then:
+
+```go
+func decodeImageURL(url string) (api.ImageData, error) {
+    if strings.HasPrefix(url, "http://") || strings.HasPrefix(url, "https://") {
+        return nil, errors.New("image URLs are not currently supported, please use base64 encoded data instead")
+    }
+    types := []string{"jpeg", "jpg", "png", "webp"}
+    …
+}
+```
+
+Anything whose prefix is not `data:image/{jpeg,jpg,png,webp};base64,` (or the
+bare `data:;base64,`) returns `invalid image input`, which `ChatMiddleware`
+turns into **400**. So `image/webp` — the app's normal output — is accepted, and
+`image/gif`, which `MealPhotoEncoder._mediaTypes` can produce when the device
+has no WebP encoder, is **not**.
+
+**llama.cpp — the object form works; WebP does not.** The README documents the
+part shape precisely: *"If `type == "image_url"`: `image_url.url` can be a remote
+URL, base64 (raw or URI-encoded via `data:image/...;base64`) or path to local
+file"*, and *"Accepts formats supported by `stb_image` (jpeg, png, tga, bmp,
+gif, ...)"*. `tools/mtmd/mtmd-helper.cpp` defines `STB_IMAGE_IMPLEMENTATION` and
+decodes with `stbi_load_from_memory`. stb_image has no WebP decoder, and
+llama.cpp's own web UI carries `webpBase64UrlToPngDataURL` to convert WebP to
+PNG on the client before upload. Multimodality is also gated on the build and
+the run: the README calls it *"currently an experimental feature"* and it
+requires a multimodal projector to be loaded.
+
+**vLLM — the object form works and the declared media type is ignored.** Its
+multimodal guide's own base64 example is
+`{"type": "image_url", "image_url": {"url": f"data:image/jpeg;base64,{base64_image}"}}`.
+`ImageMediaIO.load_base64(media_type, data)` discards `media_type` and calls
+`load_bytes`, which is `Image.open(BytesIO(data))` — so the format question is
+"what can this Pillow build open", and WebP is in Pillow's standard set. One
+documented rejection worth knowing: if `width × height` exceeds
+`VLLM_MAX_IMAGE_PIXELS` the loader raises a `ValueError`, and vLLM maps
+`ValueError` to **400**. The docs also note *"`image_url.detail` parameter is not
+supported"*, which the app does not send.
+
+**LM Studio — undocumented.** Its OpenAI-compatibility overview describes the
+endpoint as *"Chat Completions (text and images)"* and stops there. The string
+`image_url` appears **nowhere** in `lmstudio-ai/docs`. Its own `/api/v1/chat`
+endpoint uses a different shape entirely — `{"type": "image", "data_url":
+"data:image/png;base64,…"}` — which is evidence about the native API and not
+about the compatibility layer. Whether `/v1/chat/completions` accepts the
+OpenAI `image_url` object, a bare string, or either, is a live-server question.
+
+**Which models can see at all** is per-model on every runtime, and only two of
+them will tell a client: LM Studio's `GET /api/v1/models` has
+`capabilities.vision: boolean`, and Ollama's `POST /api/show` has
+`capabilities: ["completion", "vision"]`. Both are outside the OpenAI-compatible
+surface. llama-server's router mode reports `architecture.input_modalities`
+containing `"image"` on the handler bound to both `/models` and `/v1/models`.
+vLLM offers nothing.
+
+## F. Auth
+
+| Runtime | Key concept | Default | Bearer to a keyless server |
+| --- | --- | --- | --- |
+| Ollama | none for local; `OLLAMA_API_KEY` is for `ollama.com`, not for a local server | no auth | ignored — no field reads it |
+| LM Studio | API tokens with per-token permissions, behind a *Require Authentication* switch | off | ignored (docs state the default; behaviour not verified) |
+| llama.cpp | `--api-key`, `--api-key-file`, `LLAMA_API_KEY`; comma-separated list | none | ignored — *"If API key is not set, skip validation"* |
+| vLLM | `--api-key` / `VLLM_API_KEY` | none | ignored — middleware only mounted `if tokens := …` |
+
+Ollama's own quickstart is the clearest statement of the shape of this problem:
+its Python example passes `api_key='ollama',  # required but ignored` — the key
+exists to satisfy the OpenAI SDK's client constructor, not the server. Its
+authentication page: *"No authentication is required when accessing Ollama's API
+locally via `http://localhost:11434`."*
+
+Where a key **is** set, all four take `Authorization: Bearer <key>`. llama.cpp
+additionally falls back to an `X-Api-Key` header for Anthropic-shaped clients,
+and returns `401 {"error":{"message":"Invalid API Key","type":"authentication_error","code":401}}`
+on a mismatch. vLLM returns `401 {"error": "Unauthorized"}` — note that shape is
+**not** the OpenAI error envelope, so a client that parses `error.message` finds
+a string where it expected an object.
+
+This bears on `AiSelection.apiKey` being a non-nullable `String`, as #732
+records: the correct behaviour for this provider is to omit the header when the
+user supplied nothing, not to send `Bearer ` with an empty value.
+
+## G. HTTPS
+
+- **Ollama: none.** No TLS listener exists. The FAQ's answer is a reverse proxy
+  (*"Ollama runs an HTTP server and can be exposed using a proxy server such as
+  Nginx"*), or `ngrok`/`cloudflared` with a rewritten host header.
+- **LM Studio: none documented.** The server settings are Port, Require
+  Authentication, Serve on Local Network, MCP toggles, CORS and JIT loading.
+  There is no certificate setting, and the page on leaving localhost recommends
+  authentication rather than TLS: *"Any bind other than `127.0.0.1` exposes the
+  server beyond `localhost`; we recommend enabling authentication."*
+- **llama.cpp: optional, and needs the right build.** `--ssl-key-file FNAME`
+  and `--ssl-cert-file FNAME`, both PEM, with *"`llama-server` can also be built
+  with SSL support using OpenSSL 3"* via `-DLLAMA_OPENSSL=ON`. A binary built
+  without it logs *"the server is built without SSL support"* and refuses to
+  start with those flags.
+- **vLLM: optional.** `--ssl-keyfile`, `--ssl-certfile`, plus `--ssl-ca-certs`,
+  `--ssl-cert-reqs`, `--ssl-ciphers` and `--enable-ssl-refresh`.
+
+In every case a user who turns TLS on for a home server is almost certainly
+using a self-signed certificate, which is a second problem and not this ticket's.
+
+## H. Failure shapes
+
+**Ollama** publishes a status-code list: `200`, `400` *"(missing parameters,
+invalid JSON, etc.)"*, `404` *"(model doesn't exist, etc.)"*, `429`, `500`,
+`502` *"(e.g. when a cloud model cannot be reached)"*. The body is
+`{"error": "…"}` natively, and the compatibility middleware rewrites it into
+`{"error":{"type":…,"message":…}}` while **preserving the status code**, with
+`type` being `invalid_request_error` for 400, `not_found_error` for 404 and
+`api_error` otherwise.
+
+Three specific cases, from `server/routes.go` and `server/images.go`:
+
+- **Model not pulled** → `404` with `model %q not found, try pulling it first`.
+- **Tools to a model with no tool capability** → `400`. `ChatHandler` appends
+  `model.CapabilityTools` to the requested capabilities whenever `tools` is
+  non-empty; `CheckCapabilities` fails with `errCapabilities` (`"does not
+  support"`) joined with `errCapabilityTools` (`"tools"`), and
+  `handleScheduleError` maps `errCapabilities` to `http.StatusBadRequest`.
+- **Image to a text-only model** → **no check exists**. `ChatHandler` never adds
+  `model.CapabilityVision` to the requested set, even when the message carries
+  images. The image is decoded, the request proceeds, and what the model does
+  with pixels it has no projector for is a runtime question this note cannot
+  answer.
+
+**llama.cpp** maps its internal error enum to status codes in
+`format_error_response`: `400 invalid_request_error`, `401
+authentication_error`, `403 permission_error`, `404 not_found_error`, `500
+server_error`, `501 not_supported_error`, `503 unavailable_error`, and the
+README confirms *"`llama-server` returns errors in the same format as OAI"*.
+The trap is which exceptions reach which code — `ex_wrapper`:
+
+```cpp
+} catch (const std::invalid_argument & e) {
+    // treat invalid_argument as invalid request (400)
+} catch (const std::exception & e) {
+    // treat other exceptions as server error (500)
+```
+
+`"tools param requires --jinja flag"` and `"tool_choice param requires --jinja
+flag"` are both `std::runtime_error`, so **a server started without `--jinja`
+answers a tool request with 500**. That is a permanent configuration problem
+wearing a transient status code, and it is the single most likely first-run
+failure for this provider.
+
+**vLLM** maps its exception hierarchy explicitly: `VLLMValidationError` → 400
+with the offending `param`; `VLLMUnprocessableEntityError` → 422;
+`VLLMNotFoundError` → 404; any other client error → 400; raw `ValueError`,
+`TypeError`, `OverflowError` → 400; `NotImplementedError` → 501; server errors →
+500. A model name it was not started with produces `404` *"The model `X` does
+not exist."*
+
+**LM Studio** publishes no status-code table. Its changelog notes that *"Errors
+returned from streaming endpoints now follow the correct format expected by
+OpenAI clients"*, which implies the non-streaming ones already did, but that is
+an inference and not a specification.
+
+**What this costs `_failureFor`.** The current table reads 401→auth,
+400/403/422→rejected, 402→billing, 404→unsupported, else→transient. Ported
+unchanged to a local server it gets three things wrong: 404 becomes *"you named
+a model this box does not have"*, which `unsupported` covers by luck rather than
+design and which wants a different message ("pull it, or pick another"); 402 is
+unreachable, since none of these has billing; and 500 is the one status a local
+server most needs to *not* be transient, because llama.cpp uses it for the
+missing-`--jinja` case. 501 and 502 are new arrivals with no current arm.
+
+## I. So: does this need a fourth client?
+
+The evidence says **the OpenRouter client generalises**, and the
+divergence list is short enough to enumerate:
+
+1. `_endpoint` becomes a constructor field instead of a `static const`.
+2. The `provider` block is omitted. Not because anything rejects it — nothing
+   does — but because every one of its four keys is a statement about a broker
+   that is not in the path, and a request that asserts `data_collection: "deny"`
+   to a machine in the user's own house is a claim the app cannot mean.
+3. `tool_choice` becomes the string `"required"` rather than a named function,
+   or is omitted for Ollama. This is the only change that alters what the model
+   is asked to do.
+4. The `authorization` header is sent only when the user supplied a key, and
+   `x-openrouter-metadata` is dropped along with `_warnIfThePinDidNotHold`,
+   which has no metadata to check.
+5. `_failureFor` becomes a per-provider table rather than a `static` one — which
+   the existing doc comment already argues for: *"the same number does not mean
+   the same thing to every provider."*
+
+Everything below that line — `_contentJson`, `_itemsFrom`, `_argumentsFrom`,
+`mealItemsFromJson`, `validateParsedMealItems`, the tool wrapper, the data-URI
+image, the arguments-as-a-string decode — is byte-identical across all four
+runtimes and across OpenRouter.
+
+That is the opposite of the situation that made `AnthropicMealItemsApi` and
+`OpenRouterMealItemsApi` two classes. The reason recorded there is that the two
+*"agree on nothing"* about shape: a different tool wrapper, a different image
+carrier, a reversed part order, a different arguments type, a different failure
+envelope. Here the shape is the same and only the *policy* differs. Five
+constructor parameters is not "a chain of provider checks"; it is what a
+parameter is for.
+
+Two caveats the build ticket should carry. First, `tool_choice` is a genuine
+behavioural fork, not a formatting one, and it is the place a shared class would
+first grow a real branch — worth making an explicit mode on the constructor
+rather than an `if`. Second, none of this touches the parts of #732 that remain
+open: the 20-second `defaultTimeout` is unaffected by anything measured here and
+is still wrong for a 7B model on a laptop CPU, and cleartext is still refused by
+both platforms before any of this code runs.
+
+## Not verified
+
+Everything below needs a running server, or a vendor who publishes more than
+they currently do. This is the input to whatever ticket stands one up.
+
+- **Whether LM Studio rejects unknown top-level fields.** The single most
+  important gap, because it is the one runtime that could turn finding 1 from
+  "all four" into "three of four". Its server is closed source and its docs say
+  only that recognised parameters are honoured. One request carrying a
+  `provider` block settles it.
+- **Whether LM Studio's `/v1/chat/completions` accepts the OpenAI `image_url`
+  content part, and in which form.** `image_url` appears nowhere in its
+  documentation. Its native endpoint uses `{"type":"image","data_url":…}`.
+- **Whether LM Studio accepts a named-function `tool_choice` anyway.** Absence
+  from a changelog is not a rejection. If it accepts one, the next question is
+  whether it enforces it or downgrades it the way llama.cpp does.
+- **What LM Studio returns for a model that is not loaded, for an image sent to
+  a text-only model, and for a malformed tool schema.** No status-code table is
+  published at all.
+- **What LM Studio's `/v1/models` response actually contains.** The docs give
+  the endpoint and a `curl` line and no response body.
+- **What Ollama does with an image sent to a model with no vision capability.**
+  Established from source: there is no capability check on this path, so it is
+  not a 400. What it *is* — a silently text-only answer, a runner error, a 500 —
+  is unknown.
+- **Whether llama.cpp actually refuses a WebP data URI, and with what status.**
+  The stb_image inference is strong and the web UI's converter corroborates it,
+  but the failure path from `mtmd_helper_bitmap_init_from_buf` to an HTTP status
+  was not traced. Under `ex_wrapper` a non-`invalid_argument` throw is a 500.
+- **Whether a llama.cpp server started without `--jinja` really answers 500 for
+  a `tools` request.** Traced through `ex_wrapper` and the `std::runtime_error`
+  throw, not observed. This one matters enough to confirm before writing user
+  copy for it.
+- **Whether `tool_choice: "required"` on Ollama does anything at all.** The
+  field does not exist in the struct, so the expectation is "ignored", but the
+  behavioural question — how often a small local model volunteers a tool call
+  unprompted with one tool defined — is the real question and it is a
+  measurement, not a reading.
+- **What vLLM returns for an image sent to a text-only model.** Its
+  `ValueError`→400 mapping suggests 400, but no primary source names the case
+  or the message.
+- **Whether a stock Pillow build in a vLLM container decodes WebP.** Pillow
+  ships WebP support by default; a container that stripped `libwebp` would not.
+- **Ollama's behaviour when the model string names a cloud model.** The chat
+  handler has a `modelSourceCloud` branch that proxies to ollama.com and can
+  return `401` with a `signin_url`. A user typing a `-cloud` suffix would be
+  sending their photograph off their own machine, which is exactly the thing
+  this provider exists to avoid, and the app has no way to tell from the model
+  list that it happened.
+- **Latency and timeout behaviour on any of the four.** Nothing measured. #732's
+  20-second `defaultTimeout` question is untouched by this note.
+- **Whether any of the four surfaces a "model is loading" state distinguishable
+  from a hang.** llama.cpp's router publishes `status.value: "loading"` on
+  `/models` and LM Studio's `/api/v1/models` has `loaded_instances`, but neither
+  appears in a chat-completions response, and Ollama's JIT load simply blocks.
+
+## Sources
+
+Ollama (own docs and source, `main` as of 2026-08-20):
+[OpenAI compatibility](https://github.com/ollama/ollama/blob/main/docs/api/openai-compatibility.mdx) — endpoint list, supported request fields, the `tool_choice` unchecked box, the vision example, `api_key='ollama', # required but ignored` ·
+[Authentication](https://github.com/ollama/ollama/blob/main/docs/api/authentication.mdx) — no local auth ·
+[Errors](https://github.com/ollama/ollama/blob/main/docs/api/errors.mdx) — status-code list and error body ·
+[Vision](https://github.com/ollama/ollama/blob/main/docs/capabilities/vision.mdx) ·
+[Tool calling](https://github.com/ollama/ollama/blob/main/docs/capabilities/tool-calling.mdx) ·
+[API reference](https://github.com/ollama/ollama/blob/main/docs/api.md) — `/api/tags`, `/api/show` with `capabilities` ·
+[FAQ](https://github.com/ollama/ollama/blob/main/docs/faq.mdx) — default bind, no TLS, Nginx guidance ·
+[`openai/openai.go`](https://github.com/ollama/ollama/blob/main/openai/openai.go) — `ChatCompletionRequest` fields, `Model` fields, `decodeImageURL`, `ToToolCalls`, `NewError` ·
+[`middleware/openai.go`](https://github.com/ollama/ollama/blob/main/middleware/openai.go) — `ShouldBindJSON`, 400 on bind failure, error-status passthrough ·
+[`server/routes.go`](https://github.com/ollama/ollama/blob/main/server/routes.go) — route table, capability set for chat, `handleScheduleError` ·
+[`server/images.go`](https://github.com/ollama/ollama/blob/main/server/images.go) — `errCapabilities`, `CheckCapabilities` ·
+[`api/types.go`](https://github.com/ollama/ollama/blob/main/api/types.go) — `Tool`, `ToolProperty`, `ToolFunctionParameters`
+
+llama.cpp (`master` as of 2026-08-20):
+[`tools/server/README.md`](https://github.com/ggml-org/llama.cpp/blob/master/tools/server/README.md) — host/port, `--api-key`, `--ssl-*`, `/v1/models` body, multimodal part shapes and stb_image formats, `--jinja`, router mode, API errors ·
+[`tools/server/server.cpp`](https://github.com/ggml-org/llama.cpp/blob/master/tools/server/server.cpp) — `ex_wrapper` status mapping, full route table, router rebinding of `get_models` ·
+[`tools/server/server-common.cpp`](https://github.com/ggml-org/llama.cpp/blob/master/tools/server/server-common.cpp) — `format_error_response`, `tool_choice` read, unsupported-param list, the copy-remaining-properties loop ·
+[`tools/server/server-common.h`](https://github.com/ggml-org/llama.cpp/blob/master/tools/server/server-common.h) — `json_value` type-error fallback, `error_type` enum ·
+[`tools/server/server-http.cpp`](https://github.com/ggml-org/llama.cpp/blob/master/tools/server/server-http.cpp) — API-key middleware, 401 body, SSL build guard ·
+[`common/chat.h`](https://github.com/ggml-org/llama.cpp/blob/master/common/chat.h) · [`common/chat.cpp`](https://github.com/ggml-org/llama.cpp/blob/master/common/chat.cpp) — `common_chat_tool_choice`, `common_chat_tool_choice_parse_oaicompat`, `REQUIRED` grammar effects ·
+[`tools/mtmd/mtmd-helper.cpp`](https://github.com/ggml-org/llama.cpp/blob/master/tools/mtmd/mtmd-helper.cpp) — `STB_IMAGE_IMPLEMENTATION`, `stbi_load_from_memory` ·
+[`tools/ui/src/lib/utils/webp-to-png.ts`](https://github.com/ggml-org/llama.cpp/blob/master/tools/ui/src/lib/utils/webp-to-png.ts) — the web UI's client-side WebP→PNG conversion ·
+[`docs/function-calling.md`](https://github.com/ggml-org/llama.cpp/blob/master/docs/function-calling.md) — contains no `tool_choice` guidance, which is itself the finding
+
+vLLM (`main` as of 2026-08-20):
+[OpenAI-Compatible Server](https://docs.vllm.ai/en/latest/serving/online_serving/openai_compatible_server/) — supported APIs, `--api-key` warning, `image_url.detail` unsupported, extra parameters ·
+[Tool Calling](https://github.com/vllm-project/vllm/blob/main/docs/features/tool_calling.md) — named function calling guarantee, `"required"`, the constrained-decoding table, Strict Mode ·
+[Multimodal Inputs](https://github.com/vllm-project/vllm/blob/main/docs/features/multimodal_inputs.md) — data-URI example, fetch timeouts, `--allowed-local-media-path` ·
+[`vllm/entrypoints/openai/engine/protocol.py`](https://github.com/vllm-project/vllm/blob/main/vllm/entrypoints/openai/engine/protocol.py) — `OpenAIBaseModel` `extra="allow"`, `__log_extra_fields__`, `ModelCard` ·
+[`vllm/entrypoints/openai/chat_completion/protocol.py`](https://github.com/vllm-project/vllm/blob/main/vllm/entrypoints/openai/chat_completion/protocol.py) — `tool_choice` type and `check_tool_usage`, `max_tokens` deprecation ·
+[`vllm/entrypoints/openai/cli_args.py`](https://github.com/vllm-project/vllm/blob/main/vllm/entrypoints/openai/cli_args.py) — port 8000, `api_key`, `ssl_*` ·
+[`vllm/entrypoints/serve/middleware/authenticate.py`](https://github.com/vllm-project/vllm/blob/main/vllm/entrypoints/serve/middleware/authenticate.py) · [`register.py`](https://github.com/vllm-project/vllm/blob/main/vllm/entrypoints/serve/middleware/register.py) — conditional mounting, `GUARDED_PREFIX`, 401 body ·
+[`vllm/entrypoints/serve/exception_handling/error_response.py`](https://github.com/vllm-project/vllm/blob/main/vllm/entrypoints/serve/exception_handling/error_response.py) — exception→status map ·
+[`vllm/entrypoints/serve/engine/serving.py`](https://github.com/vllm-project/vllm/blob/main/vllm/entrypoints/serve/engine/serving.py) — `The model X does not exist.` ·
+[`vllm/multimodal/media/image.py`](https://github.com/vllm-project/vllm/blob/main/vllm/multimodal/media/image.py) — `Image.open`, `VLLM_MAX_IMAGE_PIXELS`
+
+LM Studio (docs only; source of the rendered site is
+[`lmstudio-ai/docs`](https://github.com/lmstudio-ai/docs)):
+[OpenAI Compatibility Endpoints](https://lmstudio.ai/docs/developer/openai-compat) — endpoint list, port 1234 ·
+[Chat Completions](https://lmstudio.ai/docs/developer/openai-compat/chat-completions) — supported payload parameters ·
+[List Models](https://lmstudio.ai/docs/developer/openai-compat/models) — JIT note ·
+[Tool Use](https://lmstudio.ai/docs/developer/openai-compat/tools) — native vs default tool support, the optional-properties example, *"All parameters recognized…"* ·
+[Structured Output](https://lmstudio.ai/docs/developer/openai-compat/structured-output) — `response_format.json_schema`, grammar/Outlines backends ·
+[REST API v0](https://lmstudio.ai/docs/developer/rest/endpoints) — `type: "vlm"` on `/api/v0/models` ·
+[List your models (`/api/v1/models`)](https://github.com/lmstudio-ai/docs/blob/main/1_developer/2_rest/list.md) — `capabilities.vision`, `capabilities.trained_for_tool_use` ·
+[Authentication](https://lmstudio.ai/docs/developer/core/authentication) — default is no auth ·
+[Server Settings](https://lmstudio.ai/docs/developer/core/server/settings) · [Serve on Local Network](https://lmstudio.ai/docs/developer/core/server/serve-on-network) — no TLS option, `--bind 0.0.0.0` ·
+[API changelog](https://github.com/lmstudio-ai/docs/blob/main/1_developer/api-changelog.md) — the `tool_choice` value list and the *"llama.cpp only"* note
+
+Related notes in this repo:
+[`ai-openai-wire-format.md`](ai-openai-wire-format.md) ·
+[`ai-model-candidates.md`](ai-model-candidates.md) ·
+[`ai-open-research-questions.md`](ai-open-research-questions.md)
+
+In-repo files cited:
+[`lib/features/add_meal/data/openrouter_meal_items_api.dart`](../lib/features/add_meal/data/openrouter_meal_items_api.dart) ·
+[`lib/features/add_meal/domain/meal_items_api.dart`](../lib/features/add_meal/domain/meal_items_api.dart) ·
+[`lib/features/add_meal/util/meal_photo_encoder.dart`](../lib/features/add_meal/util/meal_photo_encoder.dart) ·
+[`lib/features/add_meal/data/anthropic_meal_items_api.dart`](../lib/features/add_meal/data/anthropic_meal_items_api.dart)

--- a/docs/ai-model-candidates.md
+++ b/docs/ai-model-candidates.md
@@ -1,0 +1,572 @@
+# Which other models could serve AI meal logging
+
+Research notes gathered 2026-08-16 against primary sources only — OpenRouter's
+own `/api/v1/models`, `/api/v1/models/{id}/endpoints`, `/api/v1/providers` and
+`/api/frontend/v1/all-providers`, OpenRouter's own documentation and Terms of
+Service, and each vendor's own legal pages. Where a page blocked automated
+fetching (openai.com, minimax.io, mistral.ai, ai.developer.meta.com), it was
+read in a real browser rather than through a mirror, and the quotes below are
+from the vendor's own page. Nothing here rests on a leaderboard, a blog post or
+a secondary write-up.
+
+Written to answer one question for [#668](https://github.com/simonoppowa/OpenNutriTracker/issues/668):
+**beyond `anthropic/claude-sonnet-5` and `anthropic/claude-haiku-4.5`, which
+models are fit to be offered?** The constraints it is answered against are
+settled elsewhere and are not re-argued here: no model may emit a nutrition
+value, `tool_choice` must be honoured, `strict: true` is unusable, image input
+is required, and every OpenRouter request carries `require_parameters: true`,
+`data_collection: "deny"` and a vendor pin with `allow_fallbacks: false`
+([#663](https://github.com/simonoppowa/OpenNutriTracker/issues/663),
+[`lib/core/utils/ai_model_catalogue.dart`](../lib/core/utils/ai_model_catalogue.dart),
+[`lib/features/add_meal/data/openrouter_meal_items_api.dart`](../lib/features/add_meal/data/openrouter_meal_items_api.dart)).
+
+Things I could not establish from a primary source are in
+[Not verified](#not-verified) rather than inferred.
+
+## Bottom line up front
+
+**No additional vendor clears every bar, and the catalogue should stay as it
+is.** The ruled-out list is the useful output, and three of its entries are new
+rather than restatements.
+
+1. **Anthropic has nothing newer or cheaper that fits.** Haiku 4.5 is still the
+   newest Haiku — there is no Haiku 5. Nothing Anthropic-branded is cheaper
+   *and* pinnable: `anthropic/claude-3-haiku` is four times cheaper than Haiku
+   4.5 and is served **only by Amazon Bedrock**, so `only: ["anthropic"]`
+   cannot reach it. Everything else Anthropic serves is a quality-up at
+   2.5×–15× the price of the current default. Adding one is a measurement
+   question, not a policy question.
+2. **Google has not moved in our favour.** The clause moved documents but
+   survived: the under-18 restriction that excluded `google/gemini-3.7-flash`
+   is no longer only a free-tier Gemini API term — it now sits in the **Google
+   Cloud Service Specific Terms**, which is the document OpenRouter itself
+   names as the Model Terms for *both* `google-ai-studio` and `google-vertex`.
+   The training-on-input objection *has* gone away (Cloud does not train). The
+   age objection has not, and it alone is fatal.
+3. **The one genuine near-miss is xAI/SpaceXAI.** Its Acceptable Use Policy
+   contains no disordered-eating clause, no minors clause and no
+   professional-advice clause, its enterprise terms forbid training on user
+   content outright, and it offers zero-data-retention endpoints. But "no
+   prohibition found" is weaker than Anthropic's *explicit* carve-out of
+   nutrition from High-Risk Use Cases, and xAI has no equivalent carve-out to
+   point at. It is a defensible second vendor if the project wants one; it is
+   not an obvious one, and it would still need the photo screen.
+4. **Meta is newly pinnable and newly barred.** Meta now serves its own models
+   first-party on OpenRouter (`meta/muse-spark-*`, provider slug `meta`), which
+   removes the old "Meta publishes weights but does not serve them" objection.
+   Its Model API terms replace it with a harder one: *"You and your End Users
+   must be at least 18 years of age to use the Services and Integrated
+   Products, and you will not create Integrated Products targeted at
+   individuals under the age of 18."*
+
+Two operational findings that matter regardless of which models are curated:
+
+- **The pin is looser than the code comment assumes.** OpenRouter documents
+  that a base slug matches *all* endpoint variants under it. `anthropic` today
+  includes an endpoint tagged `anthropic/claude-on-aws`, whose `provider_name`
+  is **Amazon Bedrock** and whose base URL is
+  `https://aws-external-anthropic.us-east-1.api.aws/v1`. It is not currently
+  attached to either curated model — only to `claude-sonnet-4.5` — so nothing
+  is broken today. But if it appears on Sonnet 5 or Haiku 4.5, `only:
+  ["anthropic"]` will accept it and `_warnIfThePinDidNotHold` will log a false
+  alarm, because it compares the pin slug against the display name
+  "Amazon Bedrock". See [Section D](#d-what-the-routing-block-actually-buys).
+- **`:batch` variants are half price and unusable.** OpenRouter's own docs
+  index describes the Batch API as *"Submit and retrieve **asynchronous**
+  batches of inference requests"*. Every `:batch` model in the catalogue is
+  therefore out for an interactive meal entry, however attractive
+  `anthropic/claude-sonnet-5:batch` at $1/$5 looks.
+
+## A. How the filter ran, with the numbers
+
+Every figure below is from OpenRouter's own API, queried 2026-08-16.
+
+| Stage | Models left |
+| --- | --- |
+| Listed on `/api/v1/models` | **413** |
+| …with `image` in `architecture.input_modalities` | 245 |
+| …that also list both `tools` and `tool_choice` in `supported_parameters` | **216** |
+| …with at least one **first-party endpoint** — an endpoint whose provider slug is the vendor named in the model slug — that itself advertises `tools` and `tool_choice` | **178** |
+| …whose first-party provider is not tagged as training on input (fails `data_collection: "deny"`) | 176 |
+| …excluding `:batch` variants and `~vendor/...-latest` floating aliases | **124**, across 17 vendors |
+| …after applying the vendors' own usage policies and terms | **13**, all Anthropic |
+
+The 216 figure reproduces the "~215 technically capable" measurement recorded
+in the catalogue's own doc comment, so the capability screen has not drifted.
+The collapse from 124 to 13 is entirely policy, exactly as #656 found.
+
+The 17 vendors surviving the structural screen are: `anthropic` (13 models),
+`openai` (36), `qwen`/Alibaba (20), `google` (18), `mistralai` (8),
+`bytedance-seed` (6), `x-ai` (5), `moonshotai` (4), `z-ai` (3), `meta` (2),
+`sakana` (2), `nex-agi` (2), `amazon` (1), `minimax` (1), `stepfun` (1),
+`xiaomi` (1), `rekaai` (1).
+
+The 38 models that have image + tools + `tool_choice` but **no** pinnable
+first-party endpoint fail constraint 5 outright and are listed in
+[Section E](#e-ruled-out-and-the-clause-that-rules-each-out).
+
+## B. Is there a newer or cheaper Anthropic model?
+
+All 13 Anthropic models that survive the structural screen, from OpenRouter's
+`/api/v1/models` and `/endpoints` (prices per 1M tokens, input/output):
+
+| Slug | In | Out | Context | First-party endpoint tags |
+| --- | --- | --- | --- | --- |
+| `anthropic/claude-haiku-4.5` **(curated)** | $1.00 | $5.00 | 200k | `anthropic` |
+| `anthropic/claude-sonnet-5` **(curated, default)** | $2.00 | $10.00 | 1M | `anthropic` |
+| `anthropic/claude-sonnet-4.5` | $3.00 | $15.00 | 1M | `anthropic`, `anthropic/2`, **`anthropic/claude-on-aws`** |
+| `anthropic/claude-sonnet-4.6` | $3.00 | $15.00 | 1M | `anthropic`, `anthropic/2` |
+| `anthropic/claude-opus-4.5` | $5.00 | $25.00 | 200k | `anthropic`, `anthropic/2` |
+| `anthropic/claude-opus-4.6` | $5.00 | $25.00 | 1M | `anthropic`, `anthropic/2` |
+| `anthropic/claude-opus-4.7` | $5.00 | $25.00 | 1M | `anthropic`, `anthropic/2` |
+| `anthropic/claude-opus-4.8` | $5.00 | $25.00 | 1M | `anthropic`, `anthropic/2` |
+| `anthropic/claude-opus-5` | $5.00 | $25.00 | 1M | `anthropic` |
+| `anthropic/claude-opus-4.8-fast` | $10.00 | $50.00 | 1M | `anthropic` |
+| `anthropic/claude-opus-5-fast` | $10.00 | $50.00 | 1M | `anthropic` |
+| `anthropic/claude-fable-5` | $10.00 | $50.00 | 1M | `anthropic` |
+| `anthropic/claude-opus-4.7-fast` | $30.00 | $150.00 | 1M | `anthropic` |
+
+Reading that table against the question:
+
+- **Newer, cheaper: does not exist.** Haiku 4.5 (created 2025-10-15 per the
+  API's `created` field) is the most recent model in the Haiku family; the API
+  lists no Haiku 5. Sonnet 5 is the newest Sonnet and is *cheaper* than both
+  Sonnet 4.5 and 4.6, so the two curated entries are already the cheapest
+  members of their families.
+- **Cheaper at all: only by leaving Anthropic's own endpoint.**
+  `anthropic/claude-3-haiku` is listed at $0.25/$1.25 — a quarter of Haiku 4.5
+  — and its `/endpoints` response contains exactly one endpoint, tagged
+  `amazon-bedrock`, `provider_name` "Amazon Bedrock". Under
+  `only: ["anthropic"]` with `allow_fallbacks: false` it can only 404. It is
+  also a March 2024 model, so it would need the photo screen even if the pin
+  worked.
+- **Better, at a price: `anthropic/claude-opus-5`.** It is the cheapest Opus
+  ($5/$25) and pins cleanly to `anthropic`. On the price ratio alone it would
+  cost roughly 2.5× the default's measured ~$0.0033 per photo, i.e. around
+  $0.008. Whether it identifies more staples in low-quality photos than Sonnet
+  5 is not answerable from any primary source — the catalogue's own comment
+  says membership requires a behavioural screen against a photo corpus, and
+  that screen has not been run for Opus 5. **No recommendation either way.**
+- **`-fast` and `fable` are not for this.** `claude-opus-5-fast` is the same
+  model at double the price, and `claude-fable-5` is a separate $10/$50 family.
+  Neither is defensible for a task whose entire output is a list of food names.
+- **Anthropic's own policy position is unchanged and still the best available.**
+  Usage Policy, effective 15 September 2025, under *High-Risk Use Case
+  Requirements*: healthcare is high-risk, but *"Wellness advice (e.g., advice
+  on sleep, stress, nutrition, exercise, etc.) does not fall under this
+  category"* — an explicit carve-out no other vendor offers. The Universal
+  Usage Standards still prohibit content that would *"Facilitate, promote, or
+  glamorize any form of suicide or self-harm, including disordered eating and
+  unhealthy or compulsive exercise"*, which the design already respects by
+  never letting the model produce a number or a judgement. The Commercial
+  Terms state *"Anthropic may not train models on Customer Content from
+  Services"* and contain **no age gate on the customer's end users and no
+  restriction on the audience of the customer's application** — the single
+  clause that disqualifies Google and Meta.
+
+  Sources: [Usage Policy](https://www.anthropic.com/legal/aup) ·
+  [Commercial Terms of Service](https://www.anthropic.com/legal/commercial-terms)
+
+## C. xAI / SpaceXAI — the only non-Anthropic vendor with nothing against this
+
+Five models qualify structurally: `x-ai/grok-4.6` and `x-ai/grok-4.5` ($2/$6),
+`x-ai/grok-4.3`, `x-ai/grok-4.20` ($1.25/$2.50, 2M context) and
+`x-ai/grok-build-0.1`. All list image input, `tools` and `tool_choice`; all
+have first-party endpoints tagged `xai`, `xai/priority`, `xai/zdr` and
+`xai/zdr/priority`. Images are billed as prompt tokens — OpenRouter lists no
+separate per-image price for any of them. `grok-4.6` carries a documented price
+override above 200k prompt tokens, which a meal request never approaches.
+
+What its documents say, and do not say:
+
+- **Data.** OpenRouter's provider record for `xai` reports
+  `training: false, retainsPrompts: true, retentionDays: 30` — the same profile
+  as `anthropic`, so it survives `data_collection: "deny"`. The vendor's own
+  enterprise terms go further: *"SpaceXAI will not use any User Content to
+  train any foundation models, large language models, or other artificial
+  intelligence systems or to develop any new products, services, or features"*,
+  and *"All User Content will be automatically and permanently deleted no later
+  than 30 days after the end of the interaction or session in which it was
+  submitted"*.
+- **No disordered-eating clause, no body-image clause, no minors clause beyond
+  CSAM, no professional-advice clause.** The AUP (effective 14 August 2026) was
+  read in full; the words "eating", "diet", "health" and "18" do not appear in
+  any prohibition. This is a genuine absence, not a failure to find the right
+  page — the AUP is roughly 6,000 words of running text and states it *"applies
+  to anyone using our Service, including consumers, developers and
+  businesses."*
+- **The one clause that could be argued at us**, from the same AUP: users must
+  not be *"Making high-stakes automated decisions that affect a person's
+  safety, legal or material rights, or well-being (such as making financial
+  credit, educational, employment, housing, insurance, legal, medical, or
+  other important decisions about or for them)"*. A meal-name extractor whose
+  output the user reviews before anything is written is not an automated
+  decision, and the enumerated examples are all consequential third-party
+  determinations. It is still the closest thing xAI has to a health clause, and
+  it has no carve-out attached.
+- **The age wording is of a different kind to Google's and Meta's.** The
+  enterprise terms carry a scope note: *"These terms are for enterprise
+  (business) users of the SpaceXAI API and related SpaceXAI Services (including
+  Grok) who are at least 18 years old."* That reaches whoever accepts the
+  terms. It does not say the *application* may not be one that minors use,
+  which is what makes the Google and Meta clauses fatal for a general-audience
+  tracker.
+
+**Verdict: possible, not recommended on this evidence.** Anthropic's carve-out
+says nutrition is out of scope for the high-risk regime; xAI says nothing at
+all, and silence is a weaker foundation for a project that has chosen to be
+able to name and defend its destination. Adding it would also require the
+photo screen, and would double the surface the project has to re-check whenever
+a vendor edits a policy.
+
+Sources: [SpaceXAI Acceptable Use Policy](https://x.ai/legal/acceptable-use-policy) ·
+[Terms of Service — Enterprise](https://x.ai/legal/terms-of-service-enterprise)
+
+## D. What the routing block actually buys
+
+Worth recording, because two of these are stronger than the code comments
+assume and one is weaker.
+
+**`data_collection: "deny"` filters on training, not on retention.** OpenRouter's
+provider-routing documentation: `allow` is *"allow providers which store user
+data non-transiently and may train on it"*, `deny` is *"use only providers
+which do not collect user data"*. Its own provider records make the operative
+distinction visible: `anthropic` is `training: false, retainsPrompts: true,
+retentionDays: 30` and is reachable under `deny`, so `deny` is keyed on
+training rather than on retention. Across all 81 provider records only three
+are tagged `training: true` — `deepseek`, `liquid` and `nvidia`. The
+documentation also warns that the tags are *"not a definitive source of third
+party data policies, but represents our best knowledge"*, which is why
+[Section E](#e-ruled-out-and-the-clause-that-rules-each-out) treats a conflict
+between a tag and the vendor's own terms as disqualifying.
+
+**A base slug matches every variant under it.** From the same page: *"When you
+use a base provider slug (e.g. `"google-vertex"`) in any provider routing field
+(`order`, `only`, or `ignore`), it matches all endpoints for that provider,
+including any variants or regions… Note that service tier endpoints (e.g.
+`openai/priority`, `google-vertex/flex`) are not matched by base slugs — they
+require explicit opt-in."* Two consequences:
+
+- Good: for any vendor whose only first-party endpoint carries a quantisation
+  suffix — `z-ai/fp8`, `moonshotai/int4`, `seed/fp8`, `minimax/fp8`,
+  `xiaomi/fp8`, `stepfun/fp8`, `reka/bf16` — a plain `only: ["z-ai"]` would
+  still reach it. The pin mechanism is not the obstacle for those vendors.
+- Bad: `only: ["anthropic"]` also matches `anthropic/2` and
+  `anthropic/claude-on-aws`. The latter is OpenRouter's "Claude Platform on
+  AWS" provider — `provider_name` "Amazon Bedrock", base URL
+  `https://aws-external-anthropic.us-east-1.api.aws/v1`. Its governing terms
+  per OpenRouter's own record are still
+  `https://www.anthropic.com/legal/commercial-terms`, so the *policy* outcome
+  is unchanged, but the guarantee the settings screen makes — that the company
+  named is the company that answered — becomes "Anthropic's contract, on
+  Amazon's metal". Today that endpoint exists only for `claude-sonnet-4.5`, not
+  for either curated model.
+
+**A `zdr` routing flag exists and the app does not use it.** `zdr: true`
+restricts routing to zero-data-retention endpoints. It cannot simply be turned
+on: neither curated Anthropic model has a ZDR-tagged endpoint, so the flag
+would 404 every request today. It is listed here because it is the one routing
+control that would materially strengthen the privacy claim if Anthropic ever
+publishes ZDR endpoints.
+
+**OpenRouter passes the vendors' terms through to the end user.** Terms of
+Service §5.1: *"By accessing or using any Model through the Service, you agree…
+to comply with the applicable terms for each Model ("Model Terms"), a list of
+which is provided here."* The linked list renders from the same
+`terms_of_service_url` field returned by `/api/v1/providers`, which is how each
+rule-out below identifies *which* vendor document governs. §5.2 adds that the
+user *"will be responsible for all acts and omissions of your Authorized
+Users"*.
+
+This matters most for the age clauses. OpenRouter's own eligibility rule (§2)
+is *"You must be at least 13 years of age to use the Service… If you are under
+18 years of age, you must have your parent or guardian's permission"* — so the
+router itself contemplates 13-to-17-year-old key holders, while Google's and
+Meta's Model Terms forbid the application those keys would be used in.
+
+Sources: [Provider Routing](https://openrouter.ai/docs/features/provider-routing) ·
+[OpenRouter Terms of Service](https://openrouter.ai/terms) ·
+[`/api/v1/providers`](https://openrouter.ai/api/v1/providers) ·
+[`/api/frontend/v1/all-providers`](https://openrouter.ai/api/frontend/v1/all-providers)
+
+## E. Ruled out, and the clause that rules each out
+
+### E1. Ruled out by an age or audience clause
+
+These are the hard ones. A general-audience nutrition tracker distributed on
+Google Play and F-Droid cannot promise its users are adults or that minors will
+not install it.
+
+**OpenAI — 36 models** (`openai/gpt-5.x`, `gpt-5.6-*`, `gpt-4.1*`, `o3`,
+`o4-mini`, …). Usage Policies, effective 29 October 2025, read in a browser on
+openai.com. Under *Protect people*, prohibited: *"suicide, self-harm, or
+disordered eating promotion or facilitation"*. Under *Keep minors safe*,
+prohibited: *"promoting unhealthy dieting or exercise behavior to minors"* and
+*"shaming or otherwise stigmatizing the body type or appearance of minors"*.
+Also under *Protect people*: *"provision of tailored advice that requires a
+license, such as legal or medical advice, without appropriate involvement by a
+licensed professional"*. There is no wellness or nutrition carve-out anywhere
+in the document. Unchanged from the #656 finding, and independent of the
+separate fact that `strict: true` breaks every `openai/*` call.
+[Usage policies](https://openai.com/policies/usage-policies/)
+
+**Google — 18 models** (`google/gemini-3.7-flash`, `gemini-3.5-flash-lite`,
+`gemini-3.1-pro-preview`, the Gemini 2.5 line, `gemma-4-*`, …). **The document
+to cite has changed; the answer has not.** OpenRouter's provider records give
+`https://cloud.google.com/terms/` as the Model Terms for both
+`google-ai-studio` and `google-vertex`, so the free-tier
+[Gemini API Additional Terms](https://ai.google.dev/gemini-api/terms) — with
+its training clause, its human-reviewer clause and its "not for consumer use"
+line — is **not** the governing document on the OpenRouter path. Under Cloud
+terms, the training objection genuinely disappears: Service Specific Terms §18,
+*"Google will not use Customer Data to train or fine-tune any AI/ML models
+without Customer's prior permission or instruction."* The age objection does
+not. Service Specific Terms §20(d), *Age Restrictions*: *"Customer will not,
+and will not allow End Users to, use a Generative AI Service as part of a
+website, Customer Application, or other online service that is directed towards
+or is likely to be accessed by individuals under the age of 18."* §20(e) adds a
+Healthcare Restriction against use *"as a substitute for professional medical
+advice"*. Both are declared "Use Restrictions" by §20(g). Last modified
+29 July 2026.
+
+So `google/gemini-3.7-flash` — measured better and ~5× cheaper than the current
+default — stays excluded, on one clause instead of four.
+[Google Cloud Service Specific Terms](https://cloud.google.com/terms/service-terms) ·
+[Google Cloud Terms of Service](https://cloud.google.com/terms/) ·
+[Generative AI Prohibited Use Policy](https://policies.google.com/terms/generative-ai/use-policy)
+(last modified 17 December 2024; contains no eating-disorder or nutrition
+clause, so it neither helps nor hurts)
+
+**Meta — 2 models** (`meta/muse-spark-1.1`, `meta/muse-spark-1.2`, $1.25/$4.25,
+first-party endpoint tagged `meta`). Meta Model API Terms of Service, last
+updated 5 August 2026, §10.1: *"You and your End Users must be at least 18
+years of age to use the Services and Integrated Products, and you will not
+create Integrated Products targeted at individuals under the age of 18."*
+Independently, §6.1 provides that on "Discounted Services" *"Meta may use your
+Content to train, develop, evaluate, and improve Meta's artificial intelligence
+models"* and that *"the Discounted Services do not offer a mechanism to exclude
+specific traffic from training"* — so which tier OpenRouter buys would have to
+be established before `data_collection: "deny"` meant anything here.
+[Meta Model API Terms of Service](https://ai.developer.meta.com/legal/terms-of-service)
+
+**Sakana AI — 2 models** (`sakana/fugu-ultra`, `sakana/sakana-namazu`). Two
+independent bars. Age: *"You must be at least 18 years old to use the
+Service."* Geography: *"The Service is provided for users in countries or
+regions other than the European Economic Area, the UK, and Switzerland
+("Supported Regions"). The Company does not, and does not intend to, provide or
+market the Service to countries or regions outside the Supported Regions."*
+For a German-authored app with a European user base that is disqualifying on
+its own.
+[Sakana AI Terms of Service](https://console.sakana.ai/terms-of-service)
+
+### E2. Ruled out by a data clause that contradicts the routing promise
+
+The app tells the user it asked the router to exclude providers that train on
+input. Where a vendor's own terms reserve exactly that right, the promise rests
+on OpenRouter's classification overriding the vendor's own document — which
+OpenRouter itself says is only *"our best knowledge"*.
+
+**Moonshot AI — 4 models** (`moonshotai/kimi-k3`, `kimi-k2.7-code`, `kimi-k2.6`,
+`kimi-k2.5`). OpenRouter tags `moonshotai` as `training: false,
+retainsPrompts: false`. Moonshot's own model-use agreement says: *"We may use
+Content to provide, maintain, develop, support, and improve the Services…
+Customer who requires restrictions on the use of Customer Content for training
+or improving Moonshot AI models may contact Moonshot AI to discuss available
+enterprise arrangements or separate written agreements. Unless otherwise
+expressly agreed in writing, Customer Content may be used for the foregoing
+purposes."* Whether OpenRouter holds such a written agreement is not something
+any primary source discloses. The same document also requires that *"To use the
+Services as an individual, you must be at least 18 years old or the minimum age
+required by your country to consent to such use"* — an eligibility clause of
+the milder kind, but on top of the data conflict.
+[Moonshot AI model use agreement](https://platform.moonshot.ai/docs/agreement/modeluse)
+
+**Z.AI — 3 models** (`z-ai/glm-5v-turbo`, `glm-4.6v`, `glm-4.5v`). OpenRouter
+tags `z-ai` as `training: false, retainsPrompts: false`. Z.AI's own terms:
+*"For individual users, we may use User Content to provide, maintain, develop,
+and improve our Services"* and *"For individual users, we reserve the right to
+process any User Content to improve our existing Services and/or to develop new
+products and services"*. The same document also bars use *"for any services
+that require subject qualification or professional review, or as a substitute
+for professional services, including but not limited to professional fields
+such as medical care"* and *"high-risk automated decision-making in areas that
+may materially affect the safety, rights and interests, or well-being of
+individuals and society, such as health"*.
+[Z.AI Terms of Service](https://chat.z.ai/legal-agreement/terms-of-service)
+
+**NVIDIA — 2 models** (`nvidia/nemotron-3-nano-omni-30b-a3b-reasoning:free`,
+`nvidia/nemotron-nano-12b-v2-vl:free`). OpenRouter's own provider record tags
+`nvidia` as `training: true`, so both fail `data_collection: "deny"` before any
+policy reading. Structural, not arguable.
+
+**Reka — 1 model** (`rekaai/reka-edge`). Reka's terms: *"If you use the Services
+on a free basis, you acknowledge and agree that Reka may use Your Content to
+train, develop, and improve its machine learning models and related
+technologies. This may include human review and other forms of analysis."*
+Paid requests are excluded from that, so the answer depends on how OpenRouter
+is billed — undisclosed. Moot anyway: `reka-edge` has a 16k context window, the
+smallest in the candidate set, and would need the photo screen.
+[Reka Terms of Use](https://reka.ai/legal/terms-of-use)
+
+### E3. Ruled out on the absence of any policy to rely on
+
+These vendors clear every structural bar — first-party pinnable endpoint,
+image input, `tools` + `tool_choice`, not tagged as training. None of them
+publishes anything resembling Anthropic's nutrition carve-out, and several
+publish broad professional-advice or high-risk-decision restrictions with no
+carve-out attached. For a project whose defence of this feature is "the vendor
+says in writing that wellness advice is out of scope", that absence is the
+rule-out.
+
+- **Alibaba / Qwen — 20 models** (`qwen/qwen3.8-max`, `qwen3.7-flash` at
+  $0.03/$0.13 — the cheapest capable model in the whole candidate set —
+  `qwen3-vl-*`, …), served first-party by provider slug `alibaba`. The Model
+  Terms OpenRouter names are Alibaba Cloud's International Website Product
+  Terms of Service, whose §4.48 covers Model Studio; it addresses IP, Member
+  Content and end-user consent, and contains no usage-policy treatment of
+  health, nutrition or minors at all.
+  [Alibaba Cloud Product Terms of Service](https://www.alibabacloud.com/help/en/legal/latest/alibaba-cloud-international-website-product-terms-of-service-v-3-8-0)
+- **Mistral — 8 models** (`mistralai/mistral-medium-3.1` at $0.40/$2.00,
+  `mistral-small-2603` at $0.15/$0.60, `ministral-*-2512`,
+  `mistral-large-2512`), served first-party by `mistral`. Its Usage Policy
+  (effective 11 June 2026) is the one European option, and it cuts the wrong
+  way: under *Professional advice*, *"You shall not use our Mistral AI Products
+  to provide professional advice without proper qualification. This includes,
+  for instance: … Offering medical diagnoses, treatment suggestions, or **any
+  form of health-related guidance**."* Extracting "two eggs and a slice of
+  toast" into food names is not guidance, but the clause is broader than
+  anything Anthropic imposes and there is no carve-out beside it.
+  [Mistral Usage Policy](https://legal.mistral.ai/terms/usage-policy) ·
+  [Commercial Terms of Service](https://legal.mistral.ai/terms/commercial-terms-of-service)
+- **MiniMax — 1 model** (`minimax/minimax-m3`, $0.30/$1.20). Terms of Service
+  effective 30 March 2026, read in a browser: no eating-disorder, nutrition or
+  minors-audience clause; the only age wording is *"if you are under 18, please
+  read this Agreement with a guardian and obtain their consent"*. Its AI Output
+  section disclaims medical advice. Nothing prohibits this use and nothing
+  permits it. OpenRouter tags `minimax` as `retainsPrompts: true`.
+  [MiniMax Terms of Service](https://www.minimax.io/platform/protocol/terms-of-service)
+- **ByteDance Seed — 6 models** (`bytedance-seed/seed-2.0-lite`, `seed-2.0-mini`,
+  `seed-2-1-turbo`, …), first-party via `seed` (BytePlus). The BytePlus terms
+  OpenRouter names contain no health, nutrition, minors or training clause.
+  [BytePlus Terms of Service](https://docs.byteplus.com/en/docs/legal/docs-terms-of-service)
+- **Xiaomi — 1 model** (`xiaomi/mimo-v2.5`, $0.14/$0.28). Terms exist at
+  `platform.xiaomimimo.com` but the page did not render to text for automated
+  reading; see [Not verified](#not-verified).
+- **StepFun — 1 model** (`stepfun/step-3.7-flash`) and **Nex AGI — 2 models**
+  (`nex-agi/nex-n2-pro`, `nex-n2-mini`). OpenRouter's `/api/v1/providers` lists
+  **no terms-of-service URL at all** for `stepfun`, and none for `nex-agi`
+  (privacy policy only). A vendor with no published terms cannot be assessed,
+  and cannot be offered by a project that invites users to check where their
+  photograph goes.
+- **Amazon — 1 model** (`amazon/nova-2-lite-v1`, $0.30/$2.50), served via
+  `amazon-bedrock`. The AWS Acceptable Use Policy and AWS Service Terms contain
+  no eating-disorder clause and no general age clause (the only age wording in
+  the Service Terms is a DeepRacer Student provision), and Bedrock is tagged
+  `retainsPrompts: false`. It is excluded on the same reasoning that produced
+  the vendor pin in the first place: routing to Amazon puts the request under
+  Amazon's terms rather than under a policy with a nutrition carve-out, which
+  is precisely the substitution constraint 5 exists to prevent.
+  [AWS Acceptable Use Policy](https://aws.amazon.com/aup/) ·
+  [AWS Service Terms](https://aws.amazon.com/service-terms/)
+
+### E4. Ruled out structurally, before any policy question
+
+- **38 models with no pinnable first-party endpoint.** Includes all
+  `meta-llama/*` (weights published, not served by `meta`'s own endpoint),
+  `thinkingmachines/*`, `dots-studio/*`, `openrouter/*` stealth models, and
+  individual models from vendors that do serve others first-party —
+  `anthropic/claude-3-haiku` (Bedrock only), `anthropic/claude-opus-4`
+  (Vertex only), `anthropic/claude-sonnet-4` and `claude-opus-4.1` (Vertex and
+  Bedrock only), plus several `openai/*`, `google/*`, `qwen/*`,
+  `moonshotai/*`, `minimax/*`, `mistralai/*` and `x-ai/*` entries. Under
+  `only: [...]` with `allow_fallbacks: false` these can only 404.
+- **All 10 `~vendor/...-latest` aliases** in the candidate set (11 exist in
+  total; `~deepseek/deepseek-v4-flash-latest` has no image input), e.g.
+  `~anthropic/claude-sonnet-latest`,
+  `~google/gemini-flash-latest`. OpenRouter describes each as a model that
+  *"always redirects to the latest model in the … family"*. Offering one would
+  change which model an existing user's photographs go to without an app
+  update — the exact silent behaviour change the pin exists to prevent, and
+  contrary to the reasoning already recorded in `AiModelCatalogue`.
+- **All `:batch` variants**, at 50% of list price. OpenRouter's documentation
+  index describes the Batch API as *"Submit and retrieve asynchronous batches
+  of inference requests"*.
+- **168 models with no image input**, which the photo path requires, plus a
+  further **29** that accept images but do not advertise `tools` and
+  `tool_choice`, which the forced tool call requires.
+
+## Not verified
+
+- **No live request was made.** Every capability and routing claim above is
+  from OpenRouter's declarations about itself, not from a probe. In particular:
+  that `only: ["z-ai"]` reaches `z-ai/fp8` follows from the documented base-slug
+  rule, and that `only: ["xai"]` may or may not reach `xai/zdr` is genuinely
+  unclear — the docs exclude "service tier endpoints" from base-slug matching
+  and do not say whether a `/zdr` suffix counts as one. Running a probe would
+  cost the user's own credit, so none was run.
+- **Whether OpenRouter holds a written no-training agreement with Moonshot AI
+  or Z.AI.** Both vendors' terms make training-on-content the default absent a
+  separate written agreement; OpenRouter tags both `training: false`. Neither
+  party publishes the contract. This is the crux of E2 and it is unresolvable
+  from public documents.
+- **Which Meta service tier OpenRouter buys** (Standard, no training; or
+  Discounted, training with no opt-out). Not disclosed. Moot given §10.1.
+- **Whether Reka's OpenRouter traffic is billed as paid**, which is what
+  decides whether Reka's free-tier training clause applies.
+- **Xiaomi's terms.** `https://platform.xiaomimimo.com/#/docs/terms/user-agreement`
+  is client-rendered and returned no readable text to automated fetching; it
+  was not read in a browser because `xiaomi/mimo-v2.5` fails E3 regardless.
+- **Alibaba's Membership Agreement**, which §4.48 incorporates by reference and
+  which is where an age or eligibility clause would live if one exists. Only
+  the Product Terms were read.
+- **Relative photo accuracy of every model named here.** Nothing in this
+  document is a quality claim. The catalogue's stated rule — that membership
+  requires a behavioural screen against a photo corpus, because advertised
+  capability flags do not predict it — is untouched by any of this, and no
+  model should be added on the strength of policy fit alone.
+- **Anthropic Commercial Terms revision date.** The page carries no visible
+  effective date; quotes are as published on 2026-08-16.
+
+## Sources
+
+OpenRouter (own API and docs):
+[`/api/v1/models`](https://openrouter.ai/api/v1/models) ·
+[`/api/v1/models/{author}/{slug}/endpoints`](https://openrouter.ai/api/v1/models/anthropic/claude-sonnet-5/endpoints) ·
+[`/api/v1/providers`](https://openrouter.ai/api/v1/providers) ·
+[`/api/frontend/v1/all-providers`](https://openrouter.ai/api/frontend/v1/all-providers) ·
+[Provider Routing](https://openrouter.ai/docs/features/provider-routing) ·
+[Batch API Quickstart](https://openrouter.ai/docs/batch-quickstart.md) ·
+[Terms of Service](https://openrouter.ai/terms)
+
+Vendor terms and policies:
+[Anthropic Usage Policy](https://www.anthropic.com/legal/aup) ·
+[Anthropic Commercial Terms](https://www.anthropic.com/legal/commercial-terms) ·
+[OpenAI Usage Policies](https://openai.com/policies/usage-policies/) ·
+[Google Cloud Service Specific Terms](https://cloud.google.com/terms/service-terms) ·
+[Google Cloud Terms of Service](https://cloud.google.com/terms/) ·
+[Google Generative AI Prohibited Use Policy](https://policies.google.com/terms/generative-ai/use-policy) ·
+[Gemini API Additional Terms](https://ai.google.dev/gemini-api/terms) ·
+[SpaceXAI Acceptable Use Policy](https://x.ai/legal/acceptable-use-policy) ·
+[SpaceXAI Enterprise Terms](https://x.ai/legal/terms-of-service-enterprise) ·
+[Meta Model API Terms of Service](https://ai.developer.meta.com/legal/terms-of-service) ·
+[Mistral Usage Policy](https://legal.mistral.ai/terms/usage-policy) ·
+[Mistral Commercial Terms](https://legal.mistral.ai/terms/commercial-terms-of-service) ·
+[Moonshot AI model use agreement](https://platform.moonshot.ai/docs/agreement/modeluse) ·
+[Z.AI Terms of Service](https://chat.z.ai/legal-agreement/terms-of-service) ·
+[MiniMax Terms of Service](https://www.minimax.io/platform/protocol/terms-of-service) ·
+[Alibaba Cloud Product Terms of Service](https://www.alibabacloud.com/help/en/legal/latest/alibaba-cloud-international-website-product-terms-of-service-v-3-8-0) ·
+[BytePlus Terms of Service](https://docs.byteplus.com/en/docs/legal/docs-terms-of-service) ·
+[AWS Acceptable Use Policy](https://aws.amazon.com/aup/) ·
+[AWS Service Terms](https://aws.amazon.com/service-terms/) ·
+[Reka Terms of Use](https://reka.ai/legal/terms-of-use) ·
+[Sakana AI Terms of Service](https://console.sakana.ai/terms-of-service)
+
+Related notes in this repo:
+[`ai-legal-constraints.md`](ai-legal-constraints.md) ·
+[`ai-cohort-restrictions.md`](ai-cohort-restrictions.md) ·
+[`ai-open-research-questions.md`](ai-open-research-questions.md)
+
+In-repo files cited:
+[`lib/core/utils/ai_model_catalogue.dart`](../lib/core/utils/ai_model_catalogue.dart) ·
+[`lib/features/add_meal/data/openrouter_meal_items_api.dart`](../lib/features/add_meal/data/openrouter_meal_items_api.dart) ·
+[`tool/live_routing_policy.dart`](../tool/live_routing_policy.dart)

--- a/docs/ai-open-research-questions.md
+++ b/docs/ai-open-research-questions.md
@@ -1,0 +1,970 @@
+# What is still unknown before the AI work starts
+
+A gap analysis, written 2026-08-02 as the fourth and last of the AI research
+documents, after
+[`ai-in-open-source-nutrition-trackers.md`](ai-in-open-source-nutrition-trackers.md)
+(the cohort survey),
+[`ai-legal-constraints.md`](ai-legal-constraints.md) (the legal survey) and
+[`ai-cohort-restrictions.md`](ai-cohort-restrictions.md) (the restrictions
+analysis), against the design in
+[#599](https://github.com/simonoppowa/OpenNutriTracker/issues/599) as revised in
+its three comments, the tier-0 sub-issues
+[#600](https://github.com/simonoppowa/OpenNutriTracker/issues/600) /
+[#601](https://github.com/simonoppowa/OpenNutriTracker/issues/601) /
+[#602](https://github.com/simonoppowa/OpenNutriTracker/issues/602), and the
+approved implementation plan.
+
+The three earlier documents each end with a "Not verified" / "Still open" list.
+Those lists were the starting inventory, not the answer: several items on them
+had already been closed by a later document, several were never research
+questions at all, and the items that actually threaten the build were on none of
+them. This document sorts every open question by **what it blocks**, closes the
+ones that were cheap and decisive to close, and says plainly where a route
+failed.
+
+Every item is labelled:
+
+- **Research** — an answer exists somewhere; we had not found it.
+- **Decision** — no external answer exists. The maintainer has to choose.
+- **Legal** — needs a lawyer, not more reading.
+
+## Bottom line up front
+
+**Tier-0 coding can start today.** Nothing in the legal, licensing, F-Droid or
+provider-terms surface touches #600/#601/#602, and
+[`ai-cohort-restrictions.md`](ai-cohort-restrictions.md) F1 already established
+that. What it did not establish, because nobody read the code the issues depend
+on, is that **three of the tier-0 issues contain spec errors that will produce
+wrong numbers or unusable instructions if they are implemented as written.**
+None of them is a blocker in the sense of "stop"; all three are twenty-minute
+edits to the issue bodies that should happen before a first-time contributor
+picks one up.
+
+The three:
+
+1. **#600 tells the parser to emit `kg` and `l`. The app has no such units.**
+   `UnitDropdownItem` has exactly six members and neither of those is one of
+   them, and its `fromString` falls through to `g/ml`. #600's own headline test
+   case, `1,5 l milk`, therefore logs **1.5 grams of milk instead of 1500 ml** —
+   a 1000× understatement, silently.
+2. **The relevance ranker scores morphological variants at exactly 0.0.** There
+   is no stemming anywhere in the search stack, so the query `eggs` scores
+   `0.0` against a database record named `Egg` while scoring `0.29` against
+   *Cadbury Creme Eggs*. #601 auto-selects the top candidate. The failure mode
+   the plan tells you to test for — a query that matches nothing — is not the
+   dangerous one; the dangerous one is a query that matches the wrong thing
+   confidently.
+3. **The plan's and #602's localization instructions describe a repository that
+   no longer exists.** They say to hand-edit `lib/generated/intl/` and verify
+   with `just check_intl`. That directory does not exist, that recipe is not in
+   the justfile, and the current `AGENTS.md` says the exact opposite. The
+   instructions are copied from a pre-`gen-l10n` AGENTS.md that survives only in
+   a stale worktree.
+
+Beyond tier 0: **five of the six named research gaps closed today**, including
+the one everything else was dated against. The F-Droid blocker
+([RFP #2540](https://gitlab.com/fdroid/rfp/-/issues/2540)) now has a concrete,
+current, working exemplar with the exact build recipe — and it is
+*cheaper* than `ai-cohort-restrictions.md` C7 estimated, and does not use a
+Gradle build flavour at all.
+
+## The table
+
+| # | Gap | Blocks | Kind | Cost to close | Status |
+| :-- | :-- | :-- | :-- | :-- | :-- |
+| **T1** | #600 emits `kg` / `l`; the app's unit vocabulary has neither, and the fallback is a silent 1000× error | **Tier 0 (#600, #602)** | Decision | 20 min issue edit | **Closed today** — diagnosed; the choice remains |
+| **T2** | #600 segments on `,` and accepts `,` as a decimal separator, with no precedence rule | **Tier 0 (#600)** | Decision | 10 min issue edit | Open (found by `ai-cohort-restrictions.md` F2) |
+| **T3** | No stemming anywhere in the search stack; plural queries score 0.0 and sink below noise | **Tier 0 (#601 contract, #602 acceptance)** | Research → Decision | Closed by code reading; one fixture test to size | **Closed today** |
+| **T4** | `addIntake` does an unguarded `double.parse`; a batched "Log all" has no validation, no atomicity, and bypasses the #212 duplicate guard | **Tier 0 (#602)** | Decision | 30 min issue edit | **Closed today** — diagnosed |
+| **T5** | Plan §5 / #602 l10n instructions target a directory and a `just` recipe that do not exist | **Tier 0 (#602)** | Research | Closed by reading the repo | **Closed today** |
+| **T6** | `just ci` cannot pass locally; the plan makes it the verification gate | **Tier 0 (both)** | Research | Closed by reading the repo | **Closed today** |
+| **T7** | Parser emits unbounded decimals; the review field's formatter caps at 2 dp | Tier 0 (#600) | Decision | 5 min | **Closed today** — diagnosed |
+| **S1** | Digital Omnibus deferral, Reg. (EU) 2026/1744 — the timeline everything is dated against | Tier 1 scoping | Research | Closed via EUR-Lex | **Closed today** |
+| **S2** | Anthropic: image content-part + `output_config.format` in one request | Tier 2 build (not tier-1 scoping) | Research | Docs read; one live call (~$0.003) for certainty | **Partially closed today** |
+| **S3** | Decision #5 — Train Libre posture vs. accepting the 1.4.1 risk | Tier 1 scoping | **Decision** | Free; the evidence is already gathered | Open — and no research will close it |
+| **S4** | No request timeout anywhere in the design; a local endpoint needs minutes | Tier 1 scoping | Decision | 10 min | Open (found by `ai-cohort-restrictions.md` E1) |
+| **S5** | OpenAI Services Agreement §2.2 / §3.3(g) — the BYO-key blessing #599 cites | Tier 1 scoping (weakly) | Research | Blocked; route failed | **Open — route failed** |
+| **S6** | OpenAI Usage Policies currency (quoted from a 9-month-old Microsoft mirror) | Tier 1 scoping (weakly) | Research | Blocked by the same 403 | Open |
+| **S7** | Is the project an AI Act "provider" at all? | Tier 1 scoping | **Legal** | Paid consultation | Open |
+| **S8** | Does the Art. 111(4) four-month transitional reach a feature released after 2 Aug 2026? | Release | **Legal** | Same consultation | Open — EUR-Lex truncates |
+| **S9** | Does Art. 50(2)'s "does not substantially alter … the semantics" exception cover tier 1? | Tier 1 scoping | **Legal** | Same consultation | Open |
+| **R1** | Play in-app reporting/flagging requirement for AI-generated content | Release (tiers 1–2) | Research | Closed via Google's support site | **Closed today** |
+| **R2** | Apple 5.1.2(i) and the "third-party AI" clause | Release (tiers 1–2) | Research | Closed via developer.apple.com | **Closed today** |
+| **R3** | MDCG 2019-11 wellness/fitness exclusion | Release | Research | Closed via the Commission's health domain | **Closed today** |
+| **R4** | Play Health disclaimer absent from the store listing | Release — **live today, unrelated to AI** | Decision | One paragraph | Open (found by `ai-legal-constraints.md`) |
+| **R5** | Current Play content rating, Apple age rating, Health apps declaration, Impressum reachability | Release | **Decision, misfiled as research** | 5 min in the consoles | Open |
+| **N1** | The F-Droid ML Kit escape route — what Open Food Facts actually ships | Nothing (but blocks RFP #2540) | Research | Closed via fdroiddata | **Closed today** |
+| **N2** | Whether a free-software scanner covers every symbology the app needs | Nothing | Research | Closed by code reading | **Closed today** |
+| **N3** | Does #602's bloc need a new dev dependency (`bloc_test`)? | Nothing | Research | Closed by reading `test/` | **Closed today** — no |
+| **N4** | `GPL-3.0-only` vs `-or-later`; Unsplash demo assets; `minSdkVersion` resolution | Nothing | Decision ×2, Research ×1 | Cheap | Open |
+
+Twenty-four gaps. **Thirteen closed today**, two of them partially. Of the eleven
+still open, **three need a lawyer, four are decisions with no external answer,
+two are blocked by a 403, and two are cheap lookups the maintainer can do faster
+than any researcher.**
+
+---
+
+## A. What blocks tier 0
+
+Tier 0 is a deterministic parser plus a resolver plus a review screen. No model,
+no key, no network destination that is not already in the README's table, no new
+dependency. `ai-cohort-restrictions.md` F1 verified that no licence, F-Droid or
+provider-terms restriction attaches to any of it, and nothing found today
+changes that.
+
+**So the answer to "can coding start today" is yes.** What follows are not
+reasons to wait. They are errors in the issue text that will cost a contributor
+a wasted PR if they are not fixed first — and one of them ships a wrong number
+to the user.
+
+### T1 — #600's unit set does not exist in this app. Decision.
+
+`UnitDropdownItem`
+([`meal_detail_bloc.dart:248-288`](../lib/features/meal_detail/presentation/bloc/meal_detail_bloc.dart))
+has exactly six members, and its `toString()` — which is what is persisted as
+`IntakeEntity.unit` — yields exactly six strings:
+
+```
+'g'   'ml'   'g/ml'   'oz'   'fl.oz'   'serving'
+```
+
+There is **no `kg` and no `l`**. And `fromString` ends:
+
+```dart
+default:
+  return UnitDropdownItem.gml;
+```
+
+The conversion in `UpdateKcalEvent` (same file, lines 69-80) scales only
+`serving`, `oz` and `flOz`; anything else passes through **unscaled**.
+
+#600 says, twice:
+
+> Key off digits and unit **symbols** (`g`, `kg`, `ml`, `l`, `oz`) …
+
+and its test checklist asks for:
+
+> - [ ] Comma decimal (`1,5 l milk`) and period decimal (`1.5 l milk`)
+
+Put together: `1,5 l milk` parses to `quantity: 1.5, unit: 'l'`. The review row
+cannot render `'l'` in the dropdown (it is not among the items), and whatever
+reaches `addIntake` resolves through `fromString`'s `default` branch to `g/ml`,
+unscaled. **1.5 g of milk is logged where 1500 ml was meant.** Because the
+number is plausible-looking and the unit is not shown prominently on the diary
+row, this is exactly the class of bug that does not get reported.
+
+This is a **decision**, and there are two clean answers:
+
+- **(a) Normalise in the parser.** `kg` → `g` × 1000, `l` → `ml` × 1000, and
+  never emit a unit string the app cannot represent. Roughly five lines, and it
+  keeps `1,5 l milk` working as the test intends. This is the right answer.
+- **(b) Drop `kg` and `l`** from the accepted symbol set and reject those
+  segments with an indexed error.
+
+Either way the choice has to be written into #600 **before** the parser is
+coded, because the acceptance test list currently encodes the broken
+expectation. Add a test asserting the emitted unit is always a member of the
+six-string set — that is the invariant, and it is the one the issue is missing.
+
+Note that `oz` needs no work (`UnitDropdownItem.oz.toString()` is `'oz'`), and
+`fl.oz` is not in #600's symbol list at all, which is fine.
+
+### T2 — The comma still has no precedence rule. Decision.
+
+Already found and correctly characterised at `ai-cohort-restrictions.md` **F2**;
+recorded here only because it is a tier-0 blocker of exactly the same shape as
+T1 and should be fixed in the same edit. The obvious rule — *a comma flanked by
+a digit on both sides is a decimal point; every other comma is a separator* —
+costs one regex and one test (`1,5 l milk, 2 eggs`). Seven of the nine shipped
+locales use the comma decimal, so this is not an edge case.
+
+### T3 — The search stack has no stemming, and the ranker scores plurals at zero. Research, now closed.
+
+**Nobody has looked at this.** #601 assumes `searchOFFProductsByString` +
+`searchFDCFoodByString` + `mergeAndRankMeals` return usable candidates for
+inputs like `toast`, `eggs`, `black coffee`. Reading the code, they do — for
+one of those three, and not for the other two, for a reason that is arithmetic
+rather than empirical.
+
+**The mechanism.** `_textScore`
+([`meal_relevance_ranker.dart:155-177`](../lib/features/add_meal/util/meal_relevance_ranker.dart)):
+exact normalised equality returns `1.0`; otherwise the score is a Dice
+coefficient over token **sets**, plus `0.2` if the text contains the query as a
+substring, plus `0.15` if it starts with it, clamped to `0.9`. `_tokenize`
+splits on `[^\p{L}\p{N}]+`. There is **no stemming, no lemmatisation and no
+singular/plural folding anywhere in the file.**
+
+**The zero case.** Query `eggs` against a record named `Egg`:
+
+- token sets `{eggs}` ∩ `{egg}` = ∅ → Dice `0.0`
+- `'egg'.contains('eggs')` → false → no contains-bonus
+- `'egg'.startsWith('eggs')` → false → no prefix-bonus
+- **score `0.0`**
+
+Meanwhile `Cadbury Creme Eggs` (3 tokens) scores `2·1/(3+1) + 0.2 = 0.45`.
+`rankMealsByRelevance` uses a **stable `mergeSort` and filters nothing**, so the
+correct answer is retained but sinks below the noise. #601's `ResolvedMealItem`
+carries a `selectedIndex`, and the review screen prefills from it. **The plural
+form of a common food auto-selects the wrong food.**
+
+**It compounds in three places.**
+
+1. **Local sources.** `SearchProductsUseCase._buildResult`
+   ([`search_products_usecase.dart:218-222`](../lib/features/add_meal/domain/usecase/search_products_usecase.dart))
+   filters custom meals, recipes, intake history and the 90-day cache with
+   `_mealMatchesSearch`, a plain `String.contains`. Same failure, upstream of
+   the ranker: a user's own custom meal named `Egg` is **invisible** to the
+   query `eggs`. This matters more than the remote case, because own content is
+   the tier `mergeAndRankMeals` deliberately ranks above everything else.
+2. **The remote asymmetry.** [`sp_const.dart:51-52`](../lib/features/add_meal/data/dto/sp/sp_const.dart):
+
+   ```dart
+   static const foodNameFtsConfig = 'english';
+   static const translationFtsConfig = 'simple';
+   ```
+
+   Postgres' `english` text-search configuration **does** stem, so the Supabase
+   name search finds `egg` for the query `eggs` server-side — and the client
+   ranker then scores that row `0.0` and buries it. That is the worst possible
+   shape: the backend does the right thing and the client undoes it. The
+   `simple` configuration used for the eight non-English locales does **not**
+   stem, so those locales lose the match at both ends.
+3. **The score is discarded.** `mergeAndRankMeals` returns a bare
+   `List<MealEntity>`; `scoreMealRelevance` is public but the merge path throws
+   its output away. So #601 as specified **cannot** expose a confidence signal
+   to the review screen even if it wanted to. That is a scoping consequence
+   worth writing into the issue.
+
+**The multi-token degradation, worked from the code.** Query `black coffee`:
+
+| Candidate name | Tokens | Dice | contains | Total |
+| :-- | --: | --: | --: | --: |
+| `Black Coffee` | 2 | — | — | **1.00** (exact) |
+| `Nescafé Black Coffee Instant Refill 200g` | 6 | 2·2/(6+2) = 0.50 | +0.20 | **0.70** |
+| `Coffee` | 1 | 2·1/(1+2) = 0.667 | — | **0.667** |
+
+The six-token branded product **outranks the generic entry**, because the
+contains-bonus rewards names that embed the whole query phrase and the generic
+one-word entry cannot earn it. For a bulk-logging feature whose whole point is
+generic foods, that is backwards.
+
+**But the prompt's hypothesis is only half right.** Dice does *not* degrade for
+short queries in general. For a single-token query it behaves well, because
+`2·1/(n+1)` monotonically penalises long names — which is exactly the
+"shortest matching name wins" heuristic you want:
+
+| Query `toast` vs | Tokens | Score |
+| :-- | --: | --: |
+| `Toast` | 1 | **1.00** (exact) |
+| `Toast bread` | 2 | 0.667 + 0.2 + 0.15 → capped **0.90** |
+| `Nutella Toast Spread Hazelnut 400g` | 5 | 0.333 + 0.2 = **0.53** |
+
+So `toast` is fine. The failure is specific and nameable: **(a) morphological
+variants, where the score collapses to exactly zero, and (b) multi-token generic
+queries, where the contains-bonus rewards long branded names.** `2 eggs` — the
+plan's own worked example, and the first token of the outcome sentence
+*"Type `2 eggs, 100g toast, black coffee`"* — hits both.
+
+**What this blocks.** Not #600, and not #601's *contract* — the resolver is a
+thin wrapper and its signature is unaffected. It blocks **#602 being accepted**,
+and it changes what "done" means for #601. Concretely, the plan's verification
+step 4 says:
+
+> **Check the negative case explicitly** — a query that matches nothing must
+> produce a flagged row with a working fallback, not a silent drop and not a
+> crash.
+
+That is the *safe* negative case. The unsafe one is a query that matches the
+wrong thing with no visible signal that it did. #602 should require a
+candidate-picker affordance on every row (it already does) **and** a rule for
+when not to auto-select.
+
+**The test that would settle it — and it is not a network test.** Build a
+`List<MealEntity>` fixture of ~30 realistic product names (hand-written, or
+captured once from a real search and checked in under `test/fixture/`), then
+assert `mergeAndRankMeals(off, sp, q).first` for `q ∈ {toast, eggs, egg,
+black coffee, coffee, milk, chicken breast}`. Pure unit test, no network, no
+device, and it belongs in #601 as an acceptance criterion. Sizing *recall* —
+whether the OFF and Supabase APIs return the generic entry for `toast` at all —
+does need one live query, but that can be done once by hand and recorded; the
+test suite must not depend on it.
+
+**Cheapest mitigation, no further research required:** singularise the query in
+the parser (strip a trailing `s` when the stem is ≥3 characters and re-query on
+zero results), *or* add the same normalisation inside `_tokenize`. The second is
+better — it fixes the local `_mealMatchesSearch` path too — but it changes the
+ranker's behaviour for every existing search screen, which makes it a bigger
+change than tier 0 wants. This is a **decision**, and it should be taken in
+#601 rather than discovered in review.
+
+### T4 — Batched logging has no validation, no atomicity, and skips the duplicate guard. Decision.
+
+[`meal_detail_bloc.dart:164`](../lib/features/meal_detail/presentation/bloc/meal_detail_bloc.dart):
+
+```dart
+final quantity = double.parse(amountText.replaceAll(',', '.'));
+```
+
+Unguarded `double.parse`, not `tryParse`. In the existing single-item flow this
+is safe because `MealDetailBottomSheet.onAddButtonPressed` validates first
+(lines 255-284: `double.tryParse`, then `<= 0`, then `> 10000`, each with its
+own snackbar). The bloc method itself trusts its caller.
+
+#602 says to call `addIntake` in a loop and explicitly **not** to reach for
+`AddIntakeUsecase`. Three consequences it does not mention:
+
+1. **One malformed row throws mid-batch.** Rows already processed have been
+   written; there is no rollback and no transaction. The user sees a partial log
+   and an exception.
+2. **The `> 10000` and `> 0` bounds live in the widget, not in a reusable
+   validator.** #600 and #602 both say to "lift" them. There is nothing to lift
+   — they are inline `if` statements with `ScaffoldMessenger` calls. The bulk
+   screen has to re-implement the check (or, better, extract it once and have
+   the bottom sheet use it too).
+3. **`_checkForDuplicate` / `_showDuplicateDialog` are bypassed entirely.** That
+   guard exists because of issue #212. A "Log all" button that calls `addIntake`
+   directly silently drops it. Whether a bulk flow *should* prompt per duplicate
+   is a real UX decision — prompting three times in a row is worse than not
+   prompting — but it should be taken deliberately and recorded in #602, not
+   inherited by omission.
+
+The fix is small: validate every row **before** the loop, refuse to start if any
+row fails, and state the duplicate-guard policy in the issue.
+
+### T5 — The localization instructions describe a repository that no longer exists. Research, closed.
+
+Plan §5 and #602's Localization section both say:
+
+> Then edit `lib/generated/intl/` **by hand** — AGENTS.md is explicit that
+> regenerating breaks the 120-char formatting — and confirm with
+> `just check_intl`.
+
+Every clause of that is false today:
+
+| Claim | Reality |
+| :-- | :-- |
+| `lib/generated/intl/` | **Does not exist.** `lib/generated/` contains `l10n.dart` plus nine `l10n_<locale>.dart` files and no subdirectories. |
+| Edit by hand | [`AGENTS.md:150`](../AGENTS.md): "The generated files are **gitignored — never edit them by hand**. Add the key to every ARB (all nine stay at the same key count) and run `just gen_l10n`." |
+| AGENTS.md says regenerating breaks formatting | It says the opposite. The quoted sentence exists only in `.claude/worktrees/agent-a19e62d780bb333aa/AGENTS.md:150`, a stale pre-migration copy. |
+| `just check_intl` | **Not a recipe in the justfile.** The recipes are `install build format gen_l10n test ci create_emulator start_emulator dev dev_seed`. |
+
+The repository migrated from `flutter_intl` (which generated
+`lib/generated/intl/messages_*.dart` and needed hand-maintenance) to
+`flutter gen-l10n` (configured in [`l10n.yaml`](../l10n.yaml), output
+gitignored at [`.gitignore:42`](../.gitignore)). The plan and #602 were written
+against the pre-migration instructions.
+
+**Correct instruction for #602:** add the key to all nine ARBs — verified today
+at **921 keys each, zero drift** — then run `just gen_l10n`. Nothing under
+`lib/generated/` is committed.
+
+**This is also a live repo bug outside this feature.**
+[`CONTRIBUTING.md:58`](../CONTRIBUTING.md) still tells contributors:
+
+> **Verify with `just check_intl`** — this is what CI runs and will fail the PR
+> if any of the above is missing or out of sync.
+
+and [`docs/first-timer-backlog.md:73,79`](first-timer-backlog.md) repeats it
+twice. Both statements are false, and #600 / #602 are explicitly labelled
+first-timer issues, so a new contributor will hit this before they hit anything
+in the plan.
+
+### T6 — `just ci` cannot pass locally. Research, closed.
+
+The plan's Verification step 2:
+
+> **Full gate** — `just ci` (install, format check, intl check, build_runner,
+> analyze, test). Note CI itself skips the format check but runs
+> `flutter analyze` and `flutter test`.
+
+The justfile:
+
+```
+ci: install (format "--set-exit-if-changed") gen_l10n build && test
+  flutter analyze
+```
+
+The format check is *inside* `just ci`, and
+[`.github/workflows/default_workflow.yml`](../.github/workflows/default_workflow.yml)
+explains why CI does not use the recipe:
+
+> `just ci` would also run `dart format --set-exit-if-changed`, but the codebase
+> currently has accumulated pre-existing format drift from the period when CI
+> was disabled. We run the rest of `just ci` (l10n generation, build_runner,
+> analyze, test) and leave the format pass for a dedicated follow-up PR.
+
+CI therefore calls `just install`, `just gen_l10n`, `just build`,
+`flutter analyze` and `just test` individually. A contributor following the plan
+will run `just ci`, watch it fail at step two on files they never touched, and
+have no way to tell that the failure is pre-existing. Both #600 and #602 should
+say: run the individual recipes, matching CI. There is also no "intl check"
+step in `just ci` at all — `gen_l10n` regenerates rather than verifying.
+
+### T7 — Decimal precision round-trip. Decision.
+
+[`meal_detail_bottom_sheet.dart:126-130`](../lib/features/meal_detail/presentation/widgets/meal_detail_bottom_sheet.dart)
+applies `FilteringTextInputFormatter.allow(RegExp(r'^\d+([.,]\d{0,2})?$'))` —
+**at most two decimal places, no leading `.`, no sign**. #600 and #602 both say
+to lift it. #600 states no precision cap on the parser's `double?`, so
+`1.333 kg` parses and then cannot be typed or corrected in the field it lands
+in.
+
+Separately and pre-existing: `UpdateKcalEvent` emits
+`totalQuantityConverted: convertedQuantity.toString()`, an unrounded Dart double
+(1 oz becomes `28.349523125`), which the same formatter would reject. #602
+inherits this the moment it copies the bottom sheet's `addIntake` call shape.
+Cheapest fix: have the parser round to two decimals and say so in #600.
+
+---
+
+## B. What blocks tier 1 being scoped
+
+### S1 — The Digital Omnibus deferral. **Closed today.**
+
+This was flagged in #599's third comment as the one to confirm first:
+
+> The Digital Omnibus deferral (Reg. (EU) 2026/1744) said to push Annex III
+> high-risk obligations to Dec 2027. **This is the timeline claim everything
+> else is dated against — confirm it first.**
+
+**Confirmed against EUR-Lex.** The ELI record
+[`eli/reg/2026/1744/oj/eng`](https://eur-lex.europa.eu/eli/reg/2026/1744/oj/eng)
+resolves to:
+
+> Regulation (EU) 2026/1744 of the European Parliament and of the Council of
+> 8 July 2026 amending Regulations (EU) 2024/1689, (EU) 2018/1139 and
+> (EU) 2023/1230 as regards the simplification of the implementation of
+> harmonised rules on artificial intelligence (Digital Omnibus on AI)
+
+and the deferral dates are as `ai-legal-constraints.md` states:
+
+- Chapter III Sections 1–3 for **Annex III** high-risk systems → **2 December 2027**
+- Chapter III Sections 1–3 for **Annex I** high-risk systems → **2 August 2028**
+
+with the stated rationale, verbatim from recital 40 of the OJ text:
+
+> the delayed availability of standards, common specifications, and alternative
+> guidance and the delayed establishment of national competent authorities lead
+> to challenges that jeopardise the effective entry into application
+
+**And the load-bearing point holds: Article 50 was not deferred.** The only
+change to Article 50 in the Omnibus is to **Article 50(7)** — the Commission's
+implementing-act empowerment over codes of practice, replaced with "The
+Commission shall encourage and facilitate the drawing up of codes of
+practice…". Article 50(1)–(5) are untouched, and the general date of
+application, 2 August 2026, stands. So the marking duty in Article 50(2) is
+**in force as of today** and is not covered by the high-risk deferral.
+
+That is the whole of what the timeline claim needed. `ai-legal-constraints.md`'s
+application-timeline table can be treated as verified on this point.
+
+**What could not be retrieved, and why:** the *operative* amended text of
+Article 113, and the Article 111(4) transitional that
+`ai-legal-constraints.md` quotes. EUR-Lex's HTML rendering truncates
+mid-sentence in Article 63 on every route tried —
+`legal-content/EN/TXT/HTML/?uri=OJ%3AL_202601744` and
+`?uri=CELEX:32026R1744` both stop at the same place ("…without affecting the
+level of protection or the need for compl"). This is the same truncation
+behaviour #599's third comment already recorded for the consolidated AI Act
+text. The confirmation above therefore rests on the ELI record and recital 40,
+both on `eur-lex.europa.eu` and both primary; the Article 111(4) quote in
+`ai-legal-constraints.md` remains **unverified**, and it is a lawyer question
+anyway (see S8).
+
+### S2 — Anthropic: image + `output_config.format` in one request. **Partially closed today.**
+
+The plan calls this "documented only by inference" and "the load-bearing
+assumption of the photo path", and #599 makes it one of two spikes that "must
+land before either tier is scoped". Documentation only was checked today; no
+API call was made and no key was used.
+
+What the three relevant pages say:
+
+- **[Structured outputs](https://platform.claude.com/docs/en/build-with-claude/structured-outputs)**
+  — does not mention images, vision, or content blocks **at all**. Its
+  limitations section is entirely about JSON Schema features (no recursive
+  schemas, no numerical or string constraints, `additionalProperties` must be
+  `false`, `minItems` only 0 or 1, no external `$ref`), and ends "If you use an
+  unsupported feature, you'll receive a 400 error with details." **No content-type
+  restriction is stated.**
+- **[Vision](https://platform.claude.com/docs/en/build-with-claude/vision)** —
+  does not mention structured outputs, `output_config`, or JSON schemas at all.
+  Its Limitations section lists people identification, accuracy, spatial
+  reasoning, counting, AI-generated-image detection, inappropriate content and
+  healthcare. **No request-parameter restriction is stated.**
+- **[Messages API reference](https://platform.claude.com/docs/en/api/messages/create)**
+  — this is the most useful of the three and neither earlier document consulted
+  it. The endpoint description is:
+
+  > Send a structured list of input messages **with text and/or image content**,
+  > and the model will generate the next message in the conversation.
+
+  and `output_config` is documented as a **top-level body parameter**, sibling to
+  `messages`:
+
+  > `output_config: optional OutputConfig` — Configuration options for the
+  > model's output, such as the output format.
+  > … `format: optional JSONOutputFormat` — A schema to specify Claude's output
+  > format in responses.
+
+**Conclusion.** The two things are orthogonal in the documented request schema:
+`output_config` constrains the *response*, image blocks are *request* content,
+and no page in the documentation states or implies an incompatibility. That is
+materially stronger than "documented only by inference" — but it is still not a
+positive statement that the combination is supported, and Anthropic's docs do
+not enumerate valid combinations, so silence is not a guarantee.
+
+**Re-scoping this gap:** it no longer blocks tier 1 being **scoped**, only
+tier 2 being **built**. #599 lists it as a blocker on scoping *either* tier;
+that is now over-cautious. One live call at roughly $0.003 settles it, and it
+should be the first thing the tier-2 branch does, not a prerequisite for
+writing the tier-1 issue.
+
+Two related corrections while on this page, both to `ai-cohort-restrictions.md`
+**E3**, which is otherwise accurate:
+
+- The per-request image cap is **100 for models with a 200k-token context window
+  and 600 for all others**, not 20. The 20 is the threshold *above which* a
+  stricter per-image dimension limit applies ("either resize each image so that
+  neither dimension exceeds 2000 px, or keep the request to 20 or fewer image
+  and document blocks"). Immaterial for single-image requests.
+- The high-resolution tier is described as "Claude 4.7 and later models" at
+  2576 px / 4784 visual tokens; standard is 1568 px / 1568 tokens. The plan's
+  arithmetic for a 1024×1024 WebP still checks out at ⌈1024/28⌉² = 37² = **1369
+  visual tokens**.
+
+The second #599 spike — **WebP q80 vs q90 on nutrition labels** — remains open
+and is not a research question. Anthropic's warning is already quoted verbatim
+in `ai-cohort-restrictions.md` E3 and on the vision page ("this can introduce
+artifacts that are detrimental to model performance… heavy JPEG compression can
+make text difficult to read… Confirm your compression settings are appropriate
+for the task by inspecting the actual images sent to the API"). No amount of
+reading will produce the answer for *our* pipeline; it is an experiment, and it
+belongs to tier 2.
+
+### S3 — Decision #5 is a decision, not a research gap. Open, and no research will close it.
+
+#599's first comment says tier 1 "should not be scoped until decision #5 is
+re-settled — either by adopting the Train Libre posture (model names foods,
+database supplies numbers), or by explicitly accepting the store-review risk
+with a rationale recorded here."
+
+That is stated correctly. It is worth restating here because it is the single
+thing actually blocking tier-1 scoping and it is **not waiting on information**.
+The evidence is complete: the cohort survey established what every comparator
+does (Train Libre bans model-emitted numbers outright, Scranbook computes
+locally from bundled composition data, EatWise ships only ranges); #250's spike
+supplied the measured accuracy argument; `ai-cohort-restrictions.md` E4 supplied
+the only external accuracy datum (fud-ai#157: "the reported calories varied by
+about 900 ± 300 kcal" across ten identical prompts); and #599's second comment
+already narrowed the exposure to database-miss rows. Nobody needs to read
+anything else. **Someone needs to choose.**
+
+### S4 — The timeout. Decision.
+
+`ai-cohort-restrictions.md` **E1** established this and characterised it
+correctly as a hard blocker for the local-endpoint story rather than a bug.
+Recorded here only to keep the tier-1 checklist in one place: the one measured
+cohort datum is 54–100 s server-side, fixed by making the client timeout
+configurable 30–600 s with a **180 s default**. Nothing in the plan, #599, #601
+or #602 mentions a timeout. This needs a number chosen, not a source found.
+
+### S5 / S6 — OpenAI. **Route failed.**
+
+Two items remain unverified because `openai.com` returns HTTP 403 to every
+route. Per the brief this was not re-attempted today, and no first-party path
+outside `openai.com` exists for either document — OpenAI publishes its terms
+nowhere else.
+
+- **Services Agreement §2.2 / §3.3(g)**, which #599's decision table cites as
+  "explicitly blesses the BYO-key architecture". **Unverified.** This matters
+  less than it looks: #599 revision 2 already moved off a hardcoded provider to
+  a generic endpoint field, so OpenAI is no longer a named default, and the
+  clause was cited as a *point in OpenAI's favour* in a comparison OpenAI lost.
+  Nothing in the current design depends on it.
+- **Current Usage Policies.** `ai-cohort-restrictions.md` **D7** quotes them
+  from a Microsoft-hosted PDF marked "Effective: October 29, 2025", printed
+  2025-11-07 — a mirror, now roughly nine months stale. The clause that matters
+  ("automation of high-stakes decisions in sensitive areas without human review
+  … medical") is one of two independent regimes resting on #602's review screen,
+  so it should be re-checked before that argument is relied on in writing. It
+  does not block anything from being built, because the screen is being built
+  regardless.
+
+### S7 / S8 / S9 — The three genuine legal questions. Open.
+
+These need a lawyer, and both `ai-legal-constraints.md` and #599's third comment
+already say so. Restated compactly because they are the only items on this list
+that money rather than time will close:
+
+1. **Is the project a "provider" of an AI system under Article 3(3) at all**,
+   given the inference component arrives at runtime from an address the user
+   typed, and the software is free and open-source? Nearly every downstream
+   conclusion moves on the answer. Highest leverage.
+2. **Does the Article 111(4) four-month transitional reach a feature released
+   after 2 August 2026?** On its face it is scoped to systems already on the
+   market on that date, which would mean no grace period. The operative text
+   could not be retrieved today (see S1).
+3. **Does Article 50(2)'s "do not substantially alter the input data … or the
+   semantics thereof" exception cover the tier-1 text path?** If tier 1 is
+   inside it and tier 2 is not, the tier split becomes a compliance boundary as
+   well as a technical one — which is a better reason for the split than the one
+   it was chosen for.
+
+One point worth adding: **the AI Act questions are dated, not open-ended.**
+Article 50 is in force *today*; the high-risk chapters that were deferred to
+December 2027 were never in play for this app. So there is no schedule pressure
+from the deferral — the pressure, such as it is, is that tiers 1–2 would be
+placed on the market after the Article 50 application date with no transitional.
+
+---
+
+## C. What blocks a release, not development
+
+### R1 — Google Play's in-app reporting requirement. **Closed today.**
+
+Confirmed verbatim from Google's own support site,
+[AI-Generated Content policy](https://support.google.com/googleplay/android-developer/answer/13985936).
+Definition:
+
+> AI-generated content is content that is created by generative AI models based
+> on user prompts.
+
+Operative requirement:
+
+> Apps that generate content using AI must contain in-app user reporting or
+> flagging features that allow users to report or flag offensive content to
+> developers without needing to exit the app.
+
+`ai-legal-constraints.md`'s quotation is accurate and its reasoning stands: the
+operative sentence is **not** scoped to the two listed examples (chatbots,
+image/video generation), so arguing the scope is not worth it — a "Report this
+result" affordance on the review screen settles it. The page carries no
+last-updated date; the only date shown is a "©2026 Google" footer.
+
+**Does not touch tier 0.** Tier 0 generates nothing; it retrieves.
+
+### R2 — Apple Guideline 5.1.2(i). **Closed today.**
+
+Confirmed verbatim from
+[developer.apple.com](https://developer.apple.com/app-store/review/guidelines/):
+
+> Unless otherwise permitted by law, you may not use, transmit, or share
+> someone's personal data without first obtaining their permission. You must
+> provide access to information about how and where the data will be used. You
+> must clearly disclose where personal data will be shared with third parties,
+> **including with third-party AI**, and obtain explicit permission before doing
+> so.
+
+Three further confirmations that matter more than the quote:
+
+- **"third-party AI" appears exactly once in the whole document**, here.
+- **There is no separate AI-specific guideline number.**
+- **There is no requirement anywhere to label AI-generated output.**
+
+So `ai-legal-constraints.md` is right that Apple's entire AI-specific
+requirement for this feature is one sentence: disclose, and get explicit
+permission, before sharing personal data with third-party AI. Every on-screen
+"estimated" marker is driven by UWG § 5 and by the README's own citation claim,
+not by Apple.
+
+### R3 — MDCG 2019-11 rev.1. **Closed today.**
+
+Confirmed verbatim from the European Commission's own health domain
+([`mdcg_2019_11_en.pdf`](https://health.ec.europa.eu/document/download/b45335c5-1679-4c71-a91c-fc7a4d37f12b_en?filename=mdcg_2019_11_en.pdf)).
+Both sentences `ai-legal-constraints.md` relies on are accurate:
+
+> In addition, software only intended for non-medical purposes (excluding MDR
+> Annex XVI devices), such as invoicing, staff planning, e-mailing, web or voice
+> messaging, data parsing, word processing, and back-up, **wellness or fitness
+> apps, do not qualify as MDSW**.
+
+and, in the same section:
+
+> It must be highlighted that the risk of harm to patients, users of the
+> software, or any other person, related to the use of the software within
+> healthcare, including a possible malfunction **is not a criterion on whether
+> the software qualifies as a medical device**.
+
+The second sentence is the important one and it cuts both ways, exactly as
+`ai-legal-constraints.md` argues: an `estimated` flag cannot make a
+medical-purpose product non-medical, and a model's inaccuracy cannot make a
+wellness app medical. **Qualification is decided by the stated intended purpose
+and by nothing else** — which means the store listing and in-app copy are the
+whole game.
+
+### R4 — The Play health disclaimer is missing today. Decision, not research.
+
+Found by `ai-legal-constraints.md`, repeated in #599's third comment, verified by
+inspection: `fastlane/metadata/android/en-US/full_description.txt` contains no
+"not a medical device and does not diagnose, treat, cure, or prevent any medical
+condition" language, and the in-app `disclaimerText` says "not a medical
+**application**", which is a different phrase in a different place from the one
+the policy names. This is live in production, unrelated to AI, and costs one
+paragraph. It should have its own issue.
+
+### R5 — Four items misfiled as "could not verify" that are just lookups. Decision.
+
+`ai-legal-constraints.md`'s "What I could not verify" section lists these as
+research failures. They are not — they are things nobody outside the project
+*can* answer, and things the maintainer can answer in five minutes:
+
+- the app's current **Play content rating** and **App Store age rating**;
+- whether the **Play Console Health apps declaration** is currently accurate;
+- whether an **Impressum** with name, postal address and email is reachable from
+  the app and the project site (DDG § 5).
+
+Listing them under "unverified" implies a researcher could close them. None can.
+They belong on a maintainer checklist.
+
+---
+
+## D. What blocks nothing, but is worth knowing
+
+### N1 — The F-Droid ML Kit escape route. **Closed today, and it is cheaper than we thought.**
+
+`ai-cohort-restrictions.md` **C1** is the biggest finding in the four documents
+and the only present-tense blocker anyone has identified: bundled Google ML Kit
+via `mobile_scanner ^7.2.0` fails F-Droid's Free Software Requirement, so
+[RFP #2540](https://gitlab.com/fdroid/rfp/-/issues/2540) cannot succeed today.
+It says "swap the scanner, as Open Food Facts did" but does not say what the
+replacement actually is. Here it is.
+
+**Open Food Facts' Flutter app is in the F-Droid main repository right now**, at
+version 4.23.0, under the package id `openfoodfacts.github.scrachx.openfood`
+(reused from the legacy native app), licence `Apache-2.0`. The metadata is
+[`openfoodfacts.github.scrachx.openfood.yml`](https://gitlab.com/fdroid/fdroiddata/-/raw/master/metadata/openfoodfacts.github.scrachx.openfood.yml).
+The mechanism, verbatim from the most recent build entry:
+
+```yaml
+subdir: packages/smooth_app
+srclibs:
+  - flutter@stable
+rm:
+  - packages/smooth_app/ios
+  - packages/scanner/ml_kit
+  - packages/app_store/google_play
+  - packages/app_store/apple_app_store
+prebuild:
+  - git -C $$flutter$$ checkout -f $(cat ../../flutter-version.txt)
+  - sed -i -e '/ml_kit/d' -e '/apple_/d' -e '/google_play/d' -e 's/version:.*/version: $$VERSION$$+$$VERCODE$$/' pubspec.yaml
+  - export PUB_CACHE=$(pwd)/.pub-cache
+  - $$flutter$$/bin/flutter config --no-analytics
+  - $$flutter$$/bin/flutter pub get
+scanignore:
+  - packages/scanner/shared/pubspec.yaml
+  - packages/scanner/zxing/pubspec.yaml
+scandelete:
+  - packages/smooth_app/.pub-cache
+build:
+  - export PUB_CACHE=$(pwd)/.pub-cache
+  - export PATH=$$flutter$$/bin:$$flutter$$/bin/cache/dart-sdk/bin/:$PATH
+  - $$flutter$$/bin/flutter build apk -t lib/entrypoints/android/main_fdroid.dart
+output: build/app/outputs/apk/release/app-release-unsigned.apk
+ndk: r28c
+```
+
+And the replacement scanner is
+[`packages/scanner/zxing`](https://github.com/openfoodfacts/smooth-app/blob/develop/packages/scanner/zxing/pubspec.yaml),
+whose only scanning dependency is:
+
+```yaml
+qr_code_scanner: 1.0.1
+```
+
+**Four corrections to `ai-cohort-restrictions.md` follow from this.**
+
+1. **It is not a Gradle build flavour.** C3, C4 and the "build flavour"
+   framing throughout section C assume the lever is
+   `android/app/build.gradle`'s `productFlavors`. Open Food Facts does not use
+   one for this. The lever is a **second Dart entry point**
+   (`lib/entrypoints/android/main_fdroid.dart`) selected with
+   `flutter build apk -t <entrypoint>`, plus fdroiddata-side `rm` and `sed`
+   surgery that physically deletes the ML Kit package and strips its line from
+   `pubspec.yaml` before the build. Our existing `flavorDimensions "version"`
+   with `develop` / `full` is therefore **not** the thing to extend. The work is
+   (a) put the scanner behind an interface, (b) add a second `main_*.dart`, and
+   (c) write the fdroiddata recipe. That is a different, smaller and more
+   self-contained piece of work than "add a third flavour".
+2. **The Flutter SDK does not need vendoring.** C7 describes the maid recipe —
+   `submodules: true`, the SDK checked into the repo as `packages/flutter`,
+   `scanignore: [packages/flutter/bin/cache]`, `--split-per-abi`, and **one
+   metadata entry per ABI with a distinct versionCode**. Open Food Facts uses
+   `srclibs: [flutter@stable]` — F-Droid's own Flutter srclib, pinned per-build
+   by `git -C $$flutter$$ checkout -f $(cat ../../flutter-version.txt)` — and
+   ships a **single universal unsigned APK** with no per-ABI split and no
+   submodules. That is substantially less work, and it comes from a peer Flutter
+   *food* app rather than an LLM client.
+3. **Anti-features survive the swap, and inclusion survives the anti-features.**
+   OFF still carries `NonFreeNet` ("openfoodfacts.net/.org, openproductfacts.org,
+   openstreetmap.org and sentry.io servers") **and** `Tracking` ("Analytics are
+   opt-in but the app connects to sentry.io from the start, and connects even if
+   rejected") — with ML Kit removed — and is in the main repository. This is a
+   direct precedent for our own Sentry posture (**C6**): a peer app with opt-in
+   Sentry earned `Tracking` and stayed listed. It is also the cleanest possible
+   confirmation of **C8**.
+4. **The replacement is licence-clean but stale.**
+   [`qr_code_scanner`](https://pub.dev/packages/qr_code_scanner/license) is
+   **BSD-2-Clause, "Copyright 2018 Julius Canute", version 1.0.1, last published
+   about three years ago.** It is GPL-3.0-compatible and F-Droid-acceptable, but
+   it is not maintained. A better candidate for a fresh integration is
+   [`flutter_zxing`](https://pub.dev/packages/flutter_zxing) — **MIT, v2.3.0,
+   published about three months ago**, ZXing C++ via Dart FFI, Android API 21+,
+   with no Google or otherwise proprietary dependency. Both are viable; neither
+   is `mobile_scanner`, whose unbundled variant only trades a bundled
+   proprietary blob for a runtime Play Services dependency.
+
+**This has nothing to do with AI** and should be its own issue, as C1 already
+argues. It is now costed rather than hypothetical.
+
+### N2 — Does a free-software scanner cover every symbology we need? **Closed today, from the code.**
+
+`ai-cohort-restrictions.md` lists this as unverified. It is answerable without
+any network call. The required set is:
+
+- **EAN-8, UPC-A, EAN-13, GTIN-14** — enumerated explicitly in
+  [`barcode_check_digit.dart`](../lib/features/scanner/util/barcode_check_digit.dart),
+  which accepts exactly lengths `{8, 12, 13, 14}` and validates the shared
+  Modulo-10 check digit. These are the only linear formats the app acts on.
+- **QR Code** — three import screens scan QR
+  (`import_meal_scanner_screen.dart`, `import_recipe_scanner_screen.dart`,
+  `import_activity_scanner_screen.dart`) and `qr_flutter: ^4.1.0` generates it.
+
+`scanner_screen.dart:57` constructs a bare `MobileScannerController()` with no
+`formats:` argument, so nothing narrower is configured. Every format in that set
+— EAN-8, EAN-13, UPC-A, ITF (for GTIN-14) and QR — is core ZXing. **No
+symbology is lost by the swap.** Worth re-confirming against the chosen
+package's own format list at integration time, but there is no reason to expect
+a gap.
+
+### N3 — Does #602 need a new dev dependency? **Closed today: no.**
+
+`mockito: ^5.6.4` is already in `dev_dependencies` (as #601 says).
+`bloc_test` is **not** — but the repo already tests blocs without it
+(`test/features/recipes/presentation/bloc/recipes_bloc_test.dart`,
+`recipe_builder_bloc_test.dart`, `test/unit_test/products_bloc_search_test.dart`
+and others). So the plan's "no new dependency" promise holds for the test tree
+as well as for `lib/`, and #602 should follow the existing hand-rolled pattern
+rather than reaching for `bloc_test`.
+
+### N4 — Three small open items, all decisions or cheap lookups.
+
+- **`GPL-3.0-only` vs `GPL-3.0-or-later`** (`ai-cohort-restrictions.md` A9). A
+  decision, forced whenever the F-Droid metadata is written, and forced earlier
+  if any GPL-3.0-only peer code is absorbed.
+- **The bundled Unsplash demo photos** (C5). A decision: replace the twelve
+  images or accept `NonFreeAssets`. No external ruling exists to find; asking
+  F-Droid is the only way to know in advance, and asking is itself a decision.
+- **`minSdkVersion`**. [`android/app/build.gradle:63`](../android/app/build.gradle)
+  is still `minSdkVersion flutter.minSdkVersion` — unpinned, deferring to
+  whatever the Flutter SDK default is, with Flutter pinned to **3.44.6** in
+  [`.fvmrc`](../.fvmrc). #599's "runs down to minSdk 24" claim is therefore
+  still taken on trust. Irrelevant to tier 0, and `flutter_secure_storage` 10's
+  floor of 23 means E5's conclusion holds either way.
+
+---
+
+## E. Open items that are misfiled
+
+The most useful thing to say about the three existing "Not verified" lists is
+that several entries on them are not research questions at all. Leaving them
+there implies someone could close them by reading harder. Nobody can.
+
+| Item, as filed | Where | What it actually is |
+| :-- | :-- | :-- |
+| "Whether Google would read a structured meal list as AI-generated content" | `ai-legal-constraints.md` | **Already decided.** The same document says "Building the report control moots the question", and #599 accepted that. Not open. |
+| "Whether F-Droid would apply `NonFreeAssets` to the Unsplash demo photos" | `ai-cohort-restrictions.md` | **Decision.** No ruling exists to find. Either replace the images or accept the label. |
+| "Whether `ollama.com`'s Terms reach a locally-run `ollama serve`" | `ai-cohort-restrictions.md` | **Decision** (or legal, if it ever mattered). The Terms are silent; silence will not become an answer by re-reading it. |
+| Play content rating / Apple age rating / Health apps declaration / Impressum | `ai-legal-constraints.md` | **Four maintainer lookups**, five minutes total. Not researchable from outside. |
+| "Whether the app's Play Console Health apps declaration is currently accurate" | `ai-legal-constraints.md` | Same. |
+| "Whether the Article 111(4) transitional reaches a post-2 Aug 2026 feature" | `ai-legal-constraints.md` | **Legal**, correctly identified elsewhere in the same document but listed under "could not verify", which understates it. |
+| Decision #5 re-settlement | #599 comment 1 | **Decision.** Framed as blocking tier-1 scoping, which is right — but it reads as though more evidence is pending. It is not. |
+| "What Kai 9000's `foss` flavour actually removes" | `ai-cohort-restrictions.md` | Genuinely research, but **now moot**: N1 supplies a better, closer and current exemplar from a peer Flutter food app. |
+
+---
+
+## What I could not reach, and why
+
+- **The operative amended text of Article 113, and Article 111(4), of Regulation
+  (EU) 2026/1744.** EUR-Lex's HTML rendering truncates mid-sentence in
+  Article 63 on both
+  [`?uri=OJ%3AL_202601744`](https://eur-lex.europa.eu/legal-content/EN/TXT/HTML/?uri=OJ%3AL_202601744)
+  and [`?uri=CELEX:32026R1744`](https://eur-lex.europa.eu/legal-content/EN/TXT/HTML/?uri=CELEX:32026R1744),
+  stopping at the identical point ("…without affecting the level of protection
+  or the need for compl"). The same behaviour was already recorded for the
+  consolidated AI Act text in #599's third comment. The deferral dates and the
+  Article 50 position were confirmed from the
+  [ELI record](https://eur-lex.europa.eu/eli/reg/2026/1744/oj/eng) and recital
+  40 instead — both primary, both on `eur-lex.europa.eu` — so no mirror was
+  needed for the claim that mattered. **The Article 111(4) quote in
+  `ai-legal-constraints.md` remains unverified.**
+- **OpenAI's Services Agreement §2.2 / §3.3(g) and current Usage Policies.**
+  Not attempted today: `openai.com` returned HTTP 403 to every route on the
+  previous pass, and OpenAI publishes these documents on no other first-party
+  host. **The route failed and remains failed.** The Usage Policies text quoted
+  at `ai-cohort-restrictions.md` D7 is still a nine-month-old Microsoft-hosted
+  mirror.
+- **A positive statement that `output_config.format` and an image content-part
+  are supported together.** Three Anthropic documentation pages were read; none
+  states an incompatibility and none states compatibility. Documentation cannot
+  close this. One live API call can, and none was made.
+- **Whether `flutter.minSdkVersion` resolves to 24 under Flutter 3.44.6.** The
+  Flutter SDK is not on this machine's `PATH` (the repo uses FVM), so the
+  default could not be read out of `flutter.groovy`.
+- **Empirical search recall.** No live query was made against Open Food Facts or
+  the Supabase backend, per the brief. Everything in T3 is derived from the
+  source of `meal_relevance_ranker.dart`, `search_products_usecase.dart` and
+  `sp_food_data_source.dart`, and the arithmetic is reproducible by hand. What
+  the APIs actually *return* for `toast` is still unmeasured; the test that
+  would settle it is described in T3 and does not require the network.
+
+## Sources
+
+Primary, fetched today:
+
+[Regulation (EU) 2026/1744 — ELI record](https://eur-lex.europa.eu/eli/reg/2026/1744/oj/eng) ·
+[Regulation (EU) 2026/1744 — OJ HTML (truncates)](https://eur-lex.europa.eu/legal-content/EN/TXT/HTML/?uri=OJ%3AL_202601744) ·
+[Anthropic structured outputs](https://platform.claude.com/docs/en/build-with-claude/structured-outputs) ·
+[Anthropic vision](https://platform.claude.com/docs/en/build-with-claude/vision) ·
+[Anthropic Messages API reference](https://platform.claude.com/docs/en/api/messages/create) ·
+[Google Play AI-Generated Content policy](https://support.google.com/googleplay/android-developer/answer/13985936) ·
+[Apple App Review Guidelines](https://developer.apple.com/app-store/review/guidelines/) ·
+[MDCG 2019-11 rev.1](https://health.ec.europa.eu/document/download/b45335c5-1679-4c71-a91c-fc7a4d37f12b_en?filename=mdcg_2019_11_en.pdf) ·
+[fdroiddata `openfoodfacts.github.scrachx.openfood.yml`](https://gitlab.com/fdroid/fdroiddata/-/raw/master/metadata/openfoodfacts.github.scrachx.openfood.yml) ·
+[smooth-app `packages/smooth_app/pubspec.yaml`](https://github.com/openfoodfacts/smooth-app/blob/develop/packages/smooth_app/pubspec.yaml) ·
+[smooth-app `packages/scanner/zxing/pubspec.yaml`](https://github.com/openfoodfacts/smooth-app/blob/develop/packages/scanner/zxing/pubspec.yaml) ·
+[`qr_code_scanner` licence](https://pub.dev/packages/qr_code_scanner/license) ·
+[`flutter_zxing`](https://pub.dev/packages/flutter_zxing) ·
+[F-Droid RFP #2540](https://gitlab.com/fdroid/rfp/-/issues/2540)
+
+In-repo files read for sections A and D:
+
+[`AGENTS.md`](../AGENTS.md) ·
+[`CONTRIBUTING.md`](../CONTRIBUTING.md) ·
+[`justfile`](../justfile) ·
+[`l10n.yaml`](../l10n.yaml) ·
+[`.gitignore`](../.gitignore) ·
+[`.fvmrc`](../.fvmrc) ·
+[`pubspec.yaml`](../pubspec.yaml) ·
+[`.github/workflows/default_workflow.yml`](../.github/workflows/default_workflow.yml) ·
+[`android/app/build.gradle`](../android/app/build.gradle) ·
+[`lib/features/add_meal/util/meal_relevance_ranker.dart`](../lib/features/add_meal/util/meal_relevance_ranker.dart) ·
+[`lib/features/add_meal/domain/usecase/search_products_usecase.dart`](../lib/features/add_meal/domain/usecase/search_products_usecase.dart) ·
+[`lib/features/add_meal/data/data_sources/sp_food_data_source.dart`](../lib/features/add_meal/data/data_sources/sp_food_data_source.dart) ·
+[`lib/features/add_meal/data/dto/sp/sp_const.dart`](../lib/features/add_meal/data/dto/sp/sp_const.dart) ·
+[`lib/features/meal_detail/presentation/bloc/meal_detail_bloc.dart`](../lib/features/meal_detail/presentation/bloc/meal_detail_bloc.dart) ·
+[`lib/features/meal_detail/presentation/widgets/meal_detail_bottom_sheet.dart`](../lib/features/meal_detail/presentation/widgets/meal_detail_bottom_sheet.dart) ·
+[`lib/features/meal_detail/meal_detail_screen.dart`](../lib/features/meal_detail/meal_detail_screen.dart) ·
+[`lib/features/scanner/scanner_screen.dart`](../lib/features/scanner/scanner_screen.dart) ·
+[`lib/features/scanner/util/barcode_check_digit.dart`](../lib/features/scanner/util/barcode_check_digit.dart) ·
+[`lib/core/utils/food_name_validator.dart`](../lib/core/utils/food_name_validator.dart) ·
+[`lib/core/utils/json_meal_importer.dart`](../lib/core/utils/json_meal_importer.dart) ·
+[`lib/l10n/*.arb`](../lib/l10n/) (nine files, 921 keys each, zero drift)
+
+Issues and the plan:
+[#599](https://github.com/simonoppowa/OpenNutriTracker/issues/599) (body plus its three comments, the comments controlling) ·
+[#600](https://github.com/simonoppowa/OpenNutriTracker/issues/600) ·
+[#601](https://github.com/simonoppowa/OpenNutriTracker/issues/601) ·
+[#602](https://github.com/simonoppowa/OpenNutriTracker/issues/602) ·
+[#250](https://github.com/simonoppowa/OpenNutriTracker/issues/250)

--- a/docs/ai-openai-behavioural-screen.md
+++ b/docs/ai-openai-behavioural-screen.md
@@ -1,0 +1,196 @@
+# OpenAI behavioural screen (#684)
+
+**Verdict: forced tool calls and the counts-never-measurements guarantee both
+hold, on all three models, with no exceptions in 54 calls. Two model-quality
+problems disqualify `gpt-5.4-mini` and weaken `gpt-5.4-nano`, and
+`gpt-5.6-luna` is clean. One finding changes the failure taxonomy: OpenAI
+answers an unknown model with 400, not 404.**
+
+**The empty-answer rule is NOT answered here.** The non-food corpus from the
+previous screen no longer exists on disk, and it was never committed — see
+[The gap](#the-gap-the-empty-answer-rule) at the bottom. Everything else in
+#684 is answered.
+
+Run 2026-08-19 against the live API with `tool/live_openai.dart`, which drives
+the **real** `ModelMealTextInterpreter` and `ModelMealPhotoInterpreter` through
+a probe-local `MealItemsApi`. The shipping schema, prompts, `mealItemsFromJson`
+and `validateParsedMealItems` are all exercised — not re-translated, which is
+the mistake every probe before #673 made.
+
+## What was measured
+
+| | `gpt-5.4-nano` | `gpt-5.4-mini` | `gpt-5.6-luna` |
+| :-- | :-- | :-- | :-- |
+| Forced tool call returned as a tool call (text) | **7/7** | **7/7** | **7/7** |
+| Forced tool call returned as a tool call (photo) | **11/11** | **11/11** | **11/11** |
+| Unit outside the enum survived validation | 0 | 0 | 0 |
+| Measurement leaked from a photo | **0** | **0** | **0** |
+| Food photo wrongly returned empty | **0/11** | **0/11** | **0/11** |
+| Spurious `serving` on a bare count | seen | seen | not seen |
+| Duplicate rows for one food | 2 photos | **1 photo, 12 rows** | none |
+
+54 successful calls, 0 failures, 0 prose replies.
+
+## 1. Forced tool calls are reliable
+
+Every one of 54 calls came back as a `function_call`, never prose. `tool_choice`
+with an explicit `{'type': 'function', 'name': ...}` is honoured on the
+Responses API across all three models, including with an image in the input.
+
+`strict: false` must be sent explicitly. #683 predicted this and it is confirmed:
+the schema has `quantity` and `unit` outside `required`, and Responses
+normalises an unspecified `strict` into strict mode, which rejects exactly that
+shape. Omitting the field is the dangerous option, not the neutral one.
+
+## 2. The counts-never-measurements guarantee holds
+
+**Zero measurements leaked in 33 photo calls.** No model attached a unit to
+anything read from a photograph, so the discard path in
+`ModelMealPhotoInterpreter` was never even exercised. Counts did come back —
+17 rows carried `x1.0` — which is what the guarantee permits.
+
+## 3. The unit enum held, and the 1000× litre bug did not reappear
+
+`1.5 l milk` produced **1500 ml** on all three models. That is correct: the
+model returns `l` and `validateParsedMealItems` normalises to ml. The #669 bug
+was `1.5 l` → `1.5 ml`, a thousandfold under-count with nothing flagged because
+a unit *was* stated. It did not recur.
+
+`2 tbsp olive oil` produced quantity 2 with **no unit** on all three — the
+prompt's "do not substitute a different unit" rule held, and no model mapped a
+tablespoon onto grams.
+
+## 4. Two model-quality problems
+
+### Duplicate rows — disqualifying for `gpt-5.4-mini`
+
+On a photo of a bunch of bananas, `gpt-5.4-mini` returned **twelve separate
+`banana x1.0` rows**. In the app that is twelve diary entries from one
+photograph, each needing individual deletion. `gpt-5.4-nano` duplicated more
+mildly (`olive oil, olive oil, olive oil`; `яблоко, яблоки` — singular and
+plural of the same fruit as two rows). `gpt-5.6-luna` returned `bananas`,
+`apples` and `olive oil` as one row each.
+
+Nothing in the schema or the validator forbids duplicates, and nothing should:
+two separate eggs on a plate are legitimately two rows. This is a model-quality
+difference, and it is the clearest separator in the matrix.
+
+### Spurious `serving` on a bare count
+
+Twice across two runs, a bare count came back carrying `unit: serving`:
+`porridge 1.0 serving` (mini, run 1) and `Eier 2.0 serving` (nano, run 2).
+**Intermittent — different models, different inputs, not reproducible on
+demand.** `serving` is in the enum, so `validateParsedMealItems` accepts it,
+and the review row then scales by serving size rather than using the bare-count
+default. The logged amount changes silently.
+
+`gpt-5.6-luna` did not do this in either run, but two runs is not evidence of
+immunity.
+
+## 5. The failure taxonomy diverges — 400, not 404
+
+| condition | Anthropic | OpenRouter | **OpenAI** |
+| :-- | :-- | :-- | :-- |
+| bad key | 401 | 401 | **401** |
+| unknown model | 404 | 404 | **400** |
+
+> `The requested model 'gpt-does-not-exist' does not exist.` — HTTP **400**
+
+This matters because #695 gave each client its own `_failureFor`, and the
+obvious OpenAI mapping sends 400 to `rejected`. On the photo path `rejected`
+means *"Couldn't use that image. Try another photo."* — advice that can never
+work when the real problem is the model id. OpenAI reuses 400 for both, so
+**status alone cannot separate them**; a direct client has to read the error
+body, or accept that a model problem is reported as an image problem.
+
+Not a blocker, and it costs nothing today because the curated list is fixed in
+code — but it is a real difference from both shipped providers, and it is the
+kind of thing #659 spent a ticket on.
+
+## 6. One caveat about language
+
+`gpt-5.4-nano` answered `яблоко, яблоки` — Russian — for a photo of apples,
+with no locale in the request. The probe deliberately passes no `localeCode`,
+and production always passes one, so this may not reproduce in the app. Worth a
+single check when the real client is written rather than a ticket of its own.
+
+## The gap: the empty-answer rule
+
+**#684 asks for the non-food slice, and it could not be run.**
+
+The corpus from #669 — 45 images, of which a 15-image slice was scored, with
+the true answer being 13 empty and 2 with food — is not on disk. It was never
+committed, which was the right call for photographs, but it means the
+`42/45` and `15/15` baselines have nothing to compare against.
+
+What was run instead is the *opposite* slice: 11 food-bearing photos from
+`assets/demo/meals/`. That answers false negatives, and the answer is
+**0/33 — no model wrongly returned empty for a photo with food in it.**
+
+That is worth stating carefully, because it points the other way from #669:
+
+> `openai/gpt-5.4-nano` returned empty for **both** food-bearing photos
+
+— measured through OpenRouter. Here, direct, `gpt-5.4-nano` found food in
+all eleven. **Different corpus, different route, so this is not a refutation.**
+The candidates are that the OpenRouter path was the problem, that the two food
+photos in that slice were unusually hard, or that the model changed. Naming
+which would need the original images.
+
+**Still unmeasured:** whether these models invent food in a photo that has
+none. That is the false-positive direction, and it needs non-food images.
+
+## The gap, partly closed (#719, 2026-08-19)
+
+**No hallucination was observed — and the sample is too weak to conclude much
+from that.** Both statements matter; the second is why this section exists
+rather than a one-line "passed".
+
+The #669 corpus is still gone, so a set was assembled from images already in
+the repo, chosen so nothing personal left the machine:
+
+| image | what it is | correct answer |
+| :-- | :-- | :-- |
+| `alex_demo_avatar.jpg` | a portrait photograph of a man | empty |
+| `feature_graphic.png` | app logo — **a spoon** — plus "OpenNutriTracker" | empty |
+| `banner_top.png` | the same mark and wordmark | empty |
+| `logo.png` | the same mark | empty |
+| `playstore_banner.png` | Google Play badge, pure text and chevron | empty |
+
+**Scoring rule, fixed before the run** — #669 had to revise its own scoring
+after seeing results, which is exactly the trap worth avoiding:
+
+- returning **empty** is correct for all five;
+- an item naming a **food that is not depicted** is a hallucination;
+- an item naming **cutlery or brand text** is a lesser, separate error — wrong,
+  but not invented food.
+
+### Result: 5/5 empty on both shipped models
+
+`gpt-5.6-luna` and `gpt-5.6-terra`, 10 calls, no failures, nothing returned.
+
+The one genuinely informative case is the spoon. Two of the five images show
+cutlery beside the word *"NutriTracker"*, which is about as strong a nudge
+toward "this is about food" as a picture can carry without containing any.
+Neither model took it.
+
+### Why this is weak evidence
+
+- **Five images, and only one is a photograph.** The other four are flat
+  graphics with large areas of white. The failure mode worth fearing is a
+  model looking at a cluttered real scene — #669's slice was office desks —
+  and finding a snack in it. Nothing here tests that.
+- **No comparability.** The recorded baselines (`claude-haiku` pinned 15/15,
+  `gemini-3.7-flash` 15/15, direct Anthropic 42/45) were scored on different
+  images. These numbers sit beside them only by coincidence of being fractions.
+- **A null result on an easy set is close to unfalsifiable.** A model that
+  hallucinates on real scenes would very likely still return empty for a Play
+  Store badge.
+
+**What would settle it** is 15–45 photographs of ordinary scenes containing no
+food — rooms, desks, streets — run with
+`ONLY=photo MODELS=gpt-5.6-luna,gpt-5.6-terra fvm dart run tool/live_openai.dart <key-file> <dir>`.
+The harness handles jpg, webp and png. Whoever assembles that set should decide
+first whether to keep near-misses in it: #669's slice contained a desk with a
+tomato on it and another with a bottle of water, both of which two models
+correctly found, and both of which had been mislabelled non-food.

--- a/docs/ai-openai-data-handling.md
+++ b/docs/ai-openai-data-handling.md
@@ -1,0 +1,689 @@
+# What does OpenAI do with prompts and images, and what survives of the README's claims?
+
+**Verdict: OpenAI publishes no equivalent to Anthropic's ephemerality
+sentence, and the honest answer is that no such sentence exists.** The
+nearest thing OpenAI writes about images runs the *other* way: image
+inputs are covered by the same up-to-30-day abuse-monitoring retention as
+text, and the only image-specific sentence in OpenAI's data documentation
+describes a case where an image is *kept for human review even under the
+strongest retention control OpenAI sells*. The word "ephemeral" appears
+exactly once on OpenAI's data-controls page and refers to Code Interpreter
+container storage, not to images. **The README cannot quote one sentence
+for an OpenAI path; it needs two, and both are weaker than what it quotes
+today.** This is a documents review, not legal advice.
+
+## The sentences the README could stand behind
+
+There is no single-sentence answer, so these are the two that would have to
+be quoted together. Both were read on the live page on 2026-08-16.
+
+**On training** — [Data controls in the OpenAI platform](https://developers.openai.com/api/docs/guides/your-data):
+
+> Your data is your data. As of March 1, 2023, data sent to the OpenAI API
+> is not used to train or improve OpenAI models (unless you explicitly opt
+> in to share data with us).
+
+**On retention** — same page, and this is the one that must not be trimmed:
+
+> By default, abuse monitoring logs are generated for all API feature usage
+> and retained for up to 30 days, unless longer retention is required by
+> law, or is reasonably necessary to protect our services or any third
+> party from harm.
+
+Quote that qualifier in full. The [Enterprise privacy](https://openai.com/enterprise-privacy/)
+page (updated 8 January 2026) carries a **shorter** version of the same
+promise — *"After 30 days, API inputs and outputs are removed from our
+systems, unless we are legally required to retain them"* — which omits the
+"reasonably necessary … from harm" escape hatch. **Do not quote the
+enterprise-privacy version.** It is the more flattering of the two and the
+developer documentation contradicts it by being broader. Using the weaker
+text is the project's own house rule, and here the two OpenAI pages
+disagree with each other.
+
+## Bottom line up front
+
+1. **The ephemerality sentence has no counterpart.** Anthropic says image
+   uploads are *"ephemeral and not stored beyond the duration of the API
+   request"*. OpenAI's equivalent claim is "up to 30 days", with two
+   exceptions, plus a CSAM-scanning carve-out that survives even Zero Data
+   Retention. The gap is not a wording difference; it is the difference
+   between *nothing is kept* and *content is kept for a month by default*.
+   See [Section C](#c-images-the-sentence-that-does-not-exist).
+2. **Training is genuinely fine, and it is the one place OpenAI matches
+   Anthropic.** API data is not trained on by default, the position is
+   contractual-adjacent (documentation, incorporated by Service terms §1)
+   rather than marketing, and it is explicitly different from the consumer
+   products. See [Section A](#a-training).
+3. **Zero Data Retention is out of reach for the app's actual user.** It is
+   *"subject to prior approval by OpenAI and acceptance of additional
+   requirements"*, routed through a sales team, and the marketing page
+   scopes it to *"qualifying organizations"*. A solo BYO-key hobbyist is
+   not going to obtain it. **The app must therefore promise the 30-day
+   default, not the ZDR case**, and must not mention ZDR as though it were
+   available. See [Section B](#b-retention-and-whether-zdr-is-reachable).
+4. **Identity is the one question that answers in OpenAI's favour, and
+   decisively.** `safety_identifier` is documented *"optional"* and the
+   guidance says identifiers *"are recommended … but they are not
+   required."* The legacy `user` field is deprecated. On a direct path the
+   app sends no identifier at all — which is strictly better than the
+   OpenRouter path, where an account-level identity is forwarded and cannot
+   be suppressed ([#664](https://github.com/simonoppowa/OpenNutriTracker/issues/664)).
+   See [Section D](#d-identity-the-field-is-optional-and-that-is-verified).
+5. **WebP is accepted, verbatim and without qualification.** No transcode
+   is needed. The app's fallback media types are `webp`, `jpeg`, `png`,
+   `gif` — exactly OpenAI's accepted set. See
+   [Section C](#c-images-the-sentence-that-does-not-exist).
+6. **§6 is not engaged, and this time the consistency argument from
+   [#679](https://github.com/simonoppowa/OpenNutriTracker/issues/679) *is*
+   available.** Anthropic's Usage Policy prohibits misusing or soliciting
+   *"private information such as non-public contact details, health data,
+   biometric or neural data (including facial recognition)"* — which names
+   health data where OpenAI says only "private or sensitive", and which the
+   project already accepted. But §6 does change what the disclosure must
+   say. See [Section E](#e-service-terms-6-in-full).
+7. **A fourth destination is real, documented, and named.** Cloudflare is a
+   listed API sub-processor performing processing *"at the data center that
+   is closest to the End User"*, and content OpenAI's classifiers flag may
+   be shared with moderation vendors in the Philippines. The README's
+   "every destination" table cannot describe an OpenAI path as one hop. See
+   [Section F](#f-region-and-sub-processors-the-fourth-destination).
+
+## How this was read
+
+Primary sources only, all read on 2026-08-16. `openai.com` returns HTTP 403
+to automated fetching, as [`ai-openai-key-transfer.md`](ai-openai-key-transfer.md)
+recorded, so every `openai.com` quote below was read in a real browser
+against the live page. `developers.openai.com` does answer automated
+fetches, but **every quote from it was still verified against the rendered
+page**, because a summarising fetch is exactly the failure mode
+[`ai-openai-key-transfer.md`](ai-openai-key-transfer.md) §G caught inventing
+a decisive sentence. Where the finding is an *absence*, it was established
+by string search of the rendered page and the search term is stated so the
+check is repeatable. Two search-result summaries produced during this work
+were discarded rather than cited: one paraphrased the Anthropic Usage
+Policy clauses closely enough to be misleading, and one attributed ZDR
+eligibility criteria to OpenAI pages that do not state them.
+
+| Document | Date it carries |
+| --- | --- |
+| [Data controls in the OpenAI platform](https://developers.openai.com/api/docs/guides/your-data) | no date carried |
+| [Enterprise privacy at OpenAI](https://openai.com/enterprise-privacy/) | Updated **January 8, 2026** |
+| [Service terms](https://openai.com/policies/service-terms/) | Updated **June 12, 2026** |
+| [OpenAI Sub-processor list](https://openai.com/policies/sub-processor-list/) | Last updated **July 9, 2026** |
+| [Images and vision](https://developers.openai.com/api/docs/guides/images-vision) | no date carried |
+| [Safety best practices](https://developers.openai.com/api/docs/guides/safety-best-practices) | no date carried |
+| [Create chat completion (API reference)](https://developers.openai.com/api/reference/resources/chat/subresources/completions/methods/create) | no date carried |
+| [Business data privacy, security, and compliance](https://openai.com/business-data/) | no date carried — **marketing page** |
+| [Anthropic Vision documentation](https://platform.claude.com/docs/en/build-with-claude/vision) | no date carried |
+| [Anthropic Usage Policy](https://www.anthropic.com/legal/aup) | Effective **September 15, 2025** |
+
+**Note the weight of the evidence.** The single most load-bearing document
+here — the data-controls guide — **carries no date at all**. That is worse
+than the policy documents [`ai-openai-policy-fit.md`](ai-openai-policy-fit.md)
+relied on, all of which carry effective dates. The retention promise the
+README would quote is a documentation page that can change without notice
+and without a version marker. Service terms §1 (*"use APIs in accordance
+with the applicable documentation"*) makes that documentation binding on
+the Customer; it does not make it a promise binding on OpenAI.
+
+### The behaviour this is read against
+
+Verified in source, in
+[`meal_photo_encoder.dart`](../lib/features/add_meal/util/meal_photo_encoder.dart):
+
+- Encoding is *"WebP, quality 80, longest edge 1024 px"*, produced in memory
+  and never written to the app's documents directory.
+- The emitted media type is `image/webp`. If the on-device WebP encoder is
+  unavailable the raw file is sent under its own type, from the set
+  `{webp, jpeg, png, gif}` (`_mediaTypes`).
+- `maxBytes` is `3 * 1024 * 1024`, and the comment records that *"a 1024 px
+  WebP is 80–200 KB, so this never fires"*.
+- One request, no conversation history, no account, no profile.
+
+## A. Training
+
+**API input is not used for training by default, and the position is
+different from the consumer products.** This is the one axis on which
+OpenAI is not weaker than Anthropic.
+
+The operative sentence is quoted at the top of this note. What matters more
+than the sentence is the *table* on the same page, which states the answer
+per endpoint in a column headed **"Data used for training"**. For both
+endpoints the app could use:
+
+| Endpoint | Data used for training | Abuse monitoring retention | Application state retention |
+| --- | --- | --- | --- |
+| `/v1/chat/completions` | **No** | 30 days | None, see exceptions |
+| `/v1/responses` | **No** | 30 days | None, see exceptions |
+
+**The consumer contrast is stated by OpenAI itself**, on the enterprise
+privacy page, and it is worth quoting because it is the thing users
+actually worry about:
+
+> OpenAI uses data from different places including public sources, licensed
+> third-party data, and information created by human reviewers. We also use
+> data from versions of ChatGPT and other services for individuals. By
+> default, data from ChatGPT Business, ChatGPT Enterprise, ChatGPT for
+> Healthcare, ChatGPT Edu, ChatGPT for Teachers, and the API Platform
+> (after March 1, 2023) isn't used for training our models, unless you have
+> explicitly opted in to share your data with us to improve the services.
+
+*"We also use data from versions of ChatGPT and other services for
+individuals"* is the consumer position; the API is carved out of it. A user
+who has read that ChatGPT trains on conversations is reading something
+true — about a different product.
+
+**The opt-in shape.** Training requires an affirmative act by the account
+holder. The enterprise privacy page: *"If you have explicitly opted in to
+share your data with us (for example, through our opt-in feedback
+mechanisms) to improve our services, then we may use the shared data to
+train our models."* The marketing page locates the control: *"you can do so
+through explicit opt-in in the API dashboard."* It is off unless the key
+holder turns it on, and the app cannot turn it on.
+
+**Where this is stated.** In documentation and on an FAQ page, not in the
+Services Agreement or the Service terms. I searched the Service terms
+(updated 12 June 2026) end to end: it contains **no retention provision and
+no training provision at all**. So the training promise is a published
+policy statement, not a contractual warranty — the same character as
+Anthropic's, and no weaker.
+
+**One caveat the app controls.** On `/v1/chat/completions` the `store`
+parameter is *"optional boolean or null"* and is documented as *"Whether or
+not to store the output of this chat completion request for use in our
+model distillation or evals products."* On `/v1/responses` the default runs
+the other way:
+
+> The Responses API has a 30 day Application State retention period by
+> default, or when the `store` parameter is set to true. Response data will
+> be stored for at least 30 days.
+
+Note *"at least"*. **An OpenAI client should use `/v1/chat/completions`, or
+set `store: false` explicitly on `/v1/responses`** — otherwise the app opts
+its user into a 30-day application-state store *on top of* abuse-monitoring
+retention, purely by not passing a parameter. This is a concrete
+implementation requirement, not a policy observation.
+
+## B. Retention, and whether ZDR is reachable
+
+**Two stores, not one.** OpenAI distinguishes *abuse monitoring logs*
+(*"Logs generated from your use of the platform, necessary for OpenAI to
+enforce our Usage Policies"*) from *application state* (*"Data persisted
+from some API features in order to fulfill the task or request"*). For a
+single stateless chat-completions call the second is "None"; the first is
+30 days. The README must describe the first.
+
+**What is in the logs.** *"Abuse monitoring logs may contain certain
+customer content, such as prompts and responses, as well as metadata
+derived from that customer content, such as classifier outputs."* So: the
+meal line, the photo, and the model's answer.
+
+**Who can read them.** This is the part with no Anthropic counterpart in
+the README today, and it is the part a privacy-focused reader will care
+about most. From the enterprise privacy page:
+
+> Our access to API business data stored on our systems is limited to (1)
+> authorized employees that require access for engineering support,
+> investigating potential platform abuse, and legal compliance and (2)
+> specialized third-party contractors who are bound by confidentiality and
+> security obligations, solely to review for abuse and misuse.
+
+**Human review by third-party contractors is contemplated, by name, for API
+data.** Combined with [Section F](#f-region-and-sub-processors-the-fourth-destination),
+those contractors are identifiable and located.
+
+### Could a BYO-key hobbyist actually get ZDR?
+
+**No, on the published terms.** The gate is stated three times, and each
+statement is an obstacle:
+
+> Eligible customers may have their customer content excluded from these
+> abuse monitoring logs, subject to the limitations below, by getting
+> approved for the Zero Data Retention or Modified Abuse Monitoring
+> controls. **Currently, these controls are subject to prior approval by
+> OpenAI and acceptance of additional requirements.**
+
+> Get in touch with our sales team to learn more about these offerings and
+> inquire about eligibility.
+
+And from the marketing page: *"We offer data retention controls for
+**qualifying organizations** … Qualifying organizations are able to
+configure how long OpenAI retains business data, including opting for our
+zero data retention policy in the API platform."*
+
+Three separate barriers: **eligibility** (undefined, and OpenAI publishes no
+criteria), **prior approval**, and **acceptance of additional requirements**
+(an unnamed further agreement). The route is a sales conversation, and the
+noun used is *organizations*. There is also a duty attached — approved
+customers are *"responsible for ensuring their users abide by OpenAI's
+policies … and complying with any moderation and reporting requirements
+under applicable law"* — which is a compliance obligation a hobbyist has no
+apparatus to discharge.
+
+**Consequence for the app.** Any disclosure string must describe the
+default. Wording like "you can request zero data retention" would be
+technically true and practically false, and it is exactly the kind of
+generalising-from-the-stronger-case the project's README exists to avoid.
+
+**Two further retentions that apply to the default user specifically.**
+
+- *"When Zero Data Retention is not enabled for an organization, all queries
+  use extended prompt caching for all supported models."* Prompt caching
+  *"may store encrypted key/value tensors in GPU-local storage as
+  application state … not retained after the 24-hour expiration."* So a
+  non-ZDR user — every user of this app — gets a 24-hour encrypted
+  derivative of their request on a GPU host. It is not the image, and it is
+  encrypted, but it is not nothing, and it is a consequence of *not* having
+  the control they cannot obtain.
+- The 30-day window has the *"reasonably necessary to protect our services
+  or any third party from harm"* extension, which is open-ended.
+
+## C. Images: the sentence that does not exist
+
+**This is the ticket's central question, and the answer is decisive.**
+
+### The absence, established by search
+
+The string `ephemeral` occurs **exactly once** on the data-controls page.
+Its context, in full:
+
+> Hosted containers used by Hosted Shell and Code Interpreter may write
+> temporary application state to the container filesystem (backed by
+> ephemeral block storage) while the container is active.
+
+That is about Code Interpreter disk, not image inputs. **OpenAI uses the
+word, but never about images.** The images-and-vision guide contains no
+retention or training statement of any kind — it is entirely about formats,
+tokens, sizing and cost. The Service terms contain no retention provision.
+There is nowhere else for such a sentence to live.
+
+### The image-specific sentence that does exist
+
+There is exactly one, and it is not reassuring:
+
+> Images and files may be uploaded as inputs to `/v1/responses` (including
+> when using the Computer Use tool), `/v1/chat/completions`, and
+> `/v1/images`. **Image and file inputs are scanned for CSAM content upon
+> submission. If the classifier detects potential CSAM content, the image
+> will be retained for manual review, even if Zero Data Retention, Modified
+> Abuse Monitoring, or Eyes Off is enabled.**
+
+And images are singled out again, as the one exception to the strongest
+control OpenAI sells: *"Modified Abuse Monitoring excludes customer content
+**(other than image and file inputs in rare cases, as described below)**
+from abuse monitoring logs across all API endpoints."*
+
+**Every image is scanned. A false positive is retained for human review, and
+no retention control prevents it.** The scanning is unobjectionable and the
+carve-out is one almost nobody would argue against — but the README's claim
+is falsifiable, and "the image is retained only for the request" would be
+false on this path.
+
+### Side by side
+
+| | Anthropic (vision docs) | OpenAI |
+| --- | --- | --- |
+| Image retention | *"ephemeral and not stored beyond the duration of the API request"* | up to **30 days** in abuse-monitoring logs |
+| After processing | *"automatically deleted after they have been processed"* | removed after 30 days, subject to two exceptions |
+| Training on images | *"Anthropic does not use uploaded images to train models"* | not used for training (parity) |
+| Image-specific carve-out | none | CSAM classifier hit → **retained for manual review**, survives ZDR |
+| Human review | not contemplated in the vision docs | *"specialized third-party contractors … solely to review for abuse and misuse"* |
+
+Anthropic's text, verified on the live page, is a FAQ answer:
+
+> **Can I delete images I've uploaded?** No. Image uploads are ephemeral and
+> not stored beyond the duration of the API request. Uploaded images are
+> automatically deleted after they have been processed.
+
+**Note what that is.** It is an FAQ entry in a documentation page, not a
+contractual term — the same evidentiary weight as OpenAI's data-controls
+guide, and the README should not imply otherwise. The two vendors are
+promising different things at the *same* level of formality. The difference
+is in the substance, not the standing.
+
+### Formats and limits — WebP is fine
+
+Verified verbatim from the images-and-vision guide:
+
+> **Supported file types**
+> PNG (.png) - JPEG (.jpeg and .jpg) - WEBP (.webp) - Non-animated GIF (.gif)
+>
+> **Size limits**
+> Up to 512 MB total payload size per request - Up to 1500 individual image
+> inputs per request
+>
+> **Other requirements**
+> No watermarks or logos - No NSFW content - Clear enough for a human to
+> understand
+
+**WebP is accepted with no qualification, so no transcode is needed.** The
+app's `_mediaTypes` set is exactly OpenAI's accepted set. Its 3 MB cap is
+three orders of magnitude inside the 512 MB payload limit.
+
+Three notes:
+
+- **There is no global pixel-dimension cap**, only per-model patch budgets.
+  At 1024×1024 the patch count is `32 × 32 = 1024`, inside the 1,536-patch
+  budget of the mini and nano models, so **no server-side resize happens** —
+  the app's 1024 px choice lands well.
+- **Animated GIF is excluded.** The encoder's fallback path can emit
+  `image/gif` verbatim from a source file, so an animated GIF chosen from
+  the picker would be rejected. A narrow edge case; worth a guard.
+- ***"No watermarks or logos"* is stated as an input requirement**, and a
+  photo of packaged food routinely contains a brand logo. Read in context
+  the list is aimed at image-*generation* fidelity, and I found no
+  enforcement of it against vision inputs — but it is phrased as a
+  requirement for *"Input images … to be used in the API"*, and I cannot
+  show it does not apply. **Unresolved; recorded because it is the kind of
+  line that surfaces later.**
+
+## D. Identity: the field is optional, and that is verified
+
+**Confirmed on both the guidance page and the API reference.** From
+[Safety best practices](https://developers.openai.com/api/docs/guides/safety-best-practices):
+
+> Safety identifiers are recommended for products where individual users
+> interact with a model, but **they are not required**. Include safety
+> identifiers in your API requests with the `safety_identifier` parameter
+
+And OpenAI's own advice is to avoid sending anything identifying even when
+you do use it: *"A safety identifier should be a string that uniquely
+identifies each user. Hash the username or email address in order to avoid
+sending us any identifying information."*
+
+From the chat-completions reference, read field by field:
+
+- **`safety_identifier: optional string or null`** — *"A stable identifier
+  used to help detect users of your application that may be violating
+  OpenAI's usage policies. The IDs should be a string that uniquely
+  identifies each user, with a maximum length of 64 characters. We recommend
+  hashing their username or email address, in order to avoid sending us any
+  identifying information."*
+- **`prompt_cache_key: optional string or null`** — *"Used by OpenAI to
+  cache responses for similar requests to optimize your cache hit rates.
+  **Replaces the user field.**"*
+- **`user`** is marked **Deprecated**: *"This field is being replaced by
+  `safety_identifier` and `prompt_cache_key`. Use `prompt_cache_key` instead
+  to maintain caching optimizations."*
+
+**So the ticket's question is answered, with a correction: the field is no
+longer `user`.** It has been split in two, and both halves are optional.
+
+**What omitting them costs.** Nothing in policy terms — no documented
+penalty, no rate-limit consequence, no degraded eligibility; I searched the
+reference and the safety guide for any. The only stated cost is technical
+and it is a *benefit* here: `prompt_cache_key` exists to *"boost cache hit
+rates by better bucketing similar requests"*, so omitting it means requests
+are not bucketed together. A privacy-preserving app wants exactly that.
+
+**This is the one place the direct path is unambiguously better than
+OpenRouter.** There, an account-level identity is forwarded upstream and
+cannot be suppressed. Here the app simply omits both fields and OpenAI
+receives no application-level identifier at all. The account behind the key
+is still known to OpenAI as the billing customer — that is unavoidable on
+any BYO-key path and the README should not imply otherwise — but nothing
+the *app* adds distinguishes one user from another.
+
+## E. Service terms §6, in full
+
+The ticket's appended question. Quoted complete, from the live page
+(Updated: June 12, 2026). Note the heading is **"Image and Video
+Capabilities"**, not "Visual Capabilities":
+
+> **6. Image and Video Capabilities**
+>
+> Our models can accept images and videos as part of Inputs to the Services
+> ("Visual Capabilities"). You may not use Visual Capabilities to assist in
+> identifying a person nor to solicit or infer private or sensitive
+> information about a person. You may not use Visual Capabilities to
+> reproduce the likeness of any person without express consent and all
+> necessary rights. By choosing to share an image or video publicly on the
+> Services, such as by sharing it to the Sora feed or uploading it to create
+> a Sora cameo, you represent you have all necessary rights, and you give
+> OpenAI the right to reproduce, distribute, modify, display and perform it
+> for the purpose of operating and promoting the Services. You also agree to
+> give users the limited right to reproduce and remix that content solely on
+> the Services. Uploading a cameo or sharing an image or video does not give
+> other users any rights to use those materials outside of the Services.
+
+[`ai-openai-policy-fit.md`](ai-openai-policy-fit.md) §E quoted only the
+second sentence. Seeing the whole clause changes the reading in the app's
+favour.
+
+**1. The clause is a use restriction, and "use … to" is the operative
+construction.** All three prohibitions are transitive: *use Visual
+Capabilities **to** assist in identifying*, *to solicit or infer*, *to
+reproduce the likeness*. Each requires the capability to be aimed at a
+person. The photo prompt asks which foods are visible and forbids
+estimating weight or volume. Nothing is aimed at a person, and the output
+schema — `query`, `quantity`, `unit`, `additionalProperties: false` — has
+no field in which an inference about a person could be returned. **A model
+cannot infer private information about a person into a slot that does not
+exist.** That is the same structural argument that carried B1 in
+[`ai-openai-policy-fit.md`](ai-openai-policy-fit.md), and it is stronger
+here because it is about output shape rather than intent.
+
+**2. The rest of the clause is about Sora and public sharing**, which the
+API path never touches. Reading sentences two and three next to sentences
+four through six makes clear the section governs consumer image/video
+features primarily; the API is reached only by the first three sentences.
+
+**3. Incidental faces do not engage it.** The prohibition is on *using* the
+capability to identify. A face appearing in the frame is not a use. If
+incidental presence were enough, the clause would prohibit nearly all
+photography, which no reading supports.
+
+**4. Dietary information is the genuinely arguable limb, and it still
+fails.** The argument would be: food intake is health-adjacent, health data
+is "private or sensitive", the photo is of an identifiable person's meal,
+therefore the app infers sensitive information about a person. It fails on
+two independent grounds. The inference is about *the plate*, not the
+person — the output is a food list, and attributing that food to a person
+is done by the user's own diary on their own device, not by OpenAI's model.
+And *"solicit or infer … about a person"* requires a person as the object
+of the inference; there is no person-referent anywhere in the request. The
+app does not even tell the model whose meal it is, because it sends no
+identifier at all ([Section D](#d-identity-the-field-is-optional-and-that-is-verified)).
+
+**5. The consistency argument from #679 is available here — unlike in
+[`ai-openai-key-transfer.md`](ai-openai-key-transfer.md).** Anthropic's
+Usage Policy (effective 15 September 2025), under *Do Not Compromise
+Privacy or Identity Rights*, prohibits:
+
+> Misuse, collect, solicit, or gain access without permission to private
+> information such as non-public contact details, health data, biometric or
+> neural data (including facial recognition), or confidential or proprietary
+> data
+
+and under the surveillance heading:
+
+> Target or track a person's physical location, emotional state, or
+> communication without their consent, including using our products for
+> facial recognition, battlefield management applications or predictive
+> policing
+
+**Anthropic names *health data* explicitly, where OpenAI says only "private
+or sensitive information".** If dietary intake is health data, Anthropic's
+clause reaches it more clearly than OpenAI's does — and the project shipped
+on Anthropic having reviewed that policy. Anthropic's vision documentation
+adds a model-level restriction with no OpenAI equivalent: *"People
+identification: Claude cannot be used to name people in images and refuses
+to do so."* So on this axis OpenAI is **not** the stricter vendor, and §6
+cannot be what separates them. This is the move that resolved #679, and it
+works here.
+
+**Verdict on §6: not engaged, on the better reading, and more comfortably
+than [`ai-openai-policy-fit.md`](ai-openai-policy-fit.md) §E suggested.**
+
+### What the disclosure would have to say
+
+§6 is a restriction on the *user's* conduct (the Customer, under BYO-key).
+It is not engaged by the app's designed behaviour, but the app hands the
+user a camera, and the user could point it at anything. The honest
+disclosure obligation is therefore small but real:
+
+- **Say the photo goes to OpenAI and is not merely read on-device.** The
+  existing photo-path copy already does this for Anthropic.
+- **Say the photo is retained for up to 30 days**, not "sent for that one
+  request". The current README sentence — *"sent for that one request, and
+  then unreachable"* — is true of the *app's* copy but would read as a
+  claim about the provider, and on an OpenAI path it would be false.
+- **Do not claim a §6 permission.** The app should not tell the user the
+  clause is satisfied; it should avoid a feature that would engage it. It
+  already does — no face detection, no person-attribute output, no schema
+  field for either.
+- **A note that photos of other people are the user's responsibility** is
+  proportionate, because §6 binds the key holder and not the project
+  ([`ai-openai-policy-fit.md`](ai-openai-policy-fit.md) §A).
+
+## F. Region and sub-processors: the fourth destination
+
+**This is the finding with the largest effect on the README's structure.**
+The [Sub-processor list](https://openai.com/policies/sub-processor-list/)
+(last updated 9 July 2026) names, for the **API** specifically:
+
+| Entity | Purpose | Location of processing |
+| --- | --- | --- |
+| **Cloudflare, Ltd.** | Content delivery network provider; Web Hosting | *"Processing is performed at the data center that is closest to the End User"* |
+| Microsoft Corporation | Cloud infrastructure | 23 countries |
+| CoreWeave, Oracle Cloud, Google Cloud Platform, Amazon Web Services, Cerebras | Cloud infrastructure | Norway, Spain, Sweden, UK, US, Brazil, Japan, Malaysia, Netherlands, Finland, Canada |
+| **TaskUs, LLC** | Customer support; **Moderation of content** | **Philippines** |
+| **Accenture International Limited** | Customer support; **Moderation of content** | US, Canada, **Philippines** |
+| Cinder Technologies | Platform for content moderation | US *(except where ZDR is used)* |
+| Snowflake, Confluent | Data warehousing; infrastructure management | US *(except where ZDR is used)* |
+| Intercom, Salesforce, Pylon Labs, Okta (via Auth0) | Customer support; authentication | US and others |
+
+**Cloudflare terminates TLS.** The data-controls page states it for the
+residency endpoints — *"For requests sent to `us.api.openai.com` or
+`eu.api.openai.com`, OpenAI uses Cloudflare Regional Services so that TLS
+termination and HTTPS decryption occur within the selected processing
+region"* — and the sub-processor list shows Cloudflare serving the API
+generally. **A request to OpenAI is decrypted by a CDN before OpenAI
+processes it.** The README's per-destination table describes the Anthropic
+path as one hop and the OpenRouter path as two; an OpenAI path is one hop
+plus a named CDN sub-processor, and saying so is the honest version.
+
+**Flagged content reaches moderation vendors.** From the same page:
+
+> **Moderation:** For content that OpenAI's models flag as being in
+> violation of OpenAI's policies, OpenAI may share samples of the flagged
+> Customer Content with relevant Sub-processors to assist OpenAI in its
+> review and enforcement. Sharing with the Sub-processor platform only
+> occurs when content is flagged, the Sub-processor platform only retains
+> samples of content for the period of review, and OpenAI's Sub-processors
+> only process the content to assist OpenAI in its review.
+
+That is the concrete form of the enterprise page's *"specialized
+third-party contractors"*. It is conditional on a flag, time-limited, and
+purpose-limited — but the destinations are named and one of them is in a
+different jurisdiction from OpenAI. **Note that TaskUs and Accenture do
+*not* carry the "except where ZDR is used" asterisk** that Cinder,
+Snowflake and Confluent do. I would not over-read a footnote marker, but it
+is not obviously the case that ZDR removes the moderation path, and ZDR is
+unavailable to this app's users anyway.
+
+**Data residency is also out of reach, and its absence has a cost.**
+Residency is *"a project configuration option"* requiring a sales
+conversation (*"Contact our sales team to see if you're eligible"*), carries
+*"a 10% uplift"*, and every non-US region *"requires approval for abuse
+monitoring controls, and execut[ing] a Modified Retention amendment"*.
+Image support outside the US is stricter still: *"Image support in these
+regions requires approval for enhanced Zero Data Retention or enhanced
+Modified Abuse Monitoring."*
+
+**So a hobbyist's request goes to the default `api.openai.com` endpoint with
+no region selected.** OpenAI does not publish where those are served from,
+and the sub-processor list shows API cloud infrastructure across roughly
+twenty-five countries. **The README cannot state a processing region for an
+OpenAI path**, and should not imply one.
+
+## What the README would have to change
+
+Stated plainly, because the point of the exercise is a falsifiable claim:
+
+1. **The ephemerality sentence cannot be reused or adapted.** It is
+   Anthropic's, it is already marked as not travelling to OpenRouter, and
+   OpenAI has no counterpart. The README would need a new sentence quoting
+   the 30-day text with its full qualifier.
+2. **The destination table needs a sub-processor note**, at minimum naming
+   Cloudflare as terminating TLS and noting that flagged content may reach
+   moderation vendors abroad.
+3. **The photo paragraph's "sent for that one request, and then
+   unreachable" needs scoping** to the app's own copy, since on an OpenAI
+   path the provider's copy persists up to 30 days.
+4. **The identity paragraph gains a favourable line**: unlike OpenRouter,
+   the direct OpenAI path forwards no application-level identifier, because
+   `safety_identifier` and `prompt_cache_key` are both optional and the app
+   would send neither.
+5. **Nothing may reference ZDR or data residency** as available.
+
+## Not established
+
+- **Whether any individual has ever obtained ZDR without an enterprise
+  relationship.** OpenAI publishes no eligibility criteria, no application
+  form, and no self-serve path — only *"get in touch with our sales team"*.
+  The finding here is that the published route is closed to a hobbyist, not
+  that approval is impossible. Community reports exist and are not evidence;
+  none is cited.
+- **Which region serves a default `api.openai.com` request.** Not published.
+  The sub-processor list gives per-vendor country lists, not a default
+  routing rule, and the residency documentation describes only the opt-in
+  configuration. **"US by default" is a common assumption and I found no
+  primary source stating it.**
+- **Whether Cloudflare sits in front of every API request or only the
+  residency endpoints.** The Cloudflare row in the sub-processor list is
+  scoped to "API" without qualification, which suggests all requests; the
+  TLS-termination sentence in the docs is scoped to `us.`/`eu.` endpoints.
+  These are consistent with each other but do not settle the general case.
+- **Whether *"No watermarks or logos"* is enforced against vision inputs.**
+  Stated as an input requirement, plainly aimed at generation fidelity, and
+  a meal photo of packaged food will often breach it on a literal reading.
+  No enforcement evidence either way.
+- **What retention applies to a request that errors or is rejected by a
+  classifier before inference.** Not addressed anywhere I looked.
+- **Whether the 30-day promise has a contractual home.** It appears in
+  documentation and an FAQ. The Services Agreement was not re-read for this
+  note; [`ai-openai-policy-fit.md`](ai-openai-policy-fit.md) and
+  [`ai-openai-key-transfer.md`](ai-openai-key-transfer.md) between them
+  quote §§2.2, 3.1–3.3, 5.4, 8.2, 14.1, 16.10 and 17 and record no retention
+  clause, but neither was searching for one. **A DPA may contain the real
+  obligation; the DPA is executed per-customer via a form and I could not
+  read one.**
+- **The exact wording discrepancy's significance.** The docs page and the
+  enterprise page state the 30-day exception differently. Which governs is
+  unclear; this note recommends the broader text on conservatism grounds,
+  not because it is established as controlling.
+- **Anything about the `/v1/responses` "at least 30 days" upper bound.**
+  "At least" has no stated ceiling. Avoided rather than resolved, by
+  recommending `/v1/chat/completions`.
+- **Legal advice.** One non-lawyer reading published documents on one date.
+  The most load-bearing page carries no date and can change silently.
+
+## Sources
+
+OpenAI (`openai.com` read in a browser; the site 403s automated fetching):
+[Data controls in the OpenAI platform](https://developers.openai.com/api/docs/guides/your-data) ·
+[Enterprise privacy at OpenAI](https://openai.com/enterprise-privacy/) ·
+[Service terms](https://openai.com/policies/service-terms/) ·
+[OpenAI Sub-processor list](https://openai.com/policies/sub-processor-list/) ·
+[Images and vision](https://developers.openai.com/api/docs/guides/images-vision) ·
+[Safety best practices](https://developers.openai.com/api/docs/guides/safety-best-practices) ·
+[Create chat completion](https://developers.openai.com/api/reference/resources/chat/subresources/completions/methods/create) ·
+[Business data privacy, security, and compliance](https://openai.com/business-data/) ·
+[Trust Portal](https://trust.openai.com/)
+
+Comparison documents:
+[Anthropic Vision documentation](https://platform.claude.com/docs/en/build-with-claude/vision) ·
+[Anthropic Usage Policy](https://www.anthropic.com/legal/aup)
+
+Related notes in this repo:
+[`ai-openai-policy-fit.md`](ai-openai-policy-fit.md) ·
+[`ai-openai-key-transfer.md`](ai-openai-key-transfer.md) ·
+[`ai-model-candidates.md`](ai-model-candidates.md) ·
+[`ai-legal-constraints.md`](ai-legal-constraints.md) ·
+[`ai-open-research-questions.md`](ai-open-research-questions.md)
+
+In-repo files cited:
+[`lib/features/add_meal/util/meal_photo_encoder.dart`](../lib/features/add_meal/util/meal_photo_encoder.dart) ·
+[`lib/features/add_meal/domain/meal_items_api.dart`](../lib/features/add_meal/domain/meal_items_api.dart) ·
+[`lib/features/add_meal/data/model_meal_photo_interpreter.dart`](../lib/features/add_meal/data/model_meal_photo_interpreter.dart)

--- a/docs/ai-openai-key-transfer.md
+++ b/docs/ai-openai-key-transfer.md
@@ -1,0 +1,622 @@
+# Does BYO-key fall foul of OpenAI's API-key transfer prohibition?
+
+**Verdict: §3.3(g) almost certainly does not reach this design, and the best
+evidence for that is OpenAI's own — its current help centre tells users how to
+vet "third-party libraries, frameworks, and tools that request access to your
+API key" rather than telling them not to.** But two things stop this being a
+clean pass. First, **the precedent argument that resolved
+[#679](https://github.com/simonoppowa/OpenNutriTracker/issues/679) is not
+available here: neither Anthropic nor OpenRouter has any equivalent clause**, so
+the project has never accepted this restriction before and cannot argue from
+consistency. Second, **the sentence that actually bites is not §3.3(g)** — it is
+the API reference's *"Don't … expose it in any client-side code such as browsers
+or apps"*, which Service terms §1 arguably makes binding. This is a documents
+review, not legal advice.
+
+## Bottom line up front
+
+1. **This does not kill the effort.** Nothing found is a prohibition the app
+   plainly meets. §3.3(g) is a commerce-and-account-integrity clause whose every
+   neighbour concerns a credential reaching a *different person*, and no reading
+   of the shipped design puts a key in anyone else's hands.
+2. **"Transfer" is defined nowhere.** §17 of the Services Agreement carries over
+   sixty definitions and defines neither *transfer*, nor *API key*, nor *third
+   party*. The Usage Policies contain the strings "API key", "transfer" and
+   "credential" **zero times** — verified by full-text search of the live page,
+   not by reading around. There is no interpretive material in the contract
+   documents at all.
+3. **OpenAI's help centre presupposes the pattern.** *"Use caution with
+   third-party libraries, frameworks, and tools that request access to your API
+   key … review the company and the product carefully."* A vendor that read
+   §3.3(g) as barring the arrangement would write "don't", not "check reviews".
+   This is the strongest single item in the note. It is not permission, and the
+   help centre does not bind — but it is the only published signal of how OpenAI
+   reads its own rule, it is current, and it points one way.
+4. **The calibration question answers against OpenAI, and that is the finding.**
+   Anthropic's Commercial Terms of Service contain the word "transfer" **zero
+   times** and mention API keys exactly once, in a scope sentence. OpenRouter's
+   nearest clause transfers *"the access granted under these Terms or any
+   Materials"*, where "Materials" is defined as OpenRouter's own IP. **No
+   equivalent clause found in either.** OpenAI is genuinely different, and
+   "we already do this with Anthropic" is an argument from a silent document.
+5. **The guidance comparison inverts the contract comparison, and rescues the
+   consistency argument on the narrower ground of custody.** Anthropic's support
+   article is verbally *stricter* than anything OpenAI publishes — *"Never share
+   your API key"*, and a warning that uploading it to a third-party tool means
+   *"you are giving the developer of that tool access to your Claude Console
+   account."* The project shipped against Anthropic with that on the page. And
+   the case Anthropic describes is one where the key genuinely leaves the device;
+   this design is the strictly safer version of the thing already tolerated.
+6. **The real exposure is documentation, not §3.3(g).** Service terms §1 binds
+   Customer to *"use APIs in accordance with the applicable documentation"*, and
+   that documentation says *"Don't share it with others or expose it in any
+   client-side code such as browsers or apps. Load API keys from an environment
+   variable or key management service on the server."* Read with the user as
+   Customer, a long-lived key on a phone is closer to that sentence than to
+   §3.3(g). See [Section C](#c-the-clause-that-actually-bites-and-it-is-not-g).
+7. **Unresolvable to certainty from public documents.** Both questions above land
+   on genuine ambiguity, and picking a side here would be inventing confidence.
+   What would resolve it is in [What would settle
+   this](#what-would-settle-this): a support enquiry, which only the account
+   holder can make.
+
+## How this was read
+
+Primary sources only, all read on 2026-08-16. openai.com, help.openai.com and
+platform.openai.com return HTTP 403 to automated fetching, so every OpenAI quote
+below was read in a real browser against the live page. Where the finding is an
+*absence* — no definition, no clause — it was established by full-text string
+search of the rendered page rather than by reading and not noticing, and the
+search terms are stated so the check is repeatable. No secondary summary, blog
+post or forum answer is cited as evidence anywhere in this note; two that turned
+up are quarantined in [Section G](#g-enforcement-and-one-false-quote-to-watch-for)
+precisely because they are the kind of thing that gets quoted into a decision.
+
+| Document | Date it carries |
+| --- | --- |
+| [OpenAI Services Agreement](https://openai.com/policies/services-agreement/) | Updated **December 1, 2025**; Effective **January 1, 2026** |
+| [OpenAI Usage policies](https://openai.com/policies/usage-policies/) | Effective **October 29, 2025** |
+| [OpenAI Service terms](https://openai.com/policies/service-terms/) | Updated **June 12, 2026** |
+| [OpenAI API reference overview](https://developers.openai.com/api/reference/overview) | no date carried |
+| [Best Practices for API Key Safety](https://help.openai.com/en/articles/5112595-best-practices-for-api-key-safety) | "Updated: 3 days ago" (≈ **13 August 2026**) |
+| [How can I keep my OpenAI accounts secure?](https://help.openai.com/en/articles/8304786-how-can-i-keep-my-openai-accounts-secure) | "Updated: 18 days ago" (≈ **29 July 2026**) |
+| [Can I share my API key with my teammate/coworker?](https://help.openai.com/en/articles/5008148-can-i-share-my-api-key-with-my-teammatecoworker) | "Updated: 18 days ago" (≈ **29 July 2026**) |
+| [Anthropic Commercial Terms of Service](https://www.anthropic.com/legal/commercial-terms) | Effective **June 17, 2025** |
+| [Anthropic Usage Policy](https://www.anthropic.com/legal/aup) | Effective **September 15, 2025** |
+| [Anthropic Service Specific Terms](https://www.anthropic.com/legal/service-specific-terms) | Effective **June 8, 2026** |
+| [Anthropic API Key Best Practices](https://support.claude.com/en/articles/9767949-api-key-best-practices-keeping-your-keys-safe-and-secure) | **March 16, 2026** |
+| [OpenRouter Terms of Service](https://openrouter.ai/terms) | Last Updated **July 29, 2026** |
+
+The three help-centre pages render a relative age rather than a date; the
+absolute dates above are derived from the read date and are approximate. The
+Services Agreement, Usage Policies and Service terms all carry explicit dates.
+
+### The behaviour the clauses are read against
+
+Verified in source rather than assumed, in
+[`ai_credential_storage.dart`](../lib/core/utils/ai_credential_storage.dart) and
+the two API clients:
+
+- The key is typed by the holder into the app's settings on their own device.
+- It is written through `flutter_secure_storage` to the platform keystore, using
+  the hardened options on
+  [`SecureAppStorageProvider`](../lib/core/utils/secure_app_storage_provider.dart)
+  — `AES_CBC_PKCS7Padding` and `resetOnError: false`.
+- `readApiKey` is called at request time and the value is not retained: the
+  class documents this as *"nothing should hold a credential in memory longer
+  than the request that needs it."*
+- It leaves the device only as a request header to the provider's own endpoint —
+  `'authorization': 'Bearer ${_apiKey()}'` in
+  [`openrouter_meal_items_api.dart`](../lib/features/add_meal/data/openrouter_meal_items_api.dart)
+  and `'x-api-key': _apiKey()` in
+  [`anthropic_meal_items_api.dart`](../lib/features/add_meal/data/anthropic_meal_items_api.dart).
+  Those are the only two sites in `lib/` that read a credential into a header.
+- No backend, no proxy, no telemetry, no key in the shipped binary. The project
+  holds no account and pays for nothing.
+
+So on the facts: nothing is bought, nothing is sold, no second person ever holds
+the key, and every charge lands on the holder. The only open question is whether
+"transfer … to … a third party" reaches a credential passing through software
+written by someone else while never leaving its owner's device.
+
+## A. §3.3(g) in its own document
+
+Verbatim, from the live page (Updated December 1, 2025; Effective January 1,
+2026):
+
+> **3.3. Restrictions.** Customer will not, and will not permit End Users to:
+> (a) use the Services or Customer Content in a way that violates applicable
+> laws or OpenAI Policies; (b) use the Services or Customer Content in a way
+> that violates third parties' rights; (c) allow minors to use OpenAI Services
+> without consent from their parent or guardian; (d) Reverse Engineer any aspect
+> of the Services or the systems used to provide the Services; (e) except for a
+> Permitted Exception, use Output to develop artificial intelligence models that
+> compete with OpenAI's products and services; (f) extract data from the
+> Services other than as permitted through the Services; **(g) buy, sell, or
+> transfer API keys from, to, or with a third party;** (h) interfere with or
+> disrupt the Services, including circumvent any rate limits or restrictions or
+> bypass any protective measures or safety mitigations for the Services;
+> (i) violate or circumvent Usage Limits or otherwise configure the Services to
+> avoid Usage Limits.
+
+**"Transfer" is not defined.** §17 runs to more than sixty defined terms and
+contains no entry for *transfer*, *API key*, or *third party*. It defines
+*"Third-Party Services"* — *"products, services, or content offered by parties
+other than OpenAI **through the Services**"* — which is a different concept and
+does not describe this app. It defines *"Third-Party Service Terms"*. §16.10 is
+headed *"No Third-Party Beneficiaries"*. None of these supplies a meaning for
+the lowercase "third party" in (g).
+
+**Nothing elsewhere fills the gap.** Searching the rendered Usage Policies page
+(effective 29 October 2025) for `API key`, `api key`, `transfer`, `Transfer` and
+`credential` returns **no matches at all** — the document is 9,433 characters
+and never mentions keys. The Service terms (updated 12 June 2026) contain no key
+or transfer provision either. So the whole interpretive weight sits on the
+sentence itself and its neighbours.
+
+**The neighbourhood is about credentials reaching a different person.** §3.1,
+two paragraphs earlier:
+
+> Customer must provide accurate and current Account information. Customer will
+> not share Account access credentials or individual login credentials between
+> multiple users. Customer may not resell or lease access to its Account or any
+> End User Account.
+
+and §3.2: *"End User Accounts may only be provisioned to, registered for, and
+used by, a single End User."* Read together with (g)'s own verbs — **buy**,
+**sell**, transfer — and its prepositions — *from, to, or with* — the family is
+unmistakably a market in credentials and multi-person use of one account.
+Nothing in the shipped design is in that family. One person holds one key, uses
+it themselves, and pays for it themselves.
+
+**Two counterweights, recorded because they cut the other way.** §14.1 excludes
+*"CUSTOMER'S BREACH OF SECTION 3.3 (RESTRICTIONS)"* from the cap on indirect
+liability, so §3.3 is not a soft clause. And §8.2 lets OpenAI suspend where
+*"Customer violates the Agreement or OpenAI Policies"*. Against that: §17 defines
+*"Abusive Customer Content"* as *"Inputs or Outputs that violate Section 3.3"* —
+a definition that makes sense of (a) and (b) and makes no sense at all of (g),
+which is weak evidence that (g) was bolted into a content-shaped list as an
+account-integrity rule rather than drafted to reach software design.
+
+## B. The gloss OpenAI publishes
+
+This is the part that was missing when
+[`ai-openai-policy-fit.md`](ai-openai-policy-fit.md) called §3.3(g)
+*"unresolvable from public documents"*. OpenAI does publish interpretive
+material. It is in the help centre, not the contract, and it is consistent.
+
+**[Best Practices for API Key Safety](https://help.openai.com/en/articles/5112595-best-practices-for-api-key-safety)**,
+item 1, under the heading *"Always use a unique API key for each team member on
+your account"*:
+
+> An API key is a unique code that identifies your requests to the API. Your API
+> key is intended to be used by you. The sharing of API keys is against the
+> Terms of Use.
+>
+> As you begin experimenting, you may want to expand API access to your team.
+> OpenAI does not support the sharing of API keys. Please invite new members to
+> your account from the Members page and they will quickly receive their own
+> unique key upon sign-in.
+
+Note what the sentence *"The sharing of API keys is against the Terms of Use"*
+is doing. It is the only place OpenAI restates a key restriction as a rule, and
+the whole item is about **team members** — the remedy offered is inviting people
+to your account. It also cites the wrong instrument: the API path runs on the
+Services Agreement, not the consumer Terms of Use ([#679](https://github.com/simonoppowa/OpenNutriTracker/issues/679)).
+That imprecision is a reason not to over-read the help centre in either
+direction.
+
+**[Can I share my API key with my teammate/coworker?](https://help.openai.com/en/articles/5008148-can-i-share-my-api-key-with-my-teammatecoworker)**
+is the same idea at lower strength:
+
+> We do not recommend sharing your personal API key — even with trusted
+> coworkers or teammates. API keys grant access to your organization's usage and
+> billing …
+
+*Do not recommend*, not *may not*. Again, people.
+
+**And then the one that matters.** From
+**[How can I keep my OpenAI accounts secure?](https://help.openai.com/en/articles/8304786-how-can-i-keep-my-openai-accounts-secure)**,
+under its own heading *"Be cautious with third-party products"*:
+
+> Use caution with third-party libraries, frameworks, and tools that request
+> access to your API key. Even if a product seems reputable, there is still a
+> risk of key exposure or misuse.
+>
+> Before using a third-party product that requires your API key, review the
+> company and the product carefully. Check reviews, read the privacy policy, and
+> look for any security concerns raised by the community.
+
+**OpenAI's current security guidance treats "a third-party product that requires
+your API key" as a thing a Customer may reasonably do, and gives diligence
+advice for doing it.** If §3.3(g) barred the arrangement, this paragraph would
+be one word long. The pattern is named, contemplated, and left to the holder's
+judgement.
+
+Three honest limits on how far that goes. The help centre is not an *"OpenAI
+Policy"* — §17 defines those as *"the Service-Specific Terms, Sharing and
+Publication Policy, and Usage Policies"*, and the help centre is none of them,
+so this creates no permission and waives nothing. It is a security page, not a
+legal one, and security advice is not a licence. And it is undated in any
+durable way, so it can move without notice.
+
+## C. The clause that actually bites, and it is not (g)
+
+Same security page, a few paragraphs down, under *"Do not ship your API key"*:
+
+> It can be tempting to embed your API key directly in an application to avoid
+> running a server for a mobile app or a similar use case. However, this makes
+> the API key vulnerable to misuse.
+
+Read the possessives. *Your* key, embedded by *you*, in an app *you* ship to
+other people. That is the developer-holds-the-key shape — §2.2's *Customer
+Application* — and it is precisely the arrangement BYO-key exists to avoid. Not
+engaged. The same is true of the corresponding item in Best Practices: *"Never
+deploy your key in client-side environments like browsers or mobile apps.
+Exposing your OpenAI API key in client-side environments like browsers or mobile
+apps allows malicious users to take that key and make requests on your behalf."*
+Its threat model requires one key distributed to many users; under BYO-key each
+install holds only its own holder's key.
+
+**The API reference is different, and it is the strongest thing found against
+this design.** Service terms §1 (updated 12 June 2026):
+
+> Customer will only, and will ensure that its End Users only, use APIs in
+> accordance with the applicable documentation at
+> https://platform.openai.com/docs
+
+That URL redirects to `developers.openai.com` (verified in a browser on
+2026-08-16), whose
+[API reference overview](https://developers.openai.com/api/reference/overview)
+says, under **Authentication**:
+
+> Remember that your API key is a secret. Don't share it with others or expose
+> it in any client-side code such as browsers or apps. Load API keys from an
+> environment variable or key management service on the server.
+
+With the user as Customer, a long-lived key sitting on a phone inside a mobile
+app is nearer to *"client-side code such as … apps"* than anything in §3.3(g) is
+to this app. And it arrives through a clause — Service terms §1 — that is a real
+contractual obligation, unlike the help centre.
+
+What answers it, and how far:
+
+- **"Expose" is the operative verb, and the design's whole point is that nothing
+  is exposed.** The key sits in Android Keystore / iOS Keychain under
+  `resetOnError: false`, is read only for the request that needs it, and travels
+  only to the provider endpoint. There is no party to whom it is exposed, which
+  is the harm every neighbouring sentence names.
+- **The third sentence presupposes an addressee that does not exist here.**
+  *"Load API keys from an environment variable or key management service on the
+  server"* is instruction to someone operating a server. Under BYO-key nobody
+  is. The passage is written for the developer-as-Customer shape throughout.
+- **It is guidance phrased as advice inside a reference page.** Whether *"use
+  APIs in accordance with the applicable documentation"* converts every
+  *"Remember that…"* into a term is itself undecided, and the documentation
+  behind that link is mostly tutorials.
+
+**And OpenAI does document a client-side pattern — it is the opposite of this
+one.** The Realtime guide: *"Use `POST /v1/realtime/client_secrets` to create
+ephemeral credentials for browser or mobile clients."* That is OpenAI's answer
+for a mobile client that must reach the API, and it requires a backend to mint
+the token. It is worth recording plainly: the sanctioned shape for mobile is
+server-minted ephemeral credentials, and a serverless GPL app with no
+infrastructure cannot implement it. BYO-key is not what OpenAI points mobile
+developers at; it is what remains when the pointed-at option is unavailable.
+
+## D. Custody or movement
+
+**Nothing in the contract documents turns on where a key is stored.** §3.3(g) is
+a movement test — buy, sell, transfer. §3.1 is a sharing test — *"between
+multiple users"*. §3.2 is a per-account test. Storage, encryption, keystores and
+device custody appear nowhere in the Services Agreement, nowhere in the Usage
+Policies, and nowhere in the Service terms. Searched for; absent.
+
+So the answer to the ticket's third question is: **custody does not change the
+§3.3(g) answer, because §3.3(g) does not ask about custody.** Where custody
+*does* appear is in documentation and help-centre guidance — which is exactly
+the material [Section C](#c-the-clause-that-actually-bites-and-it-is-not-g) is
+about — and there it helps rather than hurts.
+
+One place custody matters concretely. The only specific enforcement mechanism
+OpenAI publishes anywhere is exposure-triggered:
+
+> When OpenAI detects an API key on the public internet, or leaked inside an app
+> in an app store, the API key is disabled immediately.
+
+That is automated scanning for keys **embedded in shipped artifacts**. The app
+ships no key in its binary — the credential is user-entered and never enters the
+repository or the build — so there is nothing there for that scanner to find.
+It is the one point where the design is not merely defensible but actively,
+mechanically compliant, and it is worth stating because it is the mechanism most
+likely to touch a real user.
+
+## E. Anthropic and OpenRouter: no equivalent clause found
+
+This is the calibration question, and the answer is that **OpenAI is different**.
+
+### Anthropic
+
+**[Commercial Terms of Service](https://www.anthropic.com/legal/commercial-terms),
+effective June 17, 2025** — the current version; the page offers a "Previous
+Version" link. This is the API instrument: *"They govern Customer's use of
+Anthropic API keys and any other Anthropic offerings that references these
+Terms."*
+
+Full-text search of the rendered page (26,103 characters):
+
+| Term | Occurrences |
+| --- | --- |
+| `transfer` / `Transfer` | **0** |
+| `credential` / `Credential` | **0** |
+| `API key` | **1** — the scope sentence quoted above |
+
+The entire restrictions provision is D.4, and it is three lines:
+
+> **D.4. Use Restrictions.** Customer may not and must not attempt to (a) access
+> the Services to build a competing product or service, including to train
+> competing AI models or resell the Services except as expressly approved by
+> Anthropic; (b) reverse engineer or duplicate the Services; or (c) support any
+> third party's attempt at any of the conduct restricted in this sentence.
+
+The only account provision is responsibility, not restriction:
+
+> **D.5. Service Account.** Customer is responsible for all activity under its
+> account. Customer will promptly notify Anthropic if Customer believes the
+> account it uses to access the Services has been compromised …
+
+The [Usage Policy](https://www.anthropic.com/legal/aup) (effective 15 September
+2025) and the [Service Specific Terms](https://www.anthropic.com/legal/service-specific-terms)
+(effective 8 June 2026) were searched for the same terms and return **zero**
+matches in each. **No equivalent clause exists anywhere in Anthropic's API
+regime.**
+
+### OpenRouter
+
+**[Terms of Service](https://openrouter.ai/terms), Last Updated July 29, 2026.**
+§3.2 is the only key provision and it is a confidentiality-and-responsibility
+clause:
+
+> **3.2 API Credentials.** You are responsible for maintaining the
+> confidentiality and security of all API keys, tokens, passwords, and other
+> credentials used to access the Service ("API Credentials"). You are
+> responsible for all activity and charges under its account or API Credentials,
+> whether or not authorized by you, except to the extent caused directly by
+> OpenRouter's breach of these Terms.
+
+The nearest thing in §7 (Prohibited Conduct) is:
+
+> sell or otherwise transfer the access granted under these Terms or any
+> Materials (as defined in 12) or any right or ability to view, access, or use
+> any Material
+
+and §12 defines Materials as OpenRouter's own property — *"The visual
+interfaces, graphics, design, compilation, information, data, computer code
+(including source code or object code), products, software, services, and all
+other elements of the Service ("Materials")"*. That is an IP and licence clause,
+not a credential clause. §4 adds that *"Credits are non-transferable, including
+between accounts"* — again about value, not keys. **No equivalent clause found.**
+
+### What this means for the consistency argument
+
+| | OpenAI | Anthropic | OpenRouter |
+| --- | --- | --- | --- |
+| Key buy/sell/transfer clause | **§3.3(g)** | **none** | **none** |
+| Credential-sharing clause | §3.1, between users | none | none |
+| Key custody obligation in contract | none | none | §3.2, confidentiality |
+| Documented third-party-key flow | no | no | **yes** — OAuth PKCE |
+| Guidance on giving your key to third-party software | "use caution … review the company" | "never share … exercise caution with third-party tools" | — |
+
+**The precedent argument does not carry.** #679's internal-consistency move
+worked because Anthropic's disordered-eating prohibition was demonstrably
+*wider* than OpenAI's, so accepting one and rejecting the other was incoherent.
+Here the comparison runs the other way: OpenAI has a clause and the other two
+have nothing resembling it. The project did not previously accept this
+restriction; there was none to accept. Anyone arguing "we already ship BYO-key
+against two vendors, so this is settled" is arguing from silence in the two
+documents that are silent.
+
+**But the guidance comparison inverts the contract comparison, and that partly
+restores the argument on the narrower ground of custody.** Anthropic's
+[API Key Best Practices](https://support.claude.com/en/articles/9767949-api-key-best-practices-keeping-your-keys-safe-and-secure)
+(March 16, 2026) is verbally stricter than anything OpenAI publishes:
+
+> **1. Never share your API key**
+>
+> Keep it confidential: Just as you wouldn't share your personal password, don't
+> share your API key. If someone needs access to the Claude API, they should
+> obtain their own key.
+>
+> Exercise caution with third-party tools: Consider that when you upload your
+> API key to third-party tools or platforms (such as an web-based IDE, Cloud
+> Provider, or CI/CD platform), you are giving the developer of that tool access
+> to your Claude Console account. If you don't trust their reputation, don't
+> trust them with your API key.
+
+The project reviewed Anthropic and shipped. And read the case Anthropic
+describes: a web IDE, a cloud provider, a CI/CD platform — arrangements where
+the key genuinely leaves the user's machine and the developer really does gain
+access to the Console account. Anthropic treats that as the holder's risk
+decision, not a breach. **OpenNutriTracker's design is the strictly safer
+version of the arrangement Anthropic explicitly tolerates**: the key never
+reaches the developer, never reaches a server, and never leaves the keystore
+except as a header to the provider. So on custody, consistency does hold; it is
+only on the *existence of a contractual key clause* that OpenAI stands alone.
+
+### Is there a sanctioned pattern anywhere?
+
+- **OpenAI: no.** Searched the Services Agreement, Usage Policies, Service
+  terms, the help centre's security collection and the API reference. There is
+  no partner programme, no docs page and no FAQ describing a user supplying
+  their own key to third-party software. What exists is the diligence paragraph
+  in [Section B](#b-the-gloss-openai-publishes), which presupposes the pattern
+  without blessing it, and the ephemeral-client-secret alternative in
+  [Section C](#c-the-clause-that-actually-bites-and-it-is-not-g).
+- **Do not cite OpenAI's "BYOK" as support.** In OpenAI's documentation the
+  acronym means something else: *"OpenAI supports Bring Your Own Key (BYOK)
+  encryption with external accounts in AWS KMS, Google Cloud (GCP), and Azure
+  Key Vault"* — customer-managed **encryption** keys for enterprise data at
+  rest. It has nothing to do with API credentials, and a search for "BYOK" on
+  OpenAI's site will surface it first.
+- **OpenRouter: yes, explicitly.** It documents OAuth PKCE for exactly this —
+  *"Users can connect to OpenRouter in one click using Proof Key for Code
+  Exchange (PKCE)"*, with the app exchanging the code for *"a user-controlled
+  API key"*. A vendor that builds and documents a flow for third-party apps to
+  receive a per-user key is not prohibiting the arrangement.
+- **Anthropic: neither.** No third-party key-provisioning flow found in the API
+  docs, and no prohibition. The support article contemplates the pattern and
+  warns about it.
+
+## F. What §2.2 and "Customer Application" still do not do
+
+Unchanged from [`ai-openai-policy-fit.md`](ai-openai-policy-fit.md) and restated
+because it bears on (g): §17 defines *"Customer Application"* as *"Customer's
+applications, products, or services that integrate with an OpenAI API."* When
+the user is the Customer, this app is not their application — they did not build
+it. The Agreement simply has no category for *third-party software the Customer
+runs with their own key*, and §3.4's *"Third-Party Services"* is not it either,
+being confined to things offered *"through the Services"*.
+
+That definitional gap is the honest reason (g) cannot be resolved by text. The
+drafters were not thinking about this arrangement in either direction.
+
+## G. Enforcement, and one false quote to watch for
+
+**No enforcement found in either direction, and I do not believe it is
+findable.** OpenAI publishes no case-level developer enforcement data; its only
+enforcement reporting is the threat-intelligence *Disrupting malicious uses of
+AI* series, which covers influence operations and state actors. The one
+concrete, published mechanism touching keys is the automated leak-scanner quoted
+in [Section D](#d-custody-or-movement), and it fires on exposure, not on
+transfer. **"No enforcement found" here means "not published", not comfort.**
+
+**No OpenAI staff guidance found.** The two developer-forum threads that surface
+on any search for this question — *"Bring Your Own Key policy"* and *"Is this
+allowed? (This bring your own key usage)"* on community.openai.com — were
+checked for staff replies. There are none; the confident answers in them are
+community members, including one with no staff designation asserting that
+*"Bring your own key application are not strictly prohibited"*. That is not
+evidence and should not be cited as any.
+
+**One thing to guard against, recorded because it is exactly what gets pasted
+into a decision.** A web search summary attributed to help.openai.com the
+sentence *"users are not permitted to share their API keys with others,
+including via bring-your-own-key applications."* **That sentence does not appear
+on the page.** The page says *"Use caution with third-party libraries,
+frameworks, and tools that request access to your API key"* — close to the
+opposite in effect. The fabricated version is more decisive than anything OpenAI
+has written, and would have settled this ticket the wrong way. Every quote in
+this note was read on the live page for that reason.
+
+**On the ecosystem argument.** A large population of BYO-key third-party
+clients, CLIs and IDE plugins exists and has existed for years without visible
+consequence. This is worth *something* and much less than it looks: it is
+evidence that OpenAI has not chosen to read (g) broadly, since a party intending
+the broad reading and enforcing it would by now have produced at least one
+visible instance. That is an argument from silence, it is weak, and **widespread
+practice is not permission.** It should not appear in any decision as a reason;
+at most it is context for why the narrow reading is the plausible one.
+
+## What would settle this
+
+Only the account holder can resolve either question, and an agent must not
+contact a vendor on the user's behalf. A support enquiry from the maintainer's
+own OpenAI account — help.openai.com, new chat — asking two specific things:
+
+1. **Does Services Agreement §3.3(g) apply where a Customer enters their own API
+   key into third-party client software installed on their own device, when the
+   software's publisher never receives, stores, proxies or transmits the key,
+   and the key travels only from that device to OpenAI?**
+2. **Does the API reference's *"Don't … expose it in any client-side code such
+   as browsers or apps"* bind under Service terms §1 in that arrangement, given
+   that the key is held in the platform keystore and there is no server to load
+   it on?**
+
+Ask both. The second is the one this note found and the ticket did not, and it
+is the one likelier to get a substantive answer, because it is a documentation
+question rather than a contract-interpretation question support may decline.
+
+Absent that, the position to hold is: **proceed if the project wants OpenAI, but
+record that OpenAI carries a documented key restriction that neither incumbent
+vendor has, and that the cover is a reading rather than a permission.** That is
+one more reason to rank OpenAI below Anthropic, alongside the absent wellness
+carve-out ([`ai-openai-policy-fit.md`](ai-openai-policy-fit.md) §D) and the
+standing technical objections in
+[`ai-model-candidates.md`](ai-model-candidates.md).
+
+## Not established
+
+- **Whether pasting your own key into locally-installed third-party software is
+  a "transfer … to … a third party" under §3.3(g).** Still not resolvable to
+  certainty from public documents. What is new since
+  [`ai-openai-policy-fit.md`](ai-openai-policy-fit.md) is that the balance has
+  shifted: the term is undefined, every neighbour concerns movement between
+  people, and OpenAI's own security page gives diligence advice for the exact
+  pattern. That is a strong *reading*, not an answer.
+- **Whether Service terms §1 makes the API reference's client-side sentence a
+  contractual obligation.** The clause says *"in accordance with the applicable
+  documentation"* and the documentation says *"Don't … expose it in any
+  client-side code such as browsers or apps."* Whether an advisory sentence in a
+  reference page is a term, and whether keystore storage is "exposure", are both
+  undecided and neither is addressed anywhere OpenAI publishes. **This is now
+  the most load-bearing ambiguity in the OpenAI question, displacing §3.3(g).**
+- **Whether OpenAI would treat a hobbyist key holder as the "Customer" bound by
+  §3.3 at all.** Carried forward unresolved from
+  [`ai-openai-policy-fit.md`](ai-openai-policy-fit.md); the scope sentence names
+  APIs but addresses *"businesses and developers"*, and OpenAI states the
+  position nowhere else.
+- **Exact dates for the three OpenAI help-centre pages.** They render only a
+  relative age ("Updated: 3 days ago", "Updated: 18 days ago") with no `title`
+  or `datetime` attribute in the markup to extract. The absolute dates in the
+  table are derived from the 2026-08-16 read date and could be off by a day.
+- **Whether OpenAI's App Developer Terms contain a credential provision.** The
+  page did not render usable text in the browser on this read (1,686 characters,
+  no body). It governs ChatGPT Apps and Actions rather than API integrations
+  (Service terms §5(c), §7(a)), so it is not expected to bear on this, but it
+  was not searched and should not be described as clear.
+- **Whether Anthropic offers any third-party key-provisioning flow.** None found
+  in the API documentation, but the search was not exhaustive across the whole
+  developer site; the finding is "not found", not "does not exist".
+- **Any enforcement history for §3.3(g).** None found, in either direction. See
+  [Section G](#g-enforcement-and-one-false-quote-to-watch-for) for why "none
+  found" is close to uninformative here.
+- **Legal advice.** This is one non-lawyer reading published documents on one
+  date. All twelve documents in the table can change without notice, and the
+  dates are the only guarantee offered.
+
+## Sources
+
+OpenAI (read in a browser; the sites 403 automated fetching):
+[Services Agreement](https://openai.com/policies/services-agreement/) ·
+[Usage policies](https://openai.com/policies/usage-policies/) ·
+[Service terms](https://openai.com/policies/service-terms/) ·
+[API reference overview](https://developers.openai.com/api/reference/overview) ·
+[Realtime guide](https://developers.openai.com/api/docs/guides/realtime) ·
+[Production best practices](https://developers.openai.com/api/docs/guides/production-best-practices) ·
+[Your data](https://developers.openai.com/api/docs/guides/your-data) ·
+[Best Practices for API Key Safety](https://help.openai.com/en/articles/5112595-best-practices-for-api-key-safety) ·
+[How can I keep my OpenAI accounts secure?](https://help.openai.com/en/articles/8304786-how-can-i-keep-my-openai-accounts-secure) ·
+[Can I share my API key with my teammate/coworker?](https://help.openai.com/en/articles/5008148-can-i-share-my-api-key-with-my-teammatecoworker)
+
+Anthropic:
+[Commercial Terms of Service](https://www.anthropic.com/legal/commercial-terms) ·
+[Usage Policy](https://www.anthropic.com/legal/aup) ·
+[Service Specific Terms](https://www.anthropic.com/legal/service-specific-terms) ·
+[API Key Best Practices](https://support.claude.com/en/articles/9767949-api-key-best-practices-keeping-your-keys-safe-and-secure) ·
+[API overview](https://platform.claude.com/docs/en/api/overview)
+
+OpenRouter:
+[Terms of Service](https://openrouter.ai/terms) ·
+[OAuth PKCE](https://openrouter.ai/docs/use-cases/oauth-pkce)
+
+Related notes in this repo:
+[`ai-openai-policy-fit.md`](ai-openai-policy-fit.md) ·
+[`ai-model-candidates.md`](ai-model-candidates.md) ·
+[`ai-legal-constraints.md`](ai-legal-constraints.md) ·
+[`ai-open-research-questions.md`](ai-open-research-questions.md)
+
+In-repo files cited:
+[`lib/core/utils/ai_credential_storage.dart`](../lib/core/utils/ai_credential_storage.dart) ·
+[`lib/core/utils/secure_app_storage_provider.dart`](../lib/core/utils/secure_app_storage_provider.dart) ·
+[`lib/features/add_meal/data/anthropic_meal_items_api.dart`](../lib/features/add_meal/data/anthropic_meal_items_api.dart) ·
+[`lib/features/add_meal/data/openrouter_meal_items_api.dart`](../lib/features/add_meal/data/openrouter_meal_items_api.dart)

--- a/docs/ai-openai-policy-fit.md
+++ b/docs/ai-openai-policy-fit.md
@@ -1,0 +1,536 @@
+# Does OpenAI's usage policy permit a BYO-key nutrition tracker?
+
+**Verdict: nothing in OpenAI's current published terms prohibits this app, and
+the rejection recorded in [#599](https://github.com/simonoppowa/OpenNutriTracker/issues/599)
+decision #7 and [#656](https://github.com/simonoppowa/OpenNutriTracker/issues/656)
+does not survive a re-reading.** All three clauses are conduct tests, and the
+app's conduct does not meet any of them. The disordered-eating clause in
+particular is **narrower than the one the project already accepted from
+Anthropic**, so it cannot be what separates the two vendors. But the cover
+OpenAI offers is the *absence of a prohibition*, never a carve-out, and one
+clause the earlier reading had backwards — Services Agreement §3.3(g) — now
+cuts against BYO-key rather than for it. This is a documents review, not legal
+advice.
+
+## Bottom line up front
+
+1. **The bound party is the key holder, and under BYO-key that is the user.**
+   Both consumer Terms of Use say the API is governed by the business terms,
+   and the Services Agreement's restrictions run against "Customer". A user
+   with their own key and their own billing is the Customer. This project
+   holds no account, signs nothing, and §16.10 gives it no rights under the
+   agreement either. Our exposure is reputational and second-hand, not
+   contractual.
+2. **§3.3(g) is a restriction, not a permission, and the prior note had it
+   backwards.** It reads *"buy, sell, or transfer API keys from, to, or with a
+   third party."* Whether pasting your own key into third-party software you
+   installed on your own device is a "transfer" is genuinely unresolved. It is
+   the single most load-bearing ambiguity in this note, and it did not appear
+   in either earlier evaluation. §2.2 is real and does contemplate app
+   distribution — but it contemplates the *opposite* shape, where the developer
+   holds the key.
+3. **None of the three prohibitions is met.** No advice is given, so the
+   licensed-advice clause never engages; nothing is promoted to anyone, so the
+   minors clause never engages; and a search-term extractor with no nutrition
+   fields in its schema does not promote or facilitate disordered eating. See
+   [Section B](#b-clause-by-clause).
+4. **The distinction from Google is real and load-bearing.** Google Cloud
+   §20(d) is a **distribution** test — *"directed towards or is likely to be
+   accessed by individuals under the age of 18"* — which a general-audience app
+   on Play and F-Droid fails on the day it ships, whatever it does. OpenAI has
+   **no distribution or audience test anywhere** in the Usage Policies, the
+   Services Agreement or the Service terms. Its minors clauses ask what you
+   *do*. The two rejections were never the same rejection, and #656 conflated
+   them.
+5. **There is no equivalent to Anthropic's carve-out. Say so plainly.**
+   Anthropic writes *"Wellness advice (e.g., advice on sleep, stress,
+   nutrition, exercise, etc.) does not fall under this category"* — nutrition
+   is named and excluded. OpenAI names nutrition nowhere. What it offers is
+   silence, plus one line pointing mildly the other way (Service terms §9,
+   *"Our Services are not intended for use in the diagnosis or treatment of any
+   health condition"*). Under the project's own standard, silence is materially
+   weaker cover than a carve-out, and that difference should decide the vendor
+   question even though it does not decide the permission question.
+6. **Two clauses nobody was looking at matter more than one that was.** Service
+   terms §6 restricts Visual Capabilities in a way that touches the photo path,
+   and §3.3(c) is the only age clause on the whole API path. Neither appears in
+   #656. See [Section E](#e-clauses-nobody-was-looking-at).
+
+**This does not make OpenAI a good choice, only a permitted one.** The
+catalogue's separate technical objection stands untouched: `strict: true`
+breaks every `openai/*` call, and `openai/gpt-5.4-nano` failed the photo screen
+outright ([`ai-model-candidates.md`](ai-model-candidates.md),
+[`lib/core/utils/ai_model_catalogue.dart`](../lib/core/utils/ai_model_catalogue.dart)).
+Policy fit is a necessary condition, not a sufficient one, and no model should
+be added on the strength of this note alone.
+
+## How this was read
+
+Primary sources only, all read on 2026-08-16 directly from openai.com,
+cloud.google.com and anthropic.com. openai.com returns HTTP 403 to automated
+fetching, so every OpenAI quote below was read in a real browser against the
+live page, not a mirror, cache or PDF copy. No secondary summary, law-firm
+client alert or blog post is cited as evidence anywhere in this note; where
+search turned up commentary about these clauses it was discarded.
+
+| Document | Date it carries |
+| --- | --- |
+| [Usage policies](https://openai.com/policies/usage-policies/) | Effective **October 29, 2025** |
+| [OpenAI Services Agreement](https://openai.com/policies/services-agreement/) | Updated **December 1, 2025**; Effective **January 1, 2026** |
+| [Service terms](https://openai.com/policies/service-terms/) | Updated **June 12, 2026** |
+| [Europe Terms of Use](https://openai.com/policies/terms-of-use/) | Updated **January 16, 2026** |
+| [Terms of Use (rest of world)](https://openai.com/policies/row-terms-of-use/) | no date extracted — see [Not verified](#not-verified) |
+| [Sharing & publication policy](https://openai.com/policies/sharing-publication-policy/) | Updated **November 14, 2022** |
+| [Anthropic Usage Policy](https://www.anthropic.com/legal/aup) | Effective **September 15, 2025** |
+| [Google Cloud Service Specific Terms](https://cloud.google.com/terms/service-terms) | Last modified **July 29, 2026** |
+
+The behaviour the clauses are read against is the shipped behaviour, verified
+in source rather than assumed:
+[`mealItemsToolSchema`](../lib/features/add_meal/domain/meal_items_api.dart)
+has exactly three fields — `query`, `quantity`, `unit` — with
+`additionalProperties: false` and `required: ['query']`. There is no nutrition
+field, so a model has nowhere to put a calorie or a macro even if asked. The
+confirmation step in
+[`bulk_add_screen.dart`](../lib/features/add_meal/presentation/screens/bulk_add_screen.dart)
+is documented as *"not optional"*. Both interpreters' prompts open with "You do
+not estimate nutrition".
+
+## A. Who is bound, and by which document
+
+**The API is not on the consumer terms.** Both consumer Terms of Use say so in
+identical words: *"Our Business Terms govern use of ChatGPT Enterprise, our
+APIs, and our other services for businesses and developers."* The Business
+Terms are now the Services Agreement — the page carries a "View previous
+business terms" link, confirming the succession.
+
+**The Services Agreement claims the API path regardless of who holds the key.**
+Its scope line: *"This OpenAI Services Agreement only applies to use of
+OpenAI's APIs, ChatGPT Enterprise, ChatGPT Business, ChatGPT for Clinicians,
+and other services for customers who are businesses and developers, and does
+not apply to OpenAI services used by consumers or individuals unless specified
+above."* APIs are specified above, so API use is inside. A hobbyist with a
+personal key is treated as a developer. This is the natural reading; it is not
+the only possible one, and the sentence is clumsy enough that a contrary
+reading is not absurd.
+
+**The restriction that carries the Usage Policies is §3.3(a):** *"Customer will
+not, and will not permit End Users to: (a) use the Services or Customer Content
+in a way that violates applicable laws or OpenAI Policies"*. §17 defines
+*"OpenAI Policies"* as *"the Service-Specific Terms, Sharing and Publication
+Policy, and Usage Policies."* So the Usage Policies bind **Customer** — the
+entity with the account and the billing relationship. Under BYO-key that is the
+user, and only the user.
+
+**The project is not a party.** It has no account, no Order Form, no key, and
+pays nothing. §16.10: *"There are no intended third-party beneficiaries to this
+Agreement"* — so the arrangement gives this project no rights either, which is
+worth stating because it means the app cannot rely on anything in the agreement
+as protection.
+
+### What §2.2 actually says
+
+The prior evaluation cited §2.2 as contemplating BYO-key. It does not. Verbatim:
+
+> **2.2. Use.** OpenAI grants Customer a non-exclusive right to access and use
+> the Services during the Term. This includes the right to use OpenAI's API to
+> integrate the Services into Customer Applications and to make Customer
+> Applications available to End Users.
+
+That is a permission for the **developer-as-Customer** shape: the developer
+holds the key, builds a Customer Application, ships it to End Users, and
+answers for them under §3.2 (*"Customer is responsible for all activities that
+occur under its Account, including the activities of End Users … who access the
+Services through a Customer Application"*). That is exactly the arrangement
+BYO-key exists to avoid, and it is the arrangement under which the developer
+*would* be squarely bound by the Usage Policies.
+
+There is a definitional gap under BYO-key. *"Customer Application"* means
+*"Customer's applications, products, or services that integrate with an OpenAI
+API."* When the user is the Customer, OpenNutriTracker is not the Customer's
+application — the user did not build it. The agreement has no category for
+"third-party software the Customer runs with their own key". The arrangement is
+therefore **neither expressly permitted nor expressly forbidden**, and §2.2
+does not shift the obligation, does not permit the arrangement, and does not
+push a flow-down duty onto us. It simply addresses a different shape.
+
+### §3.3(g): the finding that changes the picture
+
+> **3.3. Restrictions.** Customer will not, and will not permit End Users to:
+> … (g) buy, sell, or transfer API keys from, to, or with a third party;
+
+This is a **prohibition**, and the prior note's characterisation of it as
+contemplating BYO-key is wrong. The question it raises is real: when a user
+pastes their own key into an app they installed, is that a "transfer … to … a
+third party"?
+
+Arguments that it is not, on the shipped design:
+
+- The project never receives the key. It is held in
+  [`ai_credential_storage`](../lib/core/utils/ai_credential_storage.dart) on
+  the user's device and travels only from that device to OpenAI. There is no
+  proxy and no server-side component.
+- The clause sits in a list about commerce and account integrity — buying,
+  selling, reselling (§3.1: *"Customer may not resell or lease access to its
+  Account"*), sharing credentials *"between multiple users"*. Every neighbour
+  concerns a key moving to a different *person*. Here it does not.
+- Nobody but the Customer ever uses the key, and all billing lands on the
+  Customer.
+
+The argument that it is: the key is made readable by software the Customer did
+not write and does not control, and "transfer … with a third party" is broad
+enough to be read as reaching that.
+
+**This is genuinely ambiguous and should not be resolved in either direction
+here.** It is, however, the clause a BYO-key design most plausibly trips, and
+it is worth more attention than the three clauses the ticket was written
+about. If it were ever read against us, the remedy is unattractive: BYO-key
+without the user handing the key to anything is not a design that exists.
+
+## B. Clause by clause
+
+### B1. *"suicide, self-harm, or disordered eating promotion or facilitation"*
+
+Under **Protect people**, Usage Policies effective 29 October 2025. Verbatim:
+
+> Protect people. Everyone has a right to safety and security. So you cannot
+> use our services for: … suicide, self-harm, or disordered eating promotion or
+> facilitation
+
+Both operative verbs describe conduct directed at an outcome. **Promotion**
+requires advocating for the behaviour. **Facilitation** requires making it
+easier or providing means toward it. Neither is a status test on the product
+category, and the clause does not name calorie tracking, dieting or weight
+management anywhere.
+
+What the model is asked to do is convert `"2 eggs, 100g toast, black coffee"`
+into `[{query: "eggs", quantity: 2}, {query: "toast", quantity: 100, unit:
+"g"}, {query: "black coffee"}]`. That is tokenisation. The model contributes no
+number the user did not type, offers no opinion on the meal, and cannot report
+a calorie count because the schema has no field for one. Every figure the user
+sees is retrieved from Open Food Facts, USDA FDC or BLS by searching the
+returned strings.
+
+**The strongest evidence is internal, not textual.** Anthropic's Usage Policy,
+under *Do Not Create Psychologically or Emotionally Harmful Content*, prohibits:
+
+> Facilitate, promote, or glamorize any form of suicide or self-harm, including
+> disordered eating and unhealthy or compulsive exercise
+
+That is the same prohibition with a **wider** reach: it adds "glamorize", and
+it adds compulsive exercise. The project reviewed it, shipped on Anthropic
+anyway, and was right to. OpenAI's narrower version cannot exclude an app that
+Anthropic's broader one does not. Either the app promotes and facilitates
+disordered eating — in which case the current Anthropic-only catalogue is also
+non-compliant and the whole feature is in question — or it does not, in which
+case B1 is not a reason to exclude OpenAI. There is no consistent third
+position, and #656 did not notice it was holding one.
+
+Where a nutrition tracker *could* meet this clause is worth naming so the line
+stays visible: emitting a deficit target, ranking foods as good or bad,
+nudging toward a calorie floor, or commenting on a logged day. The app does
+none of these, and the schema is what keeps it that way — a structural
+guarantee rather than a promise in a prompt (settled 2026-08-14; decision #5
+reversed, [#250](https://github.com/simonoppowa/OpenNutriTracker/issues/250)
+stays closed).
+
+### B2. *"promoting unhealthy dieting or exercise behavior to minors"*
+
+Under **Keep minors safe**. The section's preamble, verbatim:
+
+> Keep minors safe. Children and teens deserve special protection. Our services
+> are designed to prevent harm and support their well-being, and must never be
+> used to exploit, endanger, or sexualize anyone under 18 years old. We
+> prohibit use of our services for: … promoting unhealthy dieting or exercise
+> behavior to minors … shaming or otherwise stigmatizing the body type or
+> appearance of minors
+
+**Read the grammar.** The prohibited act is *promoting X to Y*. It requires
+three things: a promoter, something promoted, and a minor recipient. The app
+promotes nothing to anyone — it has no chat surface, no recommendations, no
+commentary. There is no output channel through which a diet could be
+advocated. The second clause, *shaming or otherwise stigmatizing*, requires an
+evaluative statement about a person's body, which nothing in this app can
+produce. A tool with no opinions cannot promote and cannot shame.
+
+**Note what is not here.** There is no requirement that the service be
+adults-only, no age-gate obligation, no audience restriction, no "not likely to
+be accessed by minors" wording, and no prohibition on general-audience
+distribution. The preamble's *"must never be used to exploit, endanger, or
+sexualize anyone under 18"* is likewise conduct, not audience. I read the whole
+document; nothing elsewhere reintroduces a distribution test.
+
+### B3. *"provision of tailored advice that requires a license"*
+
+Under **Protect people**. Verbatim:
+
+> provision of tailored advice that requires a license, such as legal or
+> medical advice, without appropriate involvement by a licensed professional
+
+Three conditions must all hold: it must be **advice**, it must be **tailored**,
+and it must be advice **that requires a license**. The app fails the first,
+which ends it. Returning `{query: "toast"}` is not advice under any reading;
+the app never tells the user what to eat, how much, or whether the day went
+well. It transcribes what the user already said or photographed.
+
+Even if a reviewer insisted the surrounding product gives dietary advice, the
+model does not, and the model is what the Usage Policies govern. And the
+numbers the app *does* show come from public food databases, not the model —
+so the model is not the source of anything advisory.
+
+**But note where this leaves us.** The defence is entirely factual — "the app
+gives no advice" — and it moves the day the product adds a suggestion, a
+summary, a coach, or any commentary at all. With Anthropic the carve-out means
+even a genuinely advisory nutrition feature stays outside the High-Risk
+category. With OpenAI, the margin is only as wide as the current feature set.
+That is what [Section D](#d-openai-against-anthropic-absence-against-carve-out)
+is about.
+
+### B4. The clause that was not on the list, and is satisfied anyway
+
+Under **Empower people**, the Usage Policies prohibit *"automation of
+high-stakes decisions in sensitive areas without human review"*, and the
+enumerated sensitive areas include **medical**. This is the closest the
+document comes to touching the app, and it comes with its own escape hatch:
+*without human review*. The confirmation step in `bulk_add_screen.dart` is
+documented as *"not optional"* and exists so nothing reaches the diary
+unreviewed. Nothing is automated and nothing is decided. Satisfied on both
+limbs.
+
+## C. OpenAI against Google: conduct test against distribution test
+
+**The distinction is real, and it is the reason the two rejections were never
+the same rejection.** Verified against the live Google document rather than
+taken from the earlier note.
+
+Google Cloud Service Specific Terms, last modified 29 July 2026, §20(d):
+
+> **d. Age Restrictions.** Customer will not, and will not allow End Users to,
+> use a Generative AI Service as part of a website, Customer Application, or
+> other online service that is directed towards or is likely to be accessed by
+> individuals under the age of 18.
+
+§20(g) makes this a "Use Restriction". §20(f) adds that Google *"may
+immediately suspend or terminate Customer's use of a Generative AI Service
+based on any suspected violation of … subsection (d)"* — suspicion, not
+finding. §20(e) adds a healthcare restriction against use *"as a substitute for
+professional medical advice"*.
+
+| | Google §20(d) | OpenAI *Keep minors safe* |
+| --- | --- | --- |
+| Test | **Distribution** — where the app is offered | **Conduct** — what the app does |
+| Trigger | *likely to be accessed by* under-18s | *promoting … to* minors |
+| Can a general-audience app comply? | **No.** Play and F-Droid are open listings; the condition is met at publication | **Yes**, by not promoting dieting |
+| Compliance evidence | would need an age gate that excludes minors | the absence of an advisory output channel |
+
+A general-audience calorie tracker on Google Play and F-Droid fails §20(d) the
+moment it lists, no matter how the model is used — the clause is about the
+storefront, not the software. OpenAI's clause can be complied with by a
+general-audience app, and this one does comply, because it has no mechanism for
+promoting anything.
+
+**I checked specifically for a re-entry point and found none.** The Usage
+Policies, the Services Agreement and the Service terms contain no age-gating
+obligation, no audience restriction and no age-verification requirement for API
+applications. The one age clause on the API path is Services Agreement §3.3(c),
+and it is a consent test rather than an exclusion:
+
+> Customer will not, and will not permit End Users to: … (c) allow minors to
+> use OpenAI Services without consent from their parent or guardian
+
+Minors are contemplated as users, conditionally. It binds the Customer — under
+BYO-key, the user, who is the only person using their key. Consumer Terms of
+Use set the floor consistently: *"You must be at least 13 years old or the
+minimum age required in your country to consent to use the Services. If you are
+under 18, you must have your parent or legal guardian's permission to use the
+Services"* (Europe ToU, 16 January 2026; the rest-of-world ToU carries the same
+sentence).
+
+**The only audience rule I found in OpenAI's developer surface runs the
+opposite way to Google's.** The Apps SDK submission guidelines require *"Plugins
+must be suitable for general audiences, including users aged 13–17"* and that
+*"Plugins may not explicitly target children under 13."* That is an
+*inclusion* requirement — build for teenagers — and it is the inverse of an
+exclusion test. It governs ChatGPT plugins and Codex, **not** a mobile app
+calling the API with the user's key, so it does not bind us. It is cited only
+as evidence of posture: OpenAI's developer-facing age rules ask apps to be safe
+for minors, not to keep minors out.
+
+## D. OpenAI against Anthropic: absence against carve-out
+
+**Anthropic gives an explicit carve-out. OpenAI gives silence. These are not
+the same thing, and the difference should survive into any decision.**
+
+Anthropic's Usage Policy lists *High-Risk Use Cases* which attract two extra
+duties — human-in-the-loop review by *"a qualified professional in that
+field"*, and disclosure that AI is involved *"at a minimum at the beginning of
+each session"*. Its healthcare entry ends with the sentence the project chose
+Anthropic for:
+
+> **Healthcare:** Use cases related to healthcare decisions, medical diagnosis,
+> patient care, therapy, mental health, or other medical guidance. Wellness
+> advice (e.g., advice on sleep, stress, nutrition, exercise, etc.) does not
+> fall under this category
+
+Nutrition is named and placed outside. That is affirmative cover: it does not
+depend on the app being read a particular way, it survives a product change
+toward advice, and it is quotable to a reviewer in one line.
+
+OpenAI has nothing comparable. There is no "High-Risk Use Cases" construct at
+all in the October 2025 Usage Policies, and no wellness, nutrition, fitness or
+diet exception anywhere in the Usage Policies, the Services Agreement or the
+Service terms. The nearest OpenAI comes to addressing the domain points
+gently the *other* way — Service terms §9, updated 12 June 2026:
+
+> **9. Medical Use.** Our Services are not intended for use in the diagnosis or
+> treatment of any health condition. You are responsible for complying with
+> applicable laws for any use of our Services in a medical or healthcare
+> context.
+
+That is a disclaimer of intent plus a compliance pass-through, not a
+prohibition and certainly not a carve-out. It is weaker than Google's §20(e)
+(which is a restriction) and weaker than Anthropic's carve-out (which is a
+permission). It does not bar the app — logging what you ate is neither
+diagnosis nor treatment — but it is the opposite of reassurance.
+
+| | Anthropic | OpenAI |
+| --- | --- | --- |
+| Disordered eating | prohibited, **wider** wording ("glamorize", compulsive exercise) | prohibited |
+| Nutrition named favourably | **yes** — explicit carve-out from High-Risk | no |
+| Advice regime | High-Risk duties, from which wellness is exempt | flat ban on unlicensed tailored advice, no exemption |
+| Minors + dieting | no clause | conduct clause, not met |
+| Audience/distribution test | none | none |
+| Health posture statement | carve-out | §9 disclaimer of intent |
+
+**So the honest summary is: OpenAI is permitted by absence.** Everything above
+holds because the app gives no advice and promotes nothing, and it would stop
+holding if either of those changed. Under Anthropic, the same product change
+would still be covered. A project that treats "no prohibition found" as weaker
+than an explicit carve-out — as this one does, and as it did when it declined
+xAI on the same reasoning ([`ai-model-candidates.md`](ai-model-candidates.md)
+finding 3) — should reach the same conclusion here. **OpenAI is not barred; it
+is simply less protected, and it should be ranked as such rather than
+re-rejected.**
+
+## E. Clauses nobody was looking at
+
+**Service terms §6 touches the photo path**, and did not appear in #656:
+
+> You may not use Visual Capabilities to assist in identifying a person nor to
+> solicit or infer private or sensitive information about a person.
+
+The photo prompt asks only which foods are visible and forbids estimating
+weight or volume, so no inference about a person is requested. Two things keep
+this from being clean: meal photographs frequently contain people incidentally,
+and dietary intake is a category some regimes treat as sensitive personal data.
+The clause is about *using* the capability to identify or infer, which the app
+does not do, so on the better reading it is not engaged — but it is closer to
+the app's behaviour than B2 or B3 are, and it deserves a look before any
+OpenAI-backed photo path ships. **Ambiguous; not resolved here.**
+
+Three more, checked and clear:
+
+- **Service terms §1** binds documentation: *"Customer will only, and will
+  ensure that its End Users only, use APIs in accordance with the applicable
+  documentation."* The safety-best-practices guide contains recommendations
+  (adversarial testing, human review, the free Moderation API) rather than
+  requirements, and imposes no AI-disclosure duty, no age gate and no
+  health-app conditions.
+- **Services Agreement §5.4** forbids processing Protected Health Information
+  without a signed Healthcare Addendum. PHI is a defined term under the HIPAA
+  Privacy Rule tied to covered entities; a person's own food diary is not PHI.
+  Not engaged, but adjacent enough to note.
+- **Sharing & Publication Policy** is incorporated into "OpenAI Policies" but
+  is dated 14 November 2022, still references GPT‑3 and a "Content Policy" that
+  no longer exists, and governs social posting and book publishing. Nothing in
+  it reaches this app.
+
+Also checked and found not to apply: the **App Developer Terms**, which govern
+ChatGPT Apps and Actions (Service terms §5(c), §7(a)), not an API integration
+in a mobile app.
+
+## Not verified
+
+- **Whether pasting your own key into third-party client software is a
+  "transfer … to … a third party" under §3.3(g).** The controlling ambiguity of
+  this whole note. OpenAI publishes no guidance, FAQ or help-centre article
+  interpreting the clause that I could find, and the surrounding restrictions
+  cut both ways. Unresolvable from public documents.
+- **Whether an individual hobbyist with a personal API key is a "business or
+  developer"** within the Services Agreement's scope sentence. The reading
+  taken here — that they are, because APIs are named — is the natural one and
+  is corroborated by both consumer ToU routing API use to the business terms,
+  but the sentence is not clean and I did not find OpenAI stating it anywhere
+  else.
+- **The rest-of-world Terms of Use date.** The page renders no "Updated:" line
+  that could be extracted; the minimum-age and business-terms sentences were
+  read from the live page on 2026-08-16 and are quoted accurately, but the
+  version date is unconfirmed. The Europe ToU date (16 January 2026) is
+  confirmed.
+- **What the pre-29-October-2025 Usage Policies required.** The January 2024
+  version is widely described as carrying a disclosure duty for consumer-facing
+  medical uses, and the changelog entry *"We've updated our Usage Policies to
+  reflect a universal set of policies"* is consistent with such
+  service-specific guidance having been dropped. OpenAI publishes no archived
+  copy I could reach, so I could not confirm what was removed. Only the current
+  document binds, and it contains no disclosure duty.
+- **Enforcement history against nutrition or fitness applications.** None
+  found, and I do not believe it is findable. OpenAI's published enforcement
+  reporting is the *Disrupting malicious uses of AI* series, which covers
+  influence operations, scams, cyber intrusion and state-affiliated actors —
+  threat-intelligence categories, not consumer app policy. OpenAI does not
+  publish case-level developer enforcement data, so **"no enforcement found"
+  here means "not published", not "has not happened"**, and should not be
+  cited as comfort.
+- **Any OpenAI developer guidance specific to health or wellness apps.** I
+  looked in the Usage Policies, Services Agreement, Service terms, the API
+  safety-best-practices guide and the Apps SDK submission guidelines. There is
+  none. The Apps SDK guidelines' prohibited-category list reaches
+  prescription-only drugs but says nothing about diet, nutrition or fitness —
+  and governs ChatGPT plugins regardless.
+- **Whether OpenAI's Model Spec bears on this.** It does not, as far as I can
+  tell. Both the 2025-10-27 and 2025-12-18 versions were searched for eating
+  disorders, dieting, nutrition, calories and body image; the only near-match
+  is a section heading, *"Do not encourage self-harm, delusions, or mania"*,
+  whose body I could not retrieve in full. It governs model behaviour rather
+  than developer permission in any case.
+- **How OpenAI would actually read B1 against this app.** Everything in
+  [Section B1](#b1-suicide-self-harm-or-disordered-eating-promotion-or-facilitation)
+  is textual analysis plus an internal-consistency argument. No OpenAI
+  interpretation of "disordered eating promotion or facilitation" exists in
+  public, and a reviewer minded to treat calorie tracking as a category risk
+  would not be contradicted by anything in the document.
+- **Legal advice.** This is a reading of published documents on one date by a
+  non-lawyer. Terms on all three sites change without notice — Google's moved
+  documents entirely between #656 and now — and the dates above are the only
+  guarantee offered.
+
+## Sources
+
+OpenAI (read in a browser; the site 403s automated fetching):
+[Usage policies](https://openai.com/policies/usage-policies/) ·
+[OpenAI Services Agreement](https://openai.com/policies/services-agreement/) ·
+[Service terms](https://openai.com/policies/service-terms/) ·
+[Europe Terms of Use](https://openai.com/policies/terms-of-use/) ·
+[Terms of Use (rest of world)](https://openai.com/policies/row-terms-of-use/) ·
+[Sharing & publication policy](https://openai.com/policies/sharing-publication-policy/) ·
+[Safety best practices](https://developers.openai.com/api/docs/guides/safety-best-practices) ·
+[Apps SDK app submission guidelines](https://developers.openai.com/apps-sdk/app-submission-guidelines) ·
+[Disrupting malicious uses of AI](https://openai.com/index/disrupting-malicious-ai-uses/) ·
+[Model Spec (2025/12/18)](https://model-spec.openai.com/2025-12-18.html)
+
+Comparison documents:
+[Anthropic Usage Policy](https://www.anthropic.com/legal/aup) ·
+[Google Cloud Service Specific Terms](https://cloud.google.com/terms/service-terms)
+
+Related notes in this repo:
+[`ai-model-candidates.md`](ai-model-candidates.md) ·
+[`ai-legal-constraints.md`](ai-legal-constraints.md) ·
+[`ai-cohort-restrictions.md`](ai-cohort-restrictions.md) ·
+[`ai-open-research-questions.md`](ai-open-research-questions.md)
+
+In-repo files cited:
+[`lib/features/add_meal/domain/meal_items_api.dart`](../lib/features/add_meal/domain/meal_items_api.dart) ·
+[`lib/features/add_meal/data/model_meal_text_interpreter.dart`](../lib/features/add_meal/data/model_meal_text_interpreter.dart) ·
+[`lib/features/add_meal/data/model_meal_photo_interpreter.dart`](../lib/features/add_meal/data/model_meal_photo_interpreter.dart) ·
+[`lib/features/add_meal/presentation/screens/bulk_add_screen.dart`](../lib/features/add_meal/presentation/screens/bulk_add_screen.dart) ·
+[`lib/core/utils/ai_model_catalogue.dart`](../lib/core/utils/ai_model_catalogue.dart)

--- a/docs/ai-openai-wire-format.md
+++ b/docs/ai-openai-wire-format.md
@@ -1,0 +1,906 @@
+# Which OpenAI API, and what does its wire format demand?
+
+**Verdict: build the direct client on the Responses API (`POST
+https://api.openai.com/v1/responses`), not on Chat Completions — and send
+`store: false` on every request.** OpenAI recommends Responses in three
+separate places in its own reference, and the choice removes a problem rather
+than adding one: on Chat Completions, `max_tokens` is already deprecated and
+`reasoning: none` is incompatible with tool calling on the models this feature
+would actually use.
+
+**The storage objection is real and does not change the answer.** A parallel
+reading for [#680](https://github.com/simonoppowa/OpenNutriTracker/issues/680)
+found that `/v1/responses` stores by default and concluded the app should use
+Chat Completions instead. The first half is correct — verified, quoted in
+[A2](#a2-the-storage-default). The second
+half does not follow, for three documented reasons: **Chat Completions has a
+storage default too** (*"Chat completions are stored by default for new
+accounts"* — and a user creating an account to use this app is a new account);
+**the retention that actually holds the meal text and the photograph is
+abuse-monitoring retention, which is 30 days on both endpoints and is not
+governed by `store` at all**; and **`store: false` is documented for both**, so
+the delta is a field the client sends, not an endpoint it picks. Choosing Chat
+Completions to avoid a parameter you have to send anyway costs the tool-calling
+combination this feature needs.
+
+**But the port is larger than the map assumed.** The map's note that
+`OpenRouterMealItemsApi` is *"the OpenAI-compatible shape"* is true of **Chat
+Completions**, which is not the API to build on. Against Responses, the
+existing client agrees on almost nothing at the wire level: not the endpoint,
+not the message array, not the tool wrapper, not the token field, not the
+response envelope, not the failure signal. The parts that survive unchanged are
+the JSON Schema itself, the `arguments`-as-a-string decode, and the data-URI
+image. **Everything else is a rewrite**, which bears directly on
+[#685](https://github.com/simonoppowa/OpenNutriTracker/issues/685) — a shared
+"OpenAI dialect" base with OpenRouter would be sharing a dialect neither client
+speaks.
+
+Three findings the existing code has backwards, each documented below:
+
+1. **404 is not a capability refusal on OpenAI.** OpenAI documents no 404 for
+   this endpoint at all, and documents capability as a *property of the model*,
+   listed per model in the docs. `isCapabilityRefusal` has nothing to detect.
+2. **429 is not reliably transient**, and **403 is not an auth failure.** 429
+   carries billing and quota exhaustion — *"Retrying billing, spend, or quota
+   errors won't restore API access"* — and the only documented 403 is
+   *"Country, region, or territory not supported"*.
+3. **A failed generation can arrive as HTTP 200**, exactly as it does on
+   OpenRouter, but with a different shape: `status: "failed"` plus a top-level
+   `error` object. There is no `finish_reason: "error"` — that value does not
+   exist in OpenAI's enum, and Responses has no `finish_reason` field at all.
+
+The strict-mode answer is in [Section F](#f-strict-mode). Short version: the
+nullable union **is** the sanctioned way to express an optional field, the
+documentation says so in as many words, and the objection recorded in
+`openrouter_meal_items_api.dart` — that `required` would oblige the model to
+produce a number for every item — does not survive it. That is for
+[#683](https://github.com/simonoppowa/OpenNutriTracker/issues/683) to decide,
+not this note.
+
+## How this was read
+
+Primary sources only, all read on **2026-08-16** from `developers.openai.com`.
+`platform.openai.com/docs` now redirects there.
+
+Every page on that site publishes a Markdown twin — *"Markdown versions of
+documentation pages are available by appending `.md` to the page URL"* — and
+every quote below was taken from that twin and then grep-verified verbatim
+against the downloaded file rather than transcribed from a rendering or a
+summary. Where the documentation is silent, this note says silent. It does not
+fill the gap with what OpenRouter does; that is the mistake the ticket was
+written to avoid.
+
+No live call was made and no key was used. [#684](https://github.com/simonoppowa/OpenNutriTracker/issues/684)
+covers probing, and [Not established](#not-established-without-a-live-call)
+lists what it has to settle.
+
+| Page read | URL |
+| --- | --- |
+| Function calling | [`/api/docs/guides/function-calling`](https://developers.openai.com/api/docs/guides/function-calling) |
+| Structured model outputs | [`/api/docs/guides/structured-outputs`](https://developers.openai.com/api/docs/guides/structured-outputs) |
+| Images and vision | [`/api/docs/guides/images-vision`](https://developers.openai.com/api/docs/guides/images-vision) |
+| Migrate to the Responses API | [`/api/docs/guides/migrate-to-responses`](https://developers.openai.com/api/docs/guides/migrate-to-responses) |
+| Error codes | [`/api/docs/guides/error-codes`](https://developers.openai.com/api/docs/guides/error-codes) |
+| Rate limits | [`/api/docs/guides/rate-limits`](https://developers.openai.com/api/docs/guides/rate-limits) |
+| Reasoning | [`/api/docs/guides/reasoning`](https://developers.openai.com/api/docs/guides/reasoning) |
+| Deprecations | [`/api/docs/deprecations`](https://developers.openai.com/api/docs/deprecations) |
+| How we use your data | [`/api/docs/guides/your-data`](https://developers.openai.com/api/docs/guides/your-data) |
+| Chat Completions — Get | [`/api/reference/resources/chat/subresources/completions/methods/retrieve`](https://developers.openai.com/api/reference/resources/chat/subresources/completions/methods/retrieve) |
+| API Overview (auth, headers) | [`/api/reference/overview`](https://developers.openai.com/api/reference/overview) |
+| Responses — Create | [`/api/reference/resources/responses/methods/create`](https://developers.openai.com/api/reference/resources/responses/methods/create) |
+| Chat — Create chat completion | [`/api/reference/resources/chat`](https://developers.openai.com/api/reference/resources/chat) |
+| Chat Completions Overview | [`/api/reference/chat-completions/overview`](https://developers.openai.com/api/reference/chat-completions/overview) |
+| Models, and per-model pages | [`/api/docs/models`](https://developers.openai.com/api/docs/models) |
+
+## What differs from the existing OpenRouter client
+
+Read against
+[`openrouter_meal_items_api.dart`](../lib/features/add_meal/data/openrouter_meal_items_api.dart)
+line by line. "Same" means the byte-level shape is identical and the code
+transfers unchanged.
+
+| What | `OpenRouterMealItemsApi` sends today | Direct OpenAI, Responses API | Same? |
+| --- | --- | --- | --- |
+| Endpoint | `openrouter.ai/api/v1/chat/completions` | `api.openai.com/v1/responses` | no |
+| Auth header | `authorization: Bearer …` | `Authorization: Bearer …` | **yes** |
+| Version header | none | none required | **yes** |
+| System prompt | first element of `messages`, `role: "system"` | top-level `instructions` string | no |
+| User content | `messages[].content` | `input[].content` | no |
+| Text part | `{"type": "text", "text": …}` | `{"type": "input_text", "text": …}` | no |
+| Image part | `{"type": "image_url", "image_url": {"url": "data:…"}}` | `{"type": "input_image", "image_url": "data:…"}` | no — flattened |
+| Part order | text, then image | docs are **silent**; every example is text, then image | effectively yes |
+| Tool wrapper | `{"type":"function","function":{name, description, parameters}}` | `{"type":"function", name, description, parameters}` | no — *"externally tagged"* vs *"internally tagged"* |
+| Forced tool | `{"type":"function","function":{"name": …}}` | `{"type":"function","name": …}` | no |
+| Token cap | `max_tokens` | `max_output_tokens` | no |
+| Token cap covers | visible output | visible output **+ reasoning tokens** | no |
+| `strict` omitted means | non-strict | **attempts strict**, falls back | no |
+| Routing block | `provider: {require_parameters, data_collection, only}` | no equivalent; drop it | no |
+| Metadata header | `x-openrouter-metadata: enabled` | no equivalent; drop it | no |
+| Storage | not applicable | **stored by default**, 30 days; must send `store: false` ([A2](#a2-the-storage-default)) | new field |
+| Success envelope | `choices[0].message.tool_calls[]` | `output[]`, filtered on `type == "function_call"` | no |
+| Tool `arguments` | JSON **string** | JSON **string** | **yes** |
+| Schema (`mealItemsToolSchema`) | plain JSON Schema | plain JSON Schema | **yes** |
+| Failure-as-200 | `finish_reason: "error"` + `choice.error.code` | `status: "failed"` + top-level `error.code` | different shape, same hazard |
+| `finish_reason` | OpenRouter adds `"error"` | field does not exist on Responses | no |
+| 404 | capability refusal | undocumented for this endpoint | no |
+| 403 | treated as auth failure | documented only as geo-block | no |
+| 429 | treated as transient | transient **or** terminal billing/quota | no |
+| 422 | treated as non-retryable | documented as *"Please try the request again"* | inverted |
+
+## A. Which API
+
+**Settle this first, because it changes every other answer.** Both APIs support
+function calling and image input; the reference marks them both "Supported" on
+every current model page. So this is not a capability decision — it is a
+direction-of-travel decision, and OpenAI has signposted it clearly.
+
+**The recommendation, verbatim.** Migration guide, first line under the title:
+
+> **While Chat Completions remains supported, Responses is recommended for all
+> new projects.**
+
+The reference repeats it on the endpoint itself. Both
+`/api/reference/chat-completions/overview` and the `Create chat completion`
+method page open with the same block:
+
+> **Starting a new project?** We recommend trying [Responses] to take advantage
+> of the latest OpenAI platform features.
+
+And the API Overview's *"Start here"* list, step 1 — *"Choose the API surface
+for your application"* — offers three: Responses *"for direct model requests,
+tool use, audio, image, and text inputs, and stateful interactions"*, Realtime,
+and Administration. **Chat Completions is not among them.** It survives in the
+reference index as a one-page overview with no `create` method page of its own;
+the full parameter list lives under `/api/reference/resources/chat`.
+
+**Neither is deprecated, and neither is tagged legacy.** I read the whole
+deprecations page. Chat Completions appears nowhere on it, in neither the
+upcoming nor the historical sections. The page defines the term it does not
+apply here:
+
+> We use the term "legacy" to refer to models and endpoints that no longer
+> receive updates. We tag endpoints and models as legacy to signal to
+> developers where we're moving as a platform and that they should likely
+> migrate to newer models or endpoints.
+
+The endpoint that *is* tagged legacy is `/v1/completions` — the 2023
+freeform-prompt endpoint, unrelated. The Assistants API is genuinely
+deprecated, *"with a sunset date of August 26, 2026"*. Chat Completions is
+neither. So this is a recommendation, not a deadline, and a Chat Completions
+client would not stop working.
+
+**What each demands differently for this exact call.** Beyond the table above,
+two differences are decisive rather than cosmetic:
+
+- **Reasoning models and tool calling on Chat Completions.** *"Starting with
+  GPT-5.4, tool calling is not supported in Chat Completions with `reasoning:
+  none`."* Every current cheap model — `gpt-5.4-nano`, `gpt-5.6-luna` — is a
+  reasoning model with `reasoning.effort` support. On Chat Completions you
+  therefore cannot combine "don't think, just extract" with a forced tool call.
+  On Responses you can. For a one-shot tokeniser with no conversation, that is
+  the difference between paying for reasoning tokens on every meal line and
+  not.
+- **`max_tokens` is already deprecated on Chat Completions** ([Section
+  D](#d-token-limits)). Porting the current `_maxTokens = 1024` constant
+  straight across would send a deprecated field on day one.
+
+**What Chat Completions would cost this app, confirmed rather than assumed.**
+Almost everything on OpenAI's own Responses benefits list is irrelevant here —
+built-in tools, the agentic loop, `previous_response_id`, the Conversations
+API, stateful context, encrypted reasoning replay, background mode, streaming.
+This is one request with no history, so none of it applies. Three things do:
+
+- **Tool calling with `reasoning: none`.** *"Starting with GPT-5.4, tool
+  calling is not supported in Chat Completions with `reasoning: none`."* This
+  is the concrete cost, and it lands squarely on this feature: every candidate
+  model is a GPT-5.4-or-later reasoning model, and the call is a one-shot
+  tokenisation that wants no thinking at all. On Chat Completions the app would
+  pay for reasoning tokens on every meal line or drop to an older model.
+- **`max_tokens` is deprecated** there, so the constant would have to be
+  renamed at once anyway ([Section D](#d-token-limits)).
+- **`detail: "original"` is Responses-only** — the Chat Completions `detail`
+  enum in the reference is `auto | low | high` ([Section C](#c-images)).
+
+Nothing suggests Chat Completions is feature-frozen in a way that would bite
+later; it is simply not where new features land first (*"We recommend migrating
+all flows to the Responses API over time to take advantage of the latest OpenAI
+features and improvements"*). The migration guide's capability comparison table
+would settle this directly, but its check/cross glyphs are images that the
+Markdown twin strips, leaving the columns blank — so **it is not usable as
+evidence** and is not cited here.
+
+**The one honest argument from familiarity** is that Chat Completions is what
+the app already speaks, so `OpenRouterMealItemsApi` could be subclassed or
+parameterised. The divergence table is the answer: against Responses the
+overlap is three items, and against Chat Completions the overlap would be real
+but bought by building the app's newest client on the surface OpenAI tells you
+not to start new projects on.
+
+### A2. The storage default
+
+This is the only argument against Responses with real weight behind it, it came
+from the parallel [#680](https://github.com/simonoppowa/OpenNutriTracker/issues/680)
+reading rather than from this one, and it is half right.
+
+**1. `store` genuinely defaults to true on `/v1/responses`. Confirmed.** Note
+first where it is *not* documented: the create reference gives the parameter as
+`store: optional boolean or null`, *"Whether to store the generated model
+response for later retrieval via API"*, and **states no default**. The same is
+true of the Chat Completions entry. The default lives in prose on two other
+pages. The operative one, from the per-endpoint retention detail under
+`/v1/responses`:
+
+> The Responses API has a 30 day Application State retention period by default,
+> or when the `store` parameter is set to `true`. Response data will be stored
+> for at least 30 days.
+
+"By default" and "at least 30 days" are both OpenAI's words. The claim is
+correct.
+
+**2. `/v1/chat/completions` has a storage default too, which is where the
+comparison breaks.** The migration guide says it three times, in identical
+words each time:
+
+> Responses are stored by default. Chat completions are stored by default for
+> new accounts. To disable storage in either API, set `store: false`.
+
+Stored chat completions are real objects, not a figure of speech — `GET
+/chat/completions/{completion_id}` exists, and *"Only Chat Completions that
+have been created with the `store` parameter set to `true` will be returned."*
+And the purpose OpenAI documents for that storage reads, if anything, worse
+than the Responses one: *"Whether or not to store the output of this chat
+completion request for use in our model distillation or evals products."*
+Against Responses' *"for later retrieval via API"*.
+
+**There is a genuine inconsistency inside OpenAI's own documentation here, and
+it should be recorded rather than resolved.** The per-endpoint retention table
+lists `/v1/chat/completions` application state retention as *"None, see below
+for exceptions"*, and its exception bullets — audio outputs, ZDR, image inputs,
+prompt caching — contain **no** store-driven retention period, while
+`/v1/responses` gets the explicit 30-day bullet quoted above. So the retention
+page implies chat completions retain nothing by default; the migration guide
+says they are stored by default for new accounts; the reference confirms stored
+chat completions exist and are retrievable. All three are current. **Neither
+this note nor #680 can say how long a stored chat completion is kept, because
+OpenAI does not say.**
+
+**3. `store: false` does not suppress everything — and what it fails to
+suppress is identical on both endpoints.** Three retentions survive it, and all
+three are listed against `/v1/chat/completions` and `/v1/responses` in the same
+words:
+
+- **Abuse monitoring, 30 days.** *"By default, abuse monitoring logs are
+  generated for all API feature usage and retained for up to 30 days"*, and the
+  endpoint table gives both endpoints "30 days" in that column. Reducing it
+  requires Zero Data Retention or Modified Abuse Monitoring, both *"subject to
+  prior approval by OpenAI"* — unavailable to an individual with a personal key.
+- **CSAM scanning of image inputs**, applied to `/v1/responses` and
+  `/v1/chat/completions` alike: *"Image and file inputs are scanned for CSAM
+  content upon submission. If the classifier detects potential CSAM content,
+  the image will be retained for manual review, even if Zero Data Retention,
+  Modified Abuse Monitoring, or Eyes Off is enabled."*
+- **Prompt caching**, *"encrypted key/value tensors in GPU-local storage"*, not
+  retained past 24 hours — listed identically under both.
+
+**This is what decides it.** The thing the README's privacy claim is actually
+about — where the user's meal text and photograph go and how long they are kept
+— is governed by abuse-monitoring retention, which is 30 days on both endpoints
+and which `store` does not touch. The `store` delta is a separate, additive
+30-day application-state retention that the client removes with one field. So
+the two APIs are not materially different in retention once `store: false` is
+sent; they are different in what happens if you forget to send it.
+
+One asymmetry does survive: under `/v1/responses` only, *"When Zero Data
+Retention is not enabled for an organization, all queries use extended prompt
+caching for all supported models."* There is no chat-completions counterpart.
+It concerns encrypted GPU-local tensors with a 24-hour ceiling rather than
+conversation state, so it does not change the conclusion, but it is a real
+Responses-specific residue and #680 should have it.
+
+**4. Omitting `store` is unsafe on *both*, which inverts the argument.** On
+Responses, omitting it stores. On Chat Completions, omitting it stores *for new
+accounts* — meaning the behaviour of an app that omits the field depends on
+when its user opened their OpenAI account, which is worse for a client author
+than a default that is merely wrong. **Send `store: false` explicitly on
+whichever endpoint is chosen**, and once it is sent, the storage argument for
+preferring Chat Completions is spent. What remains is a defence-in-depth
+argument — that forgetting the field fails less badly on Chat Completions — and
+that is an argument for a test asserting the field is present, not for an API.
+
+**Recommendation unchanged: Responses, with `store: false` non-negotiable.**
+Two research notes reaching different conclusions from the same page is worth
+surfacing rather than smoothing over: #680's finding about the Responses
+default is sound and this note adopts it, and its inference that Chat
+Completions is therefore the safer endpoint is not supported by the retention
+table it came from.
+
+## B. Forced tool calls
+
+**The shape.** Responses takes the function name at the top level of the
+`tool_choice` object, with no nested `function` wrapper:
+
+> **Forced Function:** Call exactly one specific function.
+> `tool_choice: {"type": "function", "name": "get_weather"}`
+
+The reference calls this `ToolChoiceFunction` and describes it as *"Use this
+option to force the model to call a specific function."*
+
+Chat Completions uses the nested form, and this is one place the existing
+client's assumption **holds exactly** — the reference gives the same bytes it
+sends:
+
+> Specifying a particular tool via `{"type": "function", "function": {"name":
+> "my_function"}}` forces the model to call that tool.
+
+**Guarantee or preference? The documentation will not say, and the answer
+matters less than it looks.** "Call exactly one specific function" is
+imperative, and `ToolChoiceFunction` says "force". But nothing in the guide or
+the reference states that a forced tool call *excludes* a text message from the
+same turn, and the surrounding text cuts slightly the other way. The
+handling section says:
+
+> Since model responses can include zero, one, or multiple calls, it is best
+> practice to assume there are several.
+
+and the reference describes `output` as:
+
+> An array of content items generated by the model.
+> - The length and order of items in the `output` array is dependent on the
+>   model's response.
+> - Rather than accessing the first item in the `output` array and assuming
+>   it's an `assistant` message with the content generated by the model, you
+>   might consider using the `output_text` property where supported in SDKs.
+
+So OpenAI's own advice is that `output` is heterogeneous and position-dependent
+reads are wrong. On a reasoning model it is heterogeneous *by construction* — a
+`reasoning` item precedes the `function_call` item. **A direct client must
+iterate `output` and select `type == "function_call"`**, exactly as
+`_itemsFrom` iterates `tool_calls` today. It must not index `output[0]`.
+
+**Prose is detectable, which is what the no-macros guarantee actually needs.**
+It does not need prose to be impossible. A text answer arrives as an output
+item of `type: "message"`, never as a `function_call`, so a client filtering on
+`function_call` sees no tool call and raises — which is the behaviour
+`MealInterpreterException('response has no tool call')` already has. A
+safety refusal is likewise structurally distinct: it arrives as a content part
+of `type: "refusal"` inside a message item, described as *"A refusal from the
+model"* carrying *"The refusal explanation from the model"*. Both are
+message-shaped; neither can be mistaken for tool arguments.
+
+**And the guarantee never rested on `tool_choice` anyway.** It rests on
+`mealItemsToolSchema` having no macro fields, so there is no key a calorie
+count could be written into, and on `validateParsedMealItems` bounding
+everything that comes back. A model that ignored the forced tool and answered
+in prose would produce a handled error, not a wrong number. Structured Outputs
+is explicit that schema adherence is not semantic correctness:
+
+> Structured Outputs can still contain mistakes.
+
+and
+
+> The model will always try to adhere to the provided schema, which can result
+> in hallucinations if the input is completely unrelated to the schema.
+
+That second sentence is worth carrying into
+[#684](https://github.com/simonoppowa/OpenNutriTracker/issues/684): the
+empty-answer rule — a photo with no food in it — is precisely the "input
+unrelated to the schema" case, and the documentation predicts the model will
+invent items rather than return none. The prompt has to say what to do
+instead; the docs say so directly (*"You could include language in your prompt
+to specify that you want to return empty parameters"*).
+
+`parallel_tool_calls: false` is available and documented as ensuring *"exactly
+zero or one tool is called"* — worth sending, though with a single tool defined
+it buys little.
+
+## C. Images
+
+**Data URI or hosted URL — both, plus a third option.**
+
+> You can provide images as input to generation requests in multiple ways:
+> - By providing a fully qualified URL to an image file
+> - By providing an image as a Base64-encoded data URL
+> - By providing a file ID (created with the Files API)
+
+The reference field description is the operative one for a client that holds
+bytes: `image_url` is *"The URL of the image to be sent to the model. A fully
+qualified URL or base64 encoded image in a data URL."* The documented data-URI
+form matches what the app already builds — the Python example sends
+`f"data:image/jpeg;base64,{base64_image}"`. Only the *envelope* changes: on
+Responses the field is a bare string on the part, not a nested
+`image_url: {url: …}` object.
+
+The hosted-URL and file-ID routes are both wrong for this app for the same
+reason the photo is never written to disk: they would put the photograph
+somewhere it can be fetched from.
+
+**WebP is supported, explicitly and by name.** From the image input
+requirements table:
+
+> Supported file types: PNG (`.png`) - JPEG (`.jpeg` and `.jpg`) - WEBP
+> (`.webp`) - Non-animated GIF (`.gif`)
+
+**Size limits are on the payload, not the image.**
+
+> Size limits: Up to 512 MB total payload size per request - Up to 1500
+> individual image inputs per request
+
+Plus three requirements stated as prose rather than as validation:
+
+> Other requirements: No watermarks or logos - No NSFW content - Clear enough
+> for a human to understand
+
+Note there is **no documented pixel-dimension ceiling that rejects an image**.
+Dimensions are handled by resizing rather than refusal, per model — on
+`gpt-5.4-nano` and the other small models, *"`high` allows up to 1,536 patches
+or a 2048-pixel maximum dimension. If either limit is exceeded, we resize the
+image while preserving aspect ratio."* The app's existing WebP downscale is
+therefore a cost and latency optimisation on this path, not a compatibility
+requirement.
+
+**Detail settings.**
+
+> The `detail` parameter tells the model what level of detail to use when
+> processing and understanding the image (`low`, `high`, `original`, or
+> `auto`). If you skip the parameter, the model will use `auto`. This behavior
+> is the same in both the Responses API and the Chat Completions API.
+
+with `low` documented as *"The model receives a low-resolution 512px x 512px
+version of the image."* Two caveats for a client: `original` is *"Available on
+`gpt-5.4` and future models"* only, and Chat Completions' `detail` enum in the
+reference is `auto | low | high` — **`original` is Responses-only**. Which
+level suits a plate of food is a question for
+[#684](https://github.com/simonoppowa/OpenNutriTracker/issues/684) and not
+answerable from documentation, though the guide's warning is suggestive:
+*"`low` and `high` detail levels may resize the image before analysis, which
+can obscure small details."*
+
+**Ordering: the documentation is silent, and the OpenRouter client's comment
+does not transfer.** `_contentJson` says text-before-image is *"what its own
+image documentation recommends"* — that is a claim about OpenRouter's docs, and
+I found **no equivalent recommendation anywhere in OpenAI's**. I searched the
+images-vision, function-calling, structured-outputs and text guides for any
+ordering guidance and there is none. What OpenAI does is show text first in
+every single example, in every language binding, on both APIs. That is evidence
+of a house style, not a documented requirement, and it happens to match what
+the app already sends. **Keep text-first; do not claim the docs require it.**
+
+One limitation belongs in the photo prompt's evidence file rather than here,
+but it is directly on point for the counts-only rule:
+
+> **Counting**: The model may give approximate counts for objects in images.
+
+## D. Token limits
+
+**On Responses the question does not arise: the field is `max_output_tokens`,
+and `max_tokens` is not a Responses parameter at all.** It appears zero times
+in the Responses create reference.
+
+> `max_output_tokens: optional number or null`
+> An upper bound for the number of tokens that can be generated for a response,
+> including visible output tokens and reasoning tokens.
+
+**On Chat Completions, `max_completion_tokens` is current and `max_tokens` is
+deprecated.** Verbatim, from the `max_tokens` entry in the reference:
+
+> This value is now deprecated in favor of `max_completion_tokens`, and is not
+> compatible with [o-series models].
+
+`max_completion_tokens` is described identically to the Responses field: *"An
+upper bound for the number of tokens that can be generated for a completion,
+including visible output tokens and reasoning tokens."*
+
+**What happens if the wrong one is sent: the docs say only "not compatible with
+o-series models".** They do not say whether GPT-5-family models reject
+`max_tokens`, ignore it, or honour it, and they do not give the status code or
+message for the o-series rejection. That is an unresolved item, though on the
+Responses recommendation it is moot — the field simply does not exist there.
+
+**The finding that actually matters is the semantic one, not the naming one.**
+Both current fields count reasoning tokens against the budget, and every model
+worth using here is a reasoning model. The reasoning guide:
+
+> If the generated tokens reach the context window limit or the
+> `max_output_tokens` value you've set, you'll receive a response with a
+> `status` of `incomplete` and `incomplete_details` with `reason` set to
+> `max_output_tokens`. This might occur before any visible output tokens are
+> produced, meaning you could incur costs for input and reasoning tokens
+> without receiving a visible response.
+
+and:
+
+> OpenAI recommends reserving at least 25,000 tokens for reasoning and outputs
+> when you start experimenting with these models.
+
+**A straight port of `_maxTokens = 1024` is therefore a plausible way to get
+billed for nothing.** The Anthropic client's reasoning for 1024 — *"a large
+budget only buys a longer runaway before it is cut off"* — was sound for a
+non-reasoning model and is not sound here. The client must either raise the cap
+substantially or send `reasoning: {effort: "none"}` and keep it low, and must
+treat `status: "incomplete"` with `incomplete_details.reason ==
+"max_output_tokens"` as a distinct failure. Which combination is right is a
+measurement, not a reading.
+
+## E. Failure taxonomy
+
+**Status codes OpenAI documents for API errors**, from the error-codes table.
+This is the complete list on that page:
+
+| Status | What OpenAI documents | Against `MealInterpreterException` |
+| --- | --- | --- |
+| 401 | Invalid authentication; incorrect key; not a member of an organization; IP not on allowlist | `isAuthFailure` — **correct** |
+| 403 | *"Country, region, or territory not supported"* | `isAuthFailure` — **wrong**; this is a geo-block |
+| 429 | rate limit; `credit_balance_exhausted`; `organization_spend_limit_exceeded`; `project_spend_limit_exceeded`; `organization_usage_limit_exceeded` | `isTransient` — **only sometimes** |
+| 500 | *"Issue on our servers"* | `isTransient` — correct |
+| 503 | overloaded; *"Slow Down"* | `isTransient` — correct |
+
+**There is no 400 and no 404 in that table.** Both exist as SDK exception types
+— `BadRequestError` *"(formerly `InvalidRequestError`)"*, *"Your request was
+malformed or missing some required parameters"*, and `NotFoundError`,
+*"Requested resource does not exist"* — but neither is given a documented
+trigger on the generation endpoints.
+
+**429 is the one the existing code gets most wrong.** The rate-limits guide is
+unambiguous:
+
+> `Retry-After` may be present on `429` responses caused by a temporary rate
+> limit. It does not mean that quota, billing, or other errors that require
+> user action can be resolved by retrying.
+
+and, for a hand-rolled HTTP client, which is what this app has:
+
+> If you're using your own HTTP client, follow `Retry-After` when the header is
+> present and contains a valid value. If it's missing or invalid, fall back to
+> exponential backoff with jitter. Limit both the number of attempts and the
+> total time spent retrying. … Don't retry quota, billing, or other errors that
+> require you to take action.
+
+So on OpenAI, `isTransient` cannot be decided from the status line alone.
+Distinguishing a rate limit from an exhausted credit balance needs `error.code`
+— *"For billing-related errors, inspect `error.code` to identify the specific
+cause. The broader `error.type` can still be `insufficient_quota`."* This is a
+real user-facing difference: telling somebody to try again later when their
+prepaid balance is empty is the same failure mode
+`AiCredentialStorage` already avoids for a wrong key.
+
+**422 is documented as retryable**, which inverts `isRejectedRequest`:
+`UnprocessableEntityError`, *"Unable to process the request despite the format
+being correct. Solution: Please try the request again."* The corpus finding
+behind `isRejectedRequest` — Adobe APP14 JPEGs refused with a 400 on every
+attempt — was measured against a different provider and cannot be assumed to
+carry.
+
+**404-as-capability-refusal has no OpenAI analogue, and needs none.** The
+existing mapping exists because OpenRouter answers *"No endpoints found that
+support image input"* with a 404 when `require_parameters` is set. OpenAI has
+no broker and no routing layer, so there is nothing to find no endpoints for.
+**Capability is a published property of each model**: every model page carries
+an `Endpoints` table (`v1/responses`: Supported / Not supported) and a
+`Supported features` list naming `function_calling`, `image_input`,
+`structured_outputs` explicitly. `gpt-5.4-nano` and `gpt-5.6-luna` both list
+all three; the models index states flatly that *"All latest OpenAI models
+support text and image input, text output, multilingual capabilities, and
+vision."* A curated catalogue ([#686](https://github.com/simonoppowa/OpenNutriTracker/issues/686))
+can therefore guarantee capability at build time rather than discovering it at
+runtime, which is strictly better than a 404 the user has to be told about.
+**What OpenAI returns for a model that cannot do tools or vision, or that does
+not exist, is not documented** — see [Not established](#not-established-without-a-live-call).
+
+**Yes, a failed generation can arrive as HTTP 200 — and the code must handle
+it.** This is the hazard `_throwIfFailedGeneration` exists for, present on
+OpenAI in a different shape. The `Response` object carries:
+
+- `status`, described as *"The status of the response generation. One of
+  `completed`, `failed`, `in_progress`, `cancelled`, `queued`, or
+  `incomplete`."*
+- `error`, *"An error object returned when the model fails to generate a
+  Response"*, with `code` and a human-readable `message`.
+- `incomplete_details`, *"Details about why the response is incomplete"*, whose
+  `reason` is `max_output_tokens` or `content_filter`.
+
+The documented `error.code` values include `server_error`,
+`rate_limit_exceeded`, `invalid_prompt`, and — directly relevant to the photo
+path — `invalid_image`, `invalid_image_format`, `invalid_base64_image`,
+`image_too_large`, `image_too_small`, `image_parse_error`,
+`unsupported_image_media_type`, `image_content_policy_violation`,
+`empty_image_file`, `invalid_image_mode`. **These are string codes, not
+integers**, so the existing trick of carrying an embedded numeric code out as
+`statusCode` does not transfer; the taxonomy needs a string arm or a mapping.
+
+**The real `finish_reason` values, for the record — Responses has none.** The
+field is Chat Completions-only, and its enum is:
+
+> This will be `stop` if the model hit a natural stop point or a provided stop
+> sequence, `length` if the maximum number of tokens specified in the request
+> was reached, `content_filter` if content was omitted due to a flag from our
+> content filters, `tool_calls` if the model called a tool, or `function_call`
+> (deprecated) if the model called a function.
+
+`"error"` is **not** among them. It is an OpenRouter extension, and
+`_throwIfFailedGeneration`'s comment is right about the hazard and wrong about
+the marker as soon as it leaves OpenRouter.
+
+## F. Strict mode
+
+This section feeds [#683](https://github.com/simonoppowa/OpenNutriTracker/issues/683),
+so it quotes rather than summarises.
+
+**1. Every property must appear in `required`. Confirmed, in two places.**
+
+Function calling guide, under *Strict mode*:
+
+> Under the hood, strict mode works by leveraging our structured outputs
+> feature and therefore introduces a couple requirements:
+>
+> 1. `additionalProperties` must be set to `false` for each object in the
+>    `parameters`.
+> 2. All fields in `properties` must be marked as `required`.
+
+Structured outputs guide, under *All fields must be `required`*:
+
+> To use Structured Outputs, all fields or function parameters must be
+> specified as `required`.
+
+So the 400 recorded in `openrouter_meal_items_api.dart` — *"'required' is
+required to be supplied and to be an array including every key in properties.
+Missing 'quantity'."* — was OpenAI's documented behaviour working as designed,
+not a broker quirk. And the failure mode is documented: *"If you send `strict:
+true` and your schema does not meet the requirements above, the request will be
+rejected with details about the missing constraints."*
+
+**2. The nullable union is the sanctioned way to express an optional field.
+Documented explicitly, twice.**
+
+Function calling guide, immediately after the two requirements:
+
+> You can denote optional fields by adding `null` as a `type` option (see
+> example below).
+
+Structured outputs guide, the operative sentence:
+
+> Although all fields must be required (and the model will return a value for
+> each parameter), it is possible to emulate an optional parameter by using a
+> union type with `null`.
+
+Both guides carry a worked example doing exactly this: `"units": {"type":
+["string", "null"], "enum": ["celsius", "fahrenheit"]}` with `"required":
+["location", "units"]`.
+
+**This is the finding that reopens the schema question.** The comment in
+`openrouter_meal_items_api.dart` reasons that *"making them required would
+oblige the model to produce a number for every item, which is the estimation
+this whole design exists to prevent"* — and against a plain `required` that is
+correct. Against `required` plus `["number", "null"]` it is not: the model is
+obliged to emit the *key*, and `null` is a conforming value for it. The
+parenthesis *"and the model will return a value for each parameter"* is the
+only behavioural consequence, and the value can be `null`.
+
+The downstream effect on this app is small.
+[`_mealItemFrom`](../lib/features/add_meal/domain/meal_items_api.dart) already
+maps a non-`num`, non-`String` `quantity` to `null` and a non-`String` `unit`
+to `null`, so an explicit JSON `null` is already handled and needs no change.
+Whether to take the trade at all — a schema change affecting all three
+providers, for a guarantee that
+[`validateParsedMealItems`](../lib/features/add_meal/util/meal_text_parser.dart)
+already enforces — is [#683](https://github.com/simonoppowa/OpenNutriTracker/issues/683)'s
+call. The claim *"the schema cannot bend"* is the part that does not survive
+this reading.
+
+**3. `additionalProperties: false` is required. Confirmed, and stated as a
+requirement rather than a recommendation.**
+
+> `additionalProperties` controls whether it is allowable for an object to
+> contain additional keys / values that were not defined in the JSON Schema.
+>
+> Structured Outputs only supports generating specified keys / values, so we
+> require developers to set `additionalProperties: false` to opt into
+> Structured Outputs.
+
+The section is headed *"`additionalProperties: false` must always be set in
+objects"* — every object, at every level, not just the root.
+`mealItemsToolSchema` already satisfies this on both of its objects, so this
+requirement costs nothing.
+
+**4. The default when `strict` is omitted differs by API, and this is a live
+trap on Responses.**
+
+> If you omit `strict`, the default depends on the API: Responses requests will
+> attempt to normalize your schema into strict mode when possible, and will
+> fall back to non-strict, best-effort function calling if the schema cannot be
+> made compatible with strict mode. When fallback happens, the response tool
+> will show `strict: false`. Chat Completions requests remain non-strict by
+> default. To opt out of strict mode in Responses and keep non-strict,
+> best-effort function calling, explicitly set `strict: false`.
+
+The migration guide says it again in the imperative: *"In Chat Completions,
+functions are non-strict by default. In Responses, omitting `strict` attempts
+strict mode."*
+
+**So on Responses, "just don't send `strict`" is not the no-op it is on
+OpenRouter.** With the schema as it stands, normalisation should fail
+(`quantity` and `unit` are neither `required` nor nullable) and Responses should
+fall back — a benign outcome, but one reached by a documented code path rather
+than by the request being left alone. If the intent is genuinely non-strict, the
+client should **send `strict: false` explicitly**. If the schema changes under
+[#683](https://github.com/simonoppowa/OpenNutriTracker/issues/683),
+`strict: true` becomes available and OpenAI recommends it: *"Setting
+`strict` to `true` will ensure function calls reliably adhere to the function
+schema, instead of being best effort. We recommend always enabling strict
+mode."*
+
+**5. One inconsistency in OpenAI's own documentation, flagged because it lands
+exactly on this app's `unit` field.** The `unit` property is a nullable field
+*with an enum*, and the docs show two different answers for whether `null` must
+appear in the enum list:
+
+- The `get_weather` example, in both guides: `"type": ["string", "null"],
+  "enum": ["celsius", "fahrenheit"]` — `null` **absent** from the enum. Under
+  plain JSON Schema, `enum` is an independent constraint, so this schema admits
+  no valid value of `null` at all.
+- The moderation example's Go binding: `"type": []string{"string", "null"}, …
+  "enum": []any{"violence", "sexual", "self_harm", nil}` — `null` **present**.
+  Its own curl equivalent, on the same page, omits it.
+
+OpenAI states no rule either way. This is a probe question, not a reading
+question, and it is narrow enough to answer in one call.
+
+## G. What else a direct client must send
+
+Mostly good news: the broker was hiding less than expected.
+
+**Required headers: two, and the app already sends both.** The API Overview
+gives the whole auth surface — *"Provide API credentials with HTTP Bearer
+authentication"*, `Authorization: Bearer OPENAI_API_KEY_OR_ACCESS_TOKEN` — and
+every raw `curl` example in the quickstart sends exactly `Content-Type:
+application/json` and `Authorization: Bearer $OPENAI_API_KEY`. Nothing else.
+
+**No versioning header.** There is no `anthropic-version` equivalent to pin.
+Versioning is in the path (`/v1/`), and `openai-version` is a **response**
+header — *"REST API version used for this request (currently `2020-10-01`)"* —
+not something a client sends. The backwards-compatibility section commits to
+*"avoiding breaking changes in major API versions whenever reasonably
+possible"* and enumerates additive changes as compatible, which is the closest
+thing to a stability promise on offer.
+
+**Organisation and project headers are optional, and conditional.**
+
+> If you belong to more than one organization or access projects through a
+> legacy user API key, pass a header to specify which organization and project
+> to use for an API request
+
+— `OpenAI-Organization` and `OpenAI-Project`. Neither applies to a user with one
+personal key, and neither should be sent. There is no analogue of OpenRouter's
+`x-openrouter-metadata`, and nothing corresponding to `HTTP-Referer` /
+`X-Title`, so the deliberate omission recorded in the OpenRouter client has no
+counterpart to worry about here.
+
+**`store: false` is the one genuinely new field, it is a privacy field, and it
+is not optional.** A client that omits it opts the user into a 30-day
+server-side retention of their meal text and photograph without asking.
+[Section A2](#a2-the-storage-default) is
+the evidence and the reasoning; the short form is: send it, on whichever
+endpoint, on every request, and assert it in a test. Note what it does **not**
+do — it does not touch abuse-monitoring logs, which are *"generated for all API
+feature usage and retained for up to 30 days"* by default on both endpoints and
+can only be reduced through approved Zero Data Retention or Modified Abuse
+Monitoring controls. A client author must not read `store: false` as "OpenAI
+keeps nothing", and neither should the README. What the app can honestly claim
+belongs to [#680](https://github.com/simonoppowa/OpenNutriTracker/issues/680)
+and [#689](https://github.com/simonoppowa/OpenNutriTracker/issues/689).
+
+**Two optional fields worth a deliberate decision rather than a default.**
+
+- `safety_identifier` — *"A stable identifier used to help detect users of your
+  application that may be violating OpenAI's usage policies. … We recommend
+  hashing their username or email address, in order to avoid sending us any
+  identifying information."* This app has no account and no username; sending
+  anything here would be inventing an identifier to send. Omit.
+- `X-Client-Request-Id` — *"This header isn't added automatically; you must
+  explicitly set it on the request"*, and OpenAI *"logs this value internally"*.
+  Useful for support, and precisely the kind of correlatable per-request ID this
+  project would not add without a reason. Omit.
+
+**One structural note on the system prompt.** Responses takes it as top-level
+`instructions` — *"A system (or developer) message inserted into the model's
+context"* — which is the idiomatic form and the one the migration guide maps
+*"System or developer guidance"* onto. A `role: "system"` message in `input`
+also remains valid (`role` is *"One of `user`, `assistant`, `system`, or
+`developer`"*). Prefer `instructions`: it is one fewer array element and it
+keeps the shared prompt constants out of the message-rendering switch.
+
+## Not established without a live call
+
+Everything here is a gap in the published documentation, not a gap in the
+reading. Each is scoped for
+[#684](https://github.com/simonoppowa/OpenNutriTracker/issues/684).
+
+- **What status code a nonexistent model returns from `/v1/responses`.** The
+  error-codes table has no 404 entry. `NotFoundError` exists as an SDK type for
+  *"Requested resource does not exist"* with no endpoint named. The only place
+  in the whole API documentation set that ties 404 to model access is the
+  content-provenance guide, about a *different* endpoint — *"an organization
+  without access receives `404`"* — which is suggestive and not authoritative.
+- **What happens when a model that lacks `image_input` or `function_calling` is
+  sent an image or a tool.** Silent everywhere. I searched the combined
+  single-file export of every API guide and reference page for it. Capability
+  is documented per model as a static fact and never as an error. Whether it is
+  a 400, a 404, or a silently-ignored parameter is unknown.
+- **Whether `null` must appear in the `enum` list of a nullable enum property
+  under `strict: true`.** OpenAI's own examples disagree ([Section
+  F](#f-strict-mode) item 5). This lands directly on the `unit` field and
+  should be probed before #683 commits to a schema.
+- **Whether a forced `tool_choice` can produce a `message` output item in the
+  same turn.** The docs neither promise nor forbid it. The client is safe
+  either way if it iterates `output`, but the answer decides whether "prose is
+  impossible" or only "prose is detectable" can be written down as a property.
+- **Whether GPT-5-family models reject `max_tokens` on Chat Completions.** The
+  reference says only *"not compatible with o-series models"*. Moot on the
+  Responses recommendation.
+- **What `max_output_tokens` this workload actually needs**, and whether
+  `reasoning: {effort: "none"}` is compatible with a forced tool call on
+  Responses for the models under consideration. The Chat Completions
+  incompatibility is documented; the Responses side is not stated either way.
+  This is a measurement.
+- **Whether a strict-mode `["number", "null"]` `quantity` changes how often the
+  model volunteers an amount the user did not state.** Pure behaviour. The
+  documentation cannot answer it and the existing live corpus can.
+- **How long a stored chat completion is retained.** OpenAI's own pages
+  disagree about whether `/v1/chat/completions` retains application state by
+  default at all ([Section A2](#a2-the-storage-default)
+  item 2), and no retention period is published for the stored case the way the
+  30-day one is for Responses. Not answerable by probing either — this one
+  needs OpenAI support, and could ride along with
+  [#691](https://github.com/simonoppowa/OpenNutriTracker/issues/691).
+- **Whether `store: false` is honoured on a request that also carries an
+  image.** The documentation states it for server-side compaction (*"no data is
+  retained when `store="false"`"*) and nowhere ties it to image inputs
+  specifically. The CSAM-scanning carve-out is explicit that images survive
+  even ZDR, so the two statements need reconciling against an actual response.
+- **The exact HTTP error body schema.** `error.code` and `error.type` are
+  referenced by the error-codes guide and `{code, message, param}` appears in
+  worked examples, but no canonical schema for the non-streaming REST error
+  envelope is published in the reference.
+- **Whether the WebP the app produces passes.** *"Clear enough for a human to
+  understand"* is not a machine-checkable requirement, and
+  `unsupported_image_media_type` / `image_parse_error` exist as error codes.
+  WebP is named as supported; that a specific encoder's output is accepted is a
+  probe.
+
+## Sources
+
+OpenAI developer documentation, all read 2026-08-16 via the published Markdown
+twins (append `.md` to any page URL):
+
+[Function calling](https://developers.openai.com/api/docs/guides/function-calling) ·
+[Structured model outputs](https://developers.openai.com/api/docs/guides/structured-outputs) ·
+[Images and vision](https://developers.openai.com/api/docs/guides/images-vision) ·
+[Migrate to the Responses API](https://developers.openai.com/api/docs/guides/migrate-to-responses) ·
+[Reasoning](https://developers.openai.com/api/docs/guides/reasoning) ·
+[Error codes](https://developers.openai.com/api/docs/guides/error-codes) ·
+[Rate limits](https://developers.openai.com/api/docs/guides/rate-limits) ·
+[Deprecations](https://developers.openai.com/api/docs/deprecations) ·
+[Models](https://developers.openai.com/api/docs/models) ·
+[GPT-5.4 nano](https://developers.openai.com/api/docs/models/gpt-5.4-nano) ·
+[GPT-5.6 Luna](https://developers.openai.com/api/docs/models/gpt-5.6-luna) ·
+[How we use your data](https://developers.openai.com/api/docs/guides/your-data) ·
+[Quickstart](https://developers.openai.com/api/docs/quickstart)
+
+OpenAI API reference:
+[API Overview](https://developers.openai.com/api/reference/overview) ·
+[Responses — Create a model response](https://developers.openai.com/api/reference/resources/responses/methods/create) ·
+[Chat — Create chat completion](https://developers.openai.com/api/reference/resources/chat) ·
+[Chat Completions Overview](https://developers.openai.com/api/reference/chat-completions/overview) ·
+[Chat Completions — Get](https://developers.openai.com/api/reference/resources/chat/subresources/completions/methods/retrieve) ·
+[Responses Overview](https://developers.openai.com/api/reference/responses/overview)
+
+Related notes in this repo:
+[`ai-openai-policy-fit.md`](ai-openai-policy-fit.md) ·
+[`ai-openai-key-transfer.md`](ai-openai-key-transfer.md) ·
+[`ai-model-candidates.md`](ai-model-candidates.md) ·
+[`ai-open-research-questions.md`](ai-open-research-questions.md)
+
+In-repo files cited:
+[`lib/features/add_meal/data/openrouter_meal_items_api.dart`](../lib/features/add_meal/data/openrouter_meal_items_api.dart) ·
+[`lib/features/add_meal/data/anthropic_meal_items_api.dart`](../lib/features/add_meal/data/anthropic_meal_items_api.dart) ·
+[`lib/features/add_meal/domain/meal_items_api.dart`](../lib/features/add_meal/domain/meal_items_api.dart) ·
+[`lib/features/add_meal/domain/meal_interpreter_exception.dart`](../lib/features/add_meal/domain/meal_interpreter_exception.dart)

--- a/docs/ai-openrouter-model-expansion.md
+++ b/docs/ai-openrouter-model-expansion.md
@@ -1,0 +1,731 @@
+# Which models should join the OpenRouter list
+
+Research notes gathered **2026-08-20** against primary sources only —
+OpenRouter's own `/api/v1/models`, `/api/v1/models/{id}/endpoints`,
+`/api/v1/providers` and `/api/frontend/v1/all-providers` (queried by `curl`, no
+API key, no billed inference call), OpenRouter's own documentation and Terms of
+Service, and each vendor's own legal pages fetched from the vendor's own
+domain. Nothing here rests on a leaderboard, a model card, a blog post or a
+third-party write-up. Where a page refused automated fetching it is named in
+[Not verified](#not-verified) rather than replaced with a secondary source.
+
+Written to answer the maintainer's question — **the curated OpenRouter list has
+two entries, both Anthropic-served; what should be added?** The constraints are
+settled elsewhere and are not re-argued: vision is required, `tool_choice` must
+be honoured, `strict: true` is unusable, no model may emit a nutrition value,
+and every request carries `require_parameters: true`, `data_collection: "deny"`
+and a vendor pin with `allow_fallbacks: false`
+([`ai_model_catalogue.dart`](../lib/core/utils/ai_model_catalogue.dart),
+[`openrouter_meal_items_api.dart`](../lib/features/add_meal/data/openrouter_meal_items_api.dart),
+[#663](https://github.com/simonoppowa/OpenNutriTracker/issues/663)).
+
+**Nothing below is a decision, and nothing below can be.** The catalogue's own
+rule stands: membership requires a behavioural screen against a photo corpus,
+because a capability flag is not fitness. That has now been measured three
+times — `openai/gpt-5.4-nano` advertised everything and returned empty for both
+food-bearing photos in the #669 slice; `gpt-5.4-mini` turned one photo of a
+bunch of bananas into twelve `banana` rows
+([`ai-openai-behavioural-screen.md`](ai-openai-behavioural-screen.md)). No
+screen was run here. Section G ranks **screening candidates**, in the order I
+would spend the photo corpus on them, and that is the whole of the output.
+
+## How this relates to `ai-model-candidates.md`
+
+[`ai-model-candidates.md`](ai-model-candidates.md) answered almost this
+question on 2026-08-16 for
+[#668](https://github.com/simonoppowa/OpenNutriTracker/issues/668) and
+concluded "no additional vendor clears every bar, and the catalogue should stay
+as it is." Everything in it was re-checked against the live documents and the
+live API. The summary:
+
+| Its finding | Status now |
+| --- | --- |
+| Structural funnel: 216 capable, 124 pinnable across 17 vendors | **Re-verified.** 216 and 125 across the same 17 vendors ([Section B](#b-the-funnel-re-run)) |
+| No newer or cheaper Anthropic model that pins | **Re-verified.** Still no Haiku 5; `claude-3-haiku` is still Bedrock-only |
+| Google barred by Cloud SST §20(d) | **Re-verified verbatim** in the live document, renumbered from §19 |
+| Sakana barred on age + EEA exclusion | **Re-verified verbatim**, and a third bar found (training) |
+| Meta barred by Model API ToS §10.1 | **Could not re-verify** — the document 500s to every request ([Not verified](#not-verified)) |
+| xAI ruled out because "no prohibition found" is weaker than a carve-out | **Overturned as a standard**, and replaced by a different, stronger objection ([Section D](#d-xai-re-examined)) |
+| OpenAI barred by the *Keep minors safe* clause | **Overturned** — by [#679](https://github.com/simonoppowa/OpenNutriTracker/issues/679), not by me ([Section C](#c-the-standard-that-changed)) |
+| Mistral ruled out on its professional-advice clause alone | **Stale in both directions** ([Section E3](#e3-no-carve-out-and-the-rest-of-the-page)) |
+| Z.AI ruled out on individual-user training clauses | **Weaker than recorded** — its own terms exempt API developers |
+| Alibaba's terms "contain no usage-policy treatment of health … at all" | **Wrong.** §4.48 contains a medical restriction |
+| `anthropic/claude-on-aws` will leak through `only: ["anthropic"]` | **No longer true.** It is a top-level slug now ([Section F](#f-what-the-routing-block-buys-now)) |
+| `:batch` unusable because asynchronous | **Re-verified, and now moot** — the Batch API is documented text-only |
+| Anthropic Commercial Terms carry no visible date | **Resolved.** Effective June 17, 2025 |
+
+## Bottom line up front
+
+1. **Applying the standard the project actually shipped admits OpenAI on the
+   OpenRouter path, and the two strongest candidates are the two models the app
+   already ships direct.** `openai/gpt-5.6-luna` and `openai/gpt-5.6-terra` each
+   have a first-party endpoint tagged `openai`, each advertises `tools`,
+   `tool_choice` and `max_tokens`, and `openai` is tagged `training: false`, so
+   they survive `require_parameters: true` and `data_collection: "deny"` under
+   `only: ["openai"]`. The policy work is already done and already accepted
+   ([`ai-openai-policy-fit.md`](ai-openai-policy-fit.md),
+   [#679](https://github.com/simonoppowa/OpenNutriTracker/issues/679)); the
+   behavioural work is already done for these exact two model names
+   ([#684](https://github.com/simonoppowa/OpenNutriTracker/issues/684),
+   [#719](https://github.com/simonoppowa/OpenNutriTracker/issues/719)) — but
+   over a **different route**, which is exactly the confound #669 and #684
+   disagreed over. This is the least new evidence any candidate needs.
+2. **The xAI re-examination changes the reasoning and, in the end, not the
+   answer — but the objection is now a data clause the earlier note never
+   looked at, not the absence of a policy.** SpaceXAI's enterprise terms —
+   the document OpenRouter itself names as the Model Terms for `xai` — carry a
+   warranty not to submit Personal Data except through the ZDR-Enabled API. The
+   app's pin reaches the plain `xai` endpoint, and a meal photograph is personal
+   data. **This is fixable**: OpenRouter documents a `zdr: true` routing flag,
+   every Grok model carries an `xai/zdr` endpoint at the same price, and
+   OpenRouter names SpaceXAI as one of the model groups ZDR can be enforced
+   for. So xAI is not ruled out by policy silence; it is gated on a routing
+   change the app has not made. See [Section D](#d-xai-re-examined).
+3. **Two of the previous note's xAI quotes stop one clause short, and the
+   missing clauses cut against it.** The training sentence continues *"subject
+   to disclosures to Customer and Customer-controlled user settings"*, and the
+   30-day deletion sentence continues into three exceptions including
+   *"reasonably necessary for safety, security, compliance, moderation, abuse
+   prevention, or investigation"*. Both are accurate as far as they go and both
+   are weaker than they read.
+4. **The E1 rejections hold, and I checked rather than assumed.** Google Cloud
+   Service Specific Terms §20(d) is present verbatim in the version last
+   modified 29 July 2026; Sakana's age and EEA clauses are present verbatim.
+   Meta's document is unreachable from here, so its exclusion now rests on a
+   quote nobody has re-read — say that plainly rather than carry it forward as
+   settled.
+5. **Mistral is the interesting correction, and it moves both ways.** Under
+   #679's standard its professional-advice clause is a conduct test the app
+   does not meet, so the E3 rule-out fails — but its Commercial Terms §4.2
+   reserves training *"when you … have not opted-out of training on a Mistral AI
+   Product set to opt-in by default"*, which is a straight E2-grade conflict
+   with OpenRouter's `training: false` tag. It swaps a bad reason for a real
+   one, and stays out.
+6. **`claude-on-aws` is now its own top-level provider slug**, not
+   `anthropic/claude-on-aws`. It is attached to `claude-sonnet-5`,
+   `claude-opus-5` and others today — so the previous note's prediction came
+   true — but because it is no longer a variant *under* `anthropic`, the
+   documented base-slug rule means `only: ["anthropic"]` does not match it and
+   `_warnIfThePinDidNotHold` will not false-alarm. The hazard resolved itself.
+7. **Nothing here can be added on documentation.** Every candidate below still
+   needs the photo screen, and two of the ranked candidates
+   (`x-ai/grok-4.6`, `x-ai/grok-4.5`) carry `reasoning.mandatory: true`, which
+   interacts badly with the client's fixed `max_tokens: 1024` and should be
+   screened for truncation specifically.
+
+## A. What the app actually sends, checked against the docs
+
+Re-read from [`openrouter_meal_items_api.dart`](../lib/features/add_meal/data/openrouter_meal_items_api.dart)
+and matched line by line against OpenRouter's own
+[Provider Routing](https://openrouter.ai/docs/features/provider-routing) page,
+because three of the four filters below turn on wording that has changed since
+the last pass.
+
+- `require_parameters: true` — *"providers that don't support all the LLM
+  parameters specified in your request can still receive the request, but will
+  ignore unknown parameters. When you set `require_parameters` to `true`, the
+  request won't even be routed to that provider."* The page also now names the
+  soft-preference set used when the flag is *off*: `tools`, `response_format`
+  and `verbosity`. `tool_choice` is still not in it, so the client comment is
+  still right about why the flag is necessary.
+- `data_collection: "deny"` — *"use only providers which do not collect user
+  data"*, against `allow` = *"allow providers which store user data
+  non-transiently and may train on it"*. Still keyed on training, not
+  retention: `anthropic` is `retainsPrompts: true, retentionDays: 30` and is
+  reachable under `deny`. Across all 80 provider records only three carry
+  `training: true` — `deepseek`, `liquid`, `nvidia` — unchanged. The page still
+  warns the tags are *"not a definitive source of third party data policies, but
+  represents our best knowledge."*
+- `only` + `allow_fallbacks: false` — base-slug matching is unchanged: *"it
+  matches **all** endpoints for that provider, including any variants or
+  regions"*, and *"service tier endpoints (e.g. `openai/priority`,
+  `google-vertex/flex`) are **not** matched by base slugs."*
+- **The parameter the app sends that nobody checked: `max_tokens`.** Every
+  first-party endpoint of every candidate below lists `max_tokens` in its
+  `supported_parameters`. Azure's endpoints for the same models list
+  `max_completion_tokens` instead — so with `require_parameters: true` a pin
+  that ever reached Azure would 404. It cannot, under `only: ["openai"]`, but
+  it is worth knowing that the pin is load-bearing for capability and not only
+  for policy.
+
+## B. The funnel, re-run
+
+Every figure from OpenRouter's own API, queried 2026-08-20. The right-hand
+column is `ai-model-candidates.md`'s figure from 2026-08-16.
+
+| Stage | Models left | Was |
+| --- | --- | --- |
+| Listed on `/api/v1/models` | **414** | 413 |
+| …with `image` in `architecture.input_modalities` | 245 | 245 |
+| …also listing `tools` **and** `tool_choice` | **216** | 216 |
+| …excluding 55 `:batch` variants and 10 `~vendor/…-latest` aliases | 151 | — |
+| …with a first-party endpoint that itself advertises `tools` + `tool_choice` | 127 | — |
+| …whose first-party provider is not tagged `training: true` | **125** | 124 |
+
+The 17 surviving vendors are identical to the previous pass: `openai` (36),
+`qwen`/Alibaba (21), `google` (18), `anthropic` (13), `mistralai` (8),
+`bytedance-seed` (6), `x-ai` (5), `moonshotai` (4), `z-ai` (3), `sakana` (2),
+`meta` (2), `nex-agi` (2), `minimax` (1), `stepfun` (1), `xiaomi` (1), `rekaai`
+(1), `amazon` (1). Qwen gained one model; nothing else moved. **The structural
+screen has not drifted in four days, and the collapse from 125 to 13 was, and
+still is, entirely policy.**
+
+Two structural notes worth carrying:
+
+- **`:batch` is now excluded by documentation, not by inference.** OpenRouter's
+  Batch API Quickstart states under *Limitations* that the API *"is currently
+  text-only"* and that *"validation rejects any request that carries image,
+  audio, video, or file content parts."* The previous note excluded batch
+  because it is asynchronous, which is true and sufficient; it is now also
+  simply unable to carry the photo.
+- **Only Google prices images separately.** 29 model records carry a non-zero
+  `pricing.image` field and every one of them is a Gemini or Gemma model. For
+  Anthropic, OpenAI, xAI, Mistral, Alibaba and everyone else on the shortlist,
+  an image is billed as prompt tokens and OpenRouter publishes no per-image
+  rate. That matters for [Section G](#g-the-ranking).
+
+## C. The standard that changed
+
+`ai-model-candidates.md` §E3 rejected six vendors under a single heading:
+*"Ruled out on the absence of any policy to rely on."* Its stated rationale is
+that *"'no prohibition found' is weaker than Anthropic's explicit carve-out"*,
+and that for a project whose defence is *"the vendor says in writing that
+wellness advice is out of scope"*, silence is the rule-out.
+
+[#679](https://github.com/simonoppowa/OpenNutriTracker/issues/679) then
+accepted OpenAI as a shipping first-party provider on exactly the ground E3
+rejects. The catalogue records the reversal in its own doc comment: *"OpenAI
+offers no carve-out, only the absence of a prohibition, so the defence is
+factual — the app gives no advice."*
+[`ai-openai-policy-fit.md`](ai-openai-policy-fit.md) is explicit that it is
+applying the same test E3 used and reaching the opposite result: it notes the
+project *"declined xAI on the same reasoning"* and argues OpenAI *"is not
+barred; it is simply less protected, and it should be ranked as such rather
+than re-rejected."*
+
+**So E3 as a rule-out is dead, and what replaces it is a ranking.** Three
+consequences, and I have tried to be even-handed about all three.
+
+**C1. E3's headline reason was never the real one, and the doc half-knew it.**
+Look at what E3 actually did. Alibaba, ByteDance, StepFun, Nex AGI and MiniMax
+were excluded for having *nothing*; Mistral was excluded for having a
+professional-advice clause that is *broader* than Anthropic's. Those are
+opposite complaints filed under one heading. A vendor cannot be disqualified
+both for saying nothing about health and for saying too much about it. The
+heading concealed that the section was doing two different jobs.
+
+**C2. Applying #679 consistently, the six E3 vendors split three ways.**
+Conduct tests the app does not meet are not prohibitions (Mistral's
+*"health-related guidance"*, Z.AI's *"substitute for professional services"*,
+Alibaba's medical restriction, xAI's high-stakes-decisions clause). Vendors with
+no published terms at all are still out, but on *unassessability*, not on
+silence — you cannot promise a user where their photograph goes if the
+destination publishes nothing. And a vendor whose own document contradicts
+OpenRouter's `training` tag is out on the same E2 reasoning as before,
+regardless of any of this.
+
+**C3. Anthropic's advantage survives and should stay in the ranking.** The
+carve-out is intact, verbatim, in the version effective 15 September 2025:
+*"Wellness advice (e.g., advice on sleep, stress, nutrition, exercise, etc.)
+does not fall under this category."* And #679's finding that Anthropic's
+disordered-eating prohibition is broader than OpenAI's is, if anything,
+understated — the same section also prohibits *"behaviors that promote
+unhealthy or unattainable body image or beauty standards, such as using the
+model to critique anyone's body shape or size"*, which has no OpenAI
+counterpart at all. Anthropic remains the best-covered vendor. It is no longer
+the *only permitted* one.
+
+Sources: [Anthropic Usage Policy](https://www.anthropic.com/legal/aup) ·
+[Anthropic Commercial Terms](https://www.anthropic.com/legal/commercial-terms)
+(Effective June 17, 2025 — the date the previous note could not find)
+
+## D. xAI re-examined
+
+Five models qualify structurally, unchanged: `x-ai/grok-4.6` and `x-ai/grok-4.5`
+($2.00/$6.00 per 1M in/out, 500k context), `x-ai/grok-4.3` (1M) and
+`x-ai/grok-4.20` (2M) at $1.25/$2.50, and `x-ai/grok-build-0.1` at $1.00/$2.00.
+Every one carries four first-party endpoints — `xai`, `xai/priority`,
+`xai/zdr`, `xai/zdr/priority` — and all four advertise `tools`, `tool_choice`
+and `max_tokens`. `xai` is tagged `training: false, retainsPrompts: true,
+retentionDays: 30`, the same profile as `anthropic`, so it survives
+`data_collection: "deny"`.
+
+### D1. The AUP still says nothing about this, and I read all of it
+
+Effective **August 14, 2026**, read in full. It states that it *"applies to
+anyone using our Service, including consumers, developers and businesses."*
+The words *diet*, *nutrition*, *health*, *wellness* and *food* do not occur
+anywhere in it. The only minors provision is *"Sexualizing or exploiting
+children"*. There is no professional-advice clause except a securities one.
+
+**One correction to the previous note.** It described the AUP as *"roughly
+6,000 words of running text"* and used that length to argue the absence is
+genuine rather than a failure to find the right page. The document is **855
+words**. The absence is still real — I read every bullet — but it is the
+absence of a short document, not of an exhaustive one, and the length argument
+should not be repeated.
+
+The nearest clause remains, verbatim: users must not be *"Making high-stakes
+automated decisions that affect a person's safety, legal or material rights, or
+well-being (such as making financial credit, educational, employment, housing,
+insurance, legal, medical, or other important decisions about or for them)"*.
+Under #679's standard this is a conduct test with a human-review escape built
+into the word *automated*, and the review step in `bulk_add_screen.dart` is
+documented as *"not optional"*. It is not met.
+
+### D2. The clause that actually rules xAI out today
+
+From the **Terms of Service — Enterprise** (Last Updated August 14, 2026),
+which OpenRouter's own provider record names as the Model Terms for `xai`,
+under *Zero Data Retention*:
+
+> Customer represents and warrants that it will not intentionally submit, and
+> will use reasonable efforts to prevent Permitted Users and End Users from
+> submitting any Personal Data to the Services except through SpaceXAI's
+> ZDR-Enabled API.
+
+A meal photograph submitted by the person who took it is personal data on any
+reading. The app's pin is `only: ["xai"]` with `allow_fallbacks: false`, and
+the plain `xai` endpoint is **not** the ZDR-Enabled API. Under the documented
+base-slug rule `only: ["xai"]` matches every variant under `xai`, which means
+it matches both `xai` and `xai/zdr` — so the app would not merely land on the
+wrong one, it would land on either, non-deterministically, with no way to say
+which in the settings screen. That is a worse position than the previous note's
+"defensible but not obvious".
+
+This is not an *unfixable* objection, and that is the substantive change:
+
+- OpenRouter documents a per-request `zdr` flag: *"When `zdr` is set to `true`,
+  the request will only be routed to endpoints that have a Zero Data Retention
+  policy."* The same page names the enforceable model groups — *"Anthropic,
+  OpenAI, Google, SpaceXAI, and non-frontier"*.
+- Every Grok model above has an `xai/zdr` endpoint **at the same price** as its
+  plain endpoint. Enforcing ZDR here costs nothing.
+- The previous note listed `zdr: true` as unusable because *"neither curated
+  Anthropic model has a ZDR-tagged endpoint"*. **That is still true** — I
+  checked `/endpoints` for both, and the tags are `anthropic`, `azure`,
+  `amazon-bedrock`, `google-vertex` and (on Sonnet 5) `claude-on-aws`, none of
+  them ZDR. So `zdr: true` cannot be a blanket setting; it would have to be a
+  per-model property, which is a change to `AiModel` and not just to a request
+  body.
+
+The same document carries two more provisions worth recording, neither fatal:
+a HIPAA clause requiring a Business Associate Agreement *and* the ZDR API
+before any protected health information is submitted (a food diary is not PHI,
+which is tied to covered entities, but it is adjacent); and a flow-down
+requiring the Customer to *"maintain legally enforceable terms of service and an
+acceptable use policy with all Permitted Users and End Users that are no less
+protective"* — which is OpenRouter's obligation, not ours, but it is the
+mechanism by which xAI's terms reach a BYO-key user at all.
+
+### D3. Where the previous note's quotes stop
+
+Both xAI data quotes in `ai-model-candidates.md` are accurate and both end one
+clause early.
+
+- Training. The note quotes through *"…or to develop any new products, services,
+  or features"*. The sentence continues: *"subject to disclosures to Customer
+  and Customer-controlled user settings."* That is a settings-dependent
+  commitment, not an outright bar, and whether OpenRouter's account settings
+  are configured favourably is not public.
+- Deletion. The note quotes through *"…no later than 30 days after the end of
+  the interaction or session in which it was submitted"*. The sentence
+  continues into three exceptions, the third being *"reasonably necessary for
+  safety, security, compliance, moderation, abuse prevention, or
+  investigation"*.
+
+**Verdict: xAI is a live screening candidate, and it is gated on a routing
+change rather than on a policy reading.** With `zdr: true` sent for the model,
+the ZDR warranty is satisfied and nothing else in either document reaches this
+app. Without it, xAI should not be offered — and that is a different rule-out
+from the one recorded, on a clause the earlier note did not quote.
+
+Sources: [SpaceXAI Acceptable Use Policy](https://x.ai/legal/acceptable-use-policy) ·
+[Terms of Service — Enterprise](https://x.ai/legal/terms-of-service-enterprise) ·
+[Provider Routing](https://openrouter.ai/docs/features/provider-routing)
+
+## E. Ruled out, and the clause that rules each out
+
+### E1. Age or audience clauses — re-verified, not assumed
+
+**Google — 18 models.** Google Cloud Service Specific Terms, last modified
+**29 July 2026**, read live. The clause is intact and has only been renumbered
+(§19 → §20). §20(d), *Age Restrictions*: *"Customer will not, and will not
+allow End Users to, use a Generative AI Service as part of a website, Customer
+Application, or other online service that is directed towards or is likely to
+be accessed by individuals under the age of 18."* §20(g) makes it a Use
+Restriction; §20(f) permits suspension on *suspicion* of a violation of (d).
+§20(e) adds a healthcare restriction, and §18 confirms the training objection is
+gone (*"Google will not use Customer Data to train or fine-tune any AI/ML
+models without Customer's prior permission or instruction"*). This is a
+distribution test, which is why it survives #679 while OpenAI's minors clause
+did not — the distinction is set out at length in
+[`ai-openai-policy-fit.md`](ai-openai-policy-fit.md) §C and I found nothing to
+disturb it. `google/gemini-3.7-flash` stays out.
+[Google Cloud Service Specific Terms](https://cloud.google.com/terms/service-terms)
+
+**Sakana AI — 2 models.** Terms re-read live. *"You must be at least 18 years
+old to use the Service."* And the geography clause, which for a German-authored
+app is the harder one: the Service is *"provided for users in countries or
+regions other than the European Economic Area, the UK, and Switzerland"*, and
+the company *"may use technical means, including without limitation IP address
+controls, to restrict access"*. **A third bar, not in the previous note:** the
+same terms list *"Training AI models developed and operated by the Company"*
+among the purposes for which Content may be used, which conflicts with
+OpenRouter's `training: false` tag for `sakana`.
+[Sakana AI Terms of Service](https://console.sakana.ai/terms-of-service)
+
+**Meta — 2 models** (`meta/muse-spark-1.1`, `1.2`; a third, `muse-glimmer-30b`,
+has no first-party endpoint and fails structurally). **The governing document
+could not be re-read.** `https://ai.developer.meta.com/legal/terms-of-service`
+returned HTTP 500 to every attempt on 2026-08-20, from two URL forms and both a
+browser user-agent and WebFetch. The §10.1 age quote in `ai-model-candidates.md`
+is therefore carried forward **unverified**. Meta stays out, because nothing
+suggests the clause changed and because a vendor whose terms the project cannot
+read is not one to route a photograph to — but the exclusion should be recorded
+as resting on a four-day-old reading, not on a current one.
+
+### E2. Data clauses that contradict the routing promise
+
+**Mistral — 8 models. Newly in this category.** Commercial Terms of Service,
+Effective **August 5, 2026**, §4.2 *Training*: Mistral will not train on
+Customer Data *"except (a) when you (i) opted-in to training on a Mistral AI
+Product set to opt-out by default or (ii) have not opted-out of training on a
+Mistral AI Product set to opt-in by default"*, and *"(d) when Customer uses Labs
+or Preview Models"*. OpenRouter tags `mistral` as `training: false`. Whether
+OpenRouter's La Plateforme account has opted out, and which default applies to
+the products behind these endpoints, is not disclosed by either party. This is
+the identical shape to the Moonshot and Z.AI objections and it was not in the
+previous note.
+[Mistral Commercial Terms of Service](https://legal.mistral.ai/terms/commercial-terms-of-service)
+
+**Moonshot AI — 4 models.** Re-verified verbatim: *"Unless otherwise expressly
+agreed in writing, Customer Content may be used for the foregoing purposes"*,
+where the purposes include *"develop, support, and improve the Services"*.
+OpenRouter tags `moonshotai` `training: false`. Unresolved and unresolvable
+from public documents.
+[Moonshot AI model use agreement](https://platform.moonshot.ai/docs/agreement/modeluse)
+
+**Z.AI — 3 models. The rejection is weaker than recorded.** The individual-user
+clauses the previous note quoted are still there, but so is a sentence it did
+not quote: *"For enterprises and developers using API Services, we will not use
+your User Content for developing or improving Services unless you explicitly
+agree to such use."* OpenRouter is an API developer, so the individual-user
+training clauses probably never applied to this path. Z.AI still fails on the
+other clause the note found — no use *"for any services that require subject
+qualification or professional review, or as a substitute for professional
+services, including but not limited to professional fields such as medical
+care"* — which under #679's standard is a conduct test the app does not meet.
+**So Z.AI is now, on the project's current standard, in the same position as
+OpenAI was: permitted by absence of an applicable prohibition.** It is ranked
+low in [Section G](#g-the-ranking) on other grounds, not excluded.
+[Z.AI Terms of Service](https://chat.z.ai/legal-agreement/terms-of-service)
+
+**NVIDIA — 2 models.** `nvidia` is still one of exactly three providers tagged
+`training: true`. Structural, not arguable.
+
+**Reka — 1 model.** Re-verified: *"If you use the Services on a free basis, you
+acknowledge and agree that Reka may use Your Content to train, develop, and
+improve its machine learning models … This may include human review"*, with
+paid requests excluded. Whether OpenRouter's traffic is billed as paid is still
+undisclosed. Moot: `rekaai/reka-edge` has a 16k context window and the terms
+also require the user to be *"AT LEAST EIGHTEEN (18) YEARS OLD"*.
+[Reka Terms of Use](https://reka.ai/legal/terms-of-use)
+
+### E3. No carve-out, and the rest of the page
+
+This is the section the standard change rewrites. None of these vendors has
+anything resembling Anthropic's carve-out. Under #679 that is a **ranking
+input**, not a rule-out. What follows is what each actually says.
+
+- **Mistral — 8 models**, first-party via `mistral`, the only EU-headquartered
+  vendor on the list (FR), and the only non-Anthropic vendor with a ZDR-tagged
+  endpoint on any candidate (`mistral/zdr`, on `mistral-small-2603` alone).
+  Usage Policy effective **11 June 2026**, unchanged, under *Professional
+  advice*: *"Offering medical diagnoses, treatment suggestions, or any form of
+  health-related guidance."* Broader than OpenAI's — no licence qualifier — but
+  still a conduct test: the app offers no guidance. Its minors provision is the
+  mild consent kind, not an audience test — the Commercial Terms bar the
+  Customer from including *"personal information of children under 13 or the
+  applicable age of digital consent"* or from allowing *"minors to use the
+  Mistral AI Products without legally adequate consent from their parent or
+  guardian"*, and say nothing about who the Customer's app is distributed to.
+  **Mistral is excluded by
+  §E2, not by this clause**, which is a correction to the previous note in both
+  directions.
+  [Mistral Usage Policy](https://legal.mistral.ai/terms/usage-policy)
+- **Alibaba / Qwen — 21 models**, first-party via `alibaba`, including
+  `qwen/qwen3.7-flash` at $0.03/$0.13, still the cheapest capable model in the
+  set. **The previous note's characterisation is wrong.** Its Product Terms
+  §4.48 (Model Studio) does address the domain: output *"shall not constitute
+  (nor be treated as), nor be a substitute for, any professional, medical,
+  legal, reliable, or accurate advice or information"*, *"shall not be used as a
+  basis for making any professional, medical, legal, business, or financial
+  decisions"*, and is *"not intended for use in, or in association with, any
+  regulated uses"*. That is a disclaimer plus a use restriction. There is still
+  no minors clause and no training clause in the Product Terms, and the
+  Membership Agreement it incorporates was not read.
+  [Alibaba Cloud Product Terms of Service](https://www.alibabacloud.com/help/en/legal/latest/alibaba-cloud-international-website-product-terms-of-service-v-3-8-0)
+- **ByteDance Seed — 6 models**, first-party via `seed` (BytePlus), tagged
+  `retainsPrompts: false`. The BytePlus Terms of Service OpenRouter names carry
+  *Last Updated: August 23, 2022* and contain no health, medical, minors or
+  training provision — re-verified by searching the full text. The gap between
+  a 2022 general cloud contract and a 2026 vision model is itself the finding.
+  [BytePlus Terms of Service](https://docs.byteplus.com/en/docs/legal/docs-terms-of-service)
+- **Amazon — 1 model** (`amazon/nova-2-lite-v1`). AWS Acceptable Use Policy,
+  *Last Updated: July 1, 2021*, re-read: no eating-disorder clause, no age
+  clause, `amazon-bedrock` tagged `retainsPrompts: false`. Excluded on the same
+  reasoning that produced the vendor pin: routing to Amazon puts the request
+  under Amazon's terms rather than under a policy that names nutrition.
+  [AWS Acceptable Use Policy](https://aws.amazon.com/aup/)
+- **StepFun — 1 model** and **Nex AGI — 2 models**. `/api/v1/providers` still
+  lists **no terms-of-service URL at all** for either (`nex-agi` has a privacy
+  policy only). **This is the one E3 rule-out that survives the standard change
+  intact**, and it should be restated on its own ground: not "no carve-out" but
+  *unassessable*. An app that invites the user to check where their photograph
+  goes cannot route it to a destination that publishes no terms.
+- **MiniMax — 1 model** and **Xiaomi — 1 model.** Both terms pages are
+  client-rendered and returned no readable text; see
+  [Not verified](#not-verified). Neither is a serious candidate at the top of
+  the ranking, so neither was chased into a browser.
+
+### E4. Structural, before any policy question
+
+- **24 of the 151 candidate models have no pinnable first-party endpoint** and
+  can only 404 under `only: [...]` with `allow_fallbacks: false`. Includes all
+  `meta-llama/*` and `thinkingmachines/*`, the three `openrouter/*` router
+  models, `meta/muse-glimmer-30b`, `mistralai/mistral-small-3.2-24b-instruct`,
+  `qwen/qwen3.5-9b`, `qwen/qwen3.6-35b-a3b`, the Gemma models served only by
+  third parties, and four Anthropic models — `claude-3-haiku` (Bedrock only),
+  `claude-opus-4` (Vertex only), `claude-opus-4.1` and `claude-sonnet-4`
+  (Vertex and Bedrock only).
+- **All 10 `~vendor/…-latest` aliases** in the candidate set, now including
+  `~x-ai/grok-latest`. Each *"always redirects to the latest model"*, which is
+  the silent behaviour change the pin exists to prevent.
+- **All 55 `:batch` variants**, now on two independent grounds — asynchronous,
+  and documented as text-only.
+- **169 models with no image input**, plus **29** that accept images but do not
+  advertise `tools` and `tool_choice`.
+
+## F. What the routing block buys now
+
+Three changes since the last pass, two of them good.
+
+**The `claude-on-aws` hazard has resolved itself.** The previous note warned
+that OpenRouter's Claude-on-AWS endpoint sat at `anthropic/claude-on-aws` — a
+variant under the `anthropic` base slug — so that if it ever appeared on Sonnet
+5 or Haiku 4.5, `only: ["anthropic"]` would accept it and
+`_warnIfThePinDidNotHold` would log a false alarm against the display name
+"Amazon Bedrock". It has appeared: `anthropic/claude-sonnet-5` now lists it,
+alongside `claude-opus-5`, `claude-opus-4.5` through `4.8`, `claude-sonnet-4.5`,
+`4.6` and `claude-fable-5`. But its slug is now **`claude-on-aws`**, a
+top-level provider in `/api/v1/providers` with `provider_name` "Claude Platform
+on AWS" and base URL `https://aws-external-anthropic.us-east-1.api.aws/v1`. It
+is not under `anthropic`, so the documented base-slug rule does not reach it.
+Its governing terms are still Anthropic's Commercial Terms, so the policy answer
+would have been unchanged either way — but the warning no longer applies and
+should not be carried forward. `anthropic/2`, which the previous note also
+listed, no longer appears on any candidate model.
+
+**`zdr: true` is real, documented, and now matters to a specific candidate.**
+See [Section D2](#d2-the-clause-that-actually-rules-xai-out-today). It remains
+unusable as a blanket setting because no Anthropic endpoint is ZDR-tagged.
+
+**OpenRouter still passes vendor terms through to the end user.** Terms of
+Service, Last Updated **29 July 2026**, §5.1: *"By accessing or using any Model
+through the Service, you agree … to comply with the applicable terms for each
+Model ('Model Terms')"*, with the user *"solely responsible for reviewing the
+Model Terms applicable to each Model before accessing or using that Model"*.
+And §2 still contemplates minor key-holders: *"You must be at least 13 years of
+age to use the Service … If you are under 18 years of age, you must have your
+parent or guardian's permission."* That combination is why the Google and Meta
+audience clauses are fatal and OpenAI's conduct clause is not.
+[OpenRouter Terms of Service](https://openrouter.ai/terms)
+
+## G. The ranking
+
+**These are screening candidates in the order I would spend a photo corpus on
+them, not a shortlist and not a recommendation.** No model on it can be added
+on the strength of this document. Prices are per **1M tokens**, input/output,
+read off OpenRouter's own endpoint records for the pinned first-party endpoint
+on 2026-08-20. None of these models has a per-image price; images are billed as
+prompt tokens.
+
+| # | Model | Pin | In / Out per 1M | Cost vs. `claude-sonnet-5` | Screened? |
+| --- | --- | --- | --- | --- | --- |
+| 1 | `openai/gpt-5.6-luna` | `openai` | $0.20 / $1.20 | 10–12% | direct route only |
+| 2 | `openai/gpt-5.6-terra` | `openai` | $2.00 / $12.00 | 100–120% | direct route only |
+| 3 | `x-ai/grok-4.20` | `xai` + `zdr` | $1.25 / $2.50 | 25–63% | no |
+| 4 | `x-ai/grok-4.3` | `xai` + `zdr` | $1.25 / $2.50 | 25–63% | no |
+| 5 | `anthropic/claude-opus-5` | `anthropic` | $5.00 / $25.00 | exactly 250% | no |
+| 6 | `x-ai/grok-4.6` | `xai` + `zdr` | $2.00 / $6.00 | 60–100% | no |
+
+**How the cost column is computed, and why it is a range.** The catalogue
+records two measured figures — roughly $0.0033 a photo for Sonnet 5 and
+$0.0017 for Haiku 4.5 — and those two are in exactly the same 2:1 ratio as
+their prices, so they do **not** determine how many tokens are input and how
+many are output. Rather than invent a split, the column brackets it: the low
+end is the ratio of prompt prices, the high end the ratio of completion prices,
+and a request of any shape must fall between them. Where both ratios coincide
+the figure is exact — `claude-opus-5` is 2.5× on both, i.e. about $0.008 a
+photo, which reproduces the previous note's estimate by a different route.
+**Three things break this arithmetic and are why it is a bracket and not a
+price:** each vendor tokenises an image differently, so the input count is not
+transferable; reasoning tokens bill as output, and `grok-4.6` and `grok-4.5`
+carry `reasoning.mandatory: true` while `gpt-5.6-luna`/`terra` default reasoning
+on at medium effort; and OpenRouter's own fee on top is not modelled here.
+
+Notes on each:
+
+1. **`openai/gpt-5.6-luna`** — the same model name the app already ships on the
+   direct path, where it is the default. Endpoint `openai`, 1.05M context,
+   `tools`/`tool_choice`/`max_tokens` all present. #684 and #719 measured 18/18
+   forced tool calls, zero measurement leaks, zero duplicate rows and 5/5 empty
+   on non-food images — **through the direct API, not through OpenRouter**.
+   That is the same route confound that #684 refused to resolve about
+   `gpt-5.4-nano`, so it is a strong prior and not a substitute for the screen.
+   It is also the cheapest thing on this list by an order of magnitude.
+2. **`openai/gpt-5.6-terra`** — the app's second direct entry, offered there for
+   being the less conservative reader. Same structural profile.
+3. **`x-ai/grok-4.20`** — the Grok to screen first, not the newest one:
+   `reasoning.default_enabled` is **false**, so it will not spend the client's
+   `max_tokens: 1024` on thinking before it emits the tool call. 2M context.
+   Requires the ZDR routing change in [Section D2](#d2-the-clause-that-actually-rules-xai-out-today).
+4. **`x-ai/grok-4.3`** — same price, 1M context, reasoning on but at `low`
+   effort by default.
+5. **`anthropic/claude-opus-5`** — the only quality-up that stays inside the
+   vendor with the carve-out. Cheapest Opus, pins cleanly, and the decision is
+   purely "does it find more staples in bad photographs than Sonnet 5", which
+   no document can answer. Placed below the cheaper candidates only because
+   2.5× the current cost is a lot to pay for an unmeasured improvement.
+6. **`x-ai/grok-4.6` / `x-ai/grok-4.5`** — `reasoning.mandatory: true` on both.
+   Screen them for truncation against `max_tokens: 1024` before screening them
+   for anything else.
+
+**Deliberately not ranked**, and why: `qwen/qwen3.7-flash` at $0.03/$0.13 is
+30× cheaper than anything above it and Alibaba's §4.48 does not bar this use —
+but the pin lands in Singapore under a general cloud contract with no
+health-specific commitments in either direction, and the project has not
+decided whether it is willing to name Alibaba in the settings screen. Mistral is
+the natural European candidate and is held out by §4.2 alone. `z-ai/glm-4.6v`
+is now arguably permitted and is a 131k-context model with no published
+carve-out from a vendor whose terms conflict with the router's tag in a way
+that is only *probably* resolved.
+
+## Not verified
+
+- **No live request was made and none can be made from here.** Every capability,
+  price and routing claim is OpenRouter's declaration about itself. In
+  particular: that `only: ["xai"]` reaches `xai/zdr` follows from the documented
+  base-slug rule and was **not** probed, and the docs do not say whether a
+  `/zdr` suffix is a "variant" (matched) or a "service tier" (not matched). The
+  existence of `xai/zdr/priority` suggests `/zdr` is a variant and `/priority`
+  is the tier, but that is inference. **This is the single most load-bearing
+  unverified claim in Section D and it decides whether the ZDR warranty is
+  breached today, satisfied today, or coin-flipped per request.**
+- **Meta's Model API Terms of Service.** `ai.developer.meta.com` returned HTTP
+  500 to every attempt on 2026-08-20 — two URL forms, browser user-agent and
+  WebFetch. The §10.1 age quote and the §6.1 Discounted-Services training quote
+  in `ai-model-candidates.md` could not be re-verified. Neither was disproved.
+- **Whether OpenRouter has opted out of Mistral training**, which is the whole
+  of the §4.2 objection, and correspondingly whether it holds written
+  no-training agreements with Moonshot AI. Neither party publishes the contract.
+- **MiniMax and Xiaomi terms.** `platform.minimax.io/protocol/terms-of-service`
+  (reached via a 307 from `minimax.io`) and
+  `platform.xiaomimimo.com/#/docs/terms/user-agreement` are both
+  client-rendered and returned title-only text to automated fetching. Neither
+  was read in a browser, because neither model is near the top of the ranking.
+  The previous note's MiniMax reading is therefore carried forward unverified.
+- **Alibaba's Membership Agreement**, which §4.48 incorporates and where any age
+  or eligibility clause would live. Still only the Product Terms were read.
+- **Anthropic's "products serving minors" guideline.** The Usage Policy's
+  *Additional Use Case Guidelines* require that *"Products serving minors …
+  must comply with the additional guidelines outlined in our Help Center
+  article"*. The article was not retrieved. This binds the **currently shipping**
+  Anthropic path, so it is not a differentiator between vendors — but it is an
+  obligation the project does not appear to have recorded anywhere, and it is
+  worth a look independently of this question.
+- **Whether the OpenAI behavioural results transfer across routes.** #684
+  measured `gpt-5.6-luna` and `gpt-5.6-terra` on the direct API. #669 measured
+  `openai/gpt-5.4-nano` through OpenRouter and got the opposite result for a
+  different model. Nothing here establishes that a model behaves the same way
+  through the broker, and the catalogue's own comment about `anthropic/2` and
+  Bedrock is a reminder that OpenRouter is not a transparent pipe.
+- **Every quality claim.** There are none in this document. No model was asked
+  to read a photograph.
+- **OpenRouter's own fee.** Not modelled in Section G, and not published in the
+  endpoint data I read.
+- **Legal advice.** A reading of published documents on one date by a
+  non-lawyer. Terms on all of these sites change without notice; the dates given
+  are the only guarantee offered.
+
+## Sources
+
+OpenRouter (own API and docs, queried 2026-08-20):
+[`/api/v1/models`](https://openrouter.ai/api/v1/models) — the 414-model
+catalogue, capability flags, prices and `created` dates ·
+[`/api/v1/models/{author}/{slug}/endpoints`](https://openrouter.ai/api/v1/models/x-ai/grok-4.6/endpoints)
+— per-candidate endpoint tags, per-endpoint prices and `supported_parameters`,
+fetched for all 151 candidates ·
+[`/api/v1/providers`](https://openrouter.ai/api/v1/providers) — provider slugs
+and the terms-of-service URL naming each Model Terms document ·
+[`/api/frontend/v1/all-providers`](https://openrouter.ai/api/frontend/v1/all-providers)
+— `dataPolicy` records, base URLs, the `claude-on-aws` adapter ·
+[Provider Routing](https://openrouter.ai/docs/features/provider-routing) —
+`require_parameters`, `data_collection`, `allow_fallbacks`, base-slug matching,
+`zdr` ·
+[Batch API Quickstart](https://openrouter.ai/docs/batch-quickstart.md) — the
+text-only limitation ·
+[Terms of Service](https://openrouter.ai/terms) — §2 eligibility, §5.1 Model
+Terms pass-through
+
+Vendor documents (each fetched from the vendor's own domain):
+[Anthropic Usage Policy](https://www.anthropic.com/legal/aup) — the nutrition
+carve-out, the disordered-eating and body-image prohibitions, the minors
+guideline ·
+[Anthropic Commercial Terms](https://www.anthropic.com/legal/commercial-terms) —
+the no-training sentence and the effective date ·
+[SpaceXAI Acceptable Use Policy](https://x.ai/legal/acceptable-use-policy) —
+read in full; the high-stakes-decisions clause and the absences ·
+[SpaceXAI Terms of Service — Enterprise](https://x.ai/legal/terms-of-service-enterprise)
+— the ZDR Personal Data warranty, the training and deletion sentences in full,
+the flow-down ·
+[Google Cloud Service Specific Terms](https://cloud.google.com/terms/service-terms)
+— §20(d) age restriction, §20(e) healthcare, §18 training ·
+[Mistral Usage Policy](https://legal.mistral.ai/terms/usage-policy) —
+professional advice ·
+[Mistral Commercial Terms of Service](https://legal.mistral.ai/terms/commercial-terms-of-service)
+— §4.2 training exceptions, the minors consent clause ·
+[Moonshot AI model use agreement](https://platform.moonshot.ai/docs/agreement/modeluse) ·
+[Z.AI Terms of Service](https://chat.z.ai/legal-agreement/terms-of-service) —
+including the API-developer carve-out the previous note missed ·
+[Reka Terms of Use](https://reka.ai/legal/terms-of-use) ·
+[Sakana AI Terms of Service](https://console.sakana.ai/terms-of-service) ·
+[Alibaba Cloud Product Terms of Service](https://www.alibabacloud.com/help/en/legal/latest/alibaba-cloud-international-website-product-terms-of-service-v-3-8-0)
+— §4.48 Model Studio ·
+[BytePlus Terms of Service](https://docs.byteplus.com/en/docs/legal/docs-terms-of-service) ·
+[AWS Acceptable Use Policy](https://aws.amazon.com/aup/)
+
+Attempted and failed (see [Not verified](#not-verified)):
+[Meta Model API Terms of Service](https://ai.developer.meta.com/legal/terms-of-service)
+(HTTP 500) ·
+[MiniMax Terms of Service](https://platform.minimax.io/protocol/terms-of-service)
+(client-rendered) ·
+[Xiaomi user agreement](https://platform.xiaomimimo.com/#/docs/terms/user-agreement)
+(client-rendered)
+
+Related notes in this repo:
+[`ai-model-candidates.md`](ai-model-candidates.md) — the document this one
+re-checks ·
+[`ai-openai-policy-fit.md`](ai-openai-policy-fit.md) — the standard now in force ·
+[`ai-openai-behavioural-screen.md`](ai-openai-behavioural-screen.md) — what the
+two OpenAI models have and have not been screened for ·
+[`ai-legal-constraints.md`](ai-legal-constraints.md) ·
+[`ai-cohort-restrictions.md`](ai-cohort-restrictions.md) ·
+[`ai-open-research-questions.md`](ai-open-research-questions.md)
+
+In-repo files cited:
+[`lib/core/utils/ai_model_catalogue.dart`](../lib/core/utils/ai_model_catalogue.dart) ·
+[`lib/features/add_meal/data/openrouter_meal_items_api.dart`](../lib/features/add_meal/data/openrouter_meal_items_api.dart) ·
+[`lib/features/add_meal/domain/meal_items_api.dart`](../lib/features/add_meal/domain/meal_items_api.dart) ·
+[`lib/features/add_meal/presentation/screens/bulk_add_screen.dart`](../lib/features/add_meal/presentation/screens/bulk_add_screen.dart)

--- a/docs/ai-play-encryption-declaration.md
+++ b/docs/ai-play-encryption-declaration.md
@@ -1,0 +1,218 @@
+# How finely can Play's "Encryption in transit" declaration be scoped?
+
+Research for [#751](https://github.com/simonoppowa/OpenNutriTracker/issues/751), on
+map [#732](https://github.com/simonoppowa/OpenNutriTracker/issues/732). Researched
+2026-08-22 against Google's and Apple's own documentation, plus a live Data safety
+listing.
+
+**The short answer: it cannot be scoped at all.** It is one app-wide yes/no, it may
+only be answered *yes* if it holds for every byte the app sends off-device, there is
+no way to express "encrypted unless the user configures otherwise", and the
+prominent-disclosure exception does not reach it.
+
+---
+
+## 1. Per data type, per purpose, or once for the app?
+
+**Once for the app.** Three independent confirmations:
+
+The form asks it a single time, in the *Data collection and security* step, phrased as
+one question about the app as a whole:
+
+> Is data collected or shared by your app using encryption in transit to protect the
+> flow of user data from the end user's device to the server.
+
+The user-facing help describes it as one of several *Security practices*, not as a
+column in the data table — developers "can describe certain security practices they
+use", including that the app
+> Encrypts data that it collects or shares while it's in transit.
+
+And a live listing renders it exactly that way. On the Play Console app's own Data
+safety page the sections are **Data shared**, **Data collected**, **Security
+practices** — with the per-type list carrying only category and purpose ("App
+functionality", "Analytics", "Account management"), and the encryption statement
+appearing once, in its own section, as:
+
+> Your data is transferred over a secure connection
+
+**A search summary claimed this is declared "per data type". It is not, and no
+primary source says so.** Recorded here because it is the plausible-sounding wrong
+answer, and because it would have made the rest of this ticket look tractable.
+
+## 2. So: do Photos and Health and fitness reach other destinations?
+
+**The question dissolves.** It only mattered if the declaration were per data type. It
+is not, so which categories the AI feature touches has no bearing on the answer.
+
+For completeness, the app's compiled-in destinations are all HTTPS — Open Food Facts,
+USDA FDC, the Supabase reference backend, Sentry, Unsplash, and the three hosted AI
+providers. `grep` finds **no `http://` request URL anywhere in `lib/`**. There is no
+Health Connect or HealthKit integration. So today the declaration is honest, and a
+user-typed `http://` address under [#758](https://github.com/simonoppowa/OpenNutriTracker/issues/758)
+would be the app's only plaintext path.
+
+## 3. Can a conditional truth be expressed?
+
+**No.** Google is explicit that the declaration is all-or-nothing:
+
+> In Play's Data safety section, developers can only declare encryption in transit if
+> it applies to **all** user data that their app (including all its SDKs and
+> libraries) collects and transmits off the user's device.
+
+And the form is scoped to the union of behaviour, not the common case:
+
+> Your Data safety section describes the sum of your app's data collection and sharing
+> across all its versions currently distributed on Google Play.
+
+> If any of the collection, uses, or linkages are present in **any** version of the app
+> presently distributed on Google Play, anywhere in the world, you must indicate such
+> on the form.
+
+There is no documented exception for a path that is optional, off by default, or
+reachable only after the user types an address. "Encrypted unless the user chooses
+otherwise" has nowhere to go on this form.
+
+## 4. Does the prominent-disclosure exception help?
+
+**No — it is about sharing, not about encryption.** `docs/ai-legal-constraints.md`
+quotes the exception in its *sharing* context, and that is the only place it applies:
+
+> Transferring user data to a third party based on a specific user-initiated action,
+> where the user reasonably expects the data to be shared, or based on a prominent
+> in-app disclosure and consent.
+
+That exempts a *disclosure of sharing*. It says nothing about the security-practices
+question, and Google documents no equivalent carve-out for it. An in-app disclosure —
+however prominent, however clearly the user opted in — does not let the box stay
+ticked.
+
+## 5. What a browsing user sees when it is unchecked
+
+**Not established, and I could not settle it from documentation.** The help page
+describes what a developer *can* declare and never states how the absence renders.
+
+The live listing above shows the line present. What is not confirmed is whether an
+app without the declaration shows **nothing** in that position or an explicit negative
+("Data isn't encrypted"). The difference matters: silent absence is a badge not earned,
+an explicit negative is a warning shown next to a nutrition app handling health data.
+
+**A build ticket must not guess this.** It is one lookup on any listed app known not to
+declare encryption — cheap to settle, and worth settling before the form is submitted
+rather than after.
+
+## 6. Apple
+
+**There is no equivalent field, so iOS is unaffected.** App Privacy asks four things —
+data types collected, how each is used, whether each is linked to identity, and whether
+any is used for tracking. It asks nothing about transport security, TLS, or ATS.
+
+This is a real asymmetry rather than a gap in the research: the same feature costs
+something on Play and nothing on the App Store. #736 considered only Play, and that
+turns out to have been the right place to look.
+
+---
+
+## What this means for #736
+
+**It is worse than #736 assumed.** That decision recorded:
+
+> The "Encryption in transit" declaration remains true — HTTPS to whatever endpoint.
+
+That sentence is now false, and `docs/ai-legal-constraints.md:817` should be corrected
+rather than defended — which #736 already anticipated. What it did not anticipate is
+the *scope* of the correction: because the declaration is app-wide and all-or-nothing,
+permitting one plaintext path to a private address means the entire app stops being
+able to claim "Your data is transferred over a secure connection" — for the diary, the
+weight log, the food searches, the crash reports, everything, for every user, including
+the overwhelming majority who never enable the AI feature at all.
+
+**One question could overturn this, and it is not settled.** Play defines collection as
+
+> "Collect" means transmitting data from your app off a user's device
+
+which reads as destination-agnostic, and it confirms that
+
+> User data accessed by your app that is only processed locally on the user's device
+> and not sent off device does not need to be disclosed.
+
+Neither passage addresses a server the **end user** operates — not the developer, not a
+third party, receiving data the developer never sees. Every worked example in the
+documentation assumes the recipient is one of those two parties. If a user-run endpoint
+is outside "collection" and "sharing", the encryption declaration never covered that
+traffic and nothing needs to change. If it is inside, the badge is forfeit app-wide.
+
+**That is the decision-grade question, and documentation cannot answer it.** It wants
+Play Developer Support in writing, which is slow but definitive, and it should be asked
+before a form is submitted on a guess. Until then the honest reading is the
+conservative one: assume the traffic counts.
+
+If it does count, that is grounds to revisit the private-addresses-only decision in
+#736 — for example requiring `https://` for every user-supplied endpoint, which would
+keep the declaration intact at the cost of a reverse proxy in front of Ollama and,
+per #736's own reasoning, "a feature nobody could use". That trade is a decision, not a
+research finding, and it belongs back on the map rather than here.
+
+---
+
+## What the listing shows when the box is **not** ticked
+
+Read on **2026-08-24**, from live public listings, on the **web surface**. Google's
+own help page does not state the user-facing wording for the negative case, so
+this had to come from a real listing. #817.
+
+**It is an explicit negative, not a silent omission.**
+[SHAREit](https://play.google.com/store/apps/datasafety?id=com.lenovo.anyshare.gps)
+(`com.lenovo.anyshare.gps`) renders, verbatim:
+
+> **Security practices**
+>
+> **Data isn't encrypted**
+> Your data isn't transferred over a secure connection
+>
+> **Data can't be deleted**
+> The developer doesn't provide a way for you to request that your data be deleted
+
+Compare the same section on
+[OpenNutriTracker's own listing](https://play.google.com/store/apps/datasafety?id=com.opennutritracker.ont.opennutritracker),
+which does declare it:
+
+> **Data is encrypted in transit**
+> Your data is transferred over a secure connection
+
+So the two states are symmetrical sentences in the same block, and dropping the
+declaration replaces a reassurance with a warning rather than removing a line.
+Note that OpenNutriTracker already carries one negative there — *"Data can't be
+deleted"* — which is what confirmed the block renders negatives at all.
+
+**The Security practices block disappears entirely when nothing is collected or
+shared.** [VLC](https://play.google.com/store/apps/datasafety?id=org.videolan.vlc)
+and [Kodi](https://play.google.com/store/apps/datasafety?id=org.xbmc.kodi) both
+declare *"doesn't collect or share any user data"* and show no encryption row at
+all. That is a third state, and it bears on #816 rather than on this question —
+see below.
+
+**Not checked: the Play Store app surface.** #751 found one Play surface
+rendering a populated field as empty, so the two are worth comparing. The
+device was locked at the time and unlocking someone's phone is not a research
+step.
+
+### Incidental, and it bears on #816
+
+VLC and Kodi both stream from servers the user runs, over plain HTTP on a local
+network, and both declare **no collection at all**. Two large, long-established
+open-source projects in the same shape as this app have therefore answered
+#816's question in practice: a machine the user operates is not treated as
+collection. That is precedent, not authority — the form runs on the honour
+system and neither project's reasoning is published — but it is the closest
+real-world reading available, and it points the opposite way from the
+conservative assumption.
+
+---
+
+## Sources
+
+- [Provide information for Google Play's Data safety section — Play Console Help](https://support.google.com/googleplay/android-developer/answer/10787469)
+- [Understand app privacy & security practices with Google Play's Data safety section — Google Play Help](https://support.google.com/googleplay/answer/11416267)
+- [Data safety listing for Google Play Console (live example)](https://play.google.com/store/apps/datasafety?id=com.google.android.apps.playconsole)
+- [Declare your app's data use — Android Developers](https://developer.android.com/privacy-and-security/declare-data-use)
+- [App Privacy Details — Apple Developer](https://developer.apple.com/app-store/app-privacy-details/)

--- a/docs/ai-provider-human-review.md
+++ b/docs/ai-provider-human-review.md
@@ -1,0 +1,826 @@
+# Does anyone read my food photo, and who?
+
+**Verdict: all three providers disclose that a human can end up reading
+API content, none of them reviews everything, and only OpenAI names the
+companies whose staff do it.** Anthropic and OpenRouter both publish
+sub-processor lists, and on both lists **no content-review vendor appears
+at all** — that is an established finding, not an absence I failed to
+check. The reviewer on the Anthropic path is Anthropic's own staff; the
+reviewer on the OpenRouter path is whoever the serving vendor's is, which
+under the app's pin is Anthropic again; the reviewers on an OpenAI path
+include **TaskUs and Accenture**, named, with the Philippines among their
+stated locations. So the row [#696](https://github.com/simonoppowa/OpenNutriTracker/issues/696)
+asked for can be written for all three, and the honest shape of it is
+*"named vendors / none named / none named"*, not *"named vendors / blank
+/ blank"*. This is a documents review, not legal advice.
+
+## The row the README has to be able to write
+
+Every cell below is from a page quoted later in this note and read on
+2026-08-17.
+
+| | **Anthropic (direct)** | **OpenRouter (broker)** | **OpenAI** |
+| --- | --- | --- | --- |
+| **Human review of API content disclosed?** | **Yes** — *"Human review can occur only through a controlled access path"* | **No statement either way.** A right to *"screen"* Inputs is reserved in the Terms; no page says whether a person or a machine does it | **Yes**, and the phrase *"human review"* is OpenAI's own |
+| **Trigger** | Content flagged by *"automated trust and safety systems"* | Unstated. Automated categorisation of a **sample** of prompts is disclosed, and it is done *"by model"* | Classifier flag for the vendor path; stored abuse-monitoring logs are reachable by staff more broadly |
+| **Who reviews** | *"a small set of approved reviewers"* — Anthropic's own Safeguards / Trust & Safety staff | Not stated. Access limited to *"personnel performing the Service"* | (1) *"authorized employees"* and (2) *"specialized third-party contractors"* |
+| **Vendors named?** | **No, and none exists on the list.** The only human-touching sub-processors are user support: Intercom (US), Nutun (South Africa), Boldr (Canada) | **No, and none exists on the list.** Nearest is Google Cloud Natural Language API for *"NLP Categorization"* — a machine | **Yes. TaskUs, LLC (Philippines) and Accenture International Limited (US, Canada, Philippines)**, both purpose *"Moderation of content"* for the API |
+| **Images vs text** | Every image is perceptually hashed against NCMEC's CSAM database; a match is reported. No image-specific review carve-out beyond that | The **only** image-specific sentence anywhere: files are not persisted *"except as required for abuse detection, security, billing, or legal compliance"* | Every image is CSAM-scanned on submission; a hit is *"retained for manual review"* **even under every retention control OpenAI sells** |
+| **Avoidable by a solo BYO-key developer?** | **No.** Flag-triggered retention and review survive ZDR, and ZDR itself is a sales conversation | **Nothing to avoid, and nothing to opt out of.** The layer below is the serving vendor's answer | **No.** The exemption is called Eyes Off and it presupposes ZDR/MAM approval — and it does not cover images |
+| **Sub-processor list** | [trust.anthropic.com/subprocessors](https://trust.anthropic.com/subprocessors) | [openrouter.ai/authorized-sub-processors](https://openrouter.ai/authorized-sub-processors) | [openai.com/policies/sub-processor-list](https://openai.com/policies/sub-processor-list/) |
+
+**Read the "vendors named" row carefully, because it is the one that can
+mislead.** OpenAI naming two BPOs is *better disclosure*, not worse
+practice. Anthropic and OpenRouter publish lists on which no such vendor
+appears; that is evidence they do not use one for this, not evidence they
+declined to say. The README should say what each provider publishes, and
+should not let OpenAI's specificity read as a black mark.
+
+## Bottom line up front
+
+1. **All three sub-processor lists exist and are citable.** The
+   README's class sentence has three places to point, and #696's
+   requirement that the row ship for all three or none is satisfiable.
+   See [Section E](#e-the-three-sub-processor-lists).
+2. **TaskUs and Accenture check out, with one correction.** Both carry
+   the purpose *"Moderation of content"* scoped to *"API & ChatGPT
+   Business"* on OpenAI's own list (last updated 9 July 2026). **TaskUs
+   is Philippines-only; Accenture is United States, Canada and the
+   Philippines.** *"TaskUs and Accenture, in the Philippines"* is right
+   about TaskUs and incomplete about Accenture. See
+   [Section D](#d-openai-the-only-provider-that-names-names).
+3. **Anthropic's human-review sentence is real but narrowly scoped, and
+   the scope matters to this app.** The sentence *"By default, no
+   Anthropic personnel can read your retained conversations"* sits in an
+   article about **Covered Models** — currently only Claude Mythos 5 and
+   Claude Fable 5. The app uses `claude-haiku-4-5` and
+   `anthropic/claude-sonnet-5`, neither of which is a Covered Model. The
+   description is the best statement Anthropic publishes and it is
+   plainly meant to describe how review works generally, but **it is not
+   formally scoped to the traffic this app sends.** See
+   [Section B](#b-anthropic-review-is-internal-and-nobody-else-is-named).
+4. **OpenRouter genuinely publishes nothing about human review of
+   content, and that is the finding.** Not "we could not find it" —
+   the Terms reserve a right to *"screen"* Inputs *"in our sole
+   judgment"* without saying by whom or when, the Privacy Policy has no
+   review clause, and the sub-processor list has no reviewer on it. The
+   README must state this as an absence of disclosure, not as an
+   assurance. See [Section C](#c-openrouter-two-layers-and-only-one-of-them-is-openrouters).
+5. **The "ephemeral" sentence the README quotes has a companion Anthropic
+   does not put next to it.** Vision docs: image uploads are
+   *"ephemeral and not stored beyond the duration of the API request"*.
+   API retention docs: *"if a chat or session is flagged, Anthropic may
+   retain inputs and outputs for up to 2 years."* Both are Anthropic's,
+   both were read today, and the second is the exception to the first.
+   **A flagged meal photo is not ephemeral.** See
+   [Section F](#f-images-versus-text).
+6. **On images, OpenAI is the only provider whose review path survives
+   every control it sells.** The CSAM carve-out is one nobody would
+   argue against, but it is the single hardest fact in this note: a
+   false positive on a photograph of dinner ends in a person looking at
+   it, and no setting, tier or contract prevents that.
+7. **Nothing here is avoidable by the app's user on any path.** Review
+   is triggered by classifiers, not by settings, and every exemption on
+   offer runs through a sales team. See
+   [Section G](#g-is-review-avoidable).
+
+## How this was read
+
+Primary sources only, all read on **2026-08-17**. Every quote below was
+verified against the page itself, not against a search summary — I fetched
+each document, extracted its text, and string-searched the extracted text
+for the quoted words. Where the finding is an *absence*, the search term
+is stated so the check is repeatable.
+
+Two mechanical notes, because they changed the result:
+
+- **`openai.com` returns HTTP 403 to automated fetching**, as
+  [`ai-openai-key-transfer.md`](ai-openai-key-transfer.md) recorded. Both
+  `openai.com` pages here were read in a browser against the live
+  rendering. `developers.openai.com`, `anthropic.com`,
+  `platform.claude.com`, `privacy.claude.com`, `support.claude.com` and
+  `openrouter.ai` all answer automated fetches and render server-side.
+- **`trust.anthropic.com` and `trust.openrouter.ai` are JavaScript
+  applications** (Vanta and SafeBase respectively) that return an empty
+  shell to a plain fetch. Both sub-processor lists were read in a browser
+  from the rendered DOM. A plain `curl` of
+  `trust.anthropic.com/subprocessors` returns 4.9 KB of scaffolding and
+  **zero vendor names** — anyone repeating this check with a fetch tool
+  will conclude the list is empty. It is not.
+
+**Three search summaries produced during this work were discarded rather
+than cited.** One asserted that Anthropic's Trust & Safety access
+sentence applies to the API; the page carrying it says *"This article is
+about our consumer products such as Claude Free, Pro, Max"* in its first
+line. One asserted OpenRouter "doesn't filter content itself, but routes
+to providers that enforce their own policies" — a reasonable-sounding
+claim that appears on no OpenRouter page I could find, and which would
+have resolved question 1 for OpenRouter by invention. One reported that
+OpenRouter has no sub-processor list, which is what I had provisionally
+concluded myself after guessing four wrong URL slugs; the list exists at
+`/authorized-sub-processors` and finding it changed the answer.
+
+**One near-miss worth recording as a trap for the next reader.** Both
+Anthropic's Commercial Terms and OpenRouter's Terms contain the exact
+phrase *"human review"* — and in both it means the **customer's** duty to
+check outputs before relying on them, the opposite of what this ticket
+asks. Anthropic: *"It is Customer's responsibility to evaluate whether
+Outputs are appropriate for Customer's use case, including where human
+review is appropriate."* OpenRouter, in capitals: *"YOU ARE SOLELY
+RESPONSIBLE FOR EVALUATING OUTPUTS, IMPLEMENTING APPROPRIATE HUMAN REVIEW
+AND SAFEGUARDS."* A keyword search for "human review" finds these first
+on both sites.
+
+| Document | Date it carries |
+| --- | --- |
+| [Anthropic Privacy Policy](https://www.anthropic.com/legal/privacy) | Effective **July 8, 2026** |
+| [Anthropic Commercial Terms of Service](https://www.anthropic.com/legal/commercial-terms) | Effective **June 17, 2025** |
+| [Anthropic Data Processing Addendum](https://www.anthropic.com/legal/data-processing-addendum) | Effective **February 24, 2025** |
+| [Anthropic Usage Policy](https://www.anthropic.com/legal/aup) | Effective **September 15, 2025** |
+| [API and data retention](https://platform.claude.com/docs/en/manage-claude/api-and-data-retention) | no date carried |
+| [How long do you store my organization's data?](https://privacy.claude.com/en/articles/7996866-how-long-do-you-store-my-organization-s-data) | **July 1, 2026** |
+| [Data retention practices for Covered Models](https://privacy.claude.com/en/articles/15425996-data-retention-practices-for-covered-models) | **July 9, 2026** |
+| [Covered Models](https://support.claude.com/en/articles/15425695) | **July 1, 2026** |
+| [Our Approach to User Safety](https://support.claude.com/en/articles/8106465-our-approach-to-user-safety) | **March 16, 2026** |
+| [CSAM Detection and Reporting](https://support.claude.com/en/articles/9020328-csam-detection-and-reporting) | **March 16, 2026** |
+| [Safeguards warnings and appeals](https://support.claude.com/en/articles/8241253-safeguards-warnings-and-appeals) | **July 9, 2026** |
+| [How does Anthropic protect the personal data of Claude users?](https://privacy.claude.com/en/articles/10458704-how-does-anthropic-protect-the-personal-data-of-claude-users) | **March 16, 2026** — *consumer only* |
+| [Anthropic's Transparency Hub](https://www.anthropic.com/transparency/system-trust-reporting) | Last updated **July 23, 2026** |
+| [Anthropic Subprocessor List](https://trust.anthropic.com/subprocessors) | **no date carried** |
+| [Anthropic Vision documentation](https://platform.claude.com/docs/en/build-with-claude/vision) | no date carried |
+| [OpenRouter Privacy Policy](https://openrouter.ai/privacy) | Last Updated **July 6, 2026** |
+| [OpenRouter Terms of Service](https://openrouter.ai/terms) | Last Updated **July 29, 2026** |
+| [OpenRouter Enterprise Access Agreement](https://openrouter.ai/terms-of-service-enterprise) | Last Updated **June 22, 2026** |
+| [OpenRouter Authorized Sub-Processors](https://openrouter.ai/authorized-sub-processors) | Last Updated **January 9, 2026** |
+| [OpenRouter Data Collection](https://openrouter.ai/docs/guides/privacy/data-collection) | no date carried |
+| [OpenRouter Trust Center](https://trust.openrouter.ai/) | **no date carried** |
+| [OpenAI Sub-processor list](https://openai.com/policies/sub-processor-list/) | Last updated **July 9, 2026** |
+| [Enterprise privacy at OpenAI](https://openai.com/enterprise-privacy/) | Updated **January 8, 2026** |
+| [Data controls in the OpenAI platform](https://developers.openai.com/api/docs/guides/your-data) | no date carried |
+
+**Note the weight of the evidence, again.** The two sub-processor lists
+that a README would cite for Anthropic and OpenAI carry dates. **The
+Anthropic one does not** — the Vanta-hosted page has no last-updated
+marker anywhere in its rendered text, which is worse than OpenAI's
+dated list and worse than OpenRouter's dated one. And the single most
+load-bearing OpenAI page, the data-controls guide, still carries no date.
+
+### The behaviour this is read against
+
+From [`ai_model_catalogue.dart`](../lib/core/utils/ai_model_catalogue.dart),
+verified in source today:
+
+- Direct path: `claude-haiku-4-5`, served by Anthropic.
+- OpenRouter path: `anthropic/claude-sonnet-5` and
+  `anthropic/claude-haiku-4.5`, both with `providers: ['anthropic']` —
+  the `provider.only` pin, fallbacks off.
+- One stateless request, no history, no account, no app-added identifier.
+- A meal photo is WebP, longest edge 1024 px, held in memory only.
+
+I confirmed the pin matters by listing OpenRouter's endpoints for both
+models. `anthropic/claude-sonnet-5` is currently offered by nine
+endpoints — Anthropic, three Amazon Bedrock regions, three Google Vertex
+regions and two Azure regions. **Without the pin, eight of the nine
+answers would come from a company with a different review regime and a
+different sub-processor list.** The pin is what makes the second layer of
+the OpenRouter answer reducible to Anthropic's.
+
+## A. What the question actually resolves to
+
+The three questions are not the same question and the providers answer
+them at different levels:
+
+1. **Does a person ever read it?** All three say or imply yes, under
+   conditions.
+2. **Whose person?** Anthropic: its own. OpenRouter: unstated, and its
+   list contains nobody who could be doing it. OpenAI: its own employees
+   *and* two named contractors.
+3. **Under what trigger?** Every disclosed trigger across all three is
+   **classifier-flag-driven**. No provider discloses review of all
+   traffic, and no provider discloses random sampling of content for
+   human eyes. OpenRouter samples prompts — but for categorisation, by a
+   model, with ZDR.
+
+That third answer is the reassuring one and it holds uniformly. The
+README can say, of all three, that review is conditional on an automated
+flag and is not routine.
+
+## B. Anthropic: review is internal, and nobody else is named
+
+### The disclosure exists, and here it is
+
+From [Data retention practices for Covered Models](https://privacy.claude.com/en/articles/15425996-data-retention-practices-for-covered-models)
+(9 July 2026), under the heading *"How we protect your data"*, quoted
+complete because the qualifiers are the substance:
+
+> By default, no Anthropic personnel can read your retained
+> conversations. Human review can occur only through a controlled access
+> path—for example, when content is flagged by our automated trust and
+> safety systems for potential harm. These reviews can only be performed
+> by a small set of approved reviewers. Every instance of access is
+> recorded in a tamper-proof log that reviewers cannot suppress or
+> modify. After 30 days, the data is deleted automatically, except in the
+> rare cases where it's been flagged by our automated trust and safety
+> systems or we're legally required to keep it.
+
+That is the clearest human-review statement any of the three providers
+publishes. **It is also the one with the most awkward scope.** The same
+article says, twice:
+
+> This change only applies to organizations that have set up workspaces
+> with zero data retention (ZDR) in Claude Console, use Claude Code with
+> ZDR in Claude Enterprise, or access Claude through AWS Bedrock, Google
+> Cloud Agent Platform, or Microsoft Foundry with ZDR. The rest of this
+> article applies only to these organizations.
+
+And the [Covered Models](https://support.claude.com/en/articles/15425695)
+page (1 July 2026) names the models: *"Claude Mythos 5"* and *"Claude
+Fable 5"*, and adds — this is the sentence that fences it —
+
+> Note: These policies apply only to the models listed on this page. All
+> other Claude models continue to operate under your existing agreement
+> and configured retention settings.
+
+**The app uses neither Covered Model.** So the best sentence Anthropic
+publishes about who may read content is formally addressed to traffic the
+app does not send. I do not think Anthropic operates two different
+reviewer pools, and the sentence reads as a description of how access
+control works generally. But **the README cannot quote it as a statement
+about this app's requests** without misrepresenting its scope, and this
+note will not pretend otherwise.
+
+The Covered Models page also carries the default, which *is* general in
+tone: *"Automated review by default. Retained data is assessed by
+automated safety systems designed to flag harmful content."*
+
+### What is scoped to ordinary API traffic
+
+From [How long do you store my organization's data?](https://privacy.claude.com/en/articles/7996866-how-long-do-you-store-my-organization-s-data)
+(1 July 2026), which *is* the commercial/API article:
+
+> For Anthropic API users, we automatically delete inputs and outputs on
+> our backend within 30 days of receipt or generation, except: … If we
+> need to retain them for longer to enforce our Usage Policy (UP)
+
+> We retain inputs and outputs for up to 2 years and trust and safety
+> classification scores for up to 7 years if your chat is flagged by our
+> automated trust and safety systems as violating our Usage Policy.
+
+And the [API and data retention](https://platform.claude.com/docs/en/manage-claude/api-and-data-retention)
+docs page, under *"Retention regardless of arrangement"*:
+
+> Even with ZDR or HIPAA arrangements in place, Anthropic may retain data
+> where required by law or where it has been flagged by Anthropic's
+> automated trust and safety systems. As a result, if a chat or session
+> is flagged, Anthropic may retain inputs and outputs for up to 2 years.
+
+**Two years is a longer retention than either other provider's default
+and it is the tail that matters.** OpenAI's flagged-content window is the
+30-day abuse-monitoring log plus *"reasonably necessary … from harm"*;
+Anthropic's is a stated two years with a stated seven-year tail on the
+classification scores. Neither of these sentences says a human reads the
+retained material. The purpose stated — *"to enforce our Usage Policy"* —
+does not happen without one.
+
+### Who, by name
+
+**Nobody, and that is established rather than assumed.** I read the whole
+of [trust.anthropic.com/subprocessors](https://trust.anthropic.com/subprocessors)
+from the rendered DOM. It lists **twenty** entities. The complete set that
+could conceivably involve a person reading customer content:
+
+| Entity | Purpose as stated | Location | Products |
+| --- | --- | --- | --- |
+| Intercom | User support | United States | All Products except Claude for Government |
+| Nutun | User support | South Africa | All Products except Claude for Government |
+| Boldr | User support | Canada | All Products except Claude for Government |
+| Sift | Fraud and abuse detection | United States | All products except Claude for Government |
+| Arkose Labs | Fraud and abuse detection | United States | All products except Claude for Government |
+| Persona | Fraud and abuse detection, identity verification | United States | Claude Free/Pro/Max |
+| Yoti | Fraud and abuse detection, identity verification | United Kingdom | Claude Free/Pro/Max |
+
+The remaining thirteen are Google Cloud Platform, Amazon Web Services,
+Microsoft Azure, Cloudflare (*"Traffic Routing (CDN)"*, *"Worldwide (Local
+to Customer)"*), Stripe, WorkOS, Twilio, Iterable, Sentry, Brave Search,
+ElevenLabs, TurboPuffer and Palantir Federal Cloud Service.
+
+**There is no "Moderation of content" row and no BPO with a content
+purpose.** The search terms that return nothing on the rendered page are
+`moderation`, `moderate`, `review`, `TaskUs`, `Accenture` and
+`Teleperformance`. Nutun and Boldr are business-process outsourcers of
+the same general kind OpenAI uses — but their stated purpose is *"User
+support"*, and Persona and Yoti are scoped to consumer plans, which the
+app never touches.
+
+**Two consequences for the README.** Anthropic's answer to *"who reads
+it"* is *"Anthropic"* — so the destination table's existing single-hop row
+for the Anthropic path stays accurate, with the addition of a named
+CDN sub-processor (Cloudflare) that the README already has to think about
+for the same reason it does on the OpenAI path. And a reader who wants
+the list has one link, [Schedule 4 of the DPA](https://www.anthropic.com/legal/data-processing-addendum)
+saying so in as many words: *"Anthropic's list of subprocessors is
+available at https://www.anthropic.com/subprocessors"* — which 302s to
+the Trust Center page.
+
+### The internal team is named, even though the vendors are not
+
+Anthropic names its own reviewers to the extent of naming the team. The
+[Usage Policy](https://www.anthropic.com/legal/aup) (effective 15
+September 2025):
+
+> Anthropic's Safeguards Team will implement detection and monitoring to
+> enforce our Usage Policy, so please review this policy carefully before
+> using our products or services.
+
+The [Transparency Hub](https://www.anthropic.com/transparency/system-trust-reporting)
+(last updated 23 July 2026) repeats it and puts numbers beside it:
+*"Anthropic's Safeguards Team designs and implements detections and
+monitoring to enforce our Usage Policy"*, with **11.4 million banned
+accounts**, **398k appeals** and **42k appeal overturns** for January–June
+2026. Forty-two thousand overturned bans is not a number a purely
+automated pipeline produces; somebody looked. And
+[Safeguards warnings and appeals](https://support.claude.com/en/articles/8241253-safeguards-warnings-and-appeals)
+(9 July 2026) says so directly: *"Our Safeguards team can further
+investigate why your account was disabled."* That is a person, at
+Anthropic, and the trigger is the user's own appeal.
+
+**What describes only the consumer products, and must not be reused.**
+[How does Anthropic protect the personal data of Claude users?](https://privacy.claude.com/en/articles/10458704-how-does-anthropic-protect-the-personal-data-of-claude-users)
+(16 March 2026) opens *"This article is about our consumer products such
+as Claude Free, Pro, Max"*, then says:
+
+> By default, Anthropic employees cannot access your conversations
+> unless: You explicitly consent to share your data with us as a part of
+> giving us feedback… Review is needed to enforce our Usage Policy. In
+> such cases, your conversation data is protected through strict access
+> controls– only designated members of our Trust & Safety team may access
+> this data on a need-to-know basis as a part of their evaluation
+> process.
+
+It is the most quotable sentence on the site and **it is about a product
+this app does not use.** The Privacy Policy is fenced the same way:
+*"This Privacy Policy does not apply to content that we process on behalf
+of customers of our business offerings."*
+
+## C. OpenRouter: two layers, and only one of them is OpenRouter's
+
+The ticket asks for these to be separated. They separate cleanly, and the
+answer is different at each layer.
+
+### Layer 1 — what OpenRouter itself does
+
+**OpenRouter publishes no statement, in either direction, about human
+review of routed content.** Established by reading the Privacy Policy (6
+July 2026), the Terms (29 July 2026), the Enterprise Access Agreement,
+the Data Collection docs page and the Provider Logging docs page end to
+end. The strings `human review` (other than the customer-duty capital
+letters), `manual review`, `moderation` and `moderator` return nothing
+about OpenRouter's own staff reading prompts. `subprocessor` and
+`sub-processor` appear **zero times** in the Privacy Policy and Terms;
+they appear only in the Enterprise agreement, which points at the
+separate list.
+
+What OpenRouter *does* say:
+
+**It does not keep content by default.** From
+[Data Collection](https://openrouter.ai/docs/guides/privacy/data-collection):
+
+> OpenRouter does not store your prompts or responses, *unless* you opt
+> in to one or both of the following
+
+— those being Input & Output Logging (*"OpenRouter does not access or use
+this data"*) and OpenRouter Use of Inputs/Outputs (a 1% discount). Both
+are off by default and the app enables neither.
+
+**The one sampling disclosure is explicitly machine-only**, and it is the
+closest thing on the site to a review practice:
+
+> Anonymous Input Categorization: OpenRouter samples a small number of
+> prompts for categorization to power our reporting and model ranking. If
+> you are not opted in to OpenRouter use of inputs/outputs, any
+> categorization of your prompts is stored completely anonymously and
+> never associated with your account or user ID. **The categorization is
+> done by model with a zero-data-retention policy.**
+
+That sample can include a meal line. It is a machine, it is anonymous,
+and the sub-processor list corroborates it: **Google Cloud Natural
+Language API — *"NLP Categorization"* — *"API Requests/Responses"* —
+USA.** A named third party does receive prompt content, and it is an API,
+not a room of people.
+
+**A right to screen is reserved without describing how it is exercised.**
+Terms §6.7:
+
+> We are under no obligation to edit or control Inputs that you or other
+> users post or publish, and will not be in any way responsible or liable
+> for Inputs. OpenRouter may, however, at any time and without prior
+> notice, screen, remove, edit, or block any Inputs that in our sole
+> judgment violates these Terms or is otherwise objectionable or illegal.
+
+*"In our sole judgment"* is a person's judgment on its face. But the
+clause is a reservation of rights, not a description of practice, and
+**no OpenRouter page says whether that judgment is ever exercised, by
+whom, or on what trigger.** The honest README sentence is *"OpenRouter
+does not say"*, not *"OpenRouter does not review"*.
+
+**Access is limited by contract to its own staff.** Enterprise Access
+Agreement (22 June 2026), in the data-processing part, §4.3 *Limitation
+of Access*: *"OpenRouter shall ensure that OpenRouter's access to
+Personal Data is limited to those personnel performing the Service in
+accordance with the Agreement."* §4.2 adds that OpenRouter *"shall take
+commercially reasonable steps to ensure the reliability of any OpenRouter
+personnel engaged in the Processing of Personal Data."* Both contemplate
+people; neither says what they do.
+
+**The sub-processor list contains no reviewer.** Twenty-four entities, last
+updated 9 January 2026. The three that touch prompt content are Google
+Cloud Natural Language API (*"NLP Categorization"*), **Upstash Inc.**
+(*"Database"*, personal data processed: *"Prompts & Completions"*, USA)
+and the catch-all row **"AI Model Providers — Large language model
+providers — API Requests/Responses — Various"**. Cloudflare and Google
+Cloud Platform carry *"All Customer Data"*. Customer support is Zendesk
+and Answer H.Q., processing *"User Accounts, Customer Support
+Interactions"* — not prompts.
+
+**A discrepancy worth flagging.** OpenRouter maintains a *second*
+sub-processor list, on its SafeBase trust centre at
+[trust.openrouter.ai](https://trust.openrouter.ai/), and the two disagree.
+That one has eighteen entries, names **OpenAI, Microsoft Azure and Google
+Cloud with the purpose *"Inference"***, adds four entities the other
+lacks (GitHub, Microsoft Azure, OpenAI, Pylon), omits nine it has
+(including Supabase, Attio, Airbyte, Hex and the whole *"AI Model
+Providers"* row) and gives Google Cloud Natural Language API no row of
+its own, and **carries no date**. Notably it does **not name
+Anthropic** — the vendor the app's traffic actually reaches. The
+`/authorized-sub-processors` page handles the same problem with the
+generic *"AI Model Providers … Various"* row. **Cite
+`/authorized-sub-processors`**: it is dated, it is the one the Enterprise
+Access Agreement incorporates as Schedule 3 (*"Available at
+https://openrouter.ai/authorized-sub-processors"*), and it does not
+mislead by naming three inference vendors and omitting a fourth.
+
+### Layer 2 — what the serving vendor does
+
+**Under the app's pin this reduces to Anthropic, and therefore to
+[Section B](#b-anthropic-review-is-internal-and-nobody-else-is-named).**
+Both curated OpenRouter models carry `providers: ['anthropic']` with
+fallbacks off. OpenRouter's own providers API confirms what that resolves
+to: the `anthropic` slug's `privacy_policy_url` is
+`https://www.anthropic.com/legal/privacy` and its `terms_of_service_url`
+is `https://www.anthropic.com/legal/commercial-terms` — Anthropic's own
+commercial regime, the same documents Section B reads.
+
+The Privacy Policy states the hand-off plainly:
+
+> Image, audio, and video data submitted through the Service is
+> transmitted to the applicable Model Provider for inference. … Model
+> Providers' retention practices vary; check the applicable provider's
+> data practices.
+
+**So the answer for the README's nested row is: adding OpenRouter adds a
+router, not a reviewer.** OpenRouter interposes itself, one named
+machine-categoriser and a set of infrastructure sub-processors; it does
+not interpose a human content reviewer, and it names none. The person who
+might read a flagged meal photo on the OpenRouter path is the same
+Anthropic person who might read it on the direct path.
+
+**Two caveats against over-claiming that.** First, "does not name one" is
+not "has none" — OpenRouter's disclosure is thinner than Anthropic's
+here, and the absence of a review clause is an absence of *disclosure*.
+Second, the reduction depends entirely on the pin holding. If a future
+model ships without `providers: ['anthropic']`, layer 2 becomes Amazon,
+Google or Microsoft and this section is void; the endpoint listing above
+shows eight of nine current endpoints for `claude-sonnet-5` are somebody
+else's.
+
+## D. OpenAI: the only provider that names names
+
+### The verification the ticket asked for
+
+Read in a browser against the live
+[Sub-processor list](https://openai.com/policies/sub-processor-list/),
+**last updated July 9, 2026**. The rows, transcribed exactly:
+
+| Entity Name | OpenAI Product or Service | Location of Processing | Purpose of Processing |
+| --- | --- | --- | --- |
+| **TaskUs, LLC** | API, ChatGPT Enterprise, ChatGPT Edu, ChatGPT Business | **Philippines** | All Services: Customer support · **API & ChatGPT Business: Moderation of content** · ChatGPT Enterprise, Edu & ChatGPT Business: Moderation of GPTs |
+| **Accenture International Limited** | API, ChatGPT Enterprise, ChatGPT Edu, ChatGPT Business | **United States, Canada, Philippines** | Customer support · **API & ChatGPT Business: Moderation of content** |
+| Cinder Technologies, Inc. | API\*, ChatGPT Enterprise, Edu, Business | United States | API & ChatGPT Business: **Platform for content moderation** |
+
+`*` on the Cinder row means *"Except where Zero Data Retention (ZDR) is
+used"*. **TaskUs and Accenture carry no such asterisk.**
+
+**The earlier note's claim survives, with a correction.** *"TaskUs and
+Accenture, in the Philippines"* understates Accenture's footprint: its
+row lists the United States and Canada as well. A README sentence should
+say *"the Philippines among them"* rather than *"in the Philippines"*, or
+name the locations per vendor.
+
+The page defines the trigger, and it is narrow:
+
+> **Moderation:** For content that OpenAI's models flag as being in
+> violation of OpenAI's policies, OpenAI may share samples of the flagged
+> Customer Content with relevant Sub-processors to assist OpenAI in its
+> review and enforcement. Sharing with the Sub-processor platform only
+> occurs when content is flagged, the Sub-processor platform only retains
+> samples of content for the period of review, and OpenAI's
+> Sub-processors only process the content to assist OpenAI in its review.
+
+Flag-triggered, sample-only, time-limited to the review, purpose-limited.
+That is a good disclosure and the README should not describe it as worse
+than it is.
+
+### OpenAI uses the phrase, structurally
+
+The [Enterprise privacy](https://openai.com/enterprise-privacy/) page
+(updated 8 January 2026) has a question titled *"Does OpenAI review my
+business data?"* — read in a browser:
+
+> We may run any business data submitted to OpenAI's services through
+> automated content classifiers and safety tools, including to better
+> understand how our services are used. The classifications created are
+> metadata about the business data but do not contain any of the business
+> data itself. Business data is only subject to human review as described
+> below on a service-by-service basis.
+
+And *"below"*, for the API specifically:
+
+> Our access to API business data stored on our systems is limited to (1)
+> authorized employees that require access for engineering support,
+> investigating potential platform abuse, and legal compliance and (2)
+> specialized third-party contractors who are bound by confidentiality
+> and security obligations, solely to review for abuse and misuse.
+
+Clause (2) plus the sub-processor list is the whole answer: the
+*"specialized third-party contractors"* are TaskUs and Accenture, and
+their locations are published.
+
+### And it prices the absence of review
+
+This is the finding that makes OpenAI's disclosure the most legible of
+the three: **OpenAI sells "not being read" as a distinct product feature,
+which means it has to define it.** From
+[Data controls](https://developers.openai.com/api/docs/guides/your-data):
+
+> **Eyes Off** … In this instance, customer content will be retained in
+> abuse monitoring logs, but such content will be excluded from **human
+> review** unless required by applicable law.
+
+> **Safety Retention** … In this instance, we may retain and **human
+> review** customer content when using these models that our classifiers
+> detect as potentially violating our Usage Policies or your agreement.
+
+**Read Eyes Off backwards and it says what the default is.** If being
+*"excluded from human review"* is a thing an approved customer can be
+given, then on the default path retained content is **not** excluded from
+human review. No other provider's documents let you make that inference
+so cleanly.
+
+## E. The three sub-processor lists
+
+The README's class sentence needs one link per provider. All three exist,
+all three were read today, and each is the one the provider's own
+contract points at.
+
+| Provider | Link | Incorporated by | Dated? |
+| --- | --- | --- | --- |
+| Anthropic | [trust.anthropic.com/subprocessors](https://trust.anthropic.com/subprocessors) | DPA Schedule 4 — *"Anthropic's list of subprocessors is available at https://www.anthropic.com/subprocessors"* (307s here) | **No** |
+| OpenRouter | [openrouter.ai/authorized-sub-processors](https://openrouter.ai/authorized-sub-processors) | Enterprise Access Agreement Schedule 3 — *"Available at https://openrouter.ai/authorized-sub-processors"* | Yes — 9 Jan 2026 |
+| OpenAI | [openai.com/policies/sub-processor-list](https://openai.com/policies/sub-processor-list/) | OpenAI Data Processing Agreement | Yes — 9 Jul 2026 |
+
+**Prefer `www.anthropic.com/subprocessors` in prose** if the README wants
+the URL the contract actually names; it redirects. Prefer the
+`trust.anthropic.com` form if the README wants the URL a reader lands on.
+Do **not** cite `trust.openrouter.ai` — see
+[Section C](#c-openrouter-two-layers-and-only-one-of-them-is-openrouters).
+
+## F. Images versus text
+
+**All three providers treat images differently from text, all three
+differences are about child-safety scanning, and only OpenAI's has a
+stated human consequence.**
+
+| | Anthropic | OpenRouter | OpenAI |
+| --- | --- | --- | --- |
+| Scanned on submission | Perceptual hash against NCMEC's database, plus *"detection classifiers"* | Not stated | CSAM classifier, *"upon submission"* |
+| On a hit | Report to NCMEC with *"information about the input and the related Account"*; the user or organization is notified | Not stated | *"the image will be retained for manual review"* |
+| Survives every retention control? | Flagged content survives ZDR (up to 2 years) | n/a | **Yes — explicitly, including Eyes Off** |
+| Any other image-specific rule | Images are *"ephemeral"* in the vision FAQ | Files not persisted *"except as required for abuse detection, security, billing, or legal compliance"* | Modified Abuse Monitoring excludes content *"other than image and file inputs in rare cases"* |
+
+Anthropic's mechanism, from [CSAM Detection and Reporting](https://support.claude.com/en/articles/9020328-csam-detection-and-reporting)
+(16 March 2026):
+
+> When an image is sent in an input to our services, we will calculate a
+> perceptual hash of the image. This hash will be automatically compared
+> against the database. In the case of a match, we will notify and
+> provide NCMEC information about the input and the related Account.
+
+Every meal photo on the Anthropic path is hashed. **The page says the
+comparison is automatic and does not say a person looks at a match before
+the report goes out.** The Transparency Hub's numbers show both paths
+running: 12,614 hash-matching CSAM reports and 2,018 from a *"Novel CSAM
+classifier"* in January–June 2026.
+
+OpenAI's, from Data controls, and this is the hardest sentence in the
+note:
+
+> Image and file inputs are scanned for CSAM content upon submission. If
+> the classifier detects potential CSAM content, the image will be
+> retained for manual review, even if Zero Data Retention, Modified Abuse
+> Monitoring, or Eyes Off is enabled.
+
+**On the OpenAI path a false positive on a photograph of dinner ends with
+a person looking at that photograph, and there is no configuration that
+prevents it.**
+
+### The tension inside Anthropic's own documents
+
+The README currently quotes Anthropic's vision FAQ, verified verbatim
+today from the page payload:
+
+> **Can I delete images I've uploaded?** No. Image uploads are ephemeral
+> and not stored beyond the duration of the API request. Uploaded images
+> are automatically deleted after they have been processed.
+
+Set that beside the API retention docs, also Anthropic's, also read
+today: *"if a chat or session is flagged, Anthropic may retain inputs and
+outputs for up to 2 years."* A meal photo is an Input. **The two
+sentences cannot both be unconditionally true, and the FAQ is the one
+without the qualifier.** House rule says quote the weaker text. This does
+not make the README's current sentence false — it is Anthropic's, quoted
+accurately, and the qualifier lives elsewhere — but a reader who takes
+"ephemeral" as absolute has been left with a wrong impression that
+Anthropic's own retention page corrects. **If the human-review row ships,
+this is the moment to attach the flagged-content exception to the
+ephemerality quote**, because the row will otherwise say a photo can be
+read while the paragraph above it says the photo no longer exists.
+
+## G. Is review avoidable?
+
+**No, on all three, for the app's actual user.** The routes and their
+gates:
+
+| Provider | The control | The gate | Reachable by a solo BYO-key developer? |
+| --- | --- | --- | --- |
+| Anthropic | Zero data retention | *"contact the Anthropic sales team"*; *"ZDR is enabled per organization"* | **No** — and it would not help: flagged content is retained *"regardless of arrangement"* for up to 2 years |
+| OpenRouter | Nothing to configure at layer 1; ZDR enforcement at layer 2 | Self-serve, per-request or per-account | **The ZDR setting is reachable** — but it constrains *retention* by the serving vendor, not review, and Anthropic's flag-triggered retention survives it |
+| OpenAI | Eyes Off | Presupposes approval for ZDR or Modified Abuse Monitoring, which are *"subject to prior approval by OpenAI and acceptance of additional requirements"* | **No** — and it does not cover images regardless |
+
+**The OpenRouter row is the interesting one and it is a genuine, if
+narrow, difference.** OpenRouter's ZDR enforcement is a self-serve
+account or per-request setting — *"You can enforce ZDR globally, per model
+group, per guardrail, or per request"* — with no sales conversation. That
+is a control the app's user can actually reach, and it is one the direct
+Anthropic path does not offer. But it routes to vendor endpoints that
+carry a ZDR policy; it does not exempt anyone from classifier flagging,
+and Anthropic's *"Retention regardless of arrangement"* clause tells you
+what happens next. **It is not an escape from review and the app should
+not present it as one.**
+
+The general finding, stated as the ticket asked: **human review on all
+three providers is triggered by an automated classifier, and no provider
+offers the app's user a setting, tier or contract that turns the
+classifier off.** [`ai-openai-data-handling.md`](ai-openai-data-handling.md)
+found ZDR unreachable for an individual on OpenAI; review is worse than
+that, because even the customers who *can* reach ZDR do not escape it on
+images.
+
+## What the README can now say
+
+Stated as sentences, because the point is a claim a sceptic can check:
+
+1. **The human-review row can ship for all three.** Anthropic: reviewed
+   by Anthropic staff, no vendor named or listed. OpenRouter: no
+   disclosure at the broker layer, and under the pin the reviewer is the
+   serving vendor's — Anthropic's. OpenAI: TaskUs and Accenture, with the
+   Philippines among the stated locations.
+2. **Say "publishes no statement" for OpenRouter, not "does not
+   review."** The distinction is the whole point of the ticket and the
+   README's credibility rests on it.
+3. **Say the trigger.** *"Only when an automated classifier flags the
+   content"* is true of all three and is the most reassuring true thing
+   available. Do not write it as "never" and do not write it as
+   "routinely".
+4. **The OpenRouter nested row stays a router row.** No third human
+   destination is added by going through the broker. What the broker adds
+   is Google Cloud Natural Language API on a sampled, anonymous,
+   model-only basis — arguably below the level the table describes, but
+   it is a named company that receives prompt text and the table's own
+   rule ([#696](https://github.com/simonoppowa/OpenNutriTracker/issues/696))
+   should be applied to it deliberately rather than by omission.
+5. **Attach the flagged-content exception to the ephemerality quote**, or
+   the two claims in the same paragraph will contradict each other.
+6. **All three sub-processor links are live and citable.** Anthropic's
+   is undated; if the README implies currency, that is worth a hedge.
+
+## Not established
+
+- **Whether Anthropic's Covered-Models review description applies to
+  ordinary API traffic.** It is the only place Anthropic writes *"human
+  review"* about its own staff and content, and it is fenced to two
+  models the app does not use. Anthropic publishes no equivalent sentence
+  scoped to `claude-haiku-4-5` or `claude-sonnet-5`. I read the API
+  retention docs, the commercial retention article, the DPA, the
+  Commercial Terms, the Trust Center FAQ and the Usage Policy looking for
+  one; the nearest is the DPA's *"Anthropic will ensure that each person
+  it authorizes to process Customer Personal Data is subject to an
+  appropriate duty of confidentiality"*, which contemplates persons
+  without describing when they read anything.
+- **The contents of Anthropic's white paper on exactly this subject.**
+  *[Anthropic] Security and Privacy Design of Anthropic Data Retention
+  and Review* is listed publicly on the Trust Center under *Best
+  Practices and Whitepapers*, marked **View** rather than *Request
+  access* — so it is not NDA-gated. **The Vanta document viewer did not
+  render in my headless browser and I could not read it.** It is at
+  [trust.anthropic.com/resources](https://trust.anthropic.com/resources?s=7ksqkied5hn0pocsj206m&name=%5Banthropic%5D-security-and-privacy-design-of-anthropic-data-retention-and-review).
+  **This is the single most likely document to change or sharpen Section
+  B, and someone with a real browser should read it before the row
+  ships.**
+- **Whether OpenRouter has ever exercised the §6.7 screening right, or
+  how.** Reserved in the Terms, never described. No transparency report,
+  no enforcement statistics, no appeals process documented.
+- **Whether Nutun or Boldr ever see Anthropic customer content.** Their
+  stated purpose is *"User support"*, which on OpenAI's list is defined
+  as initiated by the customer — but **Anthropic's list carries no such
+  definition of purposes.** The page gives entity, purpose and location
+  and nothing else. A support ticket that includes a pasted prompt is the
+  obvious way content reaches a support vendor on any platform; nothing
+  on Anthropic's page addresses it either way.
+- **The date of Anthropic's sub-processor list.** None is carried
+  anywhere in the rendered page. There is an *Updates* tab on the Trust
+  Center that I did not enumerate.
+- **Why OpenRouter's two sub-processor lists disagree**, and which
+  governs. The Enterprise agreement incorporates the
+  `/authorized-sub-processors` one, so that is the contractual list; the
+  SafeBase one is presented to security reviewers. Neither page
+  acknowledges the other.
+- **Whether Anthropic's perceptual-hash match is reviewed by a person
+  before the NCMEC report.** The page says the comparison is automatic
+  and that a match produces a notification; it does not say whether
+  anyone looks first. OpenAI's equivalent says *"retained for manual
+  review"* in as many words. **The difference in wording is real; whether
+  the difference in practice is real cannot be established from the
+  pages.**
+- **Whether the EU DSA transparency reporting Anthropic publishes
+  discloses human-moderator headcounts.** It exists — *"Anthropic
+  publishes transparency reports in accordance with its obligations under
+  the EU Digital Services Act (DSA) for certain features of Claude.ai"* —
+  and the DSA requires disclosure of human resources dedicated to content
+  moderation. **It is scoped to claude.ai features, not the API**, so it
+  was not pursued. It may nonetheless be the only public source naming
+  how many people Anthropic has doing this work.
+- **What any of the three do with a request that errors, is rejected by a
+  classifier before inference, or is truncated.** Not addressed anywhere
+  I looked, on any of the three.
+- **Legal advice.** One non-lawyer reading published documents on one
+  date. Two of the most load-bearing pages here — Anthropic's
+  sub-processor list and OpenAI's data-controls guide — carry no date and
+  can change silently.
+
+## Sources
+
+Anthropic:
+[Privacy Policy](https://www.anthropic.com/legal/privacy) ·
+[Commercial Terms of Service](https://www.anthropic.com/legal/commercial-terms) ·
+[Data Processing Addendum](https://www.anthropic.com/legal/data-processing-addendum) ·
+[Usage Policy](https://www.anthropic.com/legal/aup) ·
+[Subprocessor List](https://trust.anthropic.com/subprocessors) ·
+[Trust Center FAQ](https://trust.anthropic.com/faq) ·
+[API and data retention](https://platform.claude.com/docs/en/manage-claude/api-and-data-retention) ·
+[Vision documentation](https://platform.claude.com/docs/en/build-with-claude/vision) ·
+[How long do you store my organization's data?](https://privacy.claude.com/en/articles/7996866-how-long-do-you-store-my-organization-s-data) ·
+[Data retention practices for Covered Models](https://privacy.claude.com/en/articles/15425996-data-retention-practices-for-covered-models) ·
+[Covered Models](https://support.claude.com/en/articles/15425695) ·
+[Our Approach to User Safety](https://support.claude.com/en/articles/8106465-our-approach-to-user-safety) ·
+[CSAM Detection and Reporting](https://support.claude.com/en/articles/9020328-csam-detection-and-reporting) ·
+[Safeguards warnings and appeals](https://support.claude.com/en/articles/8241253-safeguards-warnings-and-appeals) ·
+[API Safeguards Tools](https://support.claude.com/en/articles/9199617-api-safeguards-tools) ·
+[How does Anthropic protect the personal data of Claude users?](https://privacy.claude.com/en/articles/10458704-how-does-anthropic-protect-the-personal-data-of-claude-users) ·
+[Transparency Hub](https://www.anthropic.com/transparency/system-trust-reporting)
+
+OpenRouter:
+[Privacy Policy](https://openrouter.ai/privacy) ·
+[Terms of Service](https://openrouter.ai/terms) ·
+[Enterprise Access Agreement](https://openrouter.ai/terms-of-service-enterprise) ·
+[Authorized Sub-Processors](https://openrouter.ai/authorized-sub-processors) ·
+[Trust Center](https://trust.openrouter.ai/) ·
+[Data Collection](https://openrouter.ai/docs/guides/privacy/data-collection) ·
+[Provider Logging](https://openrouter.ai/docs/guides/privacy/provider-logging) ·
+[Zero Data Retention](https://openrouter.ai/docs/guides/features/zdr) ·
+[Input & Output Logging](https://openrouter.ai/docs/guides/features/input-output-logging)
+
+OpenAI (`openai.com` read in a browser; the site 403s automated fetching):
+[Sub-processor list](https://openai.com/policies/sub-processor-list/) ·
+[Enterprise privacy](https://openai.com/enterprise-privacy/) ·
+[Data controls in the OpenAI platform](https://developers.openai.com/api/docs/guides/your-data)
+
+Related notes in this repo:
+[`ai-openai-data-handling.md`](ai-openai-data-handling.md) ·
+[`ai-openai-policy-fit.md`](ai-openai-policy-fit.md) ·
+[`ai-openai-key-transfer.md`](ai-openai-key-transfer.md) ·
+[`ai-legal-constraints.md`](ai-legal-constraints.md) ·
+[`ai-open-research-questions.md`](ai-open-research-questions.md)
+
+In-repo files cited:
+[`lib/core/utils/ai_model_catalogue.dart`](../lib/core/utils/ai_model_catalogue.dart) ·
+[`lib/features/add_meal/util/meal_photo_encoder.dart`](../lib/features/add_meal/util/meal_photo_encoder.dart)

--- a/docs/competitive-feature-gaps.md
+++ b/docs/competitive-feature-gaps.md
@@ -1,0 +1,320 @@
+# Competitive feature gaps
+
+Where OpenNutriTracker sits against mainstream calorie trackers, ranked by
+importance. Compiled 2026-08-08.
+
+## Research overview
+
+**Question:** which features do competing calorie trackers ship that
+OpenNutriTracker does not, and which of those actually matter?
+
+**Sources (triangulated):**
+
+| Source | What it gives | Limits |
+| :-- | :-- | :-- |
+| GitHub issue tracker — 49 open, ~300 closed, ranked by reaction count | Revealed demand from users who cared enough to file or vote | Skews technical; a reaction is a weak signal; silent users invisible |
+| The codebase itself (`lib/features/`, `pubspec.yaml`, `lib/core/utils/calc/`) | Ground truth on what exists | — |
+| Published 2026 feature/pricing comparisons of MyFitnessPal, Cronometer, MacroFactor, Yazio, Lose It!, and FOSS peers (Waistline, FoodYou) | Competitive parity baseline | Much of this genre is SEO content from rival apps; treated as directional, not authoritative |
+
+**No product analytics exist and that is deliberate** — there are no
+advertising or analytics SDKs in `pubspec.yaml`, and Sentry is opt-in. So
+there is no funnel data, no feature-usage data, and no churn data. Every
+frequency figure below is *issue-tracker frequency*, which is a proxy for
+demand, not a measurement of it. Findings are labelled with confidence
+accordingly.
+
+**Verified as already shipped** (candidate gaps that turned out not to be
+gaps — checked in code, not assumed):
+
+- Serving-size units rather than grams-only — `UnitDropdownItem.serving`,
+  `lib/features/meal_detail/presentation/bloc/meal_detail_bloc.dart:71`
+  (#34, merged in #391)
+- Copy an entry to another day, defaulting to the matching meal type —
+  `lib/features/diary/presentation/widgets/day_info_widget.dart:273`
+  (#67, #227)
+- Multi-profile with per-profile data — `switch_profile_usecase.dart`
+- Recent-intake ranking in search — `search_products_usecase.dart:147`
+- Micronutrients free (10 nutrients), which most competitors paywall
+
+---
+
+## Findings, ranked
+
+### 1. No health-platform integration (Apple Health / Health Connect)
+
+**Frequency:** highest signal in the tracker by a wide margin — 3 issues,
+~56 reactions combined. #103 (30 reactions, open since 2024-07-15) is the
+single most-reacted open issue in the repository. #147 (21) and #295 (5,
+closed) are duplicates of it.
+
+**Evidence:**
+
+> "the ability to import and export to and from a health app … This should
+> sync both ways, telling Apple Health what nutrients I am eating, and
+> receiving fitness information for workouts." — #103
+
+**State:** absent. No `health`, `pedometer`, or equivalent dependency in
+`pubspec.yaml`; no Health Connect permissions in the Android manifest.
+
+**Competitive position:** table stakes. MyFitnessPal, Cronometer, Yazio and
+Lose It! all sync bidirectionally with Apple Health / Health Connect, and
+several comparison pieces now treat wearable sync as a filter criterion
+before features are even compared.
+
+**Impact:** high, and structural rather than cosmetic. It blocks three
+things at once — (a) nutrition flowing out to the platform the user's other
+apps read, (b) active calories and steps flowing in, which is what powers
+the "you earned 300 kcal back" loop competitors have, and (c) weight and
+workouts arriving without double entry. Today a user with a watch logs
+their workout twice.
+
+**Tension to resolve deliberately:** this is the one high-demand feature
+that touches the privacy story. It is defensible — the data moves
+device-local to device-local, no server involved, and the permission is
+opt-in — but the Privacy section of the README currently promises "no
+health-data access", and that sentence would have to change.
+
+**Confidence:** high.
+
+---
+
+### 2. No F-Droid listing
+
+**Frequency:** second-highest signal — #126 (21 reactions, open since
+2024-11-10), #159 (14, closed), #575 (3, open). ~38 reactions.
+
+**State:** open. `docs/fdroid-submission-feasibility.md` exists, so the
+groundwork is underway.
+
+**Competitive position:** the FOSS peers this app competes with for the
+privacy-first audience — Waistline, FoodYou — are on F-Droid. Note that at
+least one third-party comparison already *claims* OpenNutriTracker is on
+F-Droid; the audience assumes it, which means the absence reads as a defect
+rather than a choice.
+
+**Impact:** high for the segment that is the app's core constituency. A
+user who avoids Google Play on principle currently cannot install this
+without side-loading a GitHub release. It is distribution, not a feature,
+but it gates reach for exactly the users most likely to stay.
+
+**Confidence:** high. Note this is reach, not retention — it will not
+change the experience of anyone already using the app.
+
+---
+
+### 3. No automatic backup or multi-device continuity
+
+**Frequency:** 5 distinct issues, low individual reaction counts — #79 (6),
+#166 (1), #86, #286, #585.
+
+**State:** manual only. Export produces a JSON zip (with CSV companions)
+that the user must remember to trigger and store somewhere. Import is a
+paste-a-blob flow. No scheduled export, no destination integration.
+
+**Competitive position:** every mainstream competitor syncs by account, so
+a lost or replaced phone is a non-event. Here it is total data loss unless
+the user exported recently.
+
+**Impact:** high severity, low frequency — it matters once, catastrophically.
+The user segment most likely to hit it (multi-year loggers with deep history)
+is also the most invested.
+
+**Design note:** the account-based answer is off the table by design, but
+the gap does not require an account. A scheduled encrypted export to a
+user-chosen destination (SAF / Files, iCloud Drive, WebDAV) closes most of
+the severity while keeping the "no account, no server" promise intact. #585
+asks for exactly this.
+
+**Confidence:** medium-high on the need, high on the severity.
+
+---
+
+### 4. No home-screen widgets, no watch app, no voice entry
+
+**Frequency:** 5 issues, minimal reactions — #192 (1), #579, #532, #533,
+#500. Low vote counts, but the cluster is consistent.
+
+**State:** absent. No widget targets in `android/` or `ios/`, no
+`home_widget` dependency.
+
+**Competitive position:** widgets and Apple Watch complications are
+standard across MyFitnessPal, Cronometer, Lose It! and Yazio, and are a
+scored category in 2026 comparison round-ups.
+
+**Impact:** medium-high, and it compounds. Logging friction is paid several
+times a day, every day, and abandonment in this category is usually death
+by friction rather than a single missing feature. A calories-left widget
+and a one-tap water widget are the two highest-leverage pieces.
+
+**Confidence:** medium — strong on competitive parity, weak on measured
+demand. This is the finding where the absence of usage analytics hurts most.
+
+---
+
+### 5. Calorie targets are static, not adaptive
+
+**Frequency:** zero user requests. This gap comes entirely from competitive
+analysis.
+
+**State:** `lib/core/utils/calc/tdee_calc.dart` computes a target from the
+IOM 2005 equations and profile inputs. It changes when the profile changes,
+plus an optional taper as goal weight approaches. It does not learn.
+
+**Competitive position:** this is MacroFactor's entire pitch, and its main
+claim over both MyFitnessPal and Cronometer, which are also static. An
+adaptive model reconciles logged intake against the observed weight trend
+and corrects the target weekly, which fixes the standard failure mode: the
+formula says 2,100 kcal, the user stalls for six weeks, and nothing in the
+app notices.
+
+**Impact:** high on outcomes, and it is the difference between an app that
+records and an app that works. Strategically it is unusually well suited
+here — it needs *only* data the app already holds locally (weight history
+and logged intake), costs nothing in privacy, requires no network, and is
+pure computation over existing Hive boxes.
+
+**Confidence:** medium. Strong reasoning, no direct user demand — nobody
+requests a feature they have not seen. Worth validating before building.
+
+---
+
+### 6. AI-assisted logging — a deliberate non-adoption, not an oversight
+
+**Frequency:** #250 (10 reactions, closed *researched-not-shipping*
+2026-05-15) plus #599–#602 open.
+
+**State:** decided against, with documented reasoning across
+`docs/ai-in-open-source-nutrition-trackers.md`,
+`docs/ai-legal-constraints.md` and `docs/ai-cohort-restrictions.md`. The
+closing argument: a model-estimated figure is "a model estimated this for
+you", not "this is from a database", which collides with the cited-sources
+guarantee — and #250 flags it as an App Store review risk for health apps,
+not merely an internal consistency question. #599–#602 pursue a
+*deterministic* text parser instead, which keeps provenance intact.
+
+**Competitive position:** MyFitnessPal (Meal Scan), Yazio (now branded "AI
+Calorie Tracker") and the Cal AI cohort all ship photo and natural-language
+logging. Independent benchmarking puts MyFitnessPal's photo recognition at
+71.2% identification accuracy with ±18% portion error — roughly one in four
+photos needing correction, which is a useful number to cite when explaining
+the choice.
+
+**Impact:** high on perceived modernity, low on actual utility at current
+accuracy. Listed here not as a recommendation to build but because it is
+the most visible feature difference a prospective user will notice, and the
+reasoning deserves to be public rather than buried in a closed issue.
+
+**Confidence:** high — the decision is documented and recent.
+
+---
+
+### 7. Micronutrient depth trails the specialist
+
+**Frequency:** no open requests. #237 (5) closed — the panel shipped.
+
+**State:** 10 nutrients (fibre, sodium, saturated fat, sugar, calcium,
+iron, potassium, vitamin D, B12, magnesium) with DRI reference bars.
+
+**Competitive position:** Cronometer tracks ~84 and is chosen specifically
+for that. OpenNutriTracker's 10 are free where competitors paywall theirs,
+which is the stronger card to play.
+
+**Impact:** medium, and confined to one segment. Broadening depends on
+source-data coverage more than UI work — USDA FoodData Central carries far
+more than 10 nutrients, Open Food Facts often does not.
+
+**Confidence:** medium.
+
+---
+
+### 8. Long tail — genuine but narrow
+
+| Gap | Evidence | Note |
+| :-- | :-- | :-- |
+| Recipe import from a URL | #503 (1) | Yazio and Lose It! paste-a-recipe-URL; needs parsing infrastructure |
+| Meal planning / forward scheduling | none filed | Yazio and EatThisMuch build plans; a different product posture — the app records the past, planning projects forward |
+| Favourites / pinned foods | none filed | No favourite mechanism in code; recent-intake ranking covers much of it |
+| Quick serving chips | #577 | Serving units shipped; this is the ergonomic follow-up |
+| Regional food databases | #263 (India), #105 (Brazil/TBCA) | Schema exists, data not loaded |
+
+---
+
+## Segments
+
+Three distinct users show up in the evidence, and they want different
+things — several findings above only matter to one of them.
+
+**The privacy refugee** — arrived from MyFitnessPal specifically to escape
+subscriptions and data collection. Dominant in the App Store and Play
+reviews quoted in the README ("Finally I don't have to sell my soul to
+MyFitnessPal"). Wants F-Droid (#2) and trustworthy backup (#3). Tolerates
+missing features; does not tolerate a privacy regression. **This segment is
+the reason to be careful with finding #1.**
+
+**The everyday logger** — wants the weight to move and does not care about
+the licence. Feels findings #1, #4 and #5 daily. Churns quietly to a
+competitor without filing an issue, which is precisely why this segment is
+under-represented in the reaction counts above.
+
+**The nutrition nerd** — here for micronutrients and citations. Best served
+today of the three; finding #7 is theirs.
+
+---
+
+## Recommendations, in order
+
+1. **Health Connect / Apple Health, read-write, opt-in.** The clearest
+   priority — highest demand by a wide margin, and it unblocks the
+   activity-adjustment loop rather than being a one-off. Ship it behind an
+   explicit toggle, default off, and update the README privacy table in the
+   same change. Start with Health Connect: #295 was already labelled
+   `backlog:high`, and the Android surface is the larger one.
+
+2. **Finish the F-Droid submission** (#575, #126). Feasibility work is
+   already written down. Highest reach-per-unit-effort item on the list,
+   and the audience already assumes it exists.
+
+3. **Scheduled encrypted backup to a user-chosen destination** (#585).
+   Closes the catastrophic-loss scenario without an account, a server, or a
+   change to the privacy story.
+
+4. **A calories-left home-screen widget, then a water widget** (#533, #532,
+   #579). Bounded work, daily payoff, and the two most-used numbers in the
+   app.
+
+5. **Prototype adaptive calorie targets** before committing. All required
+   data is already local. Validate against real weight-history data that
+   the correction is stable enough not to whipsaw a user's target
+   week-to-week — that is the failure mode, and it is worth a
+   `lib/core/utils/calc/` spike against seeded demo data first.
+
+6. **Publish the AI reasoning where prospective users will see it**, not
+   only in a closed issue. "We looked at this, here is the accuracy data,
+   here is why cited numbers matter more" is a stronger position than
+   silence, and it converts a perceived gap into a stated principle. The
+   71.2%/±18% benchmark is the concrete number to lead with.
+
+---
+
+## Open questions
+
+The honest limits of this analysis:
+
+- **No churn data.** Everything above ranks *stated* demand from people who
+  stayed long enough to file an issue. The users who installed, hit a
+  missing feature, and left are invisible. The single most valuable
+  follow-up would be a lightweight, opt-in exit survey on the store
+  listings — or reading the 1–3★ reviews systematically, which is the only
+  channel where dissatisfied non-filers speak.
+- **Is finding #4 real demand or my inference from competitor round-ups?**
+  Reaction counts are near zero. Worth asking directly in an issue before
+  investing.
+- **Would health sync cost trust with the privacy segment?** Findings #1
+  and #2 serve partly opposing audiences. This is answerable cheaply — ask
+  in #103, where 30 interested people are already subscribed.
+- **How much of the retention gap is missing features versus logging
+  friction?** These need different responses, and nothing in the current
+  evidence separates them.
+- **Micronutrient coverage per source is unmeasured.** Before expanding
+  finding #7, check what fraction of typical logged foods actually carry
+  values beyond the current 10.

--- a/docs/fdroid-submission-feasibility.md
+++ b/docs/fdroid-submission-feasibility.md
@@ -1,0 +1,409 @@
+# F-Droid submission: feasibility review of issue #575
+
+Research notes for [#575](https://github.com/simonoppowa/OpenNutriTracker/issues/575) ("Submit OpenNutriTracker to the F-Droid repository") and its parent [#126](https://github.com/simonoppowa/OpenNutriTracker/issues/126). Written against `feat/onboarding-rework` at version `2.0.2+61`, and against a shallow clone of [`fdroid/fdroiddata`](https://gitlab.com/fdroid/fdroiddata) at commit `b3626a167c61d17211c3be8e41a61a97c807ed5c` (2026-08-05). Every fdroiddata path below is relative to that repo.
+
+## Verdict
+
+**Blocked — but not on the thing the issue thread is worried about.**
+
+The `fdcApiKey` that surfaced in the #575 discussion is a nuisance, not a blocker. F-Droid's Inclusion Policy has an explicit line for it, there is a working precedent in the repo for the exact same USDA API, and — as it turns out — the key is wired to dead code in this app anyway.
+
+The actual blocker is **`mobile_scanner`**, which links `com.google.mlkit:barcode-scanning`. ML Kit is on F-Droid's non-free signature list with `"license": "NonFree"`, and fdroiddata's CI runs a binary scanner over the built APK that fails the pipeline when those classes are found. Barcode scanning is a headline feature of this app — it appears in `full_description.txt`, in the recipe builder, and in three separate import screens — so removing it is a product decision, not a packaging detail. That decision belongs to the maintainer, and #575 cannot be completed until it is made.
+
+A second, smaller decision is also maintainer-only: the Supabase project URL and anon key must be published in the clear in fdroiddata, or the F-Droid build ships with a food-search backend that does not work.
+
+Everything else — Flutter buildability, release identity, metadata reuse — is routine and well-precedented.
+
+---
+
+## 1. Inclusion Policy fit
+
+The [current Inclusion Policy](https://f-droid.org/docs/Inclusion_Policy/) has four relevant clauses. Quoting the ones that bite:
+
+> All binary dependencies including JAR files must originate either from source compilation or Debian repository downloads. Prebuilt binaries should only come from authorized trusted sources.
+
+> The implementation of proprietary tracking or advertising libraries and analytics tools such as Google Play Services and Firebase and Crashlytics and proprietary ad/tracking SDKs are strictly forbidden in all applications. Upstream developers must implement either a FLOSS alternative or a build flavour that does not require these dependencies when such features become necessary.
+
+> Non-functional assets including artwork and fonts can utilize less restrictive licenses which include game art specific to the project but must allow redistribution when using non-commercial licenses.
+
+> The application should be functional and implement all the features described in the description.
+
+I enumerated every hosted package in `pubspec.lock` (212 entries), resolved each against the local pub cache, and grepped its `android/**/*.gradle*` and `AndroidManifest.xml` files for Google/Firebase/GMS coordinates. Then I tested each hit against F-Droid's actual scanner signature database, [SUSS](https://fdroid.gitlab.io/fdroid-suss/suss.json), which `fdroidserver/scanner.py` loads at runtime (`scanner.py:553`).
+
+| Finding | Where | Verdict |
+| --- | --- | --- |
+| `mobile_scanner` 7.2.0 → `com.google.mlkit:barcode-scanning:17.3.0` | `pubspec.yaml`, `pubspec.lock:983`; [`mobile_scanner@v7.2.0 android/build.gradle:60`](https://github.com/juliansteenbakker/mobile_scanner/blob/v7.2.0/android/build.gradle#L60) | **Hard blocker** |
+| `sentry_flutter` → sentry.io crash reporting | `pubspec.yaml`, `lib/main.dart:152` | Anti-feature discussion (`Tracking`) |
+| `supabase_flutter` → maintainer's managed Supabase project | `lib/core/utils/locator.dart:142-146` | Anti-feature flag (`NonFreeNet` and/or `TetheredNet`) |
+| Bundled Unsplash demo photos | `assets/demo/`, `lib/core/utils/demo/unsplash_attribution.dart` | Anti-feature risk (`NonFreeAssets`) |
+| `dynamic_color` → `com.google.android.material` | pub cache scan | Pass (Apache-2.0, not in SUSS) |
+| `flutter_local_notifications` → `com.google.code.gson` | pub cache scan | Pass (Apache-2.0, not in SUSS) |
+| `flutter_secure_storage` → `com.google.crypto.tink:tink-android` | pub cache scan | Pass (Apache-2.0, not in SUSS) |
+| `image_picker_android` manifest `com.google.android.gms.metadata.ModuleDependencies` | pub cache scan | Probably pass — see below |
+| No Firebase, no Crashlytics, no Play Services SDK, no ad SDK anywhere in the tree | full pub cache scan | Pass |
+| Android manifest permissions: `INTERNET`, `RECEIVE_BOOT_COMPLETED`, `POST_NOTIFICATIONS` (+ `CAMERA` merged in from `mobile_scanner`) | `android/app/src/main/AndroidManifest.xml` | Pass — fdroiddata CI reports permissions at `info` severity only |
+| License GPL-3.0, `LICENSE` at repo root, fonts under `fonts/OFL.txt` | `LICENSE`, `README.md:253` | Pass |
+
+### The ML Kit blocker in detail
+
+SUSS carries an entry for ML Kit:
+
+```json
+"com.google.mlkit": {
+  "code_signatures": ["com/google/mlkit"],
+  "gradle_signatures": ["com.google.mlkit", "io.github.g00fy2.quickie"],
+  "license": "NonFree",
+  "name": "ML Kit"
+}
+```
+
+That signature is loaded into `err_gradle_signatures` and `err_code_signatures` (`fdroidserver/scanner.py:624-638`). The gradle half fires during `scan_source` on any `.gradle`/`.gradle.kts` file (`scanner.py:1067`) — which the plugin's own `android/build.gradle` inside `.pub-cache` would trip. That half can technically be worked around with `scandelete`. The code half cannot: `scan_binary` walks the built APK's dex classes and has no ignore mechanism at all (`scanner.py:665-680`), and fdroiddata's own pipeline runs it with `--exit-code` and turns every found class into a `critical` code-quality report:
+
+```yaml
+fdroid scanner --verbose --exit-code $file 2>&1 | tee result || {
+  export EXITVALUE=1;
+  for class in $(sed -n "s/.*DEBUG: Problem: found class '\(.*\)'/\1/p" result); do
+    printf "\x1b[31mERROR Found $class in $file\x1b[0m\n";
+```
+
+(`fdroiddata/.gitlab-ci.yml`, "binary scanner" section.)
+
+Two apps in fdroiddata use `mobile_scanner` upstream, and **both** strip it for F-Droid rather than shipping it:
+
+- `metadata/info.zverev.ilya.every_door.yml:375` — `sed -i -e 's/^#f\|^ *mobile_scanner.*$//' pubspec.yaml`, then `mv lib/fields/helpers/qr_code.dart.fdroid lib/fields/helpers/qr_code.dart`. The `.fdroid` variant file is shipped by *upstream* (it exists in `Zverik/every_door` at `lib/fields/helpers/qr_code.dart.fdroid`).
+- `metadata/com.nfcarchiver.banana_split.yml:28` — `sed -i -e '/mobile_scanner/d' pubspec.yaml`, then `mv lib/widgets/shard_scanner.dart.fdroid lib/widgets/shard_scanner.dart`, plus a separate `pubspec.lock.fdroid`.
+
+So the established pattern is: upstream ships a parallel `.fdroid` source file and a stripped lockfile, and the recipe swaps them in. This app would need the same, across every scanner entry point — `lib/features/scanner/scanner_screen.dart`, `lib/features/recipes/presentation/screens/import_recipe_scanner_screen.dart`, `lib/features/home/presentation/screens/import_meal_scanner_screen.dart`, and `lib/features/home/presentation/screens/import_activity_scanner_screen.dart`.
+
+That is not a trivial `sed`. It touches the QR-import path for meals, activities, and recipes, which is a documented export/import feature, and the barcode path, which `full_description.txt` advertises in two bullets ("Search, scan, or add straight as a number" and the whole "📷 Barcode scanner" line). The Inclusion Policy's quality bar — "The application should be functional and implement all the features described in the description" — means the F-Droid description would have to be trimmed to match a scanner-less build.
+
+**The alternative is to replace `mobile_scanner` with a FOSS scanner for all builds.** `flutter_zxing` is MIT-licensed, wraps the ZXing C++ library through FFI/CMake, and pulls no Google dependency ([LICENSE](https://github.com/khoren93/flutter_zxing/blob/main/LICENSE), [android/build.gradle](https://github.com/khoren93/flutter_zxing/blob/main/android/build.gradle) — CMake `externalNativeBuild`, no `implementation 'com.google...'` line). It already builds in fdroiddata: `metadata/business.braid.polycule.yml:50` uses it, with one reproducibility workaround worth copying (`add_link_options("LINKER:--build-id=none")` injected into its `CMakeLists.txt`). Swapping the dependency wholesale is more work up front but removes the fork-maintenance burden of `.fdroid` variant files forever, and it would let the F-Droid listing carry the same feature set and the same description as everywhere else.
+
+### The lesser flags
+
+**Sentry.** `sentry_flutter` is itself FLOSS and is not in SUSS, so the scanner will not object. But `sentry.io` is a proprietary network service and F-Droid routinely attaches `Tracking` for it — `metadata/com.infomaniak.drive.yml:1-6` reads:
+
+```yaml
+AntiFeatures:
+  Tracking:
+    en-US: Uses Sentry for analytics, which is enabled by default.
+```
+
+This app is in a better position than kDrive: Sentry only initialises when `kReleaseMode && hasAcceptedAnonymousData` (`lib/main.dart:114-120`), so it is opt-in and default-off. A reviewer may accept that without a flag; I could not find a policy sentence that settles it either way, so expect a conversation. If it becomes contentious, the clean fix is the same one kDrive uses — strip Sentry in the recipe (`sed -i -e '/sentry/d'`) and ship the F-Droid build without crash reporting.
+
+**Supabase.** The app initialises Supabase unconditionally at startup and routes the entire "Food" search tab through it (`lib/features/add_meal/data/data_sources/sp_food_data_source.dart`). The backend code is open (`OpenNutriTracker-Backend`) but the instance is a single managed Supabase cloud project run by the maintainer — see `docs/supabase-self-hosting.md`. That maps to `TetheredNet` ("depends entirely on a certain instance of a network service") and arguably `NonFreeNet` per the [Anti-Features list](https://f-droid.org/docs/Anti-Features/). `metadata/info.zverev.ilya.every_door.yml:1-7` carries both for less than this. Expect at least one of them. It is a label, not a rejection.
+
+**Unsplash demo assets.** `assets/demo/meals/` and `assets/demo/alex_demo_avatar.jpg` ship JPEGs under the [Unsplash License](https://unsplash.com/license), which grants copy/modify/distribute rights but adds a field-of-use carve-out: "This license does not include the right to compile images from Unsplash to replicate a similar or competing service." A field-of-use restriction fails DFSG §6 and OSD §6, so these are not free assets. The Inclusion Policy is lenient here — non-functional assets only "must allow redistribution" — so this is unlikely to block inclusion, but it is a plausible `NonFreeAssets` flag and the reviewer will ask. Worth pre-empting in the MR description.
+
+**`image_picker_android`.** Its manifest declares `<meta-data android:name="com.google.android.gms.metadata.ModuleDependencies">` for the Android Photo Picker module. SUSS's `com.google.android.gms` entry would match that string, but the gradle scan only reads `.gradle`/`.gradle.kts` files and only lines that look like Gradle dependency declarations (`scanner.py:1067`, `is_used_by_gradle_without_catalog`), and the binary scan matches dex *class* names, not manifest attributes. I believe this is a non-issue; I did not find a fdroiddata app that had to strip `image_picker` for it, which supports that reading, but I have not verified it against an actual scanner run.
+
+---
+
+## 2. The API key problem
+
+Short answer: **the API key is not the blocker, and for `FDC_API_KEY` specifically it is not even needed at runtime.**
+
+### Where the key enters the build
+
+`lib/core/utils/env.dart` declares four compile-time secrets through [`envied`](https://pub.dev/packages/envied):
+
+```dart
+@Envied(path: '.env')
+abstract class Env {
+  @EnviedField(varName: 'FDC_API_KEY', obfuscate: true)
+  static final String fdcApiKey = _Env.fdcApiKey;
+  @EnviedField(varName: 'SENTRY_DNS', obfuscate: true)
+  static final String sentryDns = _Env.sentryDns;
+  @EnviedField(varName: 'SUPABASE_PROJECT_URL', obfuscate: true)
+  static final String supabaseProjectUrl = _Env.supabaseProjectUrl;
+  @EnviedField(varName: 'SUPABASE_PROJECT_ANON_KEY', obfuscate: true)
+  static final String supabaseProjectAnonKey = _Env.supabaseProjectAnonKey;
+}
+```
+
+`env.g.dart` is gitignored (`.gitignore`, "# API Keys" block), so `dart run build_runner build` must regenerate it, and it needs a `.env`. That is exactly what the contributor hit.
+
+The failure mode is worth being precise about, because it determines the fix. `requireEnvFile` defaults to `false` (`envied_generator-1.3.8/lib/src/generator.dart:93-94`), so a *missing* `.env` is silently tolerated. What actually throws is `allowOptionalFields` also defaulting to false: any field whose variable resolves to null raises `Environment variable not found for field ...` (`envied_generator-1.3.8/lib/src/generate_field.dart:28-33`). So the build needs a `.env` containing all four keys with *some* value. It does not need real ones to compile.
+
+The repo already knows this. `.github/workflows/default_workflow.yml:40-47` writes a stub for every CI job:
+
+```yaml
+- name: Generate stub .env for CI
+  uses: ./.github/actions/write-env-file
+  with:
+    fdc_api_key: ci-stub
+    sentry_dns: https://stub@sentry.io/0
+    supabase_project_url: https://stub.supabase.co
+    supabase_project_anon_key: ci-stub
+```
+
+### What F-Droid does about secrets
+
+The Inclusion Policy is explicit:
+
+> F-Droid does not sign up for any API keys. Even if provided by a third party, we include them in both binary and source code releases.
+
+So there is no secret store, no CI variable, no mechanism. Either the upstream developer supplies the value and it is committed in the clear to the public `fdroiddata` metadata, or the build gets a dummy. There is nothing in between.
+
+That is not theoretical. **`metadata/com.flasskamp.energize.yml` — a Flutter nutrition tracker already in F-Droid, using the same USDA FoodData Central API — writes a literal USDA key into `.env` inside the recipe** (`metadata/com.flasskamp.energize.yml:470`, repeated in every one of its 33 build blocks):
+
+```yaml
+build:
+  - export PUB_CACHE=$(pwd)/.pub-cache
+  - echo "API_KEY_USDA='...'" > .env
+  - echo "COPYRIGHT_NAME='Christian Flaßkamp'" >> .env
+  ...
+  - submodules/flutter/bin/flutter pub run build_runner build --delete-conflicting-outputs
+  - submodules/flutter/bin/flutter build apk --split-per-abi --target-platform="android-arm"
+```
+
+This is the precedent to point the contributor at. It is a near-exact template for OpenNutriTracker's problem, from the same domain.
+
+Note also that `obfuscate: true` gives no protection here. `envied`'s obfuscation is a compile-time XOR against a generated key list, both of which are embedded in `env.g.dart` and therefore in the APK. Anyone who wants the values from an existing Play Store or GitHub build already has them.
+
+### Does the key matter at runtime?
+
+**`FDC_API_KEY`: no.** The direct FoodData Central client is dead code in 2.x. `FDCDataSource.fetchSearchWordResults` is the only reader of `Env.fdcApiKey` (`lib/features/add_meal/data/data_sources/fdc_data_source.dart:19`). It is reached only via `ProductsRepository.getFDCFoodsByString` (`lib/features/add_meal/data/repository/products_repository.dart:105`), and a repo-wide grep finds **zero callers** of that method. The FDC tab now goes through Supabase — `SearchProductsUseCase.searchFDCFoodByString` calls `_productsRepository.getSupabaseFoodsByString` (`lib/features/add_meal/domain/usecase/search_products_usecase.dart:71-86`). `FDCDataSource` is still registered in the locator (`lib/core/utils/locator.dart:527`) and injected into `ProductsRepository`, which is why it still compiles and still forces the key.
+
+A stub `FDC_API_KEY` therefore costs the F-Droid build nothing. (Separately: this looks like genuine dead code that could just be deleted, which would remove the whole question. That is out of scope for #575 but worth raising.)
+
+**`SUPABASE_PROJECT_URL` / `SUPABASE_PROJECT_ANON_KEY`: yes, critically.** `Supabase.initialize` runs unconditionally during `initLocator` (`lib/core/utils/locator.dart:142-146`), and the entire multi-source food database — USDA, BLS, and the localized translation table — is served from it. With stub values, the "Food" tab returns nothing on every query. Open Food Facts still works: `OFFDataSource` sends only a User-Agent and no key (`lib/features/add_meal/data/data_sources/off_data_source.dart:90`). So a stubbed F-Droid build degrades to *OFF-only search* — usable, but visibly worse than the Play/GitHub build, and half of what `full_description.txt` promises.
+
+Failure is graceful, at least: `SearchProductsUseCase._safeRemoteCall` catches and returns an empty list, and `SpFoodDataSource` retries and then errors into the same path. The app will not crash; it will just find nothing.
+
+**`SENTRY_DNS`: no.** A stub DSN is fine — the Sentry client is only constructed under opt-in consent, and a build with a dud DSN simply drops events.
+
+### So the decision is
+
+The maintainer must choose, and only the maintainer can:
+
+1. **Publish the Supabase URL + anon key in the fdroiddata recipe.** Both are already in every shipped APK, and the anon key is designed to be public (row-level security is the boundary, not secrecy). This is what Energize did with its USDA key. Cost: the values become greppable in a public GitLab repo, which raises the odds of scripted abuse against the free-tier Supabase project.
+2. **Ship stubs and accept an OFF-only F-Droid build.** Cost: a materially worse app on F-Droid, plus a description that has to be rewritten to match.
+
+Option 1 is the right call, but it is a hosting-cost and abuse-surface question, not an engineering one.
+
+---
+
+## 3. Flutter buildability in fdroiddata
+
+F-Droid builds a lot of Flutter — 482 of the 8,987 metadata files mention it. There is no magic; recipes are hand-written `prebuild:`/`build:` shell.
+
+### How the Flutter SDK gets in
+
+Two conventions, both in wide use:
+
+- **`srclibs: - flutter@<ref>`.** `srclibs/flutter.yml` is one line — `RepoType: git` / `Repo: https://github.com/flutter/flutter.git` — and the ref after `@` is checked out. Across fdroiddata: `flutter@stable` appears 3,434 times, with pinned tags (`flutter@3.3.2`, `flutter@3.10.6`, …) making up most of the rest. The SDK is then referenced as `$$flutter$$/bin/flutter`.
+- **An upstream git submodule**, with `submodules: true`. This is what the contributor's example and Energize do.
+
+The contributor named `metadata/studip_uni_passau.femtopedia.de.unipassaustudip.yml`. Its structure, quoted in full for the build section:
+
+```yaml
+Builds:
+  - versionName: 2.1.3
+    versionCode: 213
+    commit: 9dd94328ca0d4df137c826a11e7d6db43c924c41
+    submodules: true
+    sudo:
+      - mkdir -p /home/runner/work/studipassau
+      - chown -R vagrant /home/runner
+    output: build/app/outputs/flutter-apk/app-release.apk
+    rm:
+      - ios
+    prebuild:
+      - export repo=/home/runner/work/studipassau/studipassau
+      - cd ..
+      - mv studip_uni_passau.femtopedia.de.unipassaustudip $repo
+      - pushd $repo
+      - export PUB_CACHE=$(pwd)/.pub-cache
+      - .flutter/bin/flutter config --no-analytics
+      - .flutter/bin/flutter pub get --enforce-lockfile
+      - popd
+      - mv $repo studip_uni_passau.femtopedia.de.unipassaustudip
+    scanignore:
+      - .flutter/bin/cache
+    scandelete:
+      - .flutter
+      - .pub-cache
+    build:
+      - export repo=/home/runner/work/studipassau/studipassau
+      - cd ..
+      - mv studip_uni_passau.femtopedia.de.unipassaustudip $repo
+      - pushd $repo
+      - export PUB_CACHE=$(pwd)/.pub-cache
+      - .flutter/bin/dart run intl_utils:generate
+      - .flutter/bin/dart run build_runner build
+      - .flutter/bin/flutter build apk --release
+      - popd
+      - mv $repo studip_uni_passau.femtopedia.de.unipassaustudip
+
+AllowedAPKSigningKeys: f17448cfb1bd29bc4b29932de068feab87175654dfac0e1a48605f2aeecebaef
+AutoUpdateMode: Version
+UpdateCheckMode: Tags
+UpdateCheckData: pubspec.yaml|version:\s.+\+(\d+)|.|version:\s(.+)\+
+```
+
+Three things to read out of it. The `.flutter` submodule is upstream's SDK pin. The `mv`-into-`/home/runner/work/...`-and-back dance exists purely to make the build path match upstream's GitHub Actions working directory — [Reproducible Builds](https://f-droid.org/docs/Reproducible_Builds/) names this explicitly: "Embedded build paths are a source of reproducibility issues affecting apps built with e.g. Flutter". And it runs `dart run build_runner build`, so codegen in the recipe is normal and expected.
+
+Note this app has **no** Flutter submodule. `.fvmrc` pins `{"flutter": "3.44.6"}`, which FVM understands and F-Droid does not. Tag `3.44.6` does exist in `flutter/flutter` (`ee80f08bbf97172ec030b8751ceab557177a34a6`), so `srclibs: - flutter@3.44.6` is the right translation. Keeping it in sync with `.fvmrc` is manual, per release.
+
+The Inclusion Policy blesses the prebuilt SDK explicitly: "The Android SDK, Flutter SDK and Hermes have permission to use official prebuilt binaries until Debian provides alternative solutions" — which is why `scanignore: <flutter>/bin/cache` is the standard incantation.
+
+### What makes this repo's build non-trivial
+
+**Flavors.** `android/app/build.gradle` defines a `version` dimension with `develop` (`applicationIdSuffix ".develop"`) and `full` (no suffix). There is no default, so the recipe must pass `--flavor full` — which is what the release job does (`.github/workflows/default_workflow.yml:850`). This also changes the output path: Gradle writes `build/app/outputs/apk/full/release/app-release.apk` (renamed by the `applicationVariants.all` block), while Flutter's post-build copy lands at `build/app/outputs/flutter-apk/app-full-release.apk`. The CI comment at `default_workflow.yml:864-872` spells this out. Either path works as `output:`; the Gradle one is more stable.
+
+**The signing config is unconditional.** `android/app/build.gradle` reads `android/key.properties` and then sets `buildTypes.release.signingConfig = signingConfigs.release` with no guard. F-Droid has no keystore. The repo's own CI confirms the consequence — `default_workflow.yml:427` says "`--release` would need a keystore which CI doesn't have; `--debug` …" and the non-release Android job builds `--debug` for that reason. The recipe will need to strip it, the way `metadata/app.simple.peri.yml:648` does (`sed -i -e '/signingConfigs/,+1d' build.gradle`). This should be verified by an actual build rather than taken on faith.
+
+**Codegen.** `dart run build_runner build` is mandatory — it produces `env.g.dart`, Hive adapters, and JSON serializers — and `flutter gen-l10n` is mandatory too, since `lib/generated/` is gitignored (`justfile`, `gen_l10n` recipe; `.gitignore`). Both are ordinary recipe steps (Energize and studip both do exactly this).
+
+**NDK.** `android/app/build.gradle` sets `ndkVersion flutter.ndkVersion`, which for 3.44.6 resolves to `28.2.13676358` (`flutter_tools/gradle/src/main/kotlin/FlutterExtension.kt:42`). `fdroidserver` supports this through the `ndk:` build field and `auto_install_ndk()` (`fdroidserver/common.py`), so it is a one-line addition, not a blocker.
+
+**Java.** `compileOptions` and `kotlinOptions` want JVM 17; AGP is 8.11.1 and Gradle 8.14 (`android/settings.gradle`, `android/gradle/wrapper/gradle-wrapper.properties`). The buildserver installs `default-jdk-headless` and selects the highest available (`buildserver/provision-apt-get-install`), which on current Debian is 21 — fine for `sourceCompatibility 17`. If it is not, a `sudo:` block pinning a JDK is the standard fix; 5,357 build blocks in fdroiddata already do it for 17.
+
+**APK size.** The published universal APK is ~100 MB (`gh release view v2.0.2`). I found no documented size limit in `fdroidserver`. Most Flutter recipes use `--split-per-abi` with `VercodeOperation` anyway (Energize: `10 * %c + 1/2/3`). Careful: Flutter sets `versionCodeOverride = abiVersionCode * 1000 + base` when splitting (`FlutterPlugin.kt:669-671`), *and* this repo's `applicationVariants.all` rename block forces every `full`-flavor output to the same filename `app-release.apk`, which would collide across ABI splits. Splitting is possible but needs that block neutered. A universal APK is the simpler first submission.
+
+**Native deps.** None beyond what Flutter itself ships — no plugin in the tree has an `externalNativeBuild`. (That changes if `flutter_zxing` replaces `mobile_scanner`; it builds ZXing C++ via CMake, hence polycule's `--build-id=none` workaround.)
+
+---
+
+## 4. Release identity
+
+| Field | Value | Source |
+| --- | --- | --- |
+| Latest stable tag | `v2.0.2` (2026-08-02) | `gh release list` |
+| `versionName` | `2.0.2` | `pubspec.yaml:19` |
+| `versionCode` | `61` | `pubspec.yaml:19` |
+| `applicationId` | `com.opennutritracker.ont.opennutritracker` | `android/app/build.gradle` (`full` flavor, no suffix) |
+| Release APK asset | `app-release.apk`, ~100 MB, at `.../releases/download/v2.0.2/app-release.apk` | `gh release view v2.0.2` |
+| Signing cert SHA-256 | `84e86074ec7edabb10f2017986ddf09e531caf7a73080ac1172b80c49c620827` | `README.md:157`, `docs/site/release-info.json` |
+| Tag objects | Lightweight commits, **not** annotated or GPG-signed | `git cat-file -t v2.0.2` → `commit` |
+
+Version codes are monotonic across the tags that matter — I checked `pubspec.yaml` at every 1.3+ tag and got 49, 50, 56, 57, 58, 59, 60, 61 in order. (The GitHub *release titles* for v1.4.0/v1.4.1 say "build 701"/"build 703", which contradicts `pubspec.yaml`'s 56/57 and the release workflow's lack of `--build-number`. I did not download those APKs to settle it; it does not affect anything going forward.)
+
+Tag naming is historically inconsistent (`v.1.3.0`, `v1.3.2+53-build.629`) but has been clean `vX.Y.Z` since v1.4.0.
+
+**Recommendation:**
+
+```yaml
+UpdateCheckMode: Tags
+UpdateCheckData: pubspec.yaml|version:\s.+\+(\d+)|.|version:\s(.+)\+
+AutoUpdateMode: Version
+CurrentVersion: 2.0.2
+CurrentVersionCode: 61
+```
+
+That `UpdateCheckData` is the literal example the [Build Metadata Reference](https://f-droid.org/docs/Build_Metadata_Reference/) gives for "Flutter app with the pubspec.yaml in the repo root", and it is what both Energize and studip use. `AutoUpdateMode: Version` with no pattern is correct here because with `UpdateCheckMode: Tags` "the checked tag is used directly", so the historic `v.1.3.x` oddities do not matter.
+
+**On reproducible builds / `Binaries`:** do not attempt this for the first submission. Verified builds would require (a) the exact same four `.env` values as the release build, byte for byte, (b) mirroring GitHub Actions' `/home/runner/work/OpenNutriTracker/OpenNutriTracker` working directory to defeat Flutter's embedded build paths, and (c) matching the AGP/NDK/apksigner versions. The `AllowedAPKSigningKeys` value is available if it is ever wanted, but the pragmatic path is an F-Droid-signed build. The cost of that is real and should be stated in #575: **F-Droid-signed APKs cannot upgrade an existing Play Store or GitHub install** — users switching have to uninstall and lose local data unless they export first.
+
+Category: `Diet` and `Sports & Health` both exist in `config/categories.yml`; Energize uses both.
+
+---
+
+## 5. Metadata reuse
+
+F-Droid reads `fastlane/metadata/android/<locale>/` straight out of the app's source repo — it is one of the two supported structures, and the docs actively prefer it ("strongly encouraged", and "the only way to provide images"). It checks out the latest release tag and scans at that state. So the existing directory is usable as-is, with gaps.
+
+Against the [documented requirements](https://f-droid.org/docs/All_About_Descriptions_Graphics_and_Screenshots/):
+
+| Requirement | Present | Status |
+| --- | --- | --- |
+| `short_description.txt`, max 80 chars, mandatory | 76 chars | Pass |
+| `full_description.txt`, max 4000 chars, mandatory | 3,570 chars | Pass |
+| `title.txt`, max 50 chars | 16 chars | Pass |
+| `images/icon.png` | 512×512 | Pass |
+| `images/featureGraphic.png` | 512×250 | Works; half the documented "usually 1024×500" |
+| `images/phoneScreenshots/*.png` | 6 × 1080×2205 | Pass (well under `Image.MAX_IMAGE_PIXELS` = 4096×4096, `update.py:72`) |
+| `changelogs/<versionCode>.txt`, max 500 chars | only `12.txt` | **Gap** |
+| At least one locale beyond en-US | none | **Gap** for the Latest tab |
+| No prohibited HTML tags in description | plain text + emoji only | Pass |
+
+Two concrete problems:
+
+**The changelog is eight years of releases stale.** `fastlane/metadata/android/en-US/changelogs/12.txt` contains ` * Initial Fdroid release` — someone started this work long ago. Current `versionCode` is 61. F-Droid names changelog files by version code "literally, no padding", so it will find nothing for the shipping release. This also costs the Latest tab, whose criteria are: Name, Icon, Summary, Description, License, "a What's New entry for at least one release", at least one graphic, **and at least one of the above translated**. With only `en-US` and only `12.txt`, the app fails two of eight.
+
+Fix: add `61.txt` (and keep adding one per release — this belongs in `RELEASE.md`), and add at least one translated locale directory. The app already ships many locales in `lib/l10n/`, so a translated `short_description.txt` + `full_description.txt` + `changelogs/61.txt` for, say, `de` would clear it.
+
+**`playstore_banner.png` and `appstore_banner.png` are ignored.** `update.py:111` recognises only `featureGraphic`, `icon`, `promoGraphic`, `tvBanner`. Harmless, just dead weight in F-Droid's eyes.
+
+One thing #575 gets right and is worth repeating: do **not** commit F-Droid build metadata to this repo. The `fastlane/` directory is the correct and only place this repo participates.
+
+---
+
+## 6. Verdict on #575 as written
+
+**Scoping: mostly good. The acceptance criteria are in the right order and the "don't commit fdroiddata metadata here" note is correct.** But the issue is mislabelled as a good first issue, and the checklist has three problems.
+
+**It omits the ML Kit blocker entirely.** Criterion 1 says "document any blockers in this issue", which technically covers it, but a first-time contributor reading the list would reasonably expect that step to be a paperwork exercise. It is not — it terminates the task. Every subsequent checkbox is unreachable until the maintainer decides what happens to barcode scanning. This should be hoisted to the top of the issue as a stated precondition.
+
+**It assumes an MR is the entry point.** `fdroiddata/CONTRIBUTING.md` says: "If you are a 'first time' contributor, consider opening an issue at [RFP (Request for Packaging)]". More to the point, **[RFP #2540 for OpenNutriTracker already exists](https://gitlab.com/fdroid/rfp/-/issues/2540)**, filed 2023-09-11, still open, and untouched since the day it was created (`updated_at` is 5 minutes after `created_at`; the only activity is `fdroid-bot`'s auto-labelling: `flutter`, `dart`, `gradle`, `kotlin`, `fastlane`, `in-google-play`, `insecure-gradlew`, `license`). The issue should reference it. Reviving that RFP is a cheaper and more socially correct first move than a cold MR, and it is where a maintainer's "yes, we want this" carries weight.
+
+**"Configure the Flutter build and automatic update checks using stable release tags" understates the build work.** Between the flavor, the unconditional signing config, two codegen steps, an unpinned SDK (`.fvmrc` means nothing to F-Droid), the NDK pin, and a 100 MB universal APK, this is several hours of iteration against fdroiddata CI even once the dependency question is settled.
+
+**What #575 gets right:** reusing `fastlane/metadata/android/`, keeping F-Droid metadata out of this repo, running `fdroid lint`/`rewritemeta`, and linking back to #126.
+
+**The decisions only the maintainer can make:**
+
+1. **Barcode scanning.** Replace `mobile_scanner` with `flutter_zxing` everywhere (my recommendation — one dependency swap, no permanent fork, F-Droid gets feature parity), or maintain `.fdroid` source variants and ship a scanner-less F-Droid build with a trimmed description. There is no third option that keeps ML Kit.
+2. **The Supabase credentials.** Publish the project URL and anon key in public fdroiddata metadata (following Energize's precedent), or ship stubs and accept an Open-Food-Facts-only F-Droid build.
+3. **Sentry**, if a reviewer objects: accept a `Tracking` anti-feature, or strip it from the F-Droid build.
+4. **Signing stance**: F-Droid-signed (simple, but no upgrade path from existing installs) versus reproducible/`Binaries` (preserves the signature, but Flutter build-path reproducibility is a project of its own).
+
+---
+
+## Recommended next steps
+
+1. **Decide #1 and #2 above.** Nothing else is worth starting first.
+2. **Delete the dead FDC client** — `FDCDataSource`, `ProductsRepository.getFDCFoodsByString`, the `FDC_API_KEY` field in `Env`, and its locator registration. It has no callers, and removing it retires one of the four build-time secrets outright. Separate PR in this repo.
+3. **Fix the fastlane gaps** in this repo: add `changelogs/61.txt`, add a translated locale, and add "write the changelog file" to `RELEASE.md` so it does not drift again. Separate PR.
+4. **Revive [RFP #2540](https://gitlab.com/fdroid/rfp/-/issues/2540)** with a current status comment, rather than opening a cold MR.
+5. **Prototype the recipe locally** with `fdroid build --test`, starting from `metadata/com.flasskamp.energize.yml` as the shape and `metadata/studip_uni_passau.femtopedia.de.unipassaustudip.yml` as the Flutter-idiom reference. Sketch:
+
+   ```yaml
+   Builds:
+     - versionName: 2.0.2
+       versionCode: 61
+       commit: <full sha of v2.0.2>
+       srclibs:
+         - flutter@3.44.6
+       ndk: '28.2.13676358'
+       output: build/app/outputs/apk/full/release/app-release.apk
+       rm:
+         - ios
+         - integration_test
+       prebuild:
+         - sed -i -e '/signingConfig signingConfigs.release/d' android/app/build.gradle
+         - export PUB_CACHE=$(pwd)/.pub-cache
+         - $$flutter$$/bin/flutter config --no-analytics
+         - $$flutter$$/bin/flutter pub get --enforce-lockfile
+       scanignore:
+         - $$flutter$$/bin/cache
+       scandelete:
+         - .pub-cache
+       build:
+         - export PUB_CACHE=$(pwd)/.pub-cache
+         - echo "FDC_API_KEY='...'" > .env
+         - echo "SENTRY_DNS='...'" >> .env
+         - echo "SUPABASE_PROJECT_URL='...'" >> .env
+         - echo "SUPABASE_PROJECT_ANON_KEY='...'" >> .env
+         - $$flutter$$/bin/flutter gen-l10n
+         - $$flutter$$/bin/dart run build_runner build --delete-conflicting-outputs
+         - $$flutter$$/bin/flutter build apk --release --flavor full
+   ```
+
+   This is a starting point, not a working recipe — in particular the `signingConfig` sed, the `scanignore` path form for a srclib, and the `output:` path all need to be confirmed by an actual build.
+6. **Re-scope #575** with the ML Kit precondition at the top, a pointer to RFP #2540, and the maintainer decisions listed as blockers. Consider dropping the good-first-issue label until decisions 1 and 2 are made; after that, the remaining work genuinely is approachable.
+
+---
+
+## Open questions / unverified
+
+- **I did not run a build.** Every claim about what the recipe needs to patch — the `signingConfig` strip in particular — is inferred from reading `android/app/build.gradle` and the repo's own CI comment at `default_workflow.yml:427`, not from a failing build log. AGP's exact behaviour with a `signingConfig` whose `storeFile` is null was not tested.
+- **`image_picker_android`'s GMS manifest metadata.** My reading of `scanner.py` says manifest attributes are not scanned by either the gradle or the binary signature path, so it should pass. Not confirmed against a real scanner run.
+- **Whether Sentry draws a `Tracking` flag when it is opt-in and default-off.** kDrive's flag text explicitly says "enabled by default", implying default-off might be treated differently, but I found no policy text or counter-example that settles it.
+- **Whether `NonFreeAssets` gets applied to the bundled Unsplash photos.** The policy's non-functional-assets clause is lenient enough that it may not; the license's field-of-use restriction is real either way.
+- **RFP #2540's discussion.** The GitLab notes API returned `401 Unauthorized` for an anonymous request, so I could only read the issue body and its `updated_at`. The timestamps strongly suggest there is no human discussion on it, but I have not read the comments.
+- **`CustomIcons.ttf` provenance.** `fonts/OFL.txt` covers Poppins and Nunito. I could not determine where `fonts/CustomIcons.ttf` came from or under what licence. Worth pinning down before a reviewer asks.
+- **The v1.4.x versionCode discrepancy** (release titles say 701/703, `pubspec.yaml` says 56/57). Not resolved; irrelevant going forward but noted in case someone trips over it.
+- **APK size limits.** I found none documented in `fdroidserver` or `fdroiddata/.gitlab-ci.yml`. A 100 MB APK may still draw a reviewer comment.
+- **Flutter 3.44.6's exact `flutter build apk` behaviour with two flavors and no `--flavor`.** I assumed it fails or is ambiguous based on the repo always passing `--flavor full`; not tested.

--- a/docs/privacy-policy-gaps.md
+++ b/docs/privacy-policy-gaps.md
@@ -1,0 +1,800 @@
+# What the published privacy policy still does not say about what the app does
+
+**Verdict: the policy is in far better shape than a gap audit usually finds —
+it names Supabase, Sentry, Open Food Facts, OpenRouter and the gateway log,
+and the German translation is in sync. The remaining gaps are almost all of
+one kind: the policy describes the code on `develop`, and the code on
+`develop` is not what anybody is running.** v2.0.2 shipped on 2 August 2026
+and none of the four commits that make the policy's Sentry and Supabase
+paragraphs true are in it. Three of the findings below are cases where the
+released binary contradicts a sentence the policy states as fact. The AI
+feature, which the brief expected to be the large hole, is already described
+in more detail than most shipping apps manage — but it never names two of the
+four providers it can send a photograph to, one of which is the default.
+
+Audited **2026-08-27** against the policy text served that day
+(`Latest update: August 27, 2026`), against `develop` at `eb08e121`, against
+tag `v2.0.2` as the released baseline, and against `feat/own-server-settings`
+for the unreleased AI paths. This is a code-to-text comparison, not legal
+advice, and nothing here is an opinion on liability.
+
+## Bottom line up front
+
+1. **Crash reports from the released app carry the food diary.** The policy
+   says the diary, weight and profile *"are never sent"*. In v2.0.2 every
+   `log.fine` line becomes a Sentry breadcrumb, and those lines include the
+   search term the user typed and the millilitres of water they logged. The
+   fix exists and is unreleased. [Finding 1](#1-crash-reports-from-the-released-app-carry-the-diary).
+2. **Released search terms land in the Supabase gateway log.** The policy's
+   candid paragraph about what the gateway records — address, city, postal
+   code, ISP, TLS fingerprint — omits the one field that matters, because
+   in v2.0.2 the term is still in the URL. #882's fix is merged, unreleased.
+   [Finding 2](#2-in-the-released-app-the-search-term-is-in-the-url-the-gateway-logs).
+3. **Sentry is not only crash reporting.** `tracesSampleRate = 1.0` in both
+   the released and the current build. The policy's *"a crash sends a
+   technical report"* describes half of what the SDK is configured to send.
+   [Finding 3](#3-sentry-is-configured-for-performance-tracing-not-only-crashes).
+4. **Anthropic and OpenAI are never named**, and Anthropic is the provider a
+   fresh install defaults to. The policy names OpenRouter and "your own
+   server" and stops. [Finding 8](#8-two-of-the-four-ai-providers-are-never-named-and-one-is-the-default).
+5. **Health Connect / Apple Health has no section at all.** Unreleased, so
+   not yet a live gap — but it reads special-category data and ships next.
+   [Finding 7](#7-health-connect--apple-health-has-no-section).
+6. Two smaller undisclosed flows in the released app: product **photographs
+   are fetched per logged meal** ([Finding 4](#4-product-images-are-fetched-for-meals-already-in-the-diary)),
+   and the Supabase request carries the device locale and the user's
+   food-source toggles ([Finding 5](#5-the-supabase-request-carries-more-than-the-search-term)).
+7. One thing the policy claims that the **next** release will stop doing: the
+   installation identifier in crash reports. Correct today, wrong the moment
+   #901 ships. [Finding 12](#12-the-installation-identifier-is-true-today-and-false-after-the-next-release).
+
+## How this was read
+
+The policy was fetched on 2026-08-27 in its full legal view
+(`/privacy-policy/53501884/full-legal`), which is what the app links to via
+`URLConst.privacyPolicyURLEn`. The German document (`53922100`, linked for
+`de` by `URLConst.privacyPolicyFor`) was fetched too and carries the same
+`27. August 2026` date, the same sections and the same wording — it is a
+faithful translation and inherits every finding below rather than adding one.
+No cookie policy or Terms document exists at a sibling iubenda URL.
+
+Released behaviour means tag `v2.0.2` (build 61, 2026-08-02), which is the
+latest GitHub release and the version in `pubspec.yaml` on `main`. `main`
+carries three commits past the tag and none is released. Every "released"
+claim below was checked with `git merge-base --is-ancestor <commit> v2.0.2`
+and every quoted line was read out of `git show v2.0.2:<path>`, not out of
+the working tree — the two differ substantially in exactly the files that
+matter here.
+
+Citations of the form `path:NN` refer to `develop` unless the line is
+introduced as `v2.0.2:path:NN` or `feat/own-server-settings:path:NN`.
+
+---
+
+## Released behaviour the policy contradicts
+
+### 1. Crash reports from the released app carry the diary
+
+**Severity: highest. Data leaves the device to a third party, and the policy
+states the opposite as a fact.**
+
+> Your food diary, your weight and your profile are never sent, and the app
+> does not attach your IP address.
+>
+> — Sentry section, full legal view
+
+The second half is true. The first half is not true of v2.0.2.
+
+`SentryOptions.enablePrintBreadcrumbs` defaults to `true`, and
+`DebugPrintIntegration` is registered unconditionally and bows out only in
+debug mode — so it is live in precisely the builds where crash reporting can
+run. v2.0.2 sets neither:
+
+```
+v2.0.2:lib/main.dart:150-154
+    await SentryFlutter.init(
+      (options) {
+        options.dsn = Env.sentryDns;
+        options.tracesSampleRate = 1.0;
+      },
+```
+
+That is the whole of the released configuration. Meanwhile
+`v2.0.2:lib/main.dart:51` calls `LoggerConfig.intiLogger()` before anything
+else, and that pipes the entire application log through `debugPrint` with no
+level floor:
+
+```
+v2.0.2:lib/core/utils/logger_config.dart:6-12
+    Logger.root.level = Level.ALL;
+    Logger.root.onRecord.listen((record) {
+      debugPrint(...)
+```
+
+So every log record in the app becomes a breadcrumb riding along on the next
+event of any kind. What that sweeps up, in the released build:
+
+- `v2.0.2:lib/features/add_meal/data/data_sources/off_data_source.dart:94` —
+  `log.fine('Fetching OFF results from: $searchUrl')`. The URL is
+  `search.openfoodfacts.org/search?q=<what the user typed>`.
+- `lib/core/data/data_source/water_intake_data_source.dart:19` —
+  `log.fine('Adding water intake ${entry.amountMl} ml at ${entry.dateTime}')`.
+- `lib/core/data/data_source/weight_log_data_source.dart:20` — the date of
+  every weight entry.
+- Barcode lookups, custom activity names, intake edits, on the same path.
+
+The project already knows this. `lib/core/utils/sentry_config.dart:7-21` on
+`develop` documents the mechanism and the exact consent sentence it breaks,
+and `:25` fixes it with `options.enablePrintBreadcrumbs = false`. That file
+does not exist at `v2.0.2` — `git show v2.0.2:lib/core/utils/sentry_config.dart`
+returns *"exists on disk, but not in 'v2.0.2'"*. The fix landed in the
+`e53be1bc` / #877 line of work and is not in any release.
+
+The app's own in-product consent text is more specific and equally wrong in
+the shipped build: `v2.0.2:lib/l10n/intl_en.arb` reads *"Send anonymous crash
+reports to help fix bugs. No food log, weight, or personal data is included."*
+
+**What to do:** this is a release problem before it is a policy problem. Ship
+the fix. If a release is not imminent, the Sentry section needs a sentence
+saying that builds before the next version attach recent application log lines
+to a crash report, and that those lines can include food searches, barcodes,
+water and weight entries.
+
+### 2. In the released app, the search term is in the URL the gateway logs
+
+**Severity: highest. The policy discloses the gateway log in unusual detail
+and omits the single most sensitive field in it.**
+
+> Because the request travels over the internet, the platform's gateway
+> records for 24 hours the address the request came from, an approximate
+> location derived from that address (country, region, city and postal code),
+> the name of your internet access provider, and a fingerprint of the
+> encrypted connection.
+>
+> — Food reference backend (Supabase) section
+
+That list is accurate and better than most policies manage. It is also
+incomplete for anyone running v2.0.2, because the released client puts the
+search term in the query string, where it is logged in the same record beside
+the address, the city and the postal code:
+
+```
+v2.0.2:lib/features/add_meal/data/data_sources/sp_food_data_source.dart:95
+    var query = client.from(SPConst.foodSummaryTable).select().textSearch(
+```
+
+A PostgREST `select().textSearch()` is a `GET` and the term travels as a URL
+parameter. `develop` fixed this in #911 by moving every search onto an RPC —
+`lib/features/add_meal/data/data_sources/sp_food_data_source.dart:101`,
+`client.rpc(fn, params: params)`, with the term as `'term': searchString` at
+`:121` — so the URL is a bare `/rest/v1/rpc/search_food_summary`. The backend
+records why in its own schema, `sql/schema.sql:387-390`: those URLs *"sit in
+the same record as the caller's IP, city, postal code"*. The localized path
+was moved for the same reason at `:147`, and even the follow-up id fetch was
+made an RPC (`:190`) because the ids are derived from the term and would be a
+fingerprint of it in the URL.
+
+`eb08e121` is not an ancestor of `v2.0.2` or of `main`. Released users leak.
+
+**What to do:** same as Finding 1 — ship it. Until then, the Supabase
+paragraph should add the search term to the list of what the gateway records
+for 24 hours, or the policy should say that this was true of versions up to
+2.0.2 and changed in the version that carries the fix.
+
+### 3. Sentry is configured for performance tracing, not only crashes
+
+**Severity: inaccurate description of an active data flow.**
+
+> When it is on, **a crash** sends a technical report […]
+>
+> — Sentry section (emphasis added)
+
+`tracesSampleRate = 1.0` in the released build (`v2.0.2:lib/main.dart:153`)
+and in the current one (`lib/core/utils/sentry_config.dart:24`). A non-null
+traces sample rate is what enables transaction sending in `sentry_flutter`,
+and `enableAutoPerformanceTracing` is on by default — so app-start and
+screen-load transactions are produced for ordinary sessions, at a 100 % sample
+rate, with no crash involved.
+
+Two consequences the policy does not carry. First, the reader is told the
+network is touched only when something breaks, and it is touched every time
+they open the app with the toggle on. Second, the policy's own concession that
+*"Sentry's servers may derive an approximate location (country, region and
+city) from the connection"* then applies once per session rather than once per
+crash, which is a materially different picture of how often a coarse location
+is observed.
+
+The consent string is scoped the same narrow way — `"Send crash reports to
+help fix bugs"` (`lib/l10n/intl_en.arb`, `dataCollectionLabel`).
+
+**What to do:** either drop the traces sample rate to `0` (there is no
+evidence in the repo that anyone reads the performance data), or widen the
+policy sentence and the consent string to "crash and performance reports".
+The first is cheaper and matches what the toggle promises.
+
+---
+
+## Undisclosed flows in the released app
+
+### 4. Product images are fetched for meals already in the diary
+
+**Severity: undisclosed transfer to a third party. Lower than 1–3 because the
+recipient is one the policy already names, but the *occasion* is not
+disclosed and it is the more revealing of the two.**
+
+Both third-party sections scope the transfer to a search:
+
+> When you search for a food or scan a barcode, this Application sends the
+> search term or the barcode to Open Food Facts […]
+>
+> A search sends the text you typed.
+
+Neither mentions that the app then downloads the product photograph, and keeps
+downloading it long after the search is over. `MealDBO` stores Open Food Facts
+entries' thumbnails as remote URLs (`lib/core/data/dbo/meal_dbo.dart:45-50`),
+taken straight from the API's `image_url` / `image_front_thumb_url` fields
+(`lib/features/add_meal/data/dto/off/off_product_dto.dart:44-48`), and the
+diary card renders them over the network:
+
+```
+lib/core/presentation/widgets/intake_card.dart:125-128
+    } else if (intake.meal.mainImageUrl != null) {
+      content = CachedNetworkImage(
+        cacheManager: locator<CacheManager>(),
+        imageUrl: intake.meal.mainImageUrl ?? "",
+```
+
+Seven render sites do this — the diary card above, plus
+`meal_detail_screen.dart:327`, `edit_meal_screen.dart:954`,
+`meal_item_card.dart:114`, `recipe_list_item.dart:108`,
+`food_search_tab_view.dart:306` and `image_full_screen.dart:35`. The cache is
+bounded at 30 days and 200 objects
+(`lib/core/utils/ont_image_cache_manager.dart:4-5`), so for any user with more
+than 200 distinct foods, or any food they return to after a month, the request
+goes out again.
+
+The distinction worth drawing for the reader: a search term says what somebody
+was *curious about*; an image request for a diary entry, repeated whenever the
+card renders past its cache, says what they actually *ate*, at the moment they
+looked at it. That is a stronger inference than the disclosed flow and it is
+not in the policy.
+
+**What to do:** add a sentence to the Open Food Facts section — a food's
+photograph is downloaded from Open Food Facts when it appears in search
+results, in the diary or on a meal screen, and is cached for 30 days. The
+`Personal Data processed` list for that section should gain "product
+identifiers" alongside search terms and barcodes.
+
+### 5. The Supabase request carries more than the search term
+
+**Severity: incomplete `Personal Data processed` list.**
+
+> A search sends the text you typed. No account, profile or device identifier
+> is attached, and your food diary is never sent.
+>
+> Personal Data processed: search terms; IP address; approximate location;
+> connection identifiers; Usage Data.
+
+The negative claims are all true — nothing in `SpFoodDataSource` reaches for
+an identifier. But two fields travel that are not in the list:
+
+- **The device locale.** `lib/features/add_meal/data/data_sources/sp_food_data_source.dart:42`
+  resolves it from `Platform.localeName` and `:147` sends it as `'loc': locale`.
+- **The user's food-database toggles.** `:122` and `:190` send
+  `'sources': enabledSources` — the list of which of the five catalogues that
+  user has left switched on in Settings → Food databases, built at `:79-86`.
+
+Neither identifies anybody on its own. Together, arriving beside an IP address
+and a postal code in a 24-hour gateway log, they are a small settings
+fingerprint, and the policy has committed to listing what is processed per
+service. The Open Food Facts section sets the precedent by listing its own
+language parameter (albeit under the wrong name — see Finding 11).
+
+**What to do:** add "app language" and "food-source preferences" to that
+section's processed-data list.
+
+### 6. Two Open Food Facts hosts, and an undisclosed User-Agent
+
+**Severity: minor accuracy.**
+
+The policy speaks of Open Food Facts as one destination in France. The app
+talks to two hosts run on different infrastructure:
+`search.openfoodfacts.org` for text search and `world.openfoodfacts.org` for
+barcode lookups and for the fallback when the first is down
+(`lib/core/utils/off_const.dart:7, 14, 22`,
+`lib/features/add_meal/data/data_sources/off_data_source.dart:61-72`). The
+circuit breaker at `off_data_source.dart:23` means the destination for a given search silently
+depends on whether the other one 502'd in the last five minutes.
+
+Every one of those requests also carries a User-Agent naming the app, the
+platform and the version — `lib/core/utils/app_const.dart:27-31` via
+`lib/core/utils/ont_http_client.dart:11`. It is not an identifier and the
+README already discloses it, but the policy's processed-data list does not.
+
+**What to do:** low priority. A parenthetical that Open Food Facts serves
+search and product lookups from more than one host, and that requests identify
+the app and its version, would close it.
+
+---
+
+## Unreleased behaviour that needs disclosure before it ships
+
+None of the following is in v2.0.2, so none is a live gap today. All of it is
+on branches heading for release.
+
+### 7. Health Connect / Apple Health has no section
+
+**Severity: highest of the unreleased set. Special-category data under GDPR
+Article 9, and no clause of any kind exists.**
+
+`af28c39f` ("opt-in workout import from Health Connect / Apple Health", #651)
+is on `develop` and is not an ancestor of `v2.0.2` or `main`. It reads:
+
+```
+lib/core/data/data_source/health/health_package_service.dart:19-33
+    static const _coreReadTypes = [
+      HealthDataType.WORKOUT,
+      HealthDataType.BODY_FAT_PERCENTAGE,
+    ];
+    static const _androidWorkoutDetailTypes = [
+      HealthDataType.TOTAL_CALORIES_BURNED,
+      HealthDataType.DISTANCE_DELTA,
+      HealthDataType.STEPS,
+    ];
+```
+
+with the matching `android.permission.health.READ_*` grants at
+`android/app/src/main/AndroidManifest.xml:8-16` and an
+`NSHealthShareUsageDescription` at `ios/Runner/Info.plist:66`.
+
+The implementation is genuinely conservative — read-only, opt-in, nothing
+written back, and the data stays on the device. That is a good argument that
+the Owner never becomes a controller for it, and therefore that Articles 13
+and 14 do not bite. It is *not* an argument for silence, for three reasons:
+
+1. The policy's opening list is presented as complete — *"Among the types of
+   Personal Data that this Application collects […]"* — and a reader who
+   turns on workout import is entitled to find it there.
+2. Google Play's Data safety declaration must cover data the app *accesses*
+   off its own storage regardless of where it ends up, and Google is explicit
+   that *"You alone are responsible for making complete and accurate
+   declarations"*. Health and fitness is a declarable category.
+3. Finding 1 is the concrete counter-example to "on-device means out of
+   scope": until `enablePrintBreadcrumbs = false` ships, on-device values do
+   leave, through Sentry, in the released build.
+
+**What to do:** add a section stating that health data is read only after the
+user enables workout import, listing the five types, and stating plainly that
+it is never transmitted. A short "what stays on your device" section would
+also be the natural home for the encrypted Hive boxes, which the README
+describes well and the policy does not mention at all.
+
+### 8. Two of the four AI providers are never named, and one is the default
+
+**Severity: high. GDPR Article 13(1)(e) recipients, and the policy has already
+chosen the "name them" style everywhere else.**
+
+The AI section is careful and mostly excellent (see
+[what the policy gets right](#where-the-policy-is-fine)). It names exactly one
+provider:
+
+> If you choose OpenRouter, your request reaches OpenRouter and the vendor
+> serving the model you picked — two recipients, not one […] If you configure
+> your own server, the request goes to the address you entered […]
+
+There are four providers, not two, and the other two are compiled-in
+endpoints the Owner chose:
+
+- `feat/own-server-settings:lib/features/add_meal/data/anthropic_meal_items_api.dart:16`
+  — `https://api.anthropic.com/v1/messages`
+- `feat/own-server-settings:lib/features/add_meal/data/openai_meal_items_api.dart:27`
+  — `https://api.openai.com/v1/responses`
+
+And Anthropic is what a fresh install resolves to:
+
+```
+feat/own-server-settings:lib/core/utils/ai_credential_storage.dart:41-42
+    static AiProvider? fromTag(String? value) {
+      if (value == null || value.isEmpty) return AiProvider.anthropic;
+```
+
+So the single most likely destination for a user's first meal photograph is
+the one provider the policy never mentions. Article 13(1)(e) permits
+*"recipients or categories of recipients"* — a category would be defensible if
+the document used categories throughout. It does not: it names Supabase,
+Sentry, Apple Inc., Google Ireland Limited, Google LLC, Open Food Facts,
+Cloudflare and Amazon Web Services. Naming six sub-processors and omitting the
+default AI recipient is the inconsistency.
+
+Article 13(1)(f) is thinner here too. *"Place of processing: the country of
+the provider you choose — see that provider's own privacy policy"* is a
+pointer, not a transfer statement, and for the two US-headquartered providers
+the app ships endpoints for it says nothing about the safeguard relied on. The
+Supabase and Sentry sections both do this properly, which shows the document
+knows how.
+
+**What to do:** name all four. One sentence per hosted provider with its
+country is enough; the "your own server" paragraph already handles the fourth
+correctly by explaining that the Owner cannot know the address.
+
+### 9. The photo fallback path sends the original file, EXIF included
+
+**Severity: high if it fires — undisclosed location data to a third party.
+Conditional, so ranked below Finding 8.**
+
+> only the meal description you type — or a photo you deliberately pick — is
+> sent to that provider
+>
+> Personal Data processed: the text or the photo you submit for
+> interpretation; your app language.
+
+True of the pixels. Silent about the metadata, and the normal path and the
+fallback path differ.
+
+The normal path re-encodes through `FlutterImageCompress.compressWithFile` at
+quality 80 and 1024 px
+(`feat/own-server-settings:lib/features/add_meal/util/meal_photo_encoder.dart:159-175`).
+`keepExif` is never set — `git grep -i exif` over `lib` on that branch returns
+nothing — and it defaults to `false`, so re-encoding strips the metadata as a
+side effect. Good outcome, incidental cause.
+
+The fallback path does not re-encode:
+
+```
+feat/own-server-settings:lib/features/add_meal/util/meal_photo_encoder.dart:136-141
+    // The encoder failed. Send the original if the destination takes that
+    // format […]
+    final mediaType = mediaTypeForPath(sourcePath);
+    if (mediaType == null) return null;
+    final raw = await _rawBytes(sourcePath);
+    if (raw == null) return null;
+    return _fitting(raw, mediaType);
+```
+
+`_rawBytes` (`:183`) reads the picked file byte for byte, gated only on being
+under 3 MB. The comment at `:69` is explicit that this exists for *"a device
+whose encoder failed, where the file is the camera's own output"* — which is
+the case that carries the fullest EXIF block: GPS coordinates, capture
+timestamp, camera make, model and sometimes serial. The accepted extensions at
+`:76-82` include `jpg`, `jpeg` and `png`, all of which carry EXIF.
+
+Nothing about this is careless — the encoder authors thought hard about the
+fallback and about deleting the picker's cache copy (`:95-113`, verified on a
+Pixel 6). EXIF simply was not the question they were asking.
+
+**What to do:** strip metadata explicitly rather than as a side effect, on
+both paths — that removes the finding instead of disclosing it, which is the
+better outcome and matches how this codebase has handled every other
+disclosure question. If the fallback is kept as-is, "location data" has to
+join the AI section's processed-data list, and that is a much worse sentence
+to have to write.
+
+### 10. A probe request fires as soon as a key is saved
+
+**Severity: wording only.**
+
+> AI meal assistance is switched off until you enter your own API key for a
+> provider you have chosen. Nothing is sent anywhere until you do.
+
+Accurate. Worth knowing that the first thing sent is not a meal:
+`feat/own-server-settings:lib/features/add_meal/domain/usecase/probe_ai_endpoint_usecase.dart`
+sends a canned English line (`aiProbeMealLine`, *"two eggs and a slice of
+toast"*) and a bundled demo photograph (`aiProbePhotoAsset`) to establish what
+the endpoint can do. No user data is involved, so there is no disclosure
+obligation — but a reader parsing "nothing is sent until you enter a key" as
+"nothing is sent until you use the feature" would be surprised by a request,
+and by a charge, at the moment they hit save.
+
+**What to do:** optional. "…until you enter your own API key, at which point
+the app makes one test request to check the provider works."
+
+---
+
+## Things the policy claims that the source does not do
+
+### 11. "a country code derived from your device's language settings"
+
+**Severity: inaccurate description.**
+
+> […] together with a country code derived from your device's language
+> settings, which the service uses to rank results.
+>
+> Personal Data processed: search terms; barcodes; a country code; Usage Data.
+
+There is no country code on any Open Food Facts request. What is sent is a
+**language** code, in the `langs` parameter:
+
+```
+lib/features/add_meal/data/data_sources/off_data_source.dart:48-52
+    String _searchLangs() {
+      final lang = SupportedLanguage.fromCode(Platform.localeName).name;
+      return lang == 'en' ? 'en' : '$lang,en';
+    }
+```
+
+passed at `:66` into `OFFConst.getOffWordSearchUrl(searchString, langs: ...)`,
+which places it under `_salLangsTag = "langs"`
+(`lib/core/utils/off_const.dart:36, 108-117`). The legacy fallback URL
+(`:124-136`) sends no locale at all, and neither does the barcode lookup
+(`:138-148`).
+
+The two are not interchangeable: a country code would be a coarse location
+signal, and a language code is not. The policy currently over-discloses in a
+way that makes the app sound worse than it is. The README repeats the same
+wrong word — *"a country tag from your device locale"* (`README.md:133`) — so
+both inherit one error and both should be corrected together.
+
+### 12. The installation identifier is true today and false after the next release
+
+**Severity: will become an over-disclosure. Flagged so it is not missed.**
+
+> […] together with a randomly generated identifier for your installation.
+
+Correct for v2.0.2, where the native SDKs attach a stable per-installation
+UUID as `user.id` and nothing removes it. Incorrect for `develop`, which
+strips the whole user block before the event leaves the device:
+
+```
+lib/core/utils/sentry_config.dart:50-52
+    SentryEvent? _stripUser(SentryEvent event, Hint hint) {
+      event.user = null;
+      return event;
+    }
+```
+
+`4214fb5b` (#900/#901) is not an ancestor of `v2.0.2` or `main`. The policy is
+therefore right about the app people are running and will need this sentence
+removed on the same day that release ships — the same release that fixes
+Findings 1, 2 and 12 together.
+
+### 13. The AI boilerplate sentence misdescribes the feature
+
+**Severity: boilerplate, but the misleading kind.**
+
+> This service uses artificial intelligence. Certain features of AI meal
+> assistance (your own provider) are powered by automated systems that process
+> your data to personalise or improve your experience.
+
+That is iubenda's generic AI clause and it is wrong in both halves for this
+feature. Nothing is personalised: `ModelMealTextInterpreter._systemPrompt`
+(`feat/own-server-settings:lib/features/add_meal/data/model_meal_text_interpreter.dart:27-45`)
+carries no user context beyond the meal line and the app language, and the
+schema at `meal_items_api.dart:68-118` forbids nutrition fields by
+construction, so the model returns food names and quantities and nothing else.
+Nothing is improved either — no output is retained by the app, and `store:
+false` is sent to OpenAI explicitly
+(`feat/own-server-settings:lib/features/add_meal/data/openai_meal_items_api.dart`).
+
+The clause also gestures at Article 13(2)(f) territory. It should not: there is
+no automated decision producing legal or similarly significant effects here —
+the user reviews every extracted row before it enters the diary. Leaving
+boilerplate that implies otherwise invites a question the feature does not
+actually raise.
+
+**What to do:** replace with a sentence saying what it does — a model reads
+the description or the photograph and returns a list of food names and
+amounts, which the user confirms before anything is saved.
+
+---
+
+## Structural and boilerplate gaps
+
+Ranked last on purpose. None of these describes data moving anywhere
+undisclosed.
+
+**14. The opening data-type list has not been kept in step with the detailed
+sections.** The top of the document lists *"Usage Data; diagnostics; email
+address; app information; device logs; device information; Data communicated
+while using the service"*. The detailed sections below add search terms,
+barcodes, a photograph, an approximate location and an installation
+identifier. iubenda generates the summary list from the service definitions,
+so the custom-written sections have outrun it.
+
+**15. No retention period for two of the five processing activities**
+(Article 13(2)(a)). Supabase carries 24 hours and Sentry 30 days, both
+specific and good. The Open Food Facts and AI sections carry nothing —
+defensible, since neither recipient is the Owner's processor, but the honest
+version of that is a sentence saying so rather than an absence.
+
+**16. No legal basis stated for the AI section** (Article 13(1)(c)). Open Food
+Facts and Supabase both name legitimate interest *and* an objection route, in
+the same paragraph, which is genuinely well done. The AI section names
+nothing, although the basis is obviously consent — the user has to enter a key
+— and the withdrawal route (delete the key) is worth stating alongside the
+existing consent-withdrawal clause.
+
+**17. "Reset profile data" deletes less than a reader might infer.**
+`DeleteAllUserDataUsecase.deleteAll` clears eight boxes for the *active
+profile only* (`lib/core/domain/usecase/delete_all_user_data_usecase.dart:45-54`)
+and deliberately leaves the shared custom-meal, recipe and activity-template
+libraries, the shared settings box, the 90-day remote-search cache
+(`lib/main.dart:79`) and every other profile. This is a defensible design
+and the in-app confirmation text says so almost word for word
+(`settingsDeleteAllDataConfirmContent` in `lib/l10n/intl_en.arb`). It is not a
+policy gap — the Owner holds none of this data, so the Article 17 erasure
+right does not attach to it — but it is the answer to Play's "data deletion
+request" question and it is the subject of issue #892, so it belongs in the
+same review.
+
+---
+
+## Where the policy is fine
+
+Worth stating plainly, because the list above is longer than the document
+deserves.
+
+- **The Supabase gateway paragraph is unusually candid.** Naming the 24-hour
+  window, the postal code and the TLS fingerprint is more than most policies
+  concede, and it matches the backend's own note at `sql/schema.sql:387-390`.
+  Sub-processors (Cloudflare, AWS), the Frankfurt location and the SCC basis
+  are all named. Only the search term is missing, and only in released builds.
+- **The Sentry framing is accurate apart from Findings 3 and 12.** Opt-in,
+  release-builds-only, consent as the basis, immediate withdrawal — all match
+  `lib/main.dart:131` (`kReleaseMode && hasAcceptedAnonymousData`) and
+  `delete_all_user_data_usecase.dart:39` (`Sentry.close()`).
+- **"the app does not attach your IP address" is true.** `sendDefaultPii` is
+  never set to `true` anywhere in the repo, and the policy separately concedes
+  that Sentry derives a coarse location server-side — which is the honest way
+  to state it.
+- **The OpenRouter paragraph is better than the code strictly required.** Two
+  recipients rather than one, the account-level identifier that cannot be
+  switched off, and the fact that the Owner receives nothing. The client backs
+  it up: `data_collection: 'deny'` and `allow_fallbacks: false` are sent
+  (`openai_compatible_meal_items_api.dart`), and the app deliberately omits
+  OpenRouter's `HTTP-Referer` / `X-Title` attribution headers so that saving a
+  key does not put the user on a public leaderboard.
+- **API key handling matches the claim.** *"held in your device's own secure
+  credential store"* — `flutter_secure_storage` against the Android Keystore
+  and iOS Keychain, with `resetOnError: false`
+  (`lib/core/utils/secure_app_storage_provider.dart:22-30`).
+- **No ads, no analytics SDK, no advertising ID, no account.** `pubspec.yaml`
+  contains no Firebase, Crashlytics, Google Analytics or attribution SDK;
+  `AndroidManifest.xml` requests no `AD_ID`; `ios/Runner/PrivacyInfo.xcprivacy`
+  declares `NSPrivacyTracking` false with an empty tracking-domains array and
+  all three collected types marked not-linked. There is no in-app purchase,
+  donation or update-check endpoint anywhere in `lib/`.
+- **The German document is a faithful translation and equally current.**
+  Same `27. August 2026` date, same sections, same wording. `URLConst
+  .privacyPolicyFor` routes only `de` to it and everything else to English,
+  which is the right call while only two documents exist.
+- **Controller identity, contact, rights, one-month response and complaint
+  route** are all present and correct (Article 13(1)(a), 13(2)(b)–(d)).
+
+---
+
+## Not verified
+
+- **Whether Sentry's organisation has a `user.geo` scrubbing rule**, and
+  whether its retention is actually set to the 30 days the policy states.
+  Neither is visible from this repo; `sentry_config.dart:46-49` explicitly
+  notes that `user.geo` is derived server-side and *"has to be dealt with by a
+  data-scrubbing rule on the organisation instead"*. Check in the Sentry
+  dashboard.
+- **Whether an app-start transaction actually reaches Sentry** in this
+  configuration. Finding 3 is inferred from `tracesSampleRate` being non-null
+  plus `enableAutoPerformanceTracing` defaulting on, not measured on a device.
+  Confirm before rewriting the policy sentence.
+- **Which ML Kit variant `mobile_scanner` 7.2 pulls on Android** — bundled
+  model or the Play-Services-downloaded one. `android/app/build.gradle`
+  declares no ML Kit dependency of its own (`dependencies` at `:138` holds
+  only `desugar_jdk_libs`), so the plugin's default applies and it was not
+  established. If it is the unbundled variant, first use of the scanner
+  fetches a model from Google.
+- **Whether the Supabase image columns ever resolve to a URL the app
+  fetches.** `sql/schema.sql:278-280` builds a *relative*
+  `/storage/v1/object/public/food-images/…` path and nothing in `lib/` was
+  found that prefixes it with the project URL, so Finding 4 was established
+  against Open Food Facts image hosts only. If that path is ever made
+  absolute, Finding 4 extends to the Supabase storage bucket.
+- **Whether iubenda's short (simplified) view differs materially** from the
+  full legal view. Only the full view was parsed in detail.
+- **Google Play's Data safety declaration itself.** It lives in the Play
+  Console, not in this repo — no declaration file, fastlane metadata entry or
+  checked-in copy exists. Findings 4, 5 and 7 are the ones most likely to make
+  the current declaration inaccurate.
+
+---
+
+## How to re-check
+
+Re-run this audit whenever a release ships, when a new destination is added,
+or when the policy is edited.
+
+**1. Get the policy text.** The full legal view is server-rendered, so `curl`
+is enough:
+
+```sh
+curl -sL -A "Mozilla/5.0" \
+  https://www.iubenda.com/privacy-policy/53501884/full-legal \
+  | python3 -c "import re,html,sys; t=sys.stdin.read(); \
+t=re.sub(r'(?is)<(script|style).*?</\1>',' ',t); t=html.unescape(re.sub(r'(?s)<[^>]+>','\n',t)); \
+print('\n'.join(l.strip() for l in t.split('\n') if l.strip()))"
+```
+
+Repeat for `53922100/full-legal` (German) and compare the `Latest update`
+dates — a skew between them is itself a finding.
+
+**2. Fix the released baseline before reading any code.** This is the step
+that produced most of the findings above:
+
+```sh
+gh release list --limit 1                     # what is actually out
+git merge-base --is-ancestor <commit> v2.0.2  # is this fix in it?
+git show v2.0.2:<path>                        # read the released file
+```
+
+Never audit the working tree and call the result "what users experience".
+
+**3. Re-enumerate the destinations.** Anything new here needs a policy
+section:
+
+```sh
+grep -rn "Uri\.\(parse\|https\)\|http\.\|client\.rpc\|CachedNetworkImage" lib --include=*.dart
+grep -rn "SentryFlutter.init\|tracesSampleRate\|enablePrintBreadcrumbs\|sendDefaultPii" lib
+git ls-tree -r --name-only feat/own-server-settings | grep -iE "meal_items_api|ai_"
+```
+
+**4. Re-check the four claims most likely to drift.** Each maps to a finding:
+that the diary never leaves (Finding 1 — is `enablePrintBreadcrumbs = false`
+in the released build?); that search terms are not in a URL (Finding 2 — is
+every Supabase call still an `rpc`?); that only crashes are sent (Finding 3 —
+what is `tracesSampleRate`?); that every AI recipient is named (Finding 8 —
+does `AiProvider` have a new value?).
+
+**5. Diff the policy's per-service `Personal Data processed` lists against the
+request bodies.** Findings 5, 6 and 11 all came from doing exactly that, and
+all three are the kind of drift that reappears the next time a parameter is
+added to a request.
+
+---
+
+## Sources
+
+Primary policy documents, read on the live page on 2026-08-27:
+[Privacy Policy of OpenNutriTracker — full legal view](https://www.iubenda.com/privacy-policy/53501884/full-legal) ·
+[simplified view](https://www.iubenda.com/privacy-policy/53501884) ·
+[German document](https://www.iubenda.com/privacy-policy/53922100/full-legal)
+
+Obligations cited:
+[GDPR Article 13](https://gdpr-info.eu/art-13-gdpr/) ·
+[GDPR Article 9](https://gdpr-info.eu/art-9-gdpr/) ·
+[Google Play Data safety](https://support.google.com/googleplay/android-developer/answer/10787469)
+
+Related notes in this repo:
+[`ai-openai-data-handling.md`](ai-openai-data-handling.md) ·
+[`ai-openai-key-transfer.md`](ai-openai-key-transfer.md) ·
+[`ai-openai-policy-fit.md`](ai-openai-policy-fit.md) ·
+[`ai-cleartext-http-policy.md`](ai-cleartext-http-policy.md) ·
+[`ai-play-encryption-declaration.md`](ai-play-encryption-declaration.md) ·
+[`fdroid-submission-feasibility.md`](fdroid-submission-feasibility.md)
+
+In-repo files cited:
+[`lib/main.dart`](../lib/main.dart) ·
+[`lib/core/utils/sentry_config.dart`](../lib/core/utils/sentry_config.dart) ·
+[`lib/core/utils/logger_config.dart`](../lib/core/utils/logger_config.dart) ·
+[`lib/core/utils/off_const.dart`](../lib/core/utils/off_const.dart) ·
+[`lib/core/utils/app_const.dart`](../lib/core/utils/app_const.dart) ·
+[`lib/core/utils/ont_http_client.dart`](../lib/core/utils/ont_http_client.dart) ·
+[`lib/core/utils/ont_image_cache_manager.dart`](../lib/core/utils/ont_image_cache_manager.dart) ·
+[`lib/core/utils/secure_app_storage_provider.dart`](../lib/core/utils/secure_app_storage_provider.dart) ·
+[`lib/core/utils/url_const.dart`](../lib/core/utils/url_const.dart) ·
+[`lib/core/presentation/widgets/intake_card.dart`](../lib/core/presentation/widgets/intake_card.dart) ·
+[`lib/core/domain/usecase/delete_all_user_data_usecase.dart`](../lib/core/domain/usecase/delete_all_user_data_usecase.dart) ·
+[`lib/core/data/dbo/meal_dbo.dart`](../lib/core/data/dbo/meal_dbo.dart) ·
+[`lib/core/data/data_source/health/health_package_service.dart`](../lib/core/data/data_source/health/health_package_service.dart) ·
+[`lib/core/data/data_source/water_intake_data_source.dart`](../lib/core/data/data_source/water_intake_data_source.dart) ·
+[`lib/features/add_meal/data/data_sources/off_data_source.dart`](../lib/features/add_meal/data/data_sources/off_data_source.dart) ·
+[`lib/features/add_meal/data/data_sources/sp_food_data_source.dart`](../lib/features/add_meal/data/data_sources/sp_food_data_source.dart) ·
+[`android/app/src/main/AndroidManifest.xml`](../android/app/src/main/AndroidManifest.xml) ·
+[`ios/Runner/Info.plist`](../ios/Runner/Info.plist) ·
+[`ios/Runner/PrivacyInfo.xcprivacy`](../ios/Runner/PrivacyInfo.xcprivacy)
+
+On `feat/own-server-settings` only:
+`lib/core/utils/ai_credential_storage.dart` ·
+`lib/features/add_meal/util/meal_photo_encoder.dart` ·
+`lib/features/add_meal/data/anthropic_meal_items_api.dart` ·
+`lib/features/add_meal/data/openai_meal_items_api.dart` ·
+`lib/features/add_meal/data/openai_compatible_meal_items_api.dart` ·
+`lib/features/add_meal/domain/usecase/probe_ai_endpoint_usecase.dart`
+
+Backend: `opennutritracker-backend/sql/schema.sql` (RPC rationale at `:387-390`).

--- a/lib/core/utils/plaintext_destination_guard.dart
+++ b/lib/core/utils/plaintext_destination_guard.dart
@@ -138,6 +138,10 @@ class PlaintextDestinationGuard {
 /// promise is about the app's traffic to a user-supplied address and not
 /// about one call site. Anything given this client is covered, including
 /// call sites that do not exist yet.
+///
+/// **Redirects are not followed.** They would be followed below this layer,
+/// where the guard never sees them, so a 30x comes back to the caller
+/// unfollowed rather than becoming an unchecked second destination.
 class GuardedPlaintextClient extends http.BaseClient {
   final http.Client _inner;
   final PlaintextDestinationGuard _guard;
@@ -148,8 +152,22 @@ class GuardedPlaintextClient extends http.BaseClient {
   @override
   Future<http.StreamedResponse> send(http.BaseRequest request) async {
     final approved = await _guard.approve(request.url);
-    if (approved == request.url) return _inner.send(request);
-    return _inner.send(_reboundTo(approved, request));
+    final outgoing = approved == request.url
+        ? request
+        : _reboundTo(approved, request);
+
+    // Redirects are followed inside `dart:io`, below `BaseClient.send`, so a
+    // hop never comes back through here and never meets [approve]. Left on,
+    // a server answering 30x with a public `http://` target would have that
+    // connection made — from a check that reported the destination private.
+    // The guard cannot vouch for a hop it never sees, so it does not let one
+    // happen: a redirect is returned to the caller as the 30x it is.
+    //
+    // This holds for `https://` too, which [approve] waves through: an
+    // encrypted first hop says nothing about where a `Location` points.
+    if (outgoing.followRedirects) outgoing.followRedirects = false;
+
+    return _inner.send(outgoing);
   }
 
   /// Rebuilds the request against the approved address, keeping the original
@@ -166,7 +184,6 @@ class GuardedPlaintextClient extends http.BaseClient {
       ..headers.addAll(request.headers)
       ..headers['host'] = request.url.host
       ..bodyBytes = request.bodyBytes
-      ..followRedirects = request.followRedirects
       ..maxRedirects = request.maxRedirects
       ..persistentConnection = request.persistentConnection;
   }

--- a/lib/core/utils/plaintext_destination_guard.dart
+++ b/lib/core/utils/plaintext_destination_guard.dart
@@ -173,6 +173,14 @@ class GuardedPlaintextClient extends http.BaseClient {
   /// Rebuilds the request against the approved address, keeping the original
   /// authority in the `host` header so a name-based server still routes it.
   ///
+  /// **The port is part of that authority.** A local model server is almost
+  /// never on 80 — `http://ollama.lan:11434` is the ordinary shape — and a
+  /// `Host: ollama.lan` that drops the `:11434` is a different authority from
+  /// the one that was typed. A reverse proxy or a strict server routes by
+  /// what that header says, so it has to keep saying it. The port is written
+  /// only when the URL gave one, so a plain `http://ollama.lan` still sends
+  /// the bare name rather than a redundant `:80`.
+  ///
   /// Only [http.Request] can be rebuilt — its body is bytes already. A
   /// streamed request is passed through **after** the check, which still
   /// refuses a public destination; it only loses the address pinning. The app
@@ -180,9 +188,12 @@ class GuardedPlaintextClient extends http.BaseClient {
   /// guess about how to re-wrap one would be worse than the gap.
   http.BaseRequest _reboundTo(Uri url, http.BaseRequest request) {
     if (request is! http.Request) return request;
+    final origin = request.url;
     return http.Request(request.method, url)
       ..headers.addAll(request.headers)
-      ..headers['host'] = request.url.host
+      ..headers['host'] = origin.hasPort
+          ? '${origin.host}:${origin.port}'
+          : origin.host
       ..bodyBytes = request.bodyBytes
       ..maxRedirects = request.maxRedirects
       ..persistentConnection = request.persistentConnection;

--- a/test/unit_test/ai_architecture_doc_test.dart
+++ b/test/unit_test/ai_architecture_doc_test.dart
@@ -41,8 +41,17 @@ void main() {
   /// catch, and this page quotes real source comments verbatim — so scanning
   /// one means failing the build over an accurate transcription. It also
   /// keeps a `# install` line in a shell block from registering as a heading.
+  /// Indented fences count. A fence inside a list item is indented by the
+  /// list's own margin, and anchoring at column 0 would read straight past it
+  /// — scanning the sample links and headings it contains as if they were the
+  /// page's own. Up to three spaces is what CommonMark allows before a fence
+  /// stops being a fence, and the closing run has to be allowed the same.
   String withoutFences(String markdown) => markdown.replaceAll(
-    RegExp(r'^(```|~~~)[^\n]*\n.*?^\1[^\n]*$', multiLine: true, dotAll: true),
+    RegExp(
+      r'^ {0,3}(```|~~~)[^\n]*\n.*?^ {0,3}\1[^\n]*$',
+      multiLine: true,
+      dotAll: true,
+    ),
     '',
   );
 

--- a/test/unit_test/ai_architecture_doc_test.dart
+++ b/test/unit_test/ai_architecture_doc_test.dart
@@ -20,32 +20,112 @@ void main() {
   final doc = File('docs/ai-architecture.md');
   final text = doc.readAsStringSync();
 
-  /// GitHub's heading slug: lowercased, punctuation dropped, spaces hyphened.
+  /// GitHub's heading slug, as GitHub actually computes it: lowercased,
+  /// punctuation dropped, and then every remaining space turned into a hyphen
+  /// one at a time rather than a run at a time. Underscores are word
+  /// characters and survive — which matters on a page whose headings name
+  /// files like `meal_text_parser.dart`. Both details are confirmed against
+  /// this repository's own rendered pages: the `food_summary` heading in
+  /// docs/supabase-self-hosting.md is served with the id
+  /// `food_summary--one-flat-row-per-food`, keeping the underscore and both
+  /// hyphens the em dash left behind. A slug that dropped either would call a
+  /// working link broken and a broken one fine.
   String slug(String heading) => heading
-      .toLowerCase()
-      .replaceAll(RegExp(r'[^a-z0-9 -]'), '')
       .trim()
-      .replaceAll(RegExp(r'\s+'), '-');
+      .toLowerCase()
+      .replaceAll(RegExp(r'[^\p{L}\p{N}_ -]', unicode: true), '')
+      .replaceAll(' ', '-');
 
+  /// Fenced blocks, removed before anything is scanned. A link inside a fence
+  /// is text on the rendered page and cannot be the 404 this test exists to
+  /// catch, and this page quotes real source comments verbatim — so scanning
+  /// one means failing the build over an accurate transcription. It also
+  /// keeps a `# install` line in a shell block from registering as a heading.
+  String withoutFences(String markdown) => markdown.replaceAll(
+    RegExp(r'^(```|~~~)[^\n]*\n.*?^\1[^\n]*$', multiLine: true, dotAll: true),
+    '',
+  );
+
+  /// The headings a link can land on. Repeated headings get a `-1` suffix on
+  /// GitHub and this does not model that; no page it reads has one.
   Set<String> anchorsIn(String markdown) => {
     for (final match in RegExp(
       r'^#{1,6}\s+(.+)$',
       multiLine: true,
-    ).allMatches(markdown))
-      slug(match.group(1)!.trim()),
+    ).allMatches(withoutFences(markdown)))
+      slug(match.group(1)!),
   };
 
-  // Links that climb out of docs/ — every reference into lib/, test/ or the
-  // README. Anything else on the page is an external URL and not ours to
-  // keep working.
-  final outward = RegExp(
-    r'\]\(\.\./([^)\s#]+)(#[^)\s]*)?\)',
-  ).allMatches(text).map((m) => (path: m.group(1)!, anchor: m.group(2)));
+  /// Every link target, in each form that renders as a link. Reading only
+  /// `](../path)` misses three that reach a reader just the same: a title
+  /// after the target, an angle-bracketed target, and a reference definition
+  /// on its own line. Missing them here is worse than it looks — the `sed` in
+  /// docs/RELEASING.md that publishes this page rewrites `](../` and nothing
+  /// else, so a form this scan does not catch is a form that arrives on the
+  /// wiki unrewritten, as a dead link.
+  Iterable<String> targetsIn(String markdown) sync* {
+    final body = withoutFences(markdown);
+    for (final match in RegExp(
+      r'\]\(\s*<?([^)\s>]+)>?[^)]*\)',
+    ).allMatches(body)) {
+      yield match.group(1)!;
+    }
+    for (final match in RegExp(
+      r'^ {0,3}\[[^\]]+\]:\s*<?([^\s>]+)>?',
+      multiLine: true,
+    ).allMatches(body)) {
+      yield match.group(1)!;
+    }
+  }
+
+  /// A target split into the file it names and the heading it jumps to.
+  ({String path, String? anchor}) parts(String target) {
+    final hash = target.indexOf('#');
+    if (hash < 0) return (path: target, anchor: null);
+    return (path: target.substring(0, hash), anchor: target.substring(hash));
+  }
+
+  /// Where a link written in docs/ lands, or null if it lands outside the
+  /// repository. `File('../x')` resolves against the working directory rather
+  /// than against docs/, so `](../../x)` was looked for *beside* the checkout
+  /// — and on a machine that happens to have something of that name there, it
+  /// is found and the link passes. GitHub serves it as a 404. A target
+  /// starting `/` is the same failure by another route: a reader's browser
+  /// resolves it against github.com, not against the repository.
+  String? insideRepo(String linkPath) {
+    if (linkPath.startsWith('/')) return null;
+    final segments = <String>[];
+    for (final segment in 'docs/$linkPath'.split('/')) {
+      if (segment.isEmpty || segment == '.') continue;
+      if (segment == '..') {
+        if (segments.isEmpty) return null;
+        segments.removeLast();
+      } else {
+        segments.add(segment);
+      }
+    }
+    return segments.join('/');
+  }
+
+  /// Somebody else's to keep working.
+  bool isExternal(String linkPath) =>
+      RegExp(r'^[a-zA-Z][a-zA-Z0-9+.-]*:|^//').hasMatch(linkPath);
+
+  final targets = targetsIn(text).map(parts).toList();
+
+  // Links into the repository — lib/, test/, the README, and a sibling page
+  // in docs/, which a scan that recognised a link only by its `../` never saw.
+  final outward = [
+    for (final target in targets)
+      if (target.path.isNotEmpty && !isExternal(target.path)) target,
+  ];
 
   // Links to a heading on the page itself — the table of contents, mostly.
-  final internal = RegExp(
-    r'\]\(#([^)\s]+)\)',
-  ).allMatches(text).map((m) => m.group(1)!).toSet();
+  final internal = {
+    for (final target in targets)
+      if (target.path.isEmpty && target.anchor != null)
+        target.anchor!.substring(1),
+  };
 
   group('docs/ai-architecture.md', () {
     test('the page is where this test thinks it is', () {
@@ -58,24 +138,46 @@ void main() {
 
     test('the link scan actually found links', () {
       // The canary. A regex that stops matching turns every check below into
-      // a loop over nothing, and a loop over nothing passes. The floor is
-      // deliberately well under the real count — this is here to catch a
-      // scan that broke, not to police how many files the page cites.
+      // a loop over nothing, and a loop over nothing passes. The floors sit
+      // just under the real counts — 49 outward links and 9 distinct anchors
+      // as this is written — so that losing one *kind* of link fails too: the
+      // code map alone is 24 rows, and a floor low enough to survive dropping
+      // it is a floor that catches nothing. A page that genuinely sheds links
+      // is an edit somebody made on purpose, and lowering these by hand is
+      // part of it.
       expect(
         outward.length,
-        greaterThan(25),
-        reason: 'the outward-link regex matched almost nothing, so the '
-            'checks below are running over an empty list and passing '
-            'vacuously — fix the scan, not the page',
+        greaterThan(40),
+        reason: 'the outward-link scan lost links, so the checks below are '
+            'running over a short list — or an empty one — and passing '
+            'vacuously; fix the scan, not the page',
       );
-      expect(internal, isNotEmpty);
+      expect(
+        internal.length,
+        greaterThan(6),
+        reason: 'the anchor scan lost links: the table of contents alone is '
+            'nine entries',
+      );
     });
 
     test('every file the page points at exists', () {
-      final missing = [
-        for (final link in outward)
-          if (!File(link.path).existsSync()) link.path,
-      ];
+      final missing = <String>[];
+      final escaping = <String>[];
+      for (final link in outward) {
+        final resolved = insideRepo(link.path);
+        if (resolved == null) {
+          escaping.add(link.path);
+        } else if (!File(resolved).existsSync() &&
+            !Directory(resolved).existsSync()) {
+          missing.add(link.path);
+        }
+      }
+      expect(
+        escaping,
+        isEmpty,
+        reason: 'the page cites a path that leaves the repository. Whatever '
+            'it finds on the machine running this, a reader gets a 404.',
+      );
       expect(
         missing,
         isEmpty,
@@ -104,10 +206,13 @@ void main() {
       // links honest; this keeps the one link *into* it honest, because a
       // page nothing references is a page nobody reads and a rename would
       // cost it its only inbound link without failing anything.
+      // The README's links resolve from the repository root, so the target
+      // is read as written — and read in every form, so that adding a title
+      // to the link does not read as the link having been removed.
       final readme = File('README.md').readAsStringSync();
       expect(
-        readme,
-        contains('](docs/ai-architecture.md)'),
+        targetsIn(readme).map((target) => parts(target).path),
+        contains('docs/ai-architecture.md'),
         reason: 'the README no longer links to the architecture page, so the '
             'only route a reader has to it is gone',
       );
@@ -121,8 +226,8 @@ void main() {
       // repo forever.
       final releasing = File('docs/RELEASING.md').readAsStringSync();
       expect(
-        releasing,
-        contains('](ai-architecture.md)'),
+        targetsIn(releasing).map((target) => parts(target).path),
+        contains('ai-architecture.md'),
         reason: 'docs/RELEASING.md no longer links to the architecture page, '
             'so the release step that publishes it has lost its target',
       );
@@ -133,9 +238,13 @@ void main() {
       for (final link in outward) {
         final anchor = link.anchor;
         if (anchor == null || !link.path.endsWith('.md')) continue;
-        final target = File(link.path);
+        final resolved = insideRepo(link.path);
+        if (resolved == null) continue; // already reported above
+        final target = File(resolved);
         if (!target.existsSync()) continue; // already reported above
-        if (!anchorsIn(target.readAsStringSync()).contains(anchor.substring(1))) {
+        if (!anchorsIn(
+          target.readAsStringSync(),
+        ).contains(anchor.substring(1))) {
           broken.add('${link.path}$anchor');
         }
       }

--- a/test/unit_test/plaintext_destination_guard_test.dart
+++ b/test/unit_test/plaintext_destination_guard_test.dart
@@ -6,8 +6,10 @@ import 'package:opennutritracker/core/utils/plaintext_destination_guard.dart';
 
 /// Records the request that reached the socket, or the fact that none did.
 ///
-/// [sentCount] matters for the redirect tests: following a 30x would show up
-/// here as a second send, which is exactly what must not happen.
+/// [sentCount] records how many times [GuardedPlaintextClient] called through.
+/// It cannot see a redirect being followed — that happens inside `dart:io`,
+/// below this fake — so it pins that the guard itself sends once, and nothing
+/// more than that.
 class _RecordingClient extends http.BaseClient {
   http.BaseRequest? sent;
   int sentCount = 0;
@@ -22,8 +24,18 @@ class _RecordingClient extends http.BaseClient {
   Future<http.StreamedResponse> send(http.BaseRequest request) async {
     sent = request;
     sentCount++;
-    return response ??
-        http.StreamedResponse(const Stream.empty(), 200, request: request);
+    // The injected response keeps the request association too, so an
+    // assertion on `response.request` reads the same either way.
+    final canned = response;
+    if (canned != null) {
+      return http.StreamedResponse(
+        canned.stream,
+        canned.statusCode,
+        headers: canned.headers,
+        request: request,
+      );
+    }
+    return http.StreamedResponse(const Stream.empty(), 200, request: request);
   }
 }
 

--- a/test/unit_test/plaintext_destination_guard_test.dart
+++ b/test/unit_test/plaintext_destination_guard_test.dart
@@ -209,9 +209,28 @@ void main() {
       );
 
       expect(inner.sent!.url.host, '192.168.1.5');
-      expect(inner.sent!.headers['host'], 'ollama.lan');
+      // With the port. `ollama.lan` alone is a different authority from the
+      // `ollama.lan:11434` that was typed, and a local model server is
+      // essentially never on 80, so dropping it is the common case rather
+      // than the corner one.
+      expect(inner.sent!.headers['host'], 'ollama.lan:11434');
       expect(inner.sent!.headers['content-type'], 'application/json');
       expect((inner.sent! as http.Request).body, 'payload');
+    });
+
+    test('a URL without a port sends the bare name, not a redundant :80',
+        () async {
+      final inner = _RecordingClient();
+      final client = GuardedPlaintextClient(
+        inner,
+        guard: PlaintextDestinationGuard(
+          lookup: (_) async => [_v4('192.168.1.5')],
+        ),
+      );
+
+      await client.post(Uri.parse('http://ollama.lan/v1'), body: 'payload');
+
+      expect(inner.sent!.headers['host'], 'ollama.lan');
     });
 
     test('an https request reaches the socket untouched', () async {

--- a/test/unit_test/plaintext_destination_guard_test.dart
+++ b/test/unit_test/plaintext_destination_guard_test.dart
@@ -344,4 +344,111 @@ void main() {
       }
     });
   });
+
+  /// The claims above are made against a fake, which cannot follow a redirect
+  /// — `dart:io` does that below `BaseClient.send`, where no fake reaches. So
+  /// these run against a real `HttpServer` on loopback and a real `dart:io`
+  /// client, which is the only place the redirect rule is actually decided.
+  group('against a real socket', () {
+    late HttpServer server;
+    late List<String> paths;
+    late List<String?> hosts;
+    HttpOverrides? savedOverrides;
+
+    setUp(() async {
+      // `flutter_test` installs an override that answers every request with a
+      // canned 400 rather than opening a socket. These tests are about what
+      // the socket layer really does, so they need it out of the way — and
+      // put back, because the rest of the suite may rely on it.
+      savedOverrides = HttpOverrides.current;
+      HttpOverrides.global = null;
+
+      paths = [];
+      hosts = [];
+      server = await HttpServer.bind(InternetAddress.loopbackIPv4, 0);
+      server.listen((request) async {
+        paths.add(request.uri.path);
+        hosts.add(request.headers.value('host'));
+        if (request.uri.path == '/first') {
+          request.response.statusCode = HttpStatus.found;
+          request.response.headers.set('location', '/second');
+        } else {
+          request.response.statusCode = HttpStatus.ok;
+        }
+        await request.response.close();
+      });
+    });
+
+    tearDown(() async {
+      await server.close(force: true);
+      HttpOverrides.global = savedOverrides;
+    });
+
+    test('an unguarded client really does follow the redirect', () async {
+      // The control. Without it the two tests below prove nothing: they would
+      // pass just as well against a server that never redirected, or a client
+      // stack that had stopped following redirects on its own.
+      final client = http.Client();
+      addTearDown(client.close);
+
+      final response =
+          await client.get(Uri.parse('http://127.0.0.1:${server.port}/first'));
+
+      expect(paths, ['/first', '/second']);
+      expect(response.statusCode, 200);
+    });
+
+    test('the guarded client stops at the 30x — literal pass-through',
+        () async {
+      // A private literal is waved through `approve` untouched, so this is
+      // the branch where the request object reaches the socket as the caller
+      // built it. `followRedirects` still has to have been turned off.
+      final client = GuardedPlaintextClient(http.Client());
+      addTearDown(client.close);
+
+      final response =
+          await client.get(Uri.parse('http://127.0.0.1:${server.port}/first'));
+
+      expect(paths, ['/first']);
+      expect(response.statusCode, 302);
+      expect(response.headers['location'], '/second');
+    });
+
+    test('the guarded client stops at the 30x — rebound path', () async {
+      // The same claim on the other branch: a name pinned to its resolved
+      // address, rebuilt into a new request. The rebuild must not hand back a
+      // request that follows redirects.
+      final client = GuardedPlaintextClient(
+        http.Client(),
+        guard: PlaintextDestinationGuard(
+          lookup: (_) async => [_v4('127.0.0.1')],
+        ),
+      );
+      addTearDown(client.close);
+
+      final response = await client
+          .get(Uri.parse('http://ollama.lan:${server.port}/first'));
+
+      expect(paths, ['/first']);
+      expect(response.statusCode, 302);
+    });
+
+    test('the Host header arrives at the server with its port', () async {
+      // Read off the wire rather than off the request object: the header has
+      // to survive `dart:io`, which sets a Host of its own from the
+      // connection URI and would otherwise report 127.0.0.1.
+      final client = GuardedPlaintextClient(
+        http.Client(),
+        guard: PlaintextDestinationGuard(
+          lookup: (_) async => [_v4('127.0.0.1')],
+        ),
+      );
+      addTearDown(client.close);
+
+      await client.get(Uri.parse('http://ollama.lan:${server.port}/second'));
+
+      expect(hosts.single, 'ollama.lan:${server.port}');
+    });
+  });
+
 }

--- a/test/unit_test/plaintext_destination_guard_test.dart
+++ b/test/unit_test/plaintext_destination_guard_test.dart
@@ -5,13 +5,25 @@ import 'package:http/http.dart' as http;
 import 'package:opennutritracker/core/utils/plaintext_destination_guard.dart';
 
 /// Records the request that reached the socket, or the fact that none did.
+///
+/// [sentCount] matters for the redirect tests: following a 30x would show up
+/// here as a second send, which is exactly what must not happen.
 class _RecordingClient extends http.BaseClient {
   http.BaseRequest? sent;
+  int sentCount = 0;
+
+  /// Returned instead of a bare 200 when a test needs a specific status —
+  /// a 30x, for the redirect cases.
+  final http.StreamedResponse? response;
+
+  _RecordingClient({this.response});
 
   @override
   Future<http.StreamedResponse> send(http.BaseRequest request) async {
     sent = request;
-    return http.StreamedResponse(const Stream.empty(), 200, request: request);
+    sentCount++;
+    return response ??
+        http.StreamedResponse(const Stream.empty(), 200, request: request);
   }
 }
 
@@ -216,6 +228,73 @@ void main() {
         throwsA(isA<InsecureDestinationException>()),
       );
       expect(inner.sent, isNull);
+    });
+
+    test('redirects are not followed, on the rebound path', () async {
+      // The gap this closes: `dart:io` follows a 30x below `BaseClient.send`,
+      // so the hop never re-enters the guard. A private server answering with
+      // a public `http://` Location would have had that connection made, out
+      // of a check that reported the destination private.
+      final inner = _RecordingClient();
+      final client = GuardedPlaintextClient(
+        inner,
+        guard: PlaintextDestinationGuard(
+          lookup: (_) async => [_v4('192.168.1.5')],
+        ),
+      );
+
+      await client.post(
+        Uri.parse('http://ollama.lan:11434/v1/chat/completions'),
+        body: 'payload',
+      );
+
+      expect(inner.sent!.followRedirects, isFalse);
+    });
+
+    test('redirects are not followed on the https pass-through either', () async {
+      // `approve` waves https straight through, so the pass-through branch
+      // needs its own guarantee: an encrypted first hop says nothing about
+      // where a `Location` header points.
+      final inner = _RecordingClient();
+      final client = GuardedPlaintextClient(inner);
+
+      await client.post(
+        Uri.parse('https://ollama.example.com/v1/chat/completions'),
+        body: 'payload',
+      );
+
+      expect(inner.sent!.followRedirects, isFalse);
+    });
+
+    test('a 30x comes back to the caller as a response, not a second hop', () async {
+      // Contract, not regression: the following happens inside `dart:io`,
+      // below this fake, so this test passes with or without the fix above.
+      // It pins what a caller sees — a 30x surfacing rather than being
+      // swallowed — while the two tests above are the ones that fail if
+      // `followRedirects` is ever turned back on.
+      final inner = _RecordingClient(
+        response: http.StreamedResponse(
+          const Stream.empty(),
+          302,
+          headers: {'location': 'http://93.184.216.34/v1/chat/completions'},
+        ),
+      );
+      final client = GuardedPlaintextClient(
+        inner,
+        guard: PlaintextDestinationGuard(
+          lookup: (_) async => [_v4('192.168.1.5')],
+        ),
+      );
+
+      final response = await client.post(
+        Uri.parse('http://ollama.lan:11434/v1/chat/completions'),
+        body: 'payload',
+      );
+
+      // Surfaced rather than chased. The caller sees a failed request; what
+      // it does not see is a payload delivered to 93.184.216.34.
+      expect(response.statusCode, 302);
+      expect(inner.sentCount, 1);
     });
 
     test('the exception names the host and nothing else', () async {


### PR DESCRIPTION
Found by the `ai-architecture.md` review, which flagged the page's claim that the guard "is the whole of the enforcement" as overstated. It was — but the honest fix is in the code, not the sentence.

## The gap

`GuardedPlaintextClient.send` approves the URL the app builds. Redirects are followed inside `dart:io`, **below** `BaseClient.send`, so a hop never re-enters the guard and never meets `approve`.

A private server answering `302` with a public `http://` Location had that connection made — out of a check that had just reported the destination private. `AiModelListApi.list` is a GET through exactly this client, pointed at an address the user typed.

**The https pass-through had the same hole from the other side.** `approve` returns non-http URLs untouched, so an https request kept `followRedirects = true` and an `https:// → http://public` redirect was followed unchecked. This is why the fix is in `send` rather than in `_reboundTo` as first suggested — `_reboundTo` only runs on the rewritten http path, so that version would have closed one branch and left the other open.

## The fix

`followRedirects = false` for every request through the client, and a 30x is returned to the caller as the response it is. The guard cannot vouch for a hop it never sees, so it does not let one happen.

Behaviour change, and worth being explicit about it: an endpoint that redirects its own API path now fails instead of being followed. `AiModelListApi` already treats a non-200 as a failed request, so this surfaces as "that address did not work" rather than a crash. An OpenAI-compatible server redirecting `/v1/models` elsewhere is not a case worth chasing to a destination nothing checked.

## Tests

There were none for redirects, which is how this survived.

- **`redirects are not followed, on the rebound path`** — fails without the fix
- **`redirects are not followed on the https pass-through either`** — fails without the fix
- **`a 30x comes back to the caller as a response, not a second hop`** — passes either way, and says so in a comment. The following happens inside `dart:io`, below the fake client, so this pins the caller-visible contract rather than catching the regression.

I verified the first two go red with the change reverted rather than assuming they discriminate.

- [x] `flutter test` — 2110 pass
- [x] `flutter analyze` — clean

## Related

#996 corrects the documentation claim on the same subject. This PR is what makes that claim true.