### PR TITLE
ci: cancel superseded runs and gate the macOS jobs on changed paths

### DIFF
--- a/.github/workflows/default_workflow.yml
+++ b/.github/workflows/default_workflow.yml
@@ -46,7 +46,19 @@ on:
 # get superseded, and 82% of the macOS time that reclaims is the iOS
 # integration suite.
 #
-# `main` is excluded deliberately: those runs carry the deploy chain, and a
+# `main` is never CANCELLED, but note it is not excluded from the group either:
+# `cancel-in-progress: false` puts it in the group without cancelling, which
+# per the docs means a second push to `main` goes PENDING until the first run
+# finishes — and if a third arrives while the second is still pending, the
+# second is cancelled and replaced. So `main` is SERIALISED, with displacement.
+#
+# That is the intended trade: two concurrent deploy runs racing on the same
+# build number and ledger tag is worse than one waiting. It is a real behaviour
+# change though — before this block, two main pushes ran side by side. If
+# displacement is ever unwanted, `concurrency.queue: max` keeps up to 100
+# pending runs in FIFO instead, and is mutually exclusive with cancel-in-progress.
+#
+# Why cancelling `main` would be worse: those runs carry the deploy chain, and a
 # cancel mid-upload can consume a TestFlight build number with no ledger entry.
 # A pull request can never share a group with a push to `main` anyway —
 # `github.ref` is `refs/pull/N/merge` for a PR and `refs/heads/main` for the

--- a/.github/workflows/default_workflow.yml
+++ b/.github/workflows/default_workflow.yml
@@ -41,7 +41,69 @@ on:
       - 'release/**'
   workflow_dispatch:
 
+# Supersede in-flight runs for the same ref, so a force-push stops holding
+# macOS runners for a commit nobody is waiting on any more. 18.2% of PR runs
+# get superseded, and 82% of the macOS time that reclaims is the iOS
+# integration suite.
+#
+# `main` is excluded deliberately: those runs carry the deploy chain, and a
+# cancel mid-upload can consume a TestFlight build number with no ledger entry.
+# A pull request can never share a group with a push to `main` anyway —
+# `github.ref` is `refs/pull/N/merge` for a PR and `refs/heads/main` for the
+# push — so this guard is about a *second push to main*, which has happened
+# once in 26 main pushes. See #1018.
+#
+# Do NOT add a `concurrency:` block to ios-integration-attempt.yml:
+# `${{ github.workflow }}` evaluates to the CALLER's name inside a reusable
+# workflow, so it would land in this same group and the run would cancel itself.
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: ${{ github.ref != 'refs/heads/main' }}
+
 jobs:
+  # Decides whether the macOS jobs below need to run at all. Cheap, on ubuntu,
+  # and deliberately carries NO `if:` — it must run on EVERY event.
+  #
+  # A skip travels the whole dependency chain, not one hop (#1008): a job that
+  # exempts itself with `!cancelled()` does not stop the skip continuing
+  # downstream. A gate that skipped on `push: main` would therefore plant a
+  # fresh skip source directly upstream of the deploy chain, six days after
+  # exactly that shipped an empty 2.2.0. Fifteen free ubuntu seconds removes
+  # the question. See #1021.
+  #
+  # No checkout: dorny/paths-filter calls the REST API on `pull_request`
+  # events and never touches git, which is also why it works on fork PRs.
+  changes:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      pull-requests: read
+    outputs:
+      # Evaluates to the string 'true' or 'false', never empty. Written as a
+      # boolean expression rather than `steps.filter.outputs.ios || 'true'`
+      # on purpose: that form relies on the string 'false' being truthy (it
+      # is — only '' is falsy), and if that were ever wrong the gate would
+      # silently never close and this whole change would be a no-op that
+      # still looked healthy. The non-PR arm short-circuits first, so the
+      # skipped `filter` step's empty output is never consulted.
+      ios: ${{ github.event_name != 'pull_request' || steps.filter.outputs.ios == 'true' }}
+    steps:
+      - name: Check for iOS-relevant file changes
+        id: filter
+        if: github.event_name == 'pull_request'
+        uses: dorny/paths-filter@v4
+        with:
+          filters: |
+            ios:
+              - 'ios/**'
+              - 'pubspec.yaml'
+              - 'pubspec.lock'
+              # The pipeline verifies itself while we change it: an edit to the
+              # workflow or its composite actions can break the iOS jobs.
+              - '.github/workflows/**'
+              - '.github/actions/**'
+              - '.github/scripts/**'
+
   linux-checks:
     runs-on: ubuntu-latest
     permissions:
