### PR TITLE
fix(ci): only deploy from main, and never re-release a shipped version

### DIFF
--- a/.github/workflows/default_workflow.yml
+++ b/.github/workflows/default_workflow.yml
@@ -544,6 +544,155 @@ jobs:
           disable-animations: true
           script: flutter test integration_test/ --flavor full --reporter expanded
 
+  # Deploy gate, 0 of 5 — the only one that asks whether there is anything NEW
+  # to ship. The five below ask whether it is safe to ship it.
+  #
+  # This job exists because of what fixing the deploy-chain skip exposed. Until
+  # a8a78997 the five deploy jobs silently skipped on every push to `main`, so
+  # it did not matter that they are keyed on nothing but the branch. They fire
+  # for real now, and `push: main` fires on every merge — docs-only ones
+  # included. With `pubspec.yaml` still reading `2.2.0+63` the morning after
+  # 2.2.0 shipped, the next merge would re-run the whole chain against an
+  # already-published version:
+  #
+  #   * `ios-deploy` re-uploads build 63. Apple answers ITMS-90189 "Redundant
+  #     Binary Upload" and pilot raises; the lane has no rescue and the step no
+  #     `continue-on-error`, so the job goes RED — a red `main` for a docs
+  #     commit, after ~41 macOS runner minutes.
+  #   * `android-deploy` re-uploads versionCode 63. Whether that dies inside
+  #     supply's `upload_bundles` or limps to the same #942 commit failure
+  #     depends on whether the AAB was finished by hand in the console. Only
+  #     the second matches the #942 grep, so the first is correctly NOT
+  #     tolerated — also red.
+  #   * `github-release` derives `TAG_NAME=v2.2.0`, which already exists, and
+  #     softprops/action-gh-release does not fail on that — it UPDATES the
+  #     release in place. `overwrite_files` defaults to true, so it would
+  #     DELETE and re-upload the IPA, AAB and APK that 2.2.0 shipped and
+  #     regenerate the notes, while the tag stayed put (GitHub's REST docs:
+  #     `target_commitish` is "Unused if the Git tag already exists"). The
+  #     result is a published release whose binaries no longer match its tag.
+  #
+  # Today only ordering stops that last one: `ios-deploy` fails first, so
+  # `github-release` never runs. That is luck, not design. Bump only the build
+  # number — `2.2.0+64` — and iOS passes, `TAG_NAME` is still `v2.2.0`, and the
+  # luck runs out on a published release. This job turns the ordering accident
+  # into a rule.
+  #
+  # The ledger it reads is the one `github-release` writes: the `v<version>`
+  # tag, created by the last step of the last job in the chain. Tag present
+  # means a release carrying that exact version name ran to completion. No
+  # tag, nothing shipped it, so ship.
+  #
+  # Deliberately does NOT gate the build and test jobs. A push to `main` should
+  # still be compiled and tested; what it must not do is package and publish.
+  #
+  # Two consequences, both chosen rather than overlooked:
+  #
+  #   * A build-only bump will not deploy. `2.2.0+64` still derives `v2.2.0`,
+  #     so it is refused. That is deliberate — a build-only bump is exactly the
+  #     input that arms the release-overwrite above — and it matches what
+  #     docs/RELEASING.md already asks for: bump `version:` in `pubspec.yaml`,
+  #     both halves. A rebuild that must reach TestFlight needs a new version
+  #     name, not a new build number.
+  #   * The tag records a release that FINISHED. A chain that died after the
+  #     TestFlight upload leaves no tag, so this job says ship again and the
+  #     retry hits ITMS-90189. Nothing local can detect a half-published
+  #     release; bump the build number before retrying one.
+  #
+  # It reports rather than fails when there is nothing to ship. A merge that is
+  # not a release is the normal case, and a red X on `main` for every docs
+  # commit teaches everyone to stop reading main's status — the exact habit
+  # that let the deploy jobs skip unnoticed for a whole release cycle.
+  release-gate:
+    # The same ref/event test the five gates below carry (see ios-package).
+    # Repeating it here means a skipped gate — result `skipped`, not
+    # `success` — is a second, independent reason the deploy chain cannot run
+    # from a pull request or from a branch other than `main`.
+    #
+    # No `!cancelled()` here, unlike the five below, and that is not an
+    # oversight: this job has no `needs:`, so there is no upstream skip for
+    # GitHub's implicit `success()` to inherit and nothing to escape.
+    if: |
+      github.ref == 'refs/heads/main' &&
+      (github.event_name == 'push' || github.event_name == 'workflow_dispatch')
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+    outputs:
+      # The literal string 'true' and nothing else. Every gate below compares
+      # against it, so the empty string a skipped or failed job leaves behind
+      # reads as "do not ship" without any extra handling.
+      ship: ${{ steps.decide.outputs.ship }}
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v7
+
+      - name: Decide whether this version has already been released
+        id: decide
+        run: |
+          # Character-for-character the derivation `github-release` uses in its
+          # "Prepare release tag and asset names" step. The two are deliberately
+          # independent — passing the name between jobs would let an empty
+          # output fall through to action-gh-release's documented `tag_name`
+          # default of `github.ref_name`, i.e. a release tagged `main` — but
+          # they must stay in step. Edit one, edit the other.
+          APP_VERSION=$(awk '/^version:/ {print $2}' pubspec.yaml)
+          TAG_NAME="v${APP_VERSION%+*}"
+
+          # `git ls-remote --exit-code` rather than a REST call, because it
+          # separates the three answers that matter into distinct exit codes:
+          # 0 the tag exists, 2 it does not, anything else the question was
+          # never answered. A 404 body cannot be told apart from a transient
+          # failure that cheaply, and "could not reach the remote" must never
+          # read as "no tag, go ahead and release".
+          #
+          # It queries the REMOTE, which is why `actions/checkout`'s shallow,
+          # tag-less fetch does not matter here — a local `git tag -l` would
+          # answer "no such tag" for every version and wave every push through.
+          #
+          # The pattern is a full ref path, which matches exactly: with
+          # `refs/tags/v1.3.2+53-build.629` present in this repo,
+          # `refs/tags/v1.3.2` still exits 2.
+          set +e
+          git ls-remote --exit-code --tags origin "refs/tags/$TAG_NAME" >/dev/null 2>&1
+          status=$?
+          set -e
+
+          case "$status" in
+            0)
+              echo "ship=false" >> "$GITHUB_OUTPUT"
+              echo "::notice::$TAG_NAME is already released, so the packaging and deploy jobs are skipped. Bump version: in pubspec.yaml to ship a new release."
+              {
+                echo '### No release from this push'
+                echo
+                echo "\`pubspec.yaml\` is at \`$APP_VERSION\` and **\`$TAG_NAME\` already exists**,"
+                echo 'so this version has shipped. The five packaging and deploy jobs are'
+                echo 'skipped; the build and test jobs ran as normal.'
+                echo
+                echo 'This is the expected result for a docs fix or any merge that did not'
+                echo 'bump the version. To ship a release, bump `version:` in `pubspec.yaml`'
+                echo '— both halves — per docs/RELEASING.md.'
+              } >> "$GITHUB_STEP_SUMMARY"
+              ;;
+            2)
+              echo "ship=true" >> "$GITHUB_OUTPUT"
+              echo "::notice::$TAG_NAME does not exist yet. This push will package and release $APP_VERSION."
+              {
+                echo "### Releasing \`$APP_VERSION\` as \`$TAG_NAME\`"
+                echo
+                echo "No \`$TAG_NAME\` tag exists, so this push ships. Watch \`android-deploy\`'s"
+                echo 'step summary — the Play upload usually still needs doing by hand (#942).'
+              } >> "$GITHUB_STEP_SUMMARY"
+              ;;
+            *)
+              # Fail rather than guess. A failed job makes the run red and, via
+              # the `result == 'success'` term in every gate below, keeps the
+              # deploy chain shut — loudly, which is the point.
+              echo "::error::Could not read tags from origin (git ls-remote exit $status). Refusing to guess whether $TAG_NAME has already been released."
+              exit 1
+              ;;
+          esac
+
   # Deploy gate, 1 of 5 — read this one, the other four point back at it.
   #
   # Three things have to be true to package a release, and every one of them is
