### PR TITLE
fix(ci): stop a skipped retry job taking the whole deploy chain with it

### DIFF
--- a/.github/workflows/default_workflow.yml
+++ b/.github/workflows/default_workflow.yml
@@ -544,10 +544,56 @@ jobs:
           disable-animations: true
           script: flutter test integration_test/ --flavor full --reporter expanded
 
+  # Deploy gate, 1 of 5 — read this one, the other four point back at it.
+  #
+  # Two things have to be true to package a release, and BOTH halves below are
+  # load-bearing:
+  #
+  #   1. the run is a push to `main` or a manual dispatch — a pull request must
+  #      never touch signing material or a store;
+  #   2. every job in `needs:` actually SUCCEEDED.
+  #
+  # (2) used to be implicit: with no status check function in an `if:`, GitHub
+  # ANDs a `success()` onto it for free. That free check is what broke the
+  # 2.2.0 release. `ios-integration-tests-retry` is skipped on every healthy
+  # run — the first runner passed, so there is nothing to retry — and a skip
+  # travels the whole dependency chain, not one hop: "a failure or skip applies
+  # to all jobs in the dependency chain from the point of failure or skip
+  # onwards". `ios-integration-tests-result` steps out of the way of it with
+  # its own `if: !cancelled()`, but that exempts that one job; the skip keeps
+  # going. In push run 33547853809 every job below was green, this guard was
+  # true, and the entire deploy chain skipped anyway: no v2.2.0 tag, no GitHub
+  # release, nothing to TestFlight, no AAB — and the run still reported
+  # `success`, so nothing looked wrong.
+  #
+  # `!cancelled()` is the escape: a default status check of `success()` is
+  # applied unless the expression includes one of the status functions.
+  # Including one drops that implicit `success()` and with it the inherited
+  # skip. It is also why the gate then has to be written out by hand, one
+  # `result == 'success'` per dependency — a bare `!cancelled()` on its own
+  # would be strictly WORSE than the bug it fixes, because it would push an
+  # integration suite that failed on two independent runners straight to
+  # TestFlight and Play.
+  #
+  # Rules for anyone editing this:
+  #   * every entry in `needs:` needs a matching line in `if:`. The implicit
+  #     check is gone; an unmirrored dependency is an ungated dependency.
+  #   * `== 'success'` only. `!= 'failure'` is true for `skipped` and
+  #     `cancelled` too, which re-opens exactly this bug.
+  #   * `!cancelled()`, never `always()` — `always()` runs even when the run
+  #     was cancelled, i.e. it would deploy out of a run someone stopped.
+  #   * keep the event test as an AND-conjunct. Dropping it, or ORing it in,
+  #     deploys from pull requests.
   ios-package:
     if: |
-      (github.event_name == 'push' && github.ref == 'refs/heads/main') ||
-      github.event_name == 'workflow_dispatch'
+      ((github.event_name == 'push' && github.ref == 'refs/heads/main') ||
+      github.event_name == 'workflow_dispatch') &&
+      !cancelled() &&
+      needs.linux-checks.result == 'success' &&
+      needs.ios-build.result == 'success' &&
+      needs.ios-integration-tests-result.result == 'success' &&
+      needs.android-build.result == 'success' &&
+      needs.android-integration-tests.result == 'success'
     needs:
       - linux-checks
       - ios-build