@@ -111,8 +173,11 @@ jobs:
   # pubspec.yaml, pubspec.lock, or ios/Podfile actually changed —
   # otherwise the macOS minutes aren't worth burning.
   ios-podfile-lock-guard:
+    needs: changes
+    # Zero `needs:` dependents, so gating this one carries no propagation risk
+    # at all. Same fail-open shape as ios-build.
+    if: ${{ !cancelled() && github.event_name == 'pull_request' && (needs.changes.result == 'failure' || needs.changes.outputs.ios == 'true') }}
     runs-on: macos-26
-    if: github.event_name == 'pull_request'
     permissions:
       contents: read
     steps:
@@ -183,6 +248,12 @@ jobs:
           fi
 
   ios-build:
+    needs: changes
+    # Fail OPEN. `== 'failure'`, never `!= 'success'` — the latter is true for
+    # `skipped` too and would flip the gate open by accident (the same trap
+    # #1008 documents for `!= 'failure'`). `!cancelled()` drops the implicit
+    # success() so a broken gate can never withhold the build.
+    if: ${{ !cancelled() && (needs.changes.result == 'failure' || needs.changes.outputs.ios == 'true') }}
     runs-on: macos-26
     permissions:
       contents: write

--- a/.github/workflows/default_workflow.yml
+++ b/.github/workflows/default_workflow.yml
@@ -397,13 +397,17 @@ jobs:
   # a verdict, and ios-integration-tests-result below turns the pair into the
   # single required check.
   ios-integration-tests:
+    needs: changes
+    if: ${{ !cancelled() && !(needs.changes.result == 'success' && needs.changes.outputs.ios == 'false') }}
     uses: ./.github/workflows/ios-integration-attempt.yml
 
   # Only when the first runner did not pass. An empty output counts as "did not
   # pass": that is what a job killed by its own timeout-minutes leaves behind.
   ios-integration-tests-retry:
-    needs: ios-integration-tests
-    if: ${{ !cancelled() && needs.ios-integration-tests.outputs.passed != 'true' }}
+    needs:
+      - changes
+      - ios-integration-tests
+    if: ${{ !cancelled() && !(needs.changes.result == 'success' && needs.changes.outputs.ios == 'false') && needs.ios-integration-tests.outputs.passed != 'true' }}
     uses: ./.github/workflows/ios-integration-attempt.yml
 
   # The check to require in branch protection — the two jobs above are green
@@ -411,6 +415,7 @@ jobs:
   # would require nothing at all.
   ios-integration-tests-result:
     needs:
+      - changes
       - ios-integration-tests
       - ios-integration-tests-retry
     if: ${{ !cancelled() }}
@@ -420,6 +425,14 @@ jobs:
     steps:
       - name: Require one of the two runners to have passed
         run: |
+          # A skipped suite is not a failure. Without this the empty
+          # outputs below read as "neither runner passed" and this job —
+          # the one to require in branch protection — goes red on every
+          # PR that touches no iOS path.
+          if [ '${{ needs.changes.result }}' = 'success' ] && [ '${{ needs.changes.outputs.ios }}' = 'false' ]; then
+            echo 'No iOS-relevant files changed — the suite did not run.'
+            exit 0
+          fi
           first='${{ needs.ios-integration-tests.outputs.passed }}'
           second='${{ needs.ios-integration-tests-retry.outputs.passed }}'
           echo "first runner:  ${first:-<no verdict — the job was killed>}"

--- a/.github/workflows/default_workflow.yml
+++ b/.github/workflows/default_workflow.yml
@@ -176,7 +176,7 @@ jobs:
     needs: changes
     # Zero `needs:` dependents, so gating this one carries no propagation risk
     # at all. Same fail-open shape as ios-build.
-    if: ${{ !cancelled() && github.event_name == 'pull_request' && (needs.changes.result == 'failure' || needs.changes.outputs.ios == 'true') }}
+    if: ${{ !cancelled() && github.event_name == 'pull_request' && !(needs.changes.result == 'success' && needs.changes.outputs.ios == 'false') }}
     runs-on: macos-26
     permissions:
       contents: read