@@ -613,12 +762,15 @@ jobs:
       github.ref == 'refs/heads/main' &&
       (github.event_name == 'push' || github.event_name == 'workflow_dispatch') &&
       !cancelled() &&
+      needs.release-gate.result == 'success' &&
+      needs.release-gate.outputs.ship == 'true' &&
       needs.linux-checks.result == 'success' &&
       needs.ios-build.result == 'success' &&
       needs.ios-integration-tests-result.result == 'success' &&
       needs.android-build.result == 'success' &&
       needs.android-integration-tests.result == 'success'
     needs:
+      - release-gate
       - linux-checks
       - ios-build
       - ios-integration-tests-result
@@ -734,11 +886,14 @@ jobs:
       github.ref == 'refs/heads/main' &&
       (github.event_name == 'push' || github.event_name == 'workflow_dispatch') &&
       !cancelled() &&
+      needs.release-gate.result == 'success' &&
+      needs.release-gate.outputs.ship == 'true' &&
       needs.ios-package.result == 'success' &&
       needs.android-package.result == 'success'
     # Deploy only when BOTH platforms packaged successfully (see android-deploy)
     # so a one-sided failure never publishes half a release.
     needs:
+      - release-gate
       - ios-package
       - android-package
     # Must run on macOS. The TestFlight upload goes through Apple's iTunes
@@ -791,12 +946,15 @@ jobs:
       github.ref == 'refs/heads/main' &&
       (github.event_name == 'push' || github.event_name == 'workflow_dispatch') &&
       !cancelled() &&
+      needs.release-gate.result == 'success' &&
+      needs.release-gate.outputs.ship == 'true' &&
       needs.linux-checks.result == 'success' &&
       needs.ios-build.result == 'success' &&
       needs.ios-integration-tests-result.result == 'success' &&
       needs.android-build.result == 'success' &&
       needs.android-integration-tests.result == 'success'
     needs:
+      - release-gate
       - linux-checks
       - ios-build
       - ios-integration-tests-result
@@ -929,6 +1087,8 @@ jobs:
       github.ref == 'refs/heads/main' &&
       (github.event_name == 'push' || github.event_name == 'workflow_dispatch') &&
       !cancelled() &&
+      needs.release-gate.result == 'success' &&
+      needs.release-gate.outputs.ship == 'true' &&
       needs.android-package.result == 'success' &&
       needs.ios-package.result == 'success'
     # Deploy only when BOTH platforms packaged successfully. A half-success
@@ -936,6 +1096,7 @@ jobs:
     # consuming a Play versionCode and forcing a build-number bump on the
     # retry. Gating both deploys on both package jobs keeps a release atomic.
     needs:
+      - release-gate
       - android-package
       - ios-package
     runs-on: ubuntu-latest
@@ -1045,9 +1206,12 @@ jobs:
       github.ref == 'refs/heads/main' &&
       (github.event_name == 'push' || github.event_name == 'workflow_dispatch') &&
       !cancelled() &&
+      needs.release-gate.result == 'success' &&
+      needs.release-gate.outputs.ship == 'true' &&
       needs.ios-deploy.result == 'success' &&
       needs.android-deploy.result == 'success'
     needs:
+      - release-gate
       - ios-deploy
       - android-deploy
     runs-on: ubuntu-latest
@@ -1092,6 +1256,15 @@ jobs:
         uses: softprops/action-gh-release@v3
         with:
           tag_name: ${{ env.TAG_NAME }}
+          # Belt and braces behind `release-gate`, which should mean this job
+          # never runs against an existing tag at all. If one ever slips
+          # through, the action does NOT fail on an existing release — it
+          # updates it in place, and `overwrite_files` defaults to true, which
+          # deletes the published IPA/AAB/APK and re-uploads binaries from a
+          # different commit while the tag stays where it was. GitHub does not
+          # version release assets, so that deletion is permanent. Refusing the
+          # overwrite turns a silent corruption into a failed step.
+          overwrite_files: false
           name: ${{ env.RELEASE_NAME }}
           generate_release_notes: true
           files: |

--- a/.github/workflows/default_workflow.yml
+++ b/.github/workflows/default_workflow.yml
@@ -546,12 +546,36 @@ jobs:
 
   # Deploy gate, 1 of 5 — read this one, the other four point back at it.
   #
-  # Two things have to be true to package a release, and BOTH halves below are
+  # Three things have to be true to package a release, and every one of them is
   # load-bearing:
   #
-  #   1. the run is a push to `main` or a manual dispatch — a pull request must
-  #      never touch signing material or a store;
-  #   2. every job in `needs:` actually SUCCEEDED.
+  #   1. the run is on `main` — tested first, and for EVERY event;
+  #   2. the run is a push or a manual dispatch — a pull request must never
+  #      touch signing material or a store;
+  #   3. every job in `needs:` actually SUCCEEDED.
+  #
+  # (1) is its own conjunct rather than half of (2) on purpose, and that is
+  # #1011. The guard used to read
+  #
+  #     ((github.event_name == 'push' && github.ref == 'refs/heads/main') ||
+  #     github.event_name == 'workflow_dispatch') && ...
+  #
+  # which pins the ref on the `push` arm ONLY. `workflow_dispatch:` accepts no
+  # branch filter — GitHub does not offer one — so the dispatch arm accepted
+  # any branch or tag in the repository, and a manual run from a topic branch
+  # got the full release: a TestFlight upload, a Play versionCode, and a `v*`
+  # tag. Not hypothetical: run 26086317616 was a `workflow_dispatch` on
+  # `integrate-cicd-deployment` and carried ios-package, android-package,
+  # ios-deploy, android-deploy AND github-release all to success.
+  #
+  # We got away with it — that head was later merged, and every tag this repo
+  # has cut points at a commit reachable from `main`. That was luck. Nothing
+  # in the old guard required it.
+  #
+  # The parentheses around the event test are load-bearing: `&&` binds tighter
+  # than `||`, so dropping them re-associates into
+  # `(ref == main && event == push) || (event == dispatch && needs...)`, which
+  # is the bug written out longhand.
   #
   # (2) used to be implicit: with no status check function in an `if:`, GitHub
   # ANDs a `success()` onto it for free. That free check is what broke the
@@ -586,8 +610,8 @@ jobs:
   #     deploys from pull requests.
   ios-package:
     if: |
