### PR TITLE
docs: the formatter enforces 80 columns, not the 120 we document

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -156,7 +156,7 @@ Note: the `SupportedLanguage` enum maps device locales to `food_translation` loc
 
 ## Code Style
 
-The project uses a **120-character line width** (configured in `analysis_options.yaml`). The `just format` command targets only `./lib/core ./lib/features ./lib/l10n ./test` — it deliberately excludes `lib/generated/`. Do not run `dart format` on `lib/generated/` files.
+`just format` runs `dart format` with no `--line-length`, so the width `just ci` enforces is the formatter's own default of **80 characters**. Nothing configures a different one: `analysis_options.yaml` sets no width, `pubspec.yaml` has no formatter section, and there is no `.editorconfig`. About 1.7% of lines do run past 80 — those are the ones `dart format` will not break, such as long string literals, URLs and comments. The `just format` command targets only `./lib/core ./lib/features ./lib/l10n ./test` — it deliberately excludes `lib/generated/`. Do not run `dart format` on `lib/generated/` files.
 
 ## Accessibility identifiers for interactive widgets
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -67,7 +67,8 @@ Some files are produced by `build_runner` (Hive type adapters and JSON serializa
 
 ## Code style and tests
 
-- 120-character line width (configured in `analysis_options.yaml`).
+- 80-character line width — `dart format`'s own default. `just format` passes no
+  `--line-length`, and nothing in the repo configures one.
 - Format with `just format` before committing — this targets only `lib/core`, `lib/features`, `lib/l10n`, and `test` and deliberately skips `lib/generated/`.
 - Run `flutter analyze` and `just test` locally before opening the PR.
 - `just ci` runs the full CI pipeline (install, format check, l10n generation and completeness, build, analyze, test) and is the closest thing to a one-shot pre-flight check.


### PR DESCRIPTION
## Summary

Two documented facts about the formatter are wrong, and this also serves as the **live test of the path gate** in #1043 — it is based on that branch and targets it, touching only markdown.

## Type of change
- [x] Documentation
- [ ] Bug fix / New feature / Refactor / CI / Localization / Other

## Changes

`AGENTS.md` and `CONTRIBUTING.md` both claim a **120-character line width "configured in `analysis_options.yaml`"**. Neither half holds:

- `analysis_options.yaml` sets no width — it includes `flutter_lints`, excludes `lib/generated/intl` from the analyzer, and leaves the `linter: rules:` block empty. No `.editorconfig` exists; `pubspec.yaml` has no formatter section.
- `just format` runs `dart format` with **no `--line-length`**, so what `just ci` enforces via `format --set-exit-if-changed` is the formatter's default of **80**.

The code agrees. Across `lib/core`, `lib/features`, `lib/l10n` and `test` (116,728 lines):

| | |
|---|---|
| ≤ 80 columns | **98.3%** |
| over 80 | 1,940 (1.7%) |
| over 120 | 41 (0.04%) |

The 1.7% past 80 are lines `dart format` will not break — long string literals, URLs, comments. That is what a default-width codebase looks like, not a 120-column one.

Documenting 120 invites a contributor to write to a width the format check then rejects.

## Why this PR targets #1043's branch

It is the gate test. The `ios` filter matches `ios/**`, `pubspec.yaml`, `pubspec.lock`, `.github/workflows/**`, `.github/actions/**` and `.github/scripts/**`. This PR touches `AGENTS.md` and `CONTRIBUTING.md` — none of them — so the expected result is:

- `changes` → `ios: false`
- **`ios-build`, `ios-podfile-lock-guard`, `ios-integration-tests` and `ios-integration-tests-retry` all skipped**
- `ios-integration-tests-result` **green**, logging "No iOS-relevant files changed — the suite did not run."
- `linux-checks`, `android-build`, `android-integration-tests` run as normal

Neither #1043 nor #1045 can demonstrate this, because both edit `.github/workflows/default_workflow.yml` and so legitimately set `ios: true` — the filter deliberately includes the workflow so the pipeline verifies itself while it is being changed.

If `ios-integration-tests-result` comes back **red** here, that is the skip-propagation bug reappearing and `b16f929f` needs another look.

## Test plan
- [x] Described steps below were followed locally
- [ ] Unit / widget tests added or updated (n/a — documentation)
- [ ] Manual check on Android (n/a)
- [ ] Manual check on iOS (n/a)

### Steps
1. `cat analysis_options.yaml` — no width key; `ls .editorconfig` — absent; `grep -n format justfile` — no `--line-length`.
2. Counted line lengths across the four `just format` targets, excluding `lib/generated/`: 98.3% ≤ 80, 41 lines over 120.
3. Confirmed no changed path matches the `ios` filter.

## Checklist
- [x] Code follows project style — n/a, markdown only
- [x] New interactive widgets include `Semantics(identifier: '...')` — n/a
- [x] Localization updated in ARBs — n/a
- [x] Codegen ran if DBOs/DTOs/env changed — n/a
- [x] No secrets or `.env` values committed
- [x] PR title follows conventional commit style

## Note

`.github/PULL_REQUEST_TEMPLATE.md:33` repeats the same "120-char line width" claim. It is left alone here because #1045 already edits that file, and two open PRs touching it would conflict. Worth folding into whichever lands second.