@@ -249,11 +249,20 @@ jobs:
 
   ios-build:
     needs: changes
-    # Fail OPEN. `== 'failure'`, never `!= 'success'` — the latter is true for
-    # `skipped` too and would flip the gate open by accident (the same trap
-    # #1008 documents for `!= 'failure'`). `!cancelled()` drops the implicit
-    # success() so a broken gate can never withhold the build.
-    if: ${{ !cancelled() && (needs.changes.result == 'failure' || needs.changes.outputs.ios == 'true') }}
+    # Fail OPEN, and read this as: skip ONLY when the gate ran cleanly and
+    # said no. Every other state — gate failed, gate skipped, output missing —
+    # builds. `!cancelled()` drops the implicit success() so a broken gate can
+    # never withhold the build.
+    #
+    # Written this way rather than `needs.changes.result == 'failure' || ...`
+    # on purpose. That form is false for `skipped`, so it would fail CLOSED on
+    # a skipped gate: ios-build would skip, and ios-package/android-package
+    # both assert `needs.ios-build.result == 'success'` — the whole deploy
+    # chain stops while the run still reports success. That is run
+    # 33547853809 (the empty 2.2.0) recreated with a new cause. The gate below
+    # has no `if:` today so a skip is unreachable, but that invariant then
+    # lives in a comment; this expression enforces it instead.
+    if: ${{ !cancelled() && !(needs.changes.result == 'success' && needs.changes.outputs.ios == 'false') }}
     runs-on: macos-26
     permissions:
       contents: write

--- a/.github/workflows/default_workflow.yml
+++ b/.github/workflows/default_workflow.yml
@@ -184,17 +184,28 @@ jobs:
       - name: Checkout code
         uses: actions/checkout@v7
         with:
-          # Need the merge base in scope so the paths-filter step below
-          # can diff against the PR's target branch.
+          # NOT for the filter below — that claim used to live here and was
+          # wrong. On `pull_request` events dorny/paths-filter ignores `base:`
+          # entirely and asks the REST API instead of diffing git, so it needs
+          # no history and no checkout at all (which is also why the `changes`
+          # gate job can run without one). This is here for `pod install`.
           fetch-depth: 0
           ref: ${{ github.event.pull_request.head.ref }}
           repository: ${{ github.event.pull_request.head.repo.full_name }}
 
-      - name: Check for iOS-relevant file changes
-        id: changes
+      # Deliberately NARROWER than the `changes` gate that let this job start.
+      # Two questions at two granularities: the gate asks "is a macOS runner
+      # worth allocating at all", this asks "is the ~2.4 min `pod install`
+      # worth running". A PR touching ios/Runner/*.swift opens the gate but
+      # cannot shift the lockfile, so it should not pay for a resolve.
+      #
+      # Step id is NOT `changes`: this job also has `needs: changes`, and
+      # `steps.podfile-scope.outputs.ios` vs `needs.changes.outputs.ios` would be
+      # two different answers to the same-looking question.
+      - name: Check whether the pod lockfile could have drifted
+        id: podfile-scope
         uses: dorny/paths-filter@v4
         with:
-          base: ${{ github.event.pull_request.base.ref }}
           filters: |
             ios:
               - 'pubspec.yaml'
@@ -202,7 +213,7 @@ jobs:
               - 'ios/Podfile'
 
       - name: Setup Flutter + cache packages
-        if: steps.changes.outputs.ios == 'true'
+        if: steps.podfile-scope.outputs.ios == 'true'
         uses: ./.github/actions/setup-flutter-cache
 
       # Swift Package Manager is enabled by default on Flutter's stable
@@ -216,11 +227,11 @@ jobs:
       # sole iOS dependency manager until that's resolved (or until we
       # wire up real signing for CI).
       - name: Disable Swift Package Manager
-        if: steps.changes.outputs.ios == 'true'
+        if: steps.podfile-scope.outputs.ios == 'true'
         run: flutter config --no-enable-swift-package-manager
 
       - name: Generate stub .env for CI
-        if: steps.changes.outputs.ios == 'true'
+        if: steps.podfile-scope.outputs.ios == 'true'
         uses: ./.github/actions/write-env-file
         with:
           sentry_dns: https://stub@sentry.io/0