-      ((github.event_name == 'push' && github.ref == 'refs/heads/main') ||
-      github.event_name == 'workflow_dispatch') &&
+      github.ref == 'refs/heads/main' &&
+      (github.event_name == 'push' || github.event_name == 'workflow_dispatch') &&
       !cancelled() &&
       needs.linux-checks.result == 'success' &&
       needs.ios-build.result == 'success' &&
@@ -707,8 +731,8 @@ jobs:
   # the packages would go green and this would still silently skip.
   ios-deploy:
     if: |
-      ((github.event_name == 'push' && github.ref == 'refs/heads/main') ||
-      github.event_name == 'workflow_dispatch') &&
+      github.ref == 'refs/heads/main' &&
+      (github.event_name == 'push' || github.event_name == 'workflow_dispatch') &&
       !cancelled() &&
       needs.ios-package.result == 'success' &&
       needs.android-package.result == 'success'
@@ -764,8 +788,8 @@ jobs:
   # left to GitHub's implicit `success()`.
   android-package:
     if: |
-      ((github.event_name == 'push' && github.ref == 'refs/heads/main') ||
-      github.event_name == 'workflow_dispatch') &&
+      github.ref == 'refs/heads/main' &&
+      (github.event_name == 'push' || github.event_name == 'workflow_dispatch') &&
       !cancelled() &&
       needs.linux-checks.result == 'success' &&
       needs.ios-build.result == 'success' &&
@@ -902,8 +926,8 @@ jobs:
   # `needs:` edit could quietly widen.
   android-deploy:
     if: |
-      ((github.event_name == 'push' && github.ref == 'refs/heads/main') ||
-      github.event_name == 'workflow_dispatch') &&
+      github.ref == 'refs/heads/main' &&
+      (github.event_name == 'push' || github.event_name == 'workflow_dispatch') &&
       !cancelled() &&
       needs.android-package.result == 'success' &&
       needs.ios-package.result == 'success'
@@ -1018,8 +1042,8 @@ jobs:
   # here would have tagged and published it.
   github-release:
     if: |
-      ((github.event_name == 'push' && github.ref == 'refs/heads/main') ||
-      github.event_name == 'workflow_dispatch') &&
+      github.ref == 'refs/heads/main' &&
+      (github.event_name == 'push' || github.event_name == 'workflow_dispatch') &&
       !cancelled() &&
       needs.ios-deploy.result == 'success' &&
       needs.android-deploy.result == 'success'

--- a/.github/workflows/default_workflow.yml
+++ b/.github/workflows/default_workflow.yml
@@ -636,9 +636,14 @@ jobs:
       # refused: both derive `v2.2.0`. A build-only bump is a legitimate
       # TestFlight release and must ship.
       #
-      # Both are the literal string 'true' and nothing else, so the empty
-      # string a skipped or failed job leaves behind reads as "do not ship"
-      # without any extra handling.
+      # Both are written explicitly as the string 'true' or 'false' (see the
+      # `decide` step). Every consumer tests `== 'true'`, which is what makes
+      # the third case safe: a skipped or failed `release-gate` leaves the
+      # output as the EMPTY string, and '' is equal to neither 'true' nor
+      # 'false', so it reads as "do not ship" without any extra handling.
+      #
+      # Test `== 'true'`, never `!= 'false'` — the latter is TRUE for the
+      # empty string, so it would ship out of a gate that never ran.
       deploy: ${{ steps.decide.outputs.deploy }}
       publish: ${{ steps.decide.outputs.publish }}
     steps:
@@ -704,7 +709,7 @@ jobs:
               0) REF_EXISTS=yes ;;
               2) REF_EXISTS=no ;;
               *)
-                echo "::error::Could not read tags from origin (git ls-remote exit $ls_status) while asking whether refs/tags/$1 exists. Refusing to guess whether this build has already shipped."
+                echo "::error::Could not read tags from origin (git ls-remote exit $ls_status) while asking whether $1 exists. Refusing to guess whether this build has already shipped."
                 exit 1
                 ;;
             esac

--- a/.github/workflows/default_workflow.yml
+++ b/.github/workflows/default_workflow.yml
@@ -619,15 +619,33 @@ jobs:
     permissions:
       contents: read
     outputs:
-      # The literal string 'true' and nothing else. Every gate below compares
-      # against it, so the empty string a skipped or failed job leaves behind
-      # reads as "do not ship" without any extra handling.
-      ship: ${{ steps.decide.outputs.ship }}
+      # TWO answers, not one, because two different questions were being
+      # conflated and they have different ledgers and different stakes:
+      #
+      #   deploy  — is there a NEW BUILD to send to the stores? Ledger: the
+      #             build NUMBER. Read by the four packaging and deploy jobs.
+      #             Getting this wrong costs a red run and two store
+      #             rejections; nothing is destroyed.
+      #   publish — is `v<version-name>` still unclaimed? Ledger: that tag.
+      #             Read by `github-release` and by nothing else, because that
+      #             is the only destructive path in this workflow.
+      #
+      # The single `ship` output these replace answered only the second
+      # question and then gated the first on it, which is why a build-only
+      # bump — 2.2.0+63 -> 2.2.0+64, same version NAME, new binary — was
+      # refused: both derive `v2.2.0`. A build-only bump is a legitimate
+      # TestFlight release and must ship.
+      #
+      # Both are the literal string 'true' and nothing else, so the empty
+      # string a skipped or failed job leaves behind reads as "do not ship"
+      # without any extra handling.
+      deploy: ${{ steps.decide.outputs.deploy }}
+      publish: ${{ steps.decide.outputs.publish }}
     steps:
       - name: Checkout code
         uses: actions/checkout@v7
 
-      - name: Decide whether this version has already been released
+      - name: Decide what this push may deploy and what it may publish
         id: decide
         run: |
           # Character-for-character the derivation `github-release` uses in its
@@ -637,61 +655,193 @@ jobs:
           # default of `github.ref_name`, i.e. a release tagged `main` — but
           # they must stay in step. Edit one, edit the other.
           APP_VERSION=$(awk '/^version:/ {print $2}' pubspec.yaml)
-          TAG_NAME="v${APP_VERSION%+*}"
+          if [ -z "$APP_VERSION" ]; then
+            echo "::error::No 'version:' line in pubspec.yaml. Refusing to guess what this push would ship."
+            exit 1
+          fi
+          VERSION_NO_BUILD="${APP_VERSION%+*}"
+          BUILD_NUMBER="${APP_VERSION##*+}"
+          TAG_NAME="v${VERSION_NO_BUILD}"
+          BUILD_TAG="deployed/${BUILD_NUMBER}"
 
