### PR TITLE
fix(ci): stop a skipped retry job taking the whole deploy chain with it

### DIFF
--- a/.github/workflows/default_workflow.yml
+++ b/.github/workflows/default_workflow.yml
@@ -537,10 +537,56 @@ jobs:
           disable-animations: true
           script: flutter test integration_test/ --flavor full --reporter expanded
 
+  # Deploy gate, 1 of 5 — read this one, the other four point back at it.
+  #
+  # Two things have to be true to package a release, and BOTH halves below are
+  # load-bearing:
+  #
+  #   1. the run is a push to `main` or a manual dispatch — a pull request must
+  #      never touch signing material or a store;
+  #   2. every job in `needs:` actually SUCCEEDED.
+  #
+  # (2) used to be implicit: with no status check function in an `if:`, GitHub
+  # ANDs a `success()` onto it for free. That free check is what broke the
+  # 2.2.0 release. `ios-integration-tests-retry` is skipped on every healthy
+  # run — the first runner passed, so there is nothing to retry — and a skip
+  # travels the whole dependency chain, not one hop: "a failure or skip applies
+  # to all jobs in the dependency chain from the point of failure or skip
+  # onwards". `ios-integration-tests-result` steps out of the way of it with
+  # its own `if: !cancelled()`, but that exempts that one job; the skip keeps
+  # going. In push run 33547853809 every job below was green, this guard was
+  # true, and the entire deploy chain skipped anyway: no v2.2.0 tag, no GitHub
+  # release, nothing to TestFlight, no AAB — and the run still reported
+  # `success`, so nothing looked wrong.
+  #
+  # `!cancelled()` is the escape: a default status check of `success()` is
+  # applied unless the expression includes one of the status functions.
+  # Including one drops that implicit `success()` and with it the inherited
+  # skip. It is also why the gate then has to be written out by hand, one
+  # `result == 'success'` per dependency — a bare `!cancelled()` on its own
+  # would be strictly WORSE than the bug it fixes, because it would push an
+  # integration suite that failed on two independent runners straight to
+  # TestFlight and Play.
+  #
+  # Rules for anyone editing this:
+  #   * every entry in `needs:` needs a matching line in `if:`. The implicit
+  #     check is gone; an unmirrored dependency is an ungated dependency.
+  #   * `== 'success'` only. `!= 'failure'` is true for `skipped` and
+  #     `cancelled` too, which re-opens exactly this bug.
+  #   * `!cancelled()`, never `always()` — `always()` runs even when the run
+  #     was cancelled, i.e. it would deploy out of a run someone stopped.
+  #   * keep the event test as an AND-conjunct. Dropping it, or ORing it in,
+  #     deploys from pull requests.
   ios-package:
     if: |
-      (github.event_name == 'push' && github.ref == 'refs/heads/main') ||
-      github.event_name == 'workflow_dispatch'
+      ((github.event_name == 'push' && github.ref == 'refs/heads/main') ||
+      github.event_name == 'workflow_dispatch') &&
+      !cancelled() &&
+      needs.linux-checks.result == 'success' &&
+      needs.ios-build.result == 'success' &&
+      needs.ios-integration-tests-result.result == 'success' &&
+      needs.android-build.result == 'success' &&
+      needs.android-integration-tests.result == 'success'
     needs:
       - linux-checks
       - ios-build