@@ -228,11 +239,11 @@ jobs:
           supabase_project_anon_key: ci-stub
 
       - name: Install Flutter packages
-        if: steps.changes.outputs.ios == 'true'
+        if: steps.podfile-scope.outputs.ios == 'true'
         run: flutter pub get
 
       - name: Pod install (with repo update)
-        if: steps.changes.outputs.ios == 'true'
+        if: steps.podfile-scope.outputs.ios == 'true'
         run: cd ios && pod install --repo-update
 
       # If `pod install` rewrote Podfile.lock, the working tree now has a
@@ -240,7 +251,7 @@ jobs:
       # failure with a hint so the contributor knows what to do next,
       # rather than letting a stale lockfile silently ship to main.
       - name: Fail if Podfile.lock drifted
-        if: steps.changes.outputs.ios == 'true'
+        if: steps.podfile-scope.outputs.ios == 'true'
         run: |
           if ! git diff --exit-code ios/Podfile.lock; then
             echo "::error file=ios/Podfile.lock::Podfile.lock is out of date with pubspec.yaml. Run 'cd ios && pod install' on macOS and commit the result."

--- a/.github/workflows/default_workflow.yml
+++ b/.github/workflows/default_workflow.yml
@@ -91,14 +91,22 @@ jobs:
       contents: read
       pull-requests: read
     outputs:
-      # Evaluates to the string 'true' or 'false', never empty. Written as a
-      # boolean expression rather than `steps.filter.outputs.ios || 'true'`
-      # on purpose: that form relies on the string 'false' being truthy (it
-      # is — only '' is falsy), and if that were ever wrong the gate would
-      # silently never close and this whole change would be a no-op that
-      # still looked healthy. The non-PR arm short-circuits first, so the
-      # skipped `filter` step's empty output is never consulted.
+      # Both evaluate to the string 'true' or 'false', never empty. Written as
+      # boolean expressions rather than `steps.filter.outputs.X || 'true'` on
+      # purpose: that form relies on the string 'false' being truthy (it is —
+      # only '' is falsy), and if that were ever wrong the gate would silently
+      # never close and this whole change would be a no-op that still looked
+      # healthy. The non-PR arm short-circuits first, so the skipped `filter`
+      # step's empty outputs are never consulted.
+      #
+      #   ios      — could an iOS BUILD break? Gates ios-build.
+      #   pod_deps — could Podfile.lock have DRIFTED? Gates the lock guard,
+      #              and is deliberately much narrower: a PR touching
+      #              ios/Runner/*.swift can break the build but cannot shift
+      #              the lockfile, so it has no business booting a Mac for
+      #              `pod install`.
       ios: ${{ github.event_name != 'pull_request' || steps.filter.outputs.ios == 'true' }}
+      pod_deps: ${{ github.event_name != 'pull_request' || steps.filter.outputs.pod_deps == 'true' }}
     steps:
       - name: Check for iOS-relevant file changes
         id: filter
@@ -115,6 +123,10 @@ jobs:
               - '.github/workflows/**'
               - '.github/actions/**'
               - '.github/scripts/**'
+            pod_deps:
+              - 'pubspec.yaml'
+              - 'pubspec.lock'
+              - 'ios/Podfile'
 
   linux-checks:
     runs-on: ubuntu-latest
@@ -181,14 +193,18 @@ jobs:
   # PRs, but fork PRs run with a read-only token and that auto-commit
   # silently no-ops; this job exists to surface a hard failure on the PR
   # check so a human notices and refreshes the lockfile locally on a
-  # Mac. We only run it on `pull_request` events where one of
-  # pubspec.yaml, pubspec.lock, or ios/Podfile actually changed —
-  # otherwise the macOS minutes aren't worth burning.
+  # Mac. It runs only on `pull_request` events where one of pubspec.yaml,
+  # pubspec.lock or ios/Podfile actually changed — and since the `changes`
+  # gate decides that on ubuntu, a PR that cannot move the lockfile no longer
+  # allocates a macOS runner at all. Nothing is billed here (the repo is
+  # public); what is scarce is the account-wide cap of 5 concurrent macOS
+  # jobs, and this job used to hold one of them for ~11s on 4 PRs in 5.
   ios-podfile-lock-guard:
     needs: changes