-          # `git ls-remote --exit-code` rather than a REST call, because it
-          # separates the three answers that matter into distinct exit codes:
-          # 0 the tag exists, 2 it does not, anything else the question was
-          # never answered. A 404 body cannot be told apart from a transient
-          # failure that cheaply, and "could not reach the remote" must never
-          # read as "no tag, go ahead and release".
-          #
-          # It queries the REMOTE, which is why `actions/checkout`'s shallow,
-          # tag-less fetch does not matter here — a local `git tag -l` would
-          # answer "no such tag" for every version and wave every push through.
-          #
-          # The pattern is a full ref path, which matches exactly: with
-          # `refs/tags/v1.3.2+53-build.629` present in this repo,
-          # `refs/tags/v1.3.2` still exits 2.
-          set +e
-          git ls-remote --exit-code --tags origin "refs/tags/$TAG_NAME" >/dev/null 2>&1
-          status=$?
-          set -e
-
-          case "$status" in
-            0)
-              echo "ship=false" >> "$GITHUB_OUTPUT"
-              echo "::notice::$TAG_NAME is already released, so the packaging and deploy jobs are skipped. Bump version: in pubspec.yaml to ship a new release."
-              {
-                echo '### No release from this push'
-                echo
-                echo "\`pubspec.yaml\` is at \`$APP_VERSION\` and **\`$TAG_NAME\` already exists**,"
-                echo 'so this version has shipped. The five packaging and deploy jobs are'
-                echo 'skipped; the build and test jobs ran as normal.'
-                echo
-                echo 'This is the expected result for a docs fix or any merge that did not'
-                echo 'bump the version. To ship a release, bump `version:` in `pubspec.yaml`'
-                echo '— both halves — per docs/RELEASING.md.'
-              } >> "$GITHUB_STEP_SUMMARY"
-              ;;
-            2)
-              echo "ship=true" >> "$GITHUB_OUTPUT"
-              echo "::notice::$TAG_NAME does not exist yet. This push will package and release $APP_VERSION."
-              {
-                echo "### Releasing \`$APP_VERSION\` as \`$TAG_NAME\`"
-                echo
-                echo "No \`$TAG_NAME\` tag exists, so this push ships. Watch \`android-deploy\`'s"
-                echo 'step summary — the Play upload usually still needs doing by hand (#942).'
-              } >> "$GITHUB_STEP_SUMMARY"
-              ;;
-            *)
-              # Fail rather than guess. A failed job makes the run red and, via
-              # the `result == 'success'` term in every gate below, keeps the
-              # deploy chain shut — loudly, which is the point.
-              echo "::error::Could not read tags from origin (git ls-remote exit $status). Refusing to guess whether $TAG_NAME has already been released."
+          # The build number is compared numerically below, so it has to BE a
+          # number. `2.2.0` with no `+` would leave BUILD_NUMBER as the whole
+          # string and silently mis-answer; say so instead.
+          case "$BUILD_NUMBER" in
+            ''|*[!0-9]*)
+              echo "::error::Build number '$BUILD_NUMBER' in version '$APP_VERSION' is not a plain integer. Refusing to guess whether this build has already shipped."
               exit 1
               ;;
           esac
