### PR TITLE
fix(net): three plaintext-guard fixes for 2.2.0, and CI on release PRs

### DIFF
--- a/.github/workflows/default_workflow.yml
+++ b/.github/workflows/default_workflow.yml
@@ -32,6 +32,13 @@ on:
       # to add it back, and the failure mode is silent — a retargeted PR
       # still reports mergeable with no checks run.
       - 'feature/**'
+      # Release branches, for the same reason and with the same failure mode.
+      # `release/2.2.0` is cut from `main`, so a fix that landed on `develop`
+      # is not in it, and the PR carrying that fix across got exactly one
+      # check — the Copilot reviewer — while reporting `CLEAN`. A release
+      # branch is the last place that should merge unverified: everything on
+      # it is by definition about to become `main`.
+      - 'release/**'
   workflow_dispatch:
 
 jobs:

--- a/lib/core/utils/plaintext_destination_guard.dart
+++ b/lib/core/utils/plaintext_destination_guard.dart
@@ -138,6 +138,10 @@ class PlaintextDestinationGuard {
 /// promise is about the app's traffic to a user-supplied address and not
 /// about one call site. Anything given this client is covered, including
 /// call sites that do not exist yet.
+///
+/// **Redirects are not followed.** They would be followed below this layer,
+/// where the guard never sees them, so a 30x comes back to the caller
+/// unfollowed rather than becoming an unchecked second destination.
 class GuardedPlaintextClient extends http.BaseClient {
   final http.Client _inner;
   final PlaintextDestinationGuard _guard;
@@ -148,8 +152,22 @@ class GuardedPlaintextClient extends http.BaseClient {
   @override
   Future<http.StreamedResponse> send(http.BaseRequest request) async {
     final approved = await _guard.approve(request.url);
-    if (approved == request.url) return _inner.send(request);
-    return _inner.send(_reboundTo(approved, request));
+    final outgoing = approved == request.url
+        ? request
+        : _reboundTo(approved, request);
+
+    // Redirects are followed inside `dart:io`, below `BaseClient.send`, so a
+    // hop never comes back through here and never meets [approve]. Left on,
+    // a server answering 30x with a public `http://` target would have that
+    // connection made — from a check that reported the destination private.
+    // The guard cannot vouch for a hop it never sees, so it does not let one
+    // happen: a redirect is returned to the caller as the 30x it is.
+    //
+    // This holds for `https://` too, which [approve] waves through: an
+    // encrypted first hop says nothing about where a `Location` points.
+    if (outgoing.followRedirects) outgoing.followRedirects = false;
+
+    return _inner.send(outgoing);
   }
 
   /// Rebuilds the request against the approved address, keeping the original
@@ -166,7 +184,6 @@ class GuardedPlaintextClient extends http.BaseClient {
       ..headers.addAll(request.headers)
       ..headers['host'] = request.url.host
       ..bodyBytes = request.bodyBytes
-      ..followRedirects = request.followRedirects
       ..maxRedirects = request.maxRedirects
       ..persistentConnection = request.persistentConnection;
   }

--- a/lib/core/utils/plaintext_destination_guard.dart
+++ b/lib/core/utils/plaintext_destination_guard.dart
@@ -88,6 +88,32 @@ class PlaintextDestinationGuard {
   static Future<List<InternetAddress>> _resolve(String host) =>
       InternetAddress.lookup(host, type: InternetAddressType.any);
 
+  /// Turns the `%25` a URI must spell a zone id with back into the `%` that
+  /// [InternetAddress] parses.
+  ///
+  /// A link-local address needs a zone to be routable on a host with more
+  /// than one interface, and RFC 6874 says a URI escapes it: `Uri` stores
+  /// `http://[fe80::1%wlan0]` with a host of `fe80::1%25wlan0` — typing the
+  /// bare `%` gets you the same thing, so this is not a corner someone has to
+  /// know the RFC to reach. `InternetAddress.tryParse` returns null on that
+  /// escaped form, which sent the address down the DNS branch below, where
+  /// the lookup fails and the caller is told the server is **unreachable** —
+  /// about a link-local server this check exists to *permit*, and which an
+  /// unguarded client reaches perfectly well.
+  ///
+  /// `dart:io` does exactly this substitution itself, in
+  /// `escapeLinkLocalAddress`, before it resolves or connects. Doing it here
+  /// too is what makes the check agree with the socket layer it is guarding.
+  ///
+  /// Anything that still fails to parse falls through to the lookup unchanged,
+  /// so a name is never touched: the `25` is only dropped when it directly
+  /// follows the first `%`.
+  static String _withZoneUnescaped(String host) {
+    final marker = host.indexOf('%');
+    if (marker < 0 || !host.startsWith('25', marker + 1)) return host;
+    return host.replaceRange(marker + 1, marker + 3, '');
+  }
+
   /// Returns the URL to actually request, or throws
   /// [InsecureDestinationException].
   ///
@@ -103,7 +129,7 @@ class PlaintextDestinationGuard {
     if (url.scheme != 'http') return url;
 
     final host = url.host;
-    final literal = InternetAddress.tryParse(host);
+    final literal = InternetAddress.tryParse(_withZoneUnescaped(host));
     if (literal != null) {
       // No lookup to do, and nothing to pin — the user typed the address.
       if (isPrivateDestination(literal)) return url;

--- a/lib/core/utils/plaintext_destination_guard.dart
+++ b/lib/core/utils/plaintext_destination_guard.dart
@@ -173,6 +173,14 @@ class GuardedPlaintextClient extends http.BaseClient {
   /// Rebuilds the request against the approved address, keeping the original
   /// authority in the `host` header so a name-based server still routes it.
   ///
+  /// **The port is part of that authority.** A local model server is almost
+  /// never on 80 — `http://ollama.lan:11434` is the ordinary shape — and a
+  /// `Host: ollama.lan` that drops the `:11434` is a different authority from
+  /// the one that was typed. A reverse proxy or a strict server routes by
+  /// what that header says, so it has to keep saying it. The port is written
+  /// only when the URL gave one, so a plain `http://ollama.lan` still sends
+  /// the bare name rather than a redundant `:80`.
+  ///
   /// Only [http.Request] can be rebuilt — its body is bytes already. A
   /// streamed request is passed through **after** the check, which still
   /// refuses a public destination; it only loses the address pinning. The app
@@ -180,9 +188,12 @@ class GuardedPlaintextClient extends http.BaseClient {
   /// guess about how to re-wrap one would be worse than the gap.
   http.BaseRequest _reboundTo(Uri url, http.BaseRequest request) {
     if (request is! http.Request) return request;
+    final origin = request.url;
     return http.Request(request.method, url)
       ..headers.addAll(request.headers)
-      ..headers['host'] = request.url.host
+      ..headers['host'] = origin.hasPort
+          ? '${origin.host}:${origin.port}'
+          : origin.host
       ..bodyBytes = request.bodyBytes
       ..maxRedirects = request.maxRedirects
       ..persistentConnection = request.persistentConnection;

--- a/test/unit_test/plaintext_destination_guard_test.dart
+++ b/test/unit_test/plaintext_destination_guard_test.dart
@@ -168,6 +168,87 @@ void main() {
           InternetAddressType.IPv6);
     });
 
+    // A zone id is what makes a link-local address routable on a host with
+    // more than one interface, and it is the case the guard was silently
+    // breaking: `Uri` escapes the `%` to `%25`, `InternetAddress.tryParse`
+    // refuses that, and the address fell through to a DNS lookup that cannot
+    // succeed — so a link-local server this check exists to *permit* was
+    // reported unreachable, while an unguarded client reached it fine.
+    //
+    // Two things make these tests fussier than they look:
+    //
+    // - `tryParse` resolves a **named** zone against the running machine's
+    //   interfaces, so a hardcoded `%eth0` is null on a host without an eth0.
+    //   The name is asked of the machine instead.
+    // - A **numeric** zone tests nothing at all: `%1` escapes to `%251`,
+    //   which parses happily as scope 251, so the guard never stumbled. Only
+    //   a named zone reproduces the failure.
+    //
+    // There is deliberately no "zoned public address" case: `tryParse`
+    // rejects a zone on anything that is not link-local (`2001:db8::1%lo` is
+    // null), so such a URL was never reaching this branch to begin with.
+    Future<String?> anInterfaceName() async {
+      final interfaces = await NetworkInterface.list(
+        includeLoopback: true,
+        type: InternetAddressType.any,
+      );
+      return interfaces.isEmpty ? null : interfaces.first.name;
+    }
+
+    /// Fails rather than resolving. A zoned literal must be settled by the
+    /// literal branch; reaching the resolver *is* the bug.
+    PlaintextDestinationGuard guardThatMustNotResolve() =>
+        PlaintextDestinationGuard(
+          lookup: (host) async => fail('a zoned literal reached the resolver: $host'),
+        );
+
+    test('a zoned link-local literal is allowed, and left alone', () async {
+      final zone = await anInterfaceName();
+      if (zone == null) {
+        markTestSkipped('no network interface to name a zone with');
+        return;
+      }
+      final url = Uri.parse('http://[fe80::1%$zone]:11434/v1/chat/completions');
+      // What the guard actually sees, and what `tryParse` answers to it.
+      expect(url.host, 'fe80::1%25$zone');
+      expect(InternetAddress.tryParse(url.host), isNull);
+
+      // Returned untouched: the socket layer does its own unescaping, and
+      // rewriting the host here would only cost the zone.
+      expect(await guardThatMustNotResolve().approve(url), url);
+    });
+
+    test('the typed % and the RFC 6874 %25 are the same destination', () async {
+      // Nobody needs to know the RFC to hit this — both spellings land on the
+      // same escaped host, so the plain one cannot behave differently.
+      final zone = await anInterfaceName();
+      if (zone == null) {
+        markTestSkipped('no network interface to name a zone with');
+        return;
+      }
+      final typed = Uri.parse('http://[fe80::1%$zone]:11434/v1');
+      final escaped = Uri.parse('http://[fe80::1%25$zone]:11434/v1');
+      expect(typed.host, escaped.host);
+
+      final guard = guardThatMustNotResolve();
+      expect(await guard.approve(typed), typed);
+      expect(await guard.approve(escaped), escaped);
+    });
+
+    test('a hostname is never rewritten by the zone handling', () async {
+      // The `25` comes off only when it directly follows the first `%`, so a
+      // name still reaches the resolver exactly as it was typed.
+      final seen = <String>[];
+      final guard = PlaintextDestinationGuard(lookup: (host) async {
+        seen.add(host);
+        return [_v4('192.168.1.5')];
+      });
+
+      await guard.approve(Uri.parse('http://ollama.lan:11434/v1'));
+
+      expect(seen, ['ollama.lan']);
+    });
+
     test('a name that does not resolve is not a policy refusal', () async {
       // Telling someone their address is unsafe when it is merely
       // unreachable sends them to fix the wrong thing.

--- a/test/unit_test/plaintext_destination_guard_test.dart
+++ b/test/unit_test/plaintext_destination_guard_test.dart
@@ -6,8 +6,10 @@ import 'package:opennutritracker/core/utils/plaintext_destination_guard.dart';
 
 /// Records the request that reached the socket, or the fact that none did.
 ///
-/// [sentCount] matters for the redirect tests: following a 30x would show up
-/// here as a second send, which is exactly what must not happen.
+/// [sentCount] records how many times [GuardedPlaintextClient] called through.
+/// It cannot see a redirect being followed — that happens inside `dart:io`,
+/// below this fake — so it pins that the guard itself sends once, and nothing
+/// more than that.
 class _RecordingClient extends http.BaseClient {
   http.BaseRequest? sent;
   int sentCount = 0;
@@ -22,8 +24,18 @@ class _RecordingClient extends http.BaseClient {
   Future<http.StreamedResponse> send(http.BaseRequest request) async {
     sent = request;
     sentCount++;
-    return response ??
-        http.StreamedResponse(const Stream.empty(), 200, request: request);
+    // The injected response keeps the request association too, so an
+    // assertion on `response.request` reads the same either way.
+    final canned = response;
+    if (canned != null) {
+      return http.StreamedResponse(
+        canned.stream,
+        canned.statusCode,
+        headers: canned.headers,
+        request: request,
+      );
+    }
+    return http.StreamedResponse(const Stream.empty(), 200, request: request);
   }
 }
 

--- a/test/unit_test/plaintext_destination_guard_test.dart
+++ b/test/unit_test/plaintext_destination_guard_test.dart
@@ -209,9 +209,28 @@ void main() {
       );
 
       expect(inner.sent!.url.host, '192.168.1.5');
-      expect(inner.sent!.headers['host'], 'ollama.lan');
+      // With the port. `ollama.lan` alone is a different authority from the
+      // `ollama.lan:11434` that was typed, and a local model server is
+      // essentially never on 80, so dropping it is the common case rather
+      // than the corner one.
+      expect(inner.sent!.headers['host'], 'ollama.lan:11434');
       expect(inner.sent!.headers['content-type'], 'application/json');
       expect((inner.sent! as http.Request).body, 'payload');
+    });
+
+    test('a URL without a port sends the bare name, not a redundant :80',
+        () async {
+      final inner = _RecordingClient();
+      final client = GuardedPlaintextClient(
+        inner,
+        guard: PlaintextDestinationGuard(
+          lookup: (_) async => [_v4('192.168.1.5')],
+        ),
+      );
+
+      await client.post(Uri.parse('http://ollama.lan/v1'), body: 'payload');
+
+      expect(inner.sent!.headers['host'], 'ollama.lan');
     });
 
     test('an https request reaches the socket untouched', () async {

--- a/test/unit_test/plaintext_destination_guard_test.dart
+++ b/test/unit_test/plaintext_destination_guard_test.dart
@@ -344,4 +344,111 @@ void main() {
       }
     });
   });
+
+  /// The claims above are made against a fake, which cannot follow a redirect
+  /// — `dart:io` does that below `BaseClient.send`, where no fake reaches. So
+  /// these run against a real `HttpServer` on loopback and a real `dart:io`
+  /// client, which is the only place the redirect rule is actually decided.
+  group('against a real socket', () {
+    late HttpServer server;
+    late List<String> paths;
+    late List<String?> hosts;
+    HttpOverrides? savedOverrides;
+
+    setUp(() async {
+      // `flutter_test` installs an override that answers every request with a
+      // canned 400 rather than opening a socket. These tests are about what
+      // the socket layer really does, so they need it out of the way — and
+      // put back, because the rest of the suite may rely on it.
+      savedOverrides = HttpOverrides.current;
+      HttpOverrides.global = null;
+
+      paths = [];
+      hosts = [];
+      server = await HttpServer.bind(InternetAddress.loopbackIPv4, 0);
+      server.listen((request) async {
+        paths.add(request.uri.path);
+        hosts.add(request.headers.value('host'));
+        if (request.uri.path == '/first') {
+          request.response.statusCode = HttpStatus.found;
+          request.response.headers.set('location', '/second');
+        } else {
+          request.response.statusCode = HttpStatus.ok;
+        }
+        await request.response.close();
+      });
+    });
+
+    tearDown(() async {
+      await server.close(force: true);
+      HttpOverrides.global = savedOverrides;
+    });
+
+    test('an unguarded client really does follow the redirect', () async {
+      // The control. Without it the two tests below prove nothing: they would
+      // pass just as well against a server that never redirected, or a client
+      // stack that had stopped following redirects on its own.
+      final client = http.Client();
+      addTearDown(client.close);
+
+      final response =
+          await client.get(Uri.parse('http://127.0.0.1:${server.port}/first'));
+
+      expect(paths, ['/first', '/second']);
+      expect(response.statusCode, 200);
+    });
+
+    test('the guarded client stops at the 30x — literal pass-through',
+        () async {
+      // A private literal is waved through `approve` untouched, so this is
+      // the branch where the request object reaches the socket as the caller
+      // built it. `followRedirects` still has to have been turned off.
+      final client = GuardedPlaintextClient(http.Client());
+      addTearDown(client.close);
+
+      final response =
+          await client.get(Uri.parse('http://127.0.0.1:${server.port}/first'));
+
+      expect(paths, ['/first']);
+      expect(response.statusCode, 302);
+      expect(response.headers['location'], '/second');
+    });
+
+    test('the guarded client stops at the 30x — rebound path', () async {
+      // The same claim on the other branch: a name pinned to its resolved
+      // address, rebuilt into a new request. The rebuild must not hand back a
+      // request that follows redirects.
+      final client = GuardedPlaintextClient(
+        http.Client(),
+        guard: PlaintextDestinationGuard(
+          lookup: (_) async => [_v4('127.0.0.1')],
+        ),
+      );
+      addTearDown(client.close);
+
+      final response = await client
+          .get(Uri.parse('http://ollama.lan:${server.port}/first'));
+
+      expect(paths, ['/first']);
+      expect(response.statusCode, 302);
+    });
+
+    test('the Host header arrives at the server with its port', () async {
+      // Read off the wire rather than off the request object: the header has
+      // to survive `dart:io`, which sets a Host of its own from the
+      // connection URI and would otherwise report 127.0.0.1.
+      final client = GuardedPlaintextClient(
+        http.Client(),
+        guard: PlaintextDestinationGuard(
+          lookup: (_) async => [_v4('127.0.0.1')],
+        ),
+      );
+      addTearDown(client.close);
+
+      await client.get(Uri.parse('http://ollama.lan:${server.port}/second'));
+
+      expect(hosts.single, 'ollama.lan:${server.port}');
+    });
+  });
+
 }

--- a/test/unit_test/plaintext_destination_guard_test.dart
+++ b/test/unit_test/plaintext_destination_guard_test.dart
@@ -5,13 +5,25 @@ import 'package:http/http.dart' as http;
 import 'package:opennutritracker/core/utils/plaintext_destination_guard.dart';
 
 /// Records the request that reached the socket, or the fact that none did.
+///
+/// [sentCount] matters for the redirect tests: following a 30x would show up
+/// here as a second send, which is exactly what must not happen.
 class _RecordingClient extends http.BaseClient {
   http.BaseRequest? sent;
+  int sentCount = 0;
+
+  /// Returned instead of a bare 200 when a test needs a specific status —
+  /// a 30x, for the redirect cases.
+  final http.StreamedResponse? response;
+
+  _RecordingClient({this.response});
 
   @override
   Future<http.StreamedResponse> send(http.BaseRequest request) async {
     sent = request;
-    return http.StreamedResponse(const Stream.empty(), 200, request: request);
+    sentCount++;
+    return response ??
+        http.StreamedResponse(const Stream.empty(), 200, request: request);
   }
 }
 
@@ -216,6 +228,73 @@ void main() {
         throwsA(isA<InsecureDestinationException>()),
       );
       expect(inner.sent, isNull);
+    });
+
+    test('redirects are not followed, on the rebound path', () async {
+      // The gap this closes: `dart:io` follows a 30x below `BaseClient.send`,
+      // so the hop never re-enters the guard. A private server answering with
+      // a public `http://` Location would have had that connection made, out
+      // of a check that reported the destination private.
+      final inner = _RecordingClient();
+      final client = GuardedPlaintextClient(
+        inner,
+        guard: PlaintextDestinationGuard(
+          lookup: (_) async => [_v4('192.168.1.5')],
+        ),
+      );
+
+      await client.post(
+        Uri.parse('http://ollama.lan:11434/v1/chat/completions'),
+        body: 'payload',
+      );
+
+      expect(inner.sent!.followRedirects, isFalse);
+    });
+
+    test('redirects are not followed on the https pass-through either', () async {
+      // `approve` waves https straight through, so the pass-through branch
+      // needs its own guarantee: an encrypted first hop says nothing about
+      // where a `Location` header points.
+      final inner = _RecordingClient();
+      final client = GuardedPlaintextClient(inner);
+
+      await client.post(
+        Uri.parse('https://ollama.example.com/v1/chat/completions'),
+        body: 'payload',
+      );
+
+      expect(inner.sent!.followRedirects, isFalse);
+    });
+
+    test('a 30x comes back to the caller as a response, not a second hop', () async {
+      // Contract, not regression: the following happens inside `dart:io`,
+      // below this fake, so this test passes with or without the fix above.
+      // It pins what a caller sees — a 30x surfacing rather than being
+      // swallowed — while the two tests above are the ones that fail if
+      // `followRedirects` is ever turned back on.
+      final inner = _RecordingClient(
+        response: http.StreamedResponse(
+          const Stream.empty(),
+          302,
+          headers: {'location': 'http://93.184.216.34/v1/chat/completions'},
+        ),
+      );
+      final client = GuardedPlaintextClient(
+        inner,
+        guard: PlaintextDestinationGuard(
+          lookup: (_) async => [_v4('192.168.1.5')],
+        ),
+      );
+
+      final response = await client.post(
+        Uri.parse('http://ollama.lan:11434/v1/chat/completions'),
+        body: 'payload',
+      );
+
+      // Surfaced rather than chased. The caller sees a failed request; what
+      // it does not see is a payload delivered to 93.184.216.34.
+      expect(response.statusCode, 302);
+      expect(inner.sentCount, 1);
     });
 
     test('the exception names the host and nothing else', () async {


### PR DESCRIPTION
Carries the plaintext-guard fixes onto the release branch. Both findings were
raised in review of #988; neither was fixed there, because the work landed on
a branch targeting `develop` (#1002) and `release/2.2.0` is cut from `main`.

### P1 — a redirect bypassed the guard entirely

`send` validated the initial URI and then handed the request to an inner
client that follows redirects by default. Redirects are acted on inside
`dart:io`, below `BaseClient.send`, so a hop never re-entered the guard: an
approved private endpoint answering `302` with a public `http://` target
would have had that connection made, out of a check that reported the
destination private. A same-host HTTPS-to-HTTP redirect could also carry the
optional authorization header onward.

Fixed by disabling automatic redirects, so a `30x` returns to the caller as
the response it is. This holds for `https://` too, which the guard otherwise
waves through — an encrypted first hop says nothing about where a `Location`
points.

### P2 — the Host header dropped the port

Rebinding `http://ollama.lan:11434` to its resolved address wrote
`Host: ollama.lan`, a different authority from the one the user typed. A
reverse proxy or a strict server routes by what that header says, and a local
model server is essentially never on 80, so this was the common case rather
than a corner one. The port is now written whenever the URL carried one, and
omitted when it did not.

### The tests the review asked for

Review noted that the guard's tests use a recording fake, which cannot follow
a redirect — so they pinned that `followRedirects` was set false, not that
setting it false stops the second hop.

Added a group that runs against a real `HttpServer` on loopback and a real
`dart:io` client, over both branches through the guard (literal pass-through
and the rebound path). A control test proves the setup has teeth by showing an
unguarded client really does follow the `302`; without it the others would
pass just as well against a server that never redirected. A fourth reads the
Host header off the wire at the server, the only place that proves it survives
`dart:io` setting a Host of its own from the connection URI.

Both fixes were mutation-tested: removing the redirect guard fails 4 tests,
dropping the port fails 2.

### A third fix: a zoned link-local address was refused

Found auditing the guard for bypasses the #988 review might have missed. It
is not one — it is the guard refusing a destination it exists to permit.

A link-local address needs a zone id to be routable on a host with more than
one interface, and a URI spells that zone escaped: `Uri` stores
`http://[fe80::1%wlan0]` with a host of `fe80::1%25wlan0`, and typing the
bare `%` produces the identical string. `InternetAddress.tryParse` answers
`null` to that, so the address fell through to the DNS branch, the lookup
failed, and the caller was told the server is **unreachable** — about a
link-local server an unguarded client reaches perfectly well. Verified
against a real `HttpServer` bound to a link-local address: unguarded `200`,
guarded `SocketException`.

`dart:io` performs the same substitution in `escapeLinkLocalAddress` before
it resolves or connects, which is why an unguarded client works; doing it
here makes the check agree with the socket layer it guards.

Fail-closed, so the guarantee was never at risk — a refusal, not a leak. It
also predates 2.2.0, so it is not a regression in this release; it is here
because it was asked for, and it is separately open against `develop` as
#1005. The two branches carry identical content for these files.

Two earlier versions of its tests passed with the fix removed, and the
reasons are recorded in the test file: a numeric zone escapes to a valid
different scope and proves nothing, a named zone cannot be hardcoded because
`tryParse` resolves it against the running machine's interfaces, and there is
no zoned-public-address case because `tryParse` rejects a zone on anything
not link-local.

### Notes for review

- Five commits cherry-picked from `fix/plaintext-guard-redirects` (#1002,
  merged) and `fix/plaintext-guard-link-local-zone` (#1005), plus one `ci:`
  commit of this PR's own.
  `-x` trailers record the origins.
- The third is a **partial** pick: upstream it also carried 18 documents this
  branch does not have, and taking the whole of it would have dropped ~11k
  lines of unrelated docs onto a release branch. Test file only.
- After these, `plaintext_destination_guard.dart` and its test file are
  byte-identical on both branches, so the eventual merge sees no conflict in
  them.
- Locally: 25/25 in the guard's tests on this baseline, `flutter analyze`
  clean.

### A fifth commit: this PR had no CI

On opening, it registered exactly one check — the Copilot reviewer — and
reported `CLEAN`. `default_workflow.yml` fired `pull_request` on `main`,
`develop` and `feature/**` only; `release/**` was not listed, which is the
silent failure its own comment already warns about, now hit on a release
branch.

`ci: run the workflow on PRs into release branches` adds it. For
`pull_request` GitHub builds the workflow from the merge ref, so it took
effect here: all six platform jobs now run on this PR. That commit is the
reason to review this as a PR rather than a direct push.