@@ -656,10 +702,16 @@ jobs:
           path: build/ios/ipa/*.ipa
           if-no-files-found: error
 
+  # Deploy gate, 3 of 5. See ios-package. Fixing only the package jobs would not
+  # help: the skip from `ios-integration-tests-retry` reaches this job too, so
+  # the packages would go green and this would still silently skip.
   ios-deploy:
     if: |
-      (github.event_name == 'push' && github.ref == 'refs/heads/main') ||
-      github.event_name == 'workflow_dispatch'
+      ((github.event_name == 'push' && github.ref == 'refs/heads/main') ||
+      github.event_name == 'workflow_dispatch') &&
+      !cancelled() &&
+      needs.ios-package.result == 'success' &&
+      needs.android-package.result == 'success'
     # Deploy only when BOTH platforms packaged successfully (see android-deploy)
     # so a one-sided failure never publishes half a release.
     needs:
@@ -706,10 +758,20 @@ jobs:
           APP_STORE_CONNECT_API_KEY_P8: ${{ secrets.APP_STORE_CONNECT_API_KEY_P8 }}
         run: bundle exec fastlane ios beta_from_ipa
 
+  # Deploy gate, 2 of 5 — identical to ios-package by design: both package jobs
+  # gate the same release on the same evidence, so they must stay in step. See
+  # ios-package for why each dependency is checked by result instead of being
+  # left to GitHub's implicit `success()`.
   android-package:
     if: |
-      (github.event_name == 'push' && github.ref == 'refs/heads/main') ||
-      github.event_name == 'workflow_dispatch'
+      ((github.event_name == 'push' && github.ref == 'refs/heads/main') ||
+      github.event_name == 'workflow_dispatch') &&
+      !cancelled() &&
+      needs.linux-checks.result == 'success' &&
+      needs.ios-build.result == 'success' &&
+      needs.ios-integration-tests-result.result == 'success' &&
+      needs.android-build.result == 'success' &&
+      needs.android-integration-tests.result == 'success'
     needs:
       - linux-checks
       - ios-build
@@ -834,10 +896,17 @@ jobs:
           path: build/app/outputs/apk/full/release/app-release.apk
           if-no-files-found: error
 
+  # Deploy gate, 4 of 5. See ios-package. The two `result == 'success'` lines
+  # are also what now enforces the both-platforms rule described below — it is
+  # stated outright here rather than left to an implicit check that a future
+  # `needs:` edit could quietly widen.
   android-deploy:
     if: |
-      (github.event_name == 'push' && github.ref == 'refs/heads/main') ||
-      github.event_name == 'workflow_dispatch'
+      ((github.event_name == 'push' && github.ref == 'refs/heads/main') ||
+      github.event_name == 'workflow_dispatch') &&
+      !cancelled() &&
+      needs.android-package.result == 'success' &&
+      needs.ios-package.result == 'success'
     # Deploy only when BOTH platforms packaged successfully. A half-success
     # (e.g. iOS packaging fails) would otherwise still upload the Android AAB,
     # consuming a Play versionCode and forcing a build-number bump on the
@@ -941,10 +1010,19 @@ jobs:
             echo 'here needs changing when that happens.'
           } >> "$GITHUB_STEP_SUMMARY"
 
+  # Deploy gate, 5 of 5, and it needs the same treatment rather than inheriting
+  # a fix from its parents — the skip propagates past them to here. The two
+  # result checks also preserve behaviour this job already got right: in run
+  # 33243607505 android-deploy FAILED and this job correctly skipped, so no tag
+  # and no release was cut for a half-published build. A bare `!cancelled()`
+  # here would have tagged and published it.
   github-release:
     if: |
-      (github.event_name == 'push' && github.ref == 'refs/heads/main') ||
-      github.event_name == 'workflow_dispatch'
+      ((github.event_name == 'push' && github.ref == 'refs/heads/main') ||
+      github.event_name == 'workflow_dispatch') &&
+      !cancelled() &&
+      needs.ios-deploy.result == 'success' &&
+      needs.android-deploy.result == 'success'
     needs:
       - ios-deploy
       - android-deploy


### PR DESCRIPTION
**Merging [#988](https://github.com/simonoppowa/OpenNutriTracker/pull/988) shipped nothing.** Push run [33547853809](https://github.com/simonoppowa/OpenNutriTracker/actions/runs/33547853809) reported `success` with every check green, and the entire deploy chain was skipped:

```
ios-integration-tests / run     success
ios-integration-tests-retry     SKIPPED     ← skips on every healthy run
ios-integration-tests-result    success     ← has  if: !cancelled()
ios-package                     SKIPPED
ios-deploy                      SKIPPED
android-package                 SKIPPED
android-deploy                  SKIPPED
github-release                  SKIPPED
```

No `v2.2.0` tag, no GitHub release, nothing to TestFlight, no AAB. The run was green, so nothing looked wrong.

## Cause

2.2.0's own two-runner iOS integration change introduced it. `ios-integration-tests-retry` is skipped whenever the **first runner passes** — the normal case — and a skip travels the whole dependency chain, not one hop. `ios-integration-tests-result` steps out of the way with its own `if: !cancelled()`, but that exempts *that job*; the skip keeps going into the deploy jobs, whose `if:` contained no status function and so inherited GitHub's implicit `success()`.

All five of `ios-package`'s direct needs concluded `success` and it skipped anyway. **The pipeline only deployed when the first iOS runner failed.**

The A/B is clean: run [33243607505](https://github.com/simonoppowa/OpenNutriTracker/actions/runs/33243607505) fired byte-identical guards on the same event and deployed. The sole structural difference is that the package jobs then needed `ios-integration-tests` directly, before any job that skips on a healthy run existed upstream of them.

Ruled out with evidence: the `if: |` block scalar (byte-identical where deploy worked), the guard predicate (`event=push`, `head_branch=main`), reusable-workflow `uses:` jobs misbehaving in `needs`, and `ios-podfile-lock-guard` (skipped in *both* runs — it is in nobody's `needs`, which also shows the taint travels only along `needs` edges).

## The fix

Including a status function drops the implicit `success()` and with it the inherited skip. That is also why each dependency now has to be asserted by hand: **a bare `!cancelled()` would be strictly worse than the bug**, because it would push an integration suite that failed on two independent runners straight to TestFlight and Play.

So every `needs:` entry gets an explicit `result == 'success'`, and the comment on `ios-package` states the rules for keeping the two lists in step — `== 'success'` not `!= 'failure'`, `!cancelled()` not `always()`, and the event test kept as an AND-conjunct.

## Verification

Outcome matrix, evaluated against the real conditions parsed out of the file:

| case | ships |
|---|---|
| push main, first runner passes — **the bug** | ✅ yes |
| push main, first failed, retry passed | ✅ yes |
| `workflow_dispatch` on main | ✅ yes |
| pull request, all green | ❌ no |
| both iOS runners failed | ❌ no |
| android-integration-tests / linux-checks / ios-build failed | ❌ no |
| run cancelled mid-flight | ❌ no |
| push to develop | ❌ no |
| result job itself skipped | ❌ no |

`actionlint 1.7.7` reports **no new findings** (8 pre-existing `macos-26` unknown-label warnings on both baseline and patched). A structural check confirms all five guards mirror their `needs:` exactly, no dangling dependencies, and both atomicity comments intact.

## Merging this is what deploys 2.2.0

The push to `main` runs the pipeline with the fixed guards. `main` is already at `2.2.0+63` and no `v2.2.0` tag exists, so it cuts fresh.

Expect `android-deploy` to go **green with the Play upload undone** — that is the #942 tolerance, not success. Read the step summary, upload the AAB by hand, and read Play's warnings on the review step.

## Not included, deliberately

`workflow_dispatch` has **no ref test**, and the trigger has no branch filter — a dispatch from any branch passes the guard and ships. This is not theoretical: run `26086317616` cut a release from `integrate-cicd-deployment`. Closing it is a one-line change to all five guards, but it belongs in its own commit so that reverting it cannot revert this fix.