+
+          # `git ls-remote --exit-code` rather than a REST call, because it
+          # separates the three answers that matter into distinct exit codes:
+          # 0 the ref exists, 2 it does not, anything else the question was
+          # never answered. A 404 body cannot be told apart from a transient
+          # failure that cheaply, and "could not reach the remote" must never
+          # read as "no such ref, go ahead".
+          #
+          # It queries the REMOTE, which is why `actions/checkout`'s shallow,
+          # tag-less fetch does not matter here — a local `git tag -l` would
+          # answer "no such tag" for everything and wave every push through.
+          #
+          # The pattern is a full ref path, which matches exactly. That is not
+          # decoration: `git ls-remote` matches a pattern "against the 'tail'
+          # of a ref, starting either from the start of the ref or from a slash
+          # separator", so the bare pattern `v1.3.2` MATCHES the existing
+          # `refs/tags/v1.3.2+53-build.629` while `refs/tags/v1.3.2` correctly
+          # exits 2. Always pass the full path.
+          #
+          # Sets a variable rather than echoing, so the `exit 1` below exits
+          # this step. Inside `VAR=$(ref_exists ...)` it would only end the
+          # command substitution's subshell.
+          ref_exists() {
+            set +e
+            git ls-remote --exit-code --tags origin "$1" >/dev/null 2>&1
+            ls_status=$?
+            set -e
+            case "$ls_status" in
+              0) REF_EXISTS=yes ;;
+              2) REF_EXISTS=no ;;
+              *)
+                echo "::error::Could not read tags from origin (git ls-remote exit $ls_status) while asking whether refs/tags/$1 exists. Refusing to guess whether this build has already shipped."
+                exit 1
+                ;;
+            esac
+          }
+
+          ref_exists "refs/tags/$BUILD_TAG"
+          BUILD_SHIPPED="$REF_EXISTS"
+          ref_exists "refs/tags/$TAG_NAME"
+          TAG_TAKEN="$REF_EXISTS"
+
+          # THE LEDGER STARTS EMPTY, and an empty ledger says "never shipped"
+          # about builds that demonstrably have. The `deployed/<n>` tags are
+          # written by the deploy jobs below, and those jobs have never run
+          # under this design, so on the push that LANDS this change —
+          # pubspec.yaml still at 2.2.0+63, because a workflow fix does not
+          # bump the version — `deployed/63` does not exist and build 63 would
+          # read as new. Build 63 is on TestFlight and on the Play internal
+          # track right now. Re-pushing it means ITMS-90189 "Redundant Binary
+          # Upload" from Apple and "version code has already been used" from
+          # Play — and that second string is NOT one the #942 tolerance grep in
+          # android-deploy matches, so that job goes red rather than
+          # warning-green. Worse, it would not self-heal: the deploy fails, so
+          # no marker is written, so the next push repeats it forever.
+          #
+          # LAST_BUILD_BEFORE_LEDGER is the seed. It is the highest build
+          # number that shipped before this ledger existed; anything at or
+          # below it is already spoken for, tag or no tag. A constant rather
+          # than a tag pushed by hand before the merge, because a hand-pushed
+          # seed can be forgotten and forgetting it costs a red `main` and a
+          # burnt build number, whereas a constant lands atomically with the
+          # change and gets reviewed with it.
+          #
+          # It also closes a second hole this repo has actually fallen into:
+          # build numbers are NOT monotonic here. `git log -p pubspec.yaml`
+          # shows `1.3.1+51` and later `1.4.0+51` — the same Play versionCode
+          # twice — and `1.4.0+51` follows `1.3.2+55`, a regression of four. A
+          # ledger of marker tags cannot see a regression to a build that
+          # predates it; this line can.
+          #
+          # DO NOT BUMP IT. It records history, not the current build. Every
+          # build from 64 onward records itself.
+          LAST_BUILD_BEFORE_LEDGER=63
+
+          if [ "$BUILD_SHIPPED" = no ] && [ "$BUILD_NUMBER" -le "$LAST_BUILD_BEFORE_LEDGER" ]; then
+            BUILD_SHIPPED=yes
+            echo "::notice::Build $BUILD_NUMBER is at or below the pre-ledger floor ($LAST_BUILD_BEFORE_LEDGER), so it shipped before this ledger existed. Treating it as already deployed."
+          fi
+
+          # Written out rather than `[ "$X" = no ] && DEPLOY=true`. That idiom
+          # returns 1 on the false branch, and as the last command of a step it
+          # would fail the job under the `bash -e` GitHub runs `run:` with.
+          if [ "$BUILD_SHIPPED" = no ]; then DEPLOY=true; else DEPLOY=false; fi
+          if [ "$TAG_TAKEN" = no ]; then PUBLISH=true; else PUBLISH=false; fi
+
+          echo "deploy=$DEPLOY" >> "$GITHUB_OUTPUT"
+          echo "publish=$PUBLISH" >> "$GITHUB_OUTPUT"
+
+          # Four combinations, all reachable, each meaning something different
+          # to a human. Say which one this is, every time.
+          if [ "$DEPLOY" = true ] && [ "$PUBLISH" = true ]; then
+            echo "::notice::Full release: $APP_VERSION deploys to both stores and is published as $TAG_NAME."
+            {
+              echo "### Releasing \`$APP_VERSION\` as \`$TAG_NAME\`"
+              echo
+              echo "Neither \`$BUILD_TAG\` nor \`$TAG_NAME\` exists, so this push packages,"
+              echo 'deploys to both stores and cuts the GitHub release.'
+              echo
+              echo "Watch \`android-deploy\`'s step summary — the Play upload usually still"
+              echo 'needs doing by hand (#942).'
+            } >> "$GITHUB_STEP_SUMMARY"
+          elif [ "$DEPLOY" = true ]; then
+            echo "::notice::Build-only bump: $APP_VERSION deploys to both stores. $TAG_NAME is already published, so no GitHub release is cut and github-release is skipped ON PURPOSE."
+            {
+              echo "### Deploying build \`$BUILD_NUMBER\`, with no GitHub release"
+              echo
+              echo "\`$BUILD_TAG\` does not exist, so build \`$BUILD_NUMBER\` has never gone to"
+              echo 'the stores and this push ships it to TestFlight and Play. But'
+              echo "\`$TAG_NAME\` **already exists**, and \`softprops/action-gh-release\` does"
+              echo 'not fail on an existing tag — it updates the release in place, renames'
+              echo 'it and appends regenerated notes to the published body. So'
+              echo '`github-release` is skipped.'
+              echo
+              echo '**A skipped `github-release` on this path is the expected result, not the'
+              echo '#1008 failure it resembles.** A skipped job reports as Success, nothing'
+              echo 'in this workflow depends on `github-release`, and the run stays green.'
+              echo
+              echo '**Where the binaries are:** the `ios-ipa`, `android-aab` and'
+              echo '`android-apk` artifacts on this run page, kept for 90 days (the'
+              echo 'repository artifact retention setting). No release assets are published'
+              echo "or replaced, so the APK attached to \`$TAG_NAME\` still belongs to the"
+              echo 'build that release is named for. Do not "fix" that by re-running'
+              echo '`github-release`; that is the destructive path this gate exists to shut.'
+            } >> "$GITHUB_STEP_SUMMARY"
+          elif [ "$PUBLISH" = true ]; then
+            # Build already consumed, version name never published. There is no
+            # safe automatic answer here and both causes need a human, so fail
+            # rather than skip: a green run that quietly published nothing is
+            # exactly the shape of #1008, and this workflow does not get to
+            # look like that again.
+            echo "::error::Build $BUILD_NUMBER has already been deployed, but $TAG_NAME was never published. Nothing can ship from this run. See the step summary."
+            {
+              echo "### Refusing to run: build \`$BUILD_NUMBER\` is spent and \`$TAG_NAME\` is unpublished"
+              echo
+              echo "\`$BUILD_TAG\` exists (or the build is at or below the pre-ledger floor),"
+              echo "so build \`$BUILD_NUMBER\` has already gone to the stores — a Play"
+              echo "versionCode cannot be reused. But \`$TAG_NAME\` has no tag, so no GitHub"
+              echo 'release was ever cut for it.'
+              echo
+              echo 'There are two ways to get here, and they need different fixes:'
+              echo
+              echo '1. **The version NAME was bumped without the build number.** Bump the'
+              echo '   build number too, per `docs/RELEASING.md` — "Both halves. Nothing'
+              echo '   bumps it for you."'
+              echo '2. **A previous run deployed, then `github-release` failed, and someone'
+              echo '   used *Re-run all jobs*.** That re-runs this gate, which now sees the'
+              echo '   build recorded and shuts the whole chain. Use **Re-run failed jobs**'
+              echo '   on the ORIGINAL run instead — it reuses this job'"'"'s cached outputs'
+              echo '   and re-runs only what failed. If that run is gone, bump the build'
+              echo '   number and ship again, or attach the artifacts to a release by hand.'
+            } >> "$GITHUB_STEP_SUMMARY"
+            exit 1
+          else
+            echo "::notice::Nothing to ship: build $BUILD_NUMBER has already been deployed and $TAG_NAME is already released. The packaging and deploy jobs are skipped."
+            {
+              echo '### No release from this push'
+              echo
+              echo "\`pubspec.yaml\` is at \`$APP_VERSION\`; build \`$BUILD_NUMBER\` has already"
+              echo "been deployed and \`$TAG_NAME\` already exists, so this build has shipped"
+              echo 'and this version has been published. The packaging, deploy and release'
+              echo 'jobs are skipped; the build and test jobs ran as normal.'
+              echo
+              echo 'This is the expected result for a docs fix or any merge that did not'
+              echo 'bump the version. To ship, bump `version:` in `pubspec.yaml` per'
+              echo 'docs/RELEASING.md — the build number alone for a TestFlight/Play-only'
+              echo 'build, or both halves for a published release.'
+            } >> "$GITHUB_STEP_SUMMARY"
+          fi
 
   # Deploy gate, 1 of 5 — read this one, the other four point back at it.
   #
@@ -763,7 +913,7 @@ jobs:
       (github.event_name == 'push' || github.event_name == 'workflow_dispatch') &&
       !cancelled() &&
       needs.release-gate.result == 'success' &&
-      needs.release-gate.outputs.ship == 'true' &&
+      needs.release-gate.outputs.deploy == 'true' &&
       needs.linux-checks.result == 'success' &&
       needs.ios-build.result == 'success' &&
       needs.ios-integration-tests-result.result == 'success' &&
@@ -887,7 +1037,7 @@ jobs:
       (github.event_name == 'push' || github.event_name == 'workflow_dispatch') &&
       !cancelled() &&
       needs.release-gate.result == 'success' &&
-      needs.release-gate.outputs.ship == 'true' &&
+      needs.release-gate.outputs.deploy == 'true' &&
       needs.ios-package.result == 'success' &&
       needs.android-package.result == 'success'
     # Deploy only when BOTH platforms packaged successfully (see android-deploy)
@@ -903,7 +1053,10 @@ jobs:
     # in ios-package and handed off as an artifact, so this job only uploads.
     runs-on: macos-26
     permissions:
-      contents: read
+      # Widened from `read` for the ledger step at the end of this job,
+      # which pushes one lightweight tag with the GITHUB_TOKEN credentials
+      # actions/checkout persists. Nothing else in this job writes to the repo.
+      contents: write
     env:
       LANG: en_US.UTF-8
       LC_ALL: en_US.UTF-8
@@ -937,6 +1090,71 @@ jobs:
           APP_STORE_CONNECT_API_KEY_P8: ${{ secrets.APP_STORE_CONNECT_API_KEY_P8 }}
         run: bundle exec fastlane ios beta_from_ipa
 