-    # Zero `needs:` dependents, so gating this one carries no propagation risk
-    # at all. Same fail-open shape as ios-build.
-    if: ${{ !cancelled() && github.event_name == 'pull_request' && !(needs.changes.result == 'success' && needs.changes.outputs.ios == 'false') }}
+    # Gated on `pod_deps`, NOT `ios`. The broad filter would boot a macOS runner
+    # for an ios/Runner/*.swift-only PR just to discover the lockfile cannot
+    # have moved. Same fail-open shape as ios-build.
+    if: ${{ !cancelled() && github.event_name == 'pull_request' && !(needs.changes.result == 'success' && needs.changes.outputs.pod_deps == 'false') }}
     runs-on: macos-26
     permissions:
       contents: read
@@ -196,36 +212,16 @@ jobs:
       - name: Checkout code
         uses: actions/checkout@v7
         with:
-          # NOT for the filter below — that claim used to live here and was
-          # wrong. On `pull_request` events dorny/paths-filter ignores `base:`
-          # entirely and asks the REST API instead of diffing git, so it needs
-          # no history and no checkout at all (which is also why the `changes`
-          # gate job can run without one). This is here for `pod install`.
+          # For `pod install`, which wants the tree. This job used to run its
+          # own paths-filter and a comment here credited the checkout to that;
+          # both are gone — the `changes` gate answers the question on ubuntu
+          # now, and paths-filter needed neither history nor a checkout anyway
+          # (it reads the REST API on pull_request events).
           fetch-depth: 0
           ref: ${{ github.event.pull_request.head.ref }}
           repository: ${{ github.event.pull_request.head.repo.full_name }}
 
-      # Deliberately NARROWER than the `changes` gate that let this job start.
-      # Two questions at two granularities: the gate asks "is a macOS runner
-      # worth allocating at all", this asks "is the ~2.4 min `pod install`
-      # worth running". A PR touching ios/Runner/*.swift opens the gate but
-      # cannot shift the lockfile, so it should not pay for a resolve.
-      #
-      # Step id is NOT `changes`: this job also has `needs: changes`, and
-      # `steps.podfile-scope.outputs.ios` vs `needs.changes.outputs.ios` would be
-      # two different answers to the same-looking question.
-      - name: Check whether the pod lockfile could have drifted
-        id: podfile-scope
-        uses: dorny/paths-filter@v4
-        with:
-          filters: |
-            ios:
-              - 'pubspec.yaml'
-              - 'pubspec.lock'
-              - 'ios/Podfile'
-
       - name: Setup Flutter + cache packages
-        if: steps.podfile-scope.outputs.ios == 'true'
         uses: ./.github/actions/setup-flutter-cache
 
       # Swift Package Manager is enabled by default on Flutter's stable
@@ -239,11 +235,9 @@ jobs:
       # sole iOS dependency manager until that's resolved (or until we
       # wire up real signing for CI).
       - name: Disable Swift Package Manager
-        if: steps.podfile-scope.outputs.ios == 'true'
         run: flutter config --no-enable-swift-package-manager
 
       - name: Generate stub .env for CI
-        if: steps.podfile-scope.outputs.ios == 'true'
         uses: ./.github/actions/write-env-file
         with:
           sentry_dns: https://stub@sentry.io/0
@@ -251,11 +245,9 @@ jobs:
           supabase_project_anon_key: ci-stub
 
       - name: Install Flutter packages
-        if: steps.podfile-scope.outputs.ios == 'true'
         run: flutter pub get
 
       - name: Pod install (with repo update)
-        if: steps.podfile-scope.outputs.ios == 'true'
         run: cd ios && pod install --repo-update
 
       # If `pod install` rewrote Podfile.lock, the working tree now has a
@@ -263,7 +255,6 @@ jobs:
       # failure with a hint so the contributor knows what to do next,
       # rather than letting a stale lockfile silently ship to main.
       - name: Fail if Podfile.lock drifted
-        if: steps.podfile-scope.outputs.ios == 'true'
         run: |
           if ! git diff --exit-code ios/Podfile.lock; then
             echo "::error file=ios/Podfile.lock::Podfile.lock is out of date with pubspec.yaml. Run 'cd ios && pod install' on macOS and commit the result."