@@ -649,10 +695,16 @@ jobs:
           path: build/ios/ipa/*.ipa
           if-no-files-found: error
 
+  # Deploy gate, 3 of 5. See ios-package. Fixing only the package jobs would not
+  # help: the skip from `ios-integration-tests-retry` reaches this job too, so
+  # the packages would go green and this would still silently skip.
   ios-deploy:
     if: |
-      (github.event_name == 'push' && github.ref == 'refs/heads/main') ||
-      github.event_name == 'workflow_dispatch'
+      ((github.event_name == 'push' && github.ref == 'refs/heads/main') ||
+      github.event_name == 'workflow_dispatch') &&
+      !cancelled() &&
+      needs.ios-package.result == 'success' &&
+      needs.android-package.result == 'success'
     # Deploy only when BOTH platforms packaged successfully (see android-deploy)
     # so a one-sided failure never publishes half a release.
     needs:
@@ -699,10 +751,20 @@ jobs:
           APP_STORE_CONNECT_API_KEY_P8: ${{ secrets.APP_STORE_CONNECT_API_KEY_P8 }}
         run: bundle exec fastlane ios beta_from_ipa
 
+  # Deploy gate, 2 of 5 — identical to ios-package by design: both package jobs
+  # gate the same release on the same evidence, so they must stay in step. See
+  # ios-package for why each dependency is checked by result instead of being
+  # left to GitHub's implicit `success()`.
   android-package:
     if: |
-      (github.event_name == 'push' && github.ref == 'refs/heads/main') ||
-      github.event_name == 'workflow_dispatch'
+      ((github.event_name == 'push' && github.ref == 'refs/heads/main') ||
+      github.event_name == 'workflow_dispatch') &&
+      !cancelled() &&
+      needs.linux-checks.result == 'success' &&
+      needs.ios-build.result == 'success' &&
+      needs.ios-integration-tests-result.result == 'success' &&
+      needs.android-build.result == 'success' &&
+      needs.android-integration-tests.result == 'success'
     needs:
       - linux-checks
       - ios-build
@@ -827,10 +889,17 @@ jobs:
           path: build/app/outputs/apk/full/release/app-release.apk
           if-no-files-found: error
 
+  # Deploy gate, 4 of 5. See ios-package. The two `result == 'success'` lines
+  # are also what now enforces the both-platforms rule described below — it is
+  # stated outright here rather than left to an implicit check that a future
+  # `needs:` edit could quietly widen.
   android-deploy:
     if: |
-      (github.event_name == 'push' && github.ref == 'refs/heads/main') ||
-      github.event_name == 'workflow_dispatch'
+      ((github.event_name == 'push' && github.ref == 'refs/heads/main') ||
+      github.event_name == 'workflow_dispatch') &&
+      !cancelled() &&
+      needs.android-package.result == 'success' &&
+      needs.ios-package.result == 'success'
     # Deploy only when BOTH platforms packaged successfully. A half-success
     # (e.g. iOS packaging fails) would otherwise still upload the Android AAB,
     # consuming a Play versionCode and forcing a build-number bump on the
@@ -934,10 +1003,19 @@ jobs:
             echo 'here needs changing when that happens.'
           } >> "$GITHUB_STEP_SUMMARY"
 
+  # Deploy gate, 5 of 5, and it needs the same treatment rather than inheriting
+  # a fix from its parents — the skip propagates past them to here. The two
+  # result checks also preserve behaviour this job already got right: in run
+  # 33243607505 android-deploy FAILED and this job correctly skipped, so no tag
+  # and no release was cut for a half-published build. A bare `!cancelled()`
+  # here would have tagged and published it.
   github-release:
     if: |
-      (github.event_name == 'push' && github.ref == 'refs/heads/main') ||
-      github.event_name == 'workflow_dispatch'
+      ((github.event_name == 'push' && github.ref == 'refs/heads/main') ||
+      github.event_name == 'workflow_dispatch') &&
+      !cancelled() &&
+      needs.ios-deploy.result == 'success' &&
+      needs.android-deploy.result == 'success'
     needs:
       - ios-deploy
       - android-deploy


### PR DESCRIPTION
The `develop` half of [#1008](https://github.com/simonoppowa/OpenNutriTracker/pull/1008), cherry-picked with `-x`. Same commit, no conflict.

Without this, the next `develop` → `release` → `main` merge silently reverts the fix and the following release ships nothing again, in exactly the same silent way — a green pipeline that produced no tag, no release and no build.

## What it fixes

Merging 2.2.0 to `main` deployed nothing. `ios-integration-tests-retry` is skipped whenever the **first iOS runner passes** — the normal case — and that skip travels the whole `needs` chain. `ios-integration-tests-result` rescues itself with `if: !cancelled()`, but that exempts only that job; the skip continued into all five deploy jobs, whose `if:` had no status function and so inherited GitHub's implicit `success()`. Every direct need had concluded `success`.

Net effect: **the pipeline only deployed when the first iOS runner failed.**

The fix makes each dependency explicit — `needs.<job>.result == 'success'` per entry, plus `!cancelled()` to drop the inherited skip. A bare `!cancelled()` would be worse than the bug, so the per-need assertions are load-bearing, and the comment on `ios-package` states the rules for keeping the `if:` and `needs:` lists in step.

Full reasoning, the A/B against the last run where deploy fired, and what was ruled out: see #1008.

## Verified here too

All five guards mirror their `needs:` exactly; `!cancelled()` present, `always()` absent; `actionlint` reports no findings beyond the 8 pre-existing `macos-26` unknown-label warnings.

The outcome matrix from #1008 applies unchanged — the three must-ship cases ship, and pull requests, failed suites, cancelled runs and pushes to non-main branches all stay blocked. Worth noting the deploy jobs can never fire from `develop` regardless: `push` is restricted to `main`.

## Ordering

Independent of [#1006](https://github.com/simonoppowa/OpenNutriTracker/pull/1006), which touches the `on: pull_request:` trigger at the top of the same file. Different region, no conflict, either order is fine.