+      # Writes the ledger `release-gate` reads. Last step of the job, and of
+      # the sibling deploy job too — both push it, deliberately.
+      #
+      # LAST, not first: a job that dies before the upload leaves no marker, so
+      # docs/RELEASING.md's "re-running is the fix" for a `startup_failure`
+      # still works. A marker written up front would record builds that never
+      # left the runner.
+      #
+      # BOTH deploy jobs push it, rather than one shared job downstream,
+      # because the tag means "a store has consumed this build number" and
+      # consumption is per-store. If only the other job pushed and this half
+      # were the one that failed, a retry would re-upload against a build
+      # number the other store has already taken. Two writers means the record
+      # survives either half failing — which is the honest answer, because a
+      # half-failed deploy genuinely cannot be retried at the same build
+      # number. Bump the build number and ship again.
+      #
+      # The race between the two jobs is a no-op: both tag the same
+      # `github.sha`, so the loser's push reports "Everything up-to-date" and
+      # exits 0. A push at a DIFFERENT sha would be rejected, which is why
+      # there is no `--force` here — that would mean the gate had let an
+      # already-deployed build through, and that needs a human.
+      #
+      # Pushing a tag cannot retrigger this workflow, twice over: `on.push`
+      # declares only `branches:`, and "if you define only tags/tags-ignore or
+      # only branches/branches-ignore, the workflow won't run for events
+      # affecting the undefined Git ref"; and pushes made with the GITHUB_TOKEN
+      # do not create workflow runs at all. No `[skip ci]` guard is needed.
+      #
+      # `deployed/<n>`, not `v<name>+<n>`: `v2.2.0+64` is valid
+      # semver-with-build-metadata, and GitHub picks the previous tag for
+      # `generate_release_notes` on a semver-ish heuristic, so it could become
+      # the comparison base for a later release and silently truncate its
+      # changelog. `deployed/64` is not semver-shaped and is keyed on the build
+      # number ALONE — a Play versionCode is globally unique for the app
+      # forever, so the number is the thing that is spent, independent of which
+      # version name it shipped under. `git ls-remote --tags origin
+      # 'refs/tags/deployed/*'` is the whole ledger.
+      - name: Record that this build number has been deployed
+        run: |
+          BUILD_TAG="deployed/$(awk '/^version:/ {print $2}' pubspec.yaml | sed 's/.*+//')"
+
+          # Lightweight tag: needs no user.name/user.email on the runner, and
+          # there is nothing worth annotating. The push uses the credentials
+          # actions/checkout persists by default, which is the only reason this
+          # job carries `contents: write`.
+          git tag -f "$BUILD_TAG"
+
+          if git push origin "refs/tags/$BUILD_TAG"; then
+            echo "::notice::Recorded $BUILD_TAG. No later push will deploy build number ${BUILD_TAG##*/} again."
+            exit 0
+          fi
+
+          # A rejected push is not automatically a failure — the sibling deploy
+          # job may simply have won the race. Re-ask the remote instead of
+          # parsing git's message, and fail only if the marker genuinely is not
+          # there.
+          if git ls-remote --exit-code --tags origin "refs/tags/$BUILD_TAG" >/dev/null 2>&1; then
+            echo "::notice::$BUILD_TAG was already recorded (the sibling deploy job, or a concurrent run, won the race). The build number is spent either way, which is all the ledger claims."
+            exit 0
+          fi
+
+          echo "::error::Could not record $BUILD_TAG. This build HAS been uploaded but the ledger does not say so, so the next push to main would upload it again. Create the tag by hand before merging anything else: git tag $BUILD_TAG ${{ github.sha }} && git push origin $BUILD_TAG"
+          exit 1
+
   # Deploy gate, 2 of 5 — identical to ios-package by design: both package jobs
   # gate the same release on the same evidence, so they must stay in step. See
   # ios-package for why each dependency is checked by result instead of being
@@ -947,7 +1165,7 @@ jobs:
       (github.event_name == 'push' || github.event_name == 'workflow_dispatch') &&
       !cancelled() &&
       needs.release-gate.result == 'success' &&
-      needs.release-gate.outputs.ship == 'true' &&
+      needs.release-gate.outputs.deploy == 'true' &&
       needs.linux-checks.result == 'success' &&
       needs.ios-build.result == 'success' &&
       needs.ios-integration-tests-result.result == 'success' &&
@@ -1088,7 +1306,7 @@ jobs:
       (github.event_name == 'push' || github.event_name == 'workflow_dispatch') &&
       !cancelled() &&
       needs.release-gate.result == 'success' &&
-      needs.release-gate.outputs.ship == 'true' &&
+      needs.release-gate.outputs.deploy == 'true' &&
       needs.android-package.result == 'success' &&
       needs.ios-package.result == 'success'
     # Deploy only when BOTH platforms packaged successfully. A half-success
@@ -1101,7 +1319,10 @@ jobs:
       - ios-package
     runs-on: ubuntu-latest
     permissions:
-      contents: read
+      # Widened from `read` for the ledger step at the end of this job,
+      # which pushes one lightweight tag with the GITHUB_TOKEN credentials
+      # actions/checkout persists. Nothing else in this job writes to the repo.
+      contents: write
     env:
       BUNDLE_GEMFILE: ${{ github.workspace }}/android/Gemfile
     steps:
@@ -1182,7 +1403,8 @@ jobs:
             echo '**To finish the release:**'
             echo
             echo '1. Download the `android-aab` artifact from this run, or take the AAB'
-            echo '   attached to the GitHub release this workflow creates.'
+            echo '   (a full release also attaches it to the GitHub release; a build-only'
+            echo '   bump creates none, so the run artifact is the only copy).'
             echo '2. Play Console → Testen und veröffentlichen → Interner Test →'
             echo '   **Neuen Release erstellen**, and drop the AAB in.'
             echo '3. **Read the warnings on the review step before publishing.** This is the'
@@ -1194,6 +1416,71 @@ jobs:
             echo 'This step will start passing on its own once Google fixes the API; nothing'
             echo 'here needs changing when that happens.'
           } >> "$GITHUB_STEP_SUMMARY"
