### PR TITLE
chore: ignore the local live-provider probes

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -66,5 +66,14 @@ result
 # Exception for Gemfile.lock, which is needed for Fastlane / Bundler
 !**/Gemfile.lock
 
+# Live provider probes — scripts that talk to a real AI provider with a real
+# key, kept locally and never committed. They take the key as a *file path*
+# argument rather than embedding one, so the risk is not the key leaking; it
+# is a `git add -A` sweeping an ad-hoc script into a release branch, which is
+# exactly what nearly happened during 2.2.0. `tool/policy_snapshot.dart` is a
+# committed tool and stays tracked — this ignores only the probes.
+tool/live_*.dart
+tool/verify_openai_key.dart
+
 # Fastlane / Bundler — local gem install path (bundle config set path vendor/bundle)
 ios/vendor/

--- a/docs/ai-model-candidates.md
+++ b/docs/ai-model-candidates.md
@@ -568,5 +568,8 @@ Related notes in this repo:
 
 In-repo files cited:
 [`lib/core/utils/ai_model_catalogue.dart`](../lib/core/utils/ai_model_catalogue.dart) ·
-[`lib/features/add_meal/data/openrouter_meal_items_api.dart`](../lib/features/add_meal/data/openrouter_meal_items_api.dart) ·
-[`tool/live_routing_policy.dart`](../tool/live_routing_policy.dart)
+[`lib/features/add_meal/data/openrouter_meal_items_api.dart`](../lib/features/add_meal/data/openrouter_meal_items_api.dart)
+
+The routing-policy check behind the table above was run with a local probe,
+`tool/live_routing_policy.dart`. It talks to a real provider with a real key and
+is deliberately not committed, so it is named here rather than linked.


### PR DESCRIPTION
Seven probe scripts have been sitting untracked in `tool/` — `live_model_compare`, `live_openai`, `live_openai_client_check`, `live_openrouter`, `live_own_server`, `live_routing_policy` and `verify_openai_key`. They surfaced in the pre-merge audit of [#988](https://github.com/simonoppowa/OpenNutriTracker/pull/988), where `gh` warned about "7 uncommitted changes" on every command run against the release branch.

They read a key from a **file path passed as an argument** rather than embedding one, and the only key-shaped literal in them is 64 zeros — so the exposure was never a leaked key. The risk is narrower and duller: a `git add -A` sweeping an ad-hoc script into a release branch, and seven files that are neither wanted nor ignored making that easier rather than harder.

`tool/policy_snapshot.dart` is a committed tool and stays tracked. The pattern is scoped to the probes, and `git check-ignore` confirms both halves:

```
.gitignore:75:tool/live_*.dart          tool/live_openai.dart
.gitignore:76:tool/verify_openai_key.dart   tool/verify_openai_key.dart
tool/policy_snapshot.dart               → not ignored
```

## The one link that had to move

`docs/ai-model-candidates.md` listed `tool/live_routing_policy.dart` under **"In-repo files cited"** as a relative link. That was already a 404 on github.com while the file was merely untracked; once it is ignored, the heading is wrong as well as the link. It is now named in a sentence that says why it is not committed, and the two remaining entries under that heading are both real committed files.

The other two references to these scripts — `docs/ai-openai-behavioural-screen.md:14` and `:192` — are code spans inside command examples, never links, and are untouched.

## Verified

`test/unit_test/ai_architecture_doc_test.dart` passes; no heading changed, so no anchor moved. `git status` is clean with the probes present on disk.