### PR DESCRIPTION
Part of the CI-latency map, #1016. Implements the decisions from #1018, #1019 and #1021.

**Draft on purpose** — see *Verifying this* below. Nothing here should be merged before #1014 lands.

## Why

The pipeline is not slow, it **queues**. Every ubuntu job finishes inside ~10 min; runs stretch to 43–96 min only when several PRs are in flight and the macOS jobs wait for a runner. `ios-integration-tests` does 20–24 min of work whether the run takes 20 minutes or 96.

Nothing is billed — the repo is public, so standard runners are free. The scarce resource is the **hard cap of 5 concurrent macOS jobs**, which is account-wide, plan-invariant across Free/Pro/Team, and was fully binding during the 2026-09-01 burst: 5 running, 25 queued, and every one of the five was this repo's own work.

| | p50 | p90 |
|---|---|---|
| uncontended runs (n=236) | 18.0 min | 24.2 min |
| contended runs (n=56) | 27.8 min | 51.8 min |

19.2% of runs land in the contended stratum.

## What this does

**1. A `concurrency` group.** A force-push stops holding macOS runners for a commit nobody is waiting on. 18.2% of PR runs (150 of 824) are superseded by a newer push to the same branch, and 82% of the macOS time that reclaims is the iOS integration suite.

`main` is excluded deliberately. Those runs carry the deploy chain, and a cancel between a store upload completing and the ledger tag being pushed consumes a TestFlight build number with nothing to show for it. A PR can never share a group with a push to `main` anyway (`refs/pull/N/merge` vs `refs/heads/main`), so the guard is really about a *second push to main* — which has happened once in 26 main pushes.

⚠️ **Do not add a `concurrency:` block to `ios-integration-attempt.yml`.** `${{ github.workflow }}` evaluates to the *caller's* name inside a reusable workflow, so it would land in this same group and the run would cancel itself.

**2. A `changes` gate on the two macOS PR jobs.** Gates out **92 of 117** recent PRs (78.6%) and cuts hours pinned at the 5-slot cap from **5.5 → 0.6 (−89%)**.

Safety is not the trade-off here. Over four months, **all 23 genuine iOS-only failures touched `ios/**` or `pubspec.*` — the filter catches 23 of 23.** Two deliberate choices:

- **`lib/**` excluded.** Including it drops gating to 29.9% while guarding a failure mode with zero recorded instances. The one `Build iOS` break on a non-iOS diff (#410) was caught first by `linux-checks` and `android-build`.
- **`.github/**` included.** Costs ~11 percentage points, and it is honestly insurance rather than a historical catch — the record gives it zero. It is there so the pipeline keeps verifying itself while the rest of #1016 changes it.

Note the filter uses `ios/**` as a glob, **not** the guard's existing three narrow paths. Those miss both genuine iOS-only breaks on record: #368 (`ios/Runner/AppDelegate.swift`) and #448 (Xcode project, a fork PR).

## The part that is easy to get wrong

`changes` carries **no `if:`**. A skip travels the whole dependency chain rather than one hop, and a job that exempts itself with `!cancelled()` does not stop it continuing downstream — that is exactly what shipped an empty 2.2.0 (run 33547853809, fixed in #1008). A gate that skipped on `push: main` would plant a fresh skip source directly upstream of the deploy chain, so it runs on every event and simply reports `true` outside a pull request.

Both gates **fail open**, spelled `== 'failure'` and never `!= 'success'` — the latter is also true for `skipped`, which would flip the gate open by accident. Same trap #1008 documents for `!= 'failure'`.

`ios-package` and `android-package` are **untouched**; they already mirror every dependency explicitly.

## Verifying this

**This PR cannot demonstrate its own main effect.** It edits `.github/workflows/**`, so the filter matches, the gate opens and the macOS jobs run exactly as before. That is the correct behaviour and it exercises the fail-open path — but observing the *skip* path needs a subsequent docs-only PR.

Worth checking on this run:
- [ ] `changes` runs and reports `ios: true`
- [ ] `ios-build` and `ios-podfile-lock-guard` still run (gate open)
- [ ] the deploy chain is unaffected — all five jobs skip on a PR exactly as they do today
- [ ] then, on a docs-only PR: `changes` reports `false`, both macOS jobs skip, and the run still reports success

## Not in this PR

Relocating the iOS boot smoke to `push: main` (#1020) ships separately as a spec — it touches `ios-package`/`android-package` `needs:` and deserves its own review.

## Measurement

#1022 is not done when this merges. The baseline to compare against is recorded in #1017: uncontended p90 **24.2 min** [22.8, 26.0] and contention rate **19.2%** [15.1, 24.1], re-derived with the recipe in that ticket.


---

## Hazards found by verification after this PR opened

**1. Fixed in `98e0d5e0`.** The first cut spelled fail-open as `needs.changes.result == 'failure' || ...`, which is false for `skipped` — so it failed *closed* on a skipped gate, stranding the deploy chain exactly as run 33547853809 did. The gate has no `if:` so a skip is unreachable today, but that made the safety a property of a comment rather than of the expression. Now inverted: skip only when the gate ran cleanly and said no.

| gate result | output | before | after |
|---|---|---|---|
| success | `'true'` | RUN | RUN |
| success | `'false'` | SKIP | SKIP |
| failure | `''` | RUN | RUN |
| **skipped** | `''` | **SKIP** | **RUN** |

**2. Do not make `ios-build` or `ios-podfile-lock-guard` a required status check.** `develop` already has required-status-checks machinery enabled with an empty list (`{"strict":false,"contexts":[],"checks":[]}`), so adding one is a two-click operation. A path-filtered job that skips **never posts a check run**, so a required context on it leaves the PR pending forever — and 72% of recent PRs (42 of 58 sampled) would skip `ios-build`. If a required iOS check is ever wanted, require the *gate* job, which always runs.

**3. Merge-order note.** This branch and #1015 both fork from `a809810e` and both add a gate job upstream of the deploy chain. They touch disjoint line regions so git will merge them cleanly — which is precisely why a weaker guard here would not have been noticed at merge time. With `98e0d5e0` the two guards now have the same shape: `release-gate` asserts `result == 'success' && outputs.deploy == 'true'`, and `changes` skips only on `result == 'success' && outputs.ios == 'false'`.


---

## Two things for a reviewer's eye (added after further verification)

### `main` is serialised, not excluded — please sanity-check this is what you want

`cancel-in-progress: false` does **not** take `main` out of the concurrency group. It puts it in the group without cancelling, which per the docs means:

> *"When a concurrent job or workflow is queued, if another job or workflow using the same concurrency group in the repository is in progress, the queued job or workflow will be `pending`."*

and

> *"any existing `pending` job or workflow in the same concurrency group will be canceled and the new queued job or workflow will take its place."*

So a second push to `main` while the first is still deploying now **waits** instead of running alongside — and if a *third* push arrives while the second is still pending, **the second is cancelled and replaced**.

For a deploy chain, serialising is arguably the safer behaviour: two concurrent deploy runs racing on the same build number and ledger tag is worse than one waiting. But the displacement case means a middle commit's deploy run can be dropped, and that is a genuine behaviour change this PR did not previously spell out.

Historically it would have bitten rarely: 26 pushes to `main` in 143 days, one overlapping pair (21 s apart, on 2026-08-27). If displacement is unwanted, `concurrency.queue: max` preserves up to 100 pending runs in FIFO order instead — it is mutually exclusive with `cancel-in-progress`, so it would mean splitting the config by event.

### Where the macOS time actually is — this PR is the smaller half

Re-derived over the same 19-day window (7,767 PR-event macOS slot-minutes):

| Job | share of PR macOS time | gated by this PR? |
|---|---|---|
| `ios-integration-tests` (+ retry, + reusable form) | **70.8%** | ✗ — that is #1020 |
| `ios-build` | 26.9% | ✓ |
| `ios-podfile-lock-guard` | 2.3% | ✓ |

Gating 78.6% of `ios-build` + guard reclaims **23.0%** of PR macOS slot-time. The concurrency group reclaims roughly another 18% by cancelling superseded runs, and the two overlap.

The honest framing: **this PR is the smaller half of the win.** The iOS integration suite is 71% of the budget and is untouched here — relocating it (#1020) is where the bulk of the contention relief comes from.

*(An intermediate analysis put this PR's share at 2.8%; that was wrong by roughly 8x — it mistook the guard's own 2.3% share for the whole gate's benefit. The 23.0% above is re-derived directly from the job dump.)*