+
+      # Writes the ledger `release-gate` reads. Last step of the job, and of
+      # the sibling deploy job too — both push it, deliberately.
+      #
+      # LAST, not first: a job that dies before the upload leaves no marker, so
+      # docs/RELEASING.md's "re-running is the fix" for a `startup_failure`
+      # still works. A marker written up front would record builds that never
+      # left the runner.
+      #
+      # BOTH deploy jobs push it, rather than one shared job downstream,
+      # because the tag means "a store has consumed this build number" and
+      # consumption is per-store. If only the other job pushed and this half
+      # were the one that failed, a retry would re-upload against a build
+      # number the other store has already taken. Two writers means the record
+      # survives either half failing — which is the honest answer, because a
+      # half-failed deploy genuinely cannot be retried at the same build
+      # number. Bump the build number and ship again.
+      #
+      # The race between the two jobs is a no-op: both tag the same
+      # `github.sha`, so the loser's push reports "Everything up-to-date" and
+      # exits 0. A push at a DIFFERENT sha would be rejected, which is why
+      # there is no `--force` here — that would mean the gate had let an
+      # already-deployed build through, and that needs a human.
+      #
+      # Pushing a tag cannot retrigger this workflow, twice over: `on.push`
+      # declares only `branches:`, and "if you define only tags/tags-ignore or
+      # only branches/branches-ignore, the workflow won't run for events
+      # affecting the undefined Git ref"; and pushes made with the GITHUB_TOKEN
+      # do not create workflow runs at all. No `[skip ci]` guard is needed.
+      #
+      # `deployed/<n>`, not `v<name>+<n>`: `v2.2.0+64` is valid
+      # semver-with-build-metadata, and GitHub picks the previous tag for
+      # `generate_release_notes` on a semver-ish heuristic, so it could become
+      # the comparison base for a later release and silently truncate its
+      # changelog. `deployed/64` is not semver-shaped and is keyed on the build
+      # number ALONE — a Play versionCode is globally unique for the app
+      # forever, so the number is the thing that is spent, independent of which
+      # version name it shipped under. `git ls-remote --tags origin
+      # 'refs/tags/deployed/*'` is the whole ledger.
+      - name: Record that this build number has been deployed
+        run: |
+          BUILD_TAG="deployed/$(awk '/^version:/ {print $2}' pubspec.yaml | sed 's/.*+//')"
+
+          # Lightweight tag: needs no user.name/user.email on the runner, and
+          # there is nothing worth annotating. The push uses the credentials
+          # actions/checkout persists by default, which is the only reason this
+          # job carries `contents: write`.
+          git tag -f "$BUILD_TAG"
+
+          if git push origin "refs/tags/$BUILD_TAG"; then
+            echo "::notice::Recorded $BUILD_TAG. No later push will deploy build number ${BUILD_TAG##*/} again."
+            exit 0
+          fi
+
+          # A rejected push is not automatically a failure — the sibling deploy
+          # job may simply have won the race. Re-ask the remote instead of
+          # parsing git's message, and fail only if the marker genuinely is not
+          # there.
+          if git ls-remote --exit-code --tags origin "refs/tags/$BUILD_TAG" >/dev/null 2>&1; then
+            echo "::notice::$BUILD_TAG was already recorded (the sibling deploy job, or a concurrent run, won the race). The build number is spent either way, which is all the ledger claims."
+            exit 0
+          fi
+
+          echo "::error::Could not record $BUILD_TAG. This build HAS been uploaded but the ledger does not say so, so the next push to main would upload it again. Create the tag by hand before merging anything else: git tag $BUILD_TAG ${{ github.sha }} && git push origin $BUILD_TAG"
+          exit 1
 
   # Deploy gate, 5 of 5, and it needs the same treatment rather than inheriting
   # a fix from its parents — the skip propagates past them to here. The two
@@ -1207,7 +1494,7 @@ jobs:
       (github.event_name == 'push' || github.event_name == 'workflow_dispatch') &&
       !cancelled() &&
       needs.release-gate.result == 'success' &&
-      needs.release-gate.outputs.ship == 'true' &&
+      needs.release-gate.outputs.publish == 'true' &&
       needs.ios-deploy.result == 'success' &&
       needs.android-deploy.result == 'success'
     needs:
@@ -1256,14 +1543,35 @@ jobs:
         uses: softprops/action-gh-release@v3
         with:
           tag_name: ${{ env.TAG_NAME }}
-          # Belt and braces behind `release-gate`, which should mean this job
-          # never runs against an existing tag at all. If one ever slips
-          # through, the action does NOT fail on an existing release — it
-          # updates it in place, and `overwrite_files` defaults to true, which
-          # deletes the published IPA/AAB/APK and re-uploads binaries from a
-          # different commit while the tag stays where it was. GitHub does not
-          # version release assets, so that deletion is permanent. Refusing the
-          # overwrite turns a silent corruption into a failed step.
+          # Belt and braces behind `release-gate`'s `publish` output, which
+          # should mean this job never runs against an existing tag at all. If
+          # one ever slips through, the action does NOT fail on an existing
+          # release — it updates it in place, and `overwrite_files` defaults to
+          # true, which deletes the published IPA/AAB/APK and re-uploads
+          # binaries from a different commit while the tag stays where it was.
+          # GitHub does not version release assets, so that deletion is
+          # permanent.
+          #
+          # Do not read this as a tripwire, though — it is NOT one, and an
+          # earlier version of this comment claimed otherwise. In
+          # softprops/action-gh-release v3, `src/github.ts` handles the flag as
+          #
+          #     if (config.input_overwrite_files === false) {
+          #       console.log(`Asset ${name} already exists and overwrite_files is false...`);
+          #       return null;
+          #     }
+          #
+          # — it logs and returns. No throw, and the job stays GREEN. It also
+          # does not stop the rest of the existing-release path: `updateRelease`
+          # is still called with `name`, so the published release is RENAMED
+          # (`Release v2.2.0 (build 63)` becomes `(build 64)` over assets that
+          # are still build 63), and because `generate_release_notes: true`
+          # routes through `prepareReleaseMutation`, freshly generated notes are
+          # APPENDED to the existing body rather than replacing it.
+          #
+          # So this flag protects the three published binaries and nothing else.
+          # `publish` is the only thing that keeps this job away from a
+          # published release, which is why it is a hard gate and not advice.
           overwrite_files: false
           name: ${{ env.RELEASE_NAME }}
           generate_release_notes: true

--- a/docs/RELEASING.md
+++ b/docs/RELEASING.md
@@ -1,6 +1,6 @@
 # Releasing
 
-A release is **a merge of `develop` into `main`**. There is no release script and no tag to push
+A release is **a merge of `develop` into `main`**. There is no release script, and no tag to push
 by hand: pushing to `main` starts the pipeline, and the pipeline does the packaging, the store
 uploads and the GitHub release itself.
 
@@ -46,7 +46,9 @@ The step tolerates that one error and nothing else: it emits a `::warning::` and
 recovery steps into the run's **step summary**. So the job going green is not the signal — read the
 summary. When it says the upload needs doing by hand:
 
-1. Download the `android-aab` artifact from the run, or take the AAB attached to the GitHub release.
+1. Download the `android-aab` artifact from the run. (A full release also attaches the AAB to the
+   GitHub release; a build-only bump creates no release, so the run artifact is the only copy —
+   and it expires after 90 days.)
 2. Play Console → Internal testing → **Create new release**, and drop the AAB in.
 3. **Read the warnings on the review step before publishing.** That is the only place Play reports
    them, and a failing API upload never gets far enough to return them — which is how the minSdk
@@ -57,8 +59,22 @@ This step starts passing on its own once Google fixes the API; nothing here need
 
 ## Before opening the release PR
 
-- [ ] **Bump `version:` in `pubspec.yaml`.** Both halves: the name (`2.2.0`) and the build number
-      (`+63`). The build number must increase or Play rejects the upload. Nothing bumps it for you.
+- [ ] **Bump `version:` in `pubspec.yaml`.** The build number (`+63`) must increase or the
+      pipeline refuses to deploy — `release-gate` reads it and Play rejects a reused versionCode.
+      Nothing bumps it for you.
+
+      **Bumping the build number alone is a supported release.** `2.2.0+63` → `2.2.0+64` ships to
+      TestFlight and Play under the same version name. On that path `github-release` is **skipped
+      on purpose**, because `v2.2.0` already exists and re-running it would delete the published
+      release's assets and replace them with binaries from another commit. A skipped
+      `github-release` there is expected, not the #1008 skip bug — the run is green and
+      `release-gate`'s step summary says which of the two happened. The consequence: a build-only
+      bump publishes no GitHub release, so its IPA and AAB exist only as run artifacts, for 90
+      days. Bump the name as well when the build should have a durable public download.
+
+      **Bumping the name without the build fails the gate**, by design: `2.3.0+63` is refused with
+      an error naming both fixes. So does a build number that goes backwards — this repo's history
+      contains `1.3.1+51` and `1.4.0+51`, the same versionCode twice.
 - [ ] **Write the store "what's new" text** into
       `fastlane/metadata/android/en-US/changelogs/<versionCode>.txt` — `63.txt` for build 63. The
       directory also holds a stale `12.txt` from the F-Droid era; ignore that one. The pipeline does
@@ -85,6 +101,15 @@ This step starts passing on its own once Google fixes the API; nothing here need
 - [ ] **Watch the run to a terminal state.** A run can fail *before creating any job* — GitHub
       reports `startup_failure`, and the check-runs read `cancelled` for jobs that never existed.
       Re-running is the fix; it is not a fault in the branch.
+- [ ] **If you have to re-run after a deploy job failed, use "Re-run failed jobs" — never "Re-run
+      all jobs".** The former reuses `release-gate`'s cached answer. The latter recomputes it, and
+      by then the deploy jobs have recorded the build as spent, so the gate correctly answers "do
+      not deploy" and the release is stranded mid-flight with no way forward but a build bump.
+- [ ] **Know what the pipeline records.** Each deploy job pushes a `deployed/<build-number>` tag on
+      success — that is the ledger `release-gate` reads, and the one thing this workflow pushes
+      besides a release tag. It records what a store **consumed**, not what it **published**: with
+      the #942 tolerance `android-deploy` exits 0 on a rejected upload and still marks the build
+      spent. So a build you never hand-uploaded still needs a bump before you can retry it.
 - [ ] **Get the Android build onto `internal`.** Check the run's step summary first: if the API
       upload hit [#942](https://github.com/simonoppowa/OpenNutriTracker/issues/942), the track is
       still empty and the AAB needs uploading by hand. Production promotion is manual either way.


### PR DESCRIPTION
**The `main` half of #1014** — merging this is what makes the fix live; the deploy chain only ever runs from `main`.

---

## 1 · Only ever deploy from `main` — #1011

The five deploy guards pinned the ref on the `push` arm only, so the `workflow_dispatch` arm accepted **any branch or tag** — GitHub offers no branch filter for that trigger. Run [26086317616](https://github.com/simonoppowa/OpenNutriTracker/actions/runs/26086317616) was a dispatch on `integrate-cicd-deployment` and carried all five jobs to success: a release published from a feature branch.

The ref is now tested first, for every event. Pure narrowing; dispatch on `main` still works, so the manual recovery path stays. Restricted to `main` alone, not `release/**` — every release carries `target_commitish: main`, and 2.2.0 shipped from the push to `main` after #988.

## 2 · A gate that answers two questions, not one

Fixing the deploy-chain skip (#1008) means `push: main` now really deploys, on every merge — docs-only ones included. With `pubspec.yaml` at `2.2.0+63` the morning after 2.2.0 shipped, the next merge re-runs the chain against an already-published version.

Two questions were being conflated:

| output | question | ledger | read by | stakes |
|---|---|---|---|---|
| `deploy` | is there a **new build** for the stores? | the build **number** | the 4 packaging/deploy jobs | a red run, two store rejections |
| `publish` | is `v<name>` still unclaimed? | that **tag** | `github-release` **only** | **permanent asset deletion** |

Gating both on the tag — the first version of this branch — refuses a build-only bump, because `2.2.0+63` and `2.2.0+64` both derive `v2.2.0`. **A build-only bump is a legitimate TestFlight release and now ships**, while `github-release` skips so the published `v2.2.0` is never touched.

That destructive path is real: `softprops/action-gh-release` does not fail on an existing tag. It updates in place, and `overwrite_files` defaults to true — deleting the published IPA, AAB and APK and re-uploading binaries from another commit while the tag stays put. GitHub does not version release assets. `overwrite_files: false` is kept as a backstop.

### The build ledger, and why there is nothing to run before merging

A `deployed/<n>` tag pushed by both deploy jobs on success, keyed on the **build number alone** — a Play versionCode is spent forever regardless of which version name carried it, and a version-qualified key would wave through the commonest slip: bumping the name and forgetting the build.

The ledger starts empty, so it carries a constant floor, `LAST_BUILD_BEFORE_LEDGER=63`, **rather than a tag seeded by hand**. A pre-merge step performed exactly once is the step that gets forgotten, and `release-gate` has no `needs:` — it reaches the question ~30 seconds in, so there is no window to win afterwards. Without the floor the first run reads build 63 as new and re-pushes it to both stores, which now fails on Play too since 63 was uploaded manually.

The floor also catches what a marker ledger cannot: **build numbers are not monotonic in this repo.** `1.3.1+51` and `1.4.0+51` both used versionCode 51, and `1.4.0+51` follows `1.3.2+55`.

## This PR's own merge is safe

A push runs the workflow at the pushed commit, so the merge commit's run includes the gate. It reads `2.2.0+63`, hits the floor, emits `deploy=false publish=false`, and all five jobs skip. Green, no store touched, no macOS minutes burned.

## Verified — the gate script executed against the live remote

```
2.2.0+63  exit=0  deploy=false publish=false   floor hit      ← this PR's merge commit
2.2.0+64  exit=0  deploy=true  publish=false   ships, release untouched
2.3.0+64  exit=0  deploy=true  publish=true    full release
2.3.0+63  exit=1  name bumped, build forgotten — refused, names both fixes
1.4.0+51  exit=0  deploy=false — historical versionCode reuse, caught by the floor
2.2.0+abc exit=1  not a plain integer
unreachable remote -> exit 1, never "safe to deploy"
```

Outcome matrix passes: ships on a push or dispatch on `main` with a new build; does not ship for a docs merge, a skipped or failed gate, a dispatch from a feature branch or tag, a pull request, a push to `develop`, a failed integration suite, or a cancelled run. `actionlint` reports no new findings, all five guards still mirror their `needs:` exactly, and **no `needs:` entry changes anywhere**.

## Runbook updated in the same change

`docs/RELEASING.md` now covers: a build-only bump as a supported release; that a skipped `github-release` there is expected, not the #1008 bug; that such a build publishes no GitHub release, so its artifacts expire in 90 days; that **"Re-run failed jobs" is correct and "Re-run all jobs" strands the release**; and that `deployed/<n>` records what a store *consumed*, not what it *published* — with the #942 tolerance, a build nobody hand-uploaded is still spent. It also corrects two places, one of them `android-deploy`'s own step summary, that told the releaser to take the AAB from a GitHub release that a build-only bump never creates.

## Known limits, stated rather than hidden

- **A build-only bump publishes no GitHub release.** Its IPA and AAB live only as 90-day run artifacts, and `v2.2.0` keeps describing build 63. That is the price of never overwriting a published release.
- **Half-deploy** (iOS succeeds, Android fails) is not representable by any local ledger. The answer is to bump the build number, and the runbook says so.
- **No `concurrency:` group.** Two release-bearing pushes inside the same window could both see no marker; the second then fails red on a duplicate build number. Never destructive. Say the word and I'll add `cancel-in-progress: false`.


Fixes #1011
