### PR TITLE
docs: the formatter enforces 80 columns, not the 120 we document

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -156,7 +156,7 @@ Note: the `SupportedLanguage` enum maps device locales to `food_translation` loc
 
 ## Code Style
 
-The project uses a **120-character line width** (configured in `analysis_options.yaml`). The `just format` command targets only `./lib/core ./lib/features ./lib/l10n ./test` — it deliberately excludes `lib/generated/`. Do not run `dart format` on `lib/generated/` files.
+`just format` runs `dart format` with no `--line-length`, so the width `just ci` enforces is the formatter's own default of **80 characters**. Nothing configures a different one: `analysis_options.yaml` sets no width, `pubspec.yaml` has no formatter section, and there is no `.editorconfig`. About 1.7% of lines do run past 80 — those are the ones `dart format` will not break, such as long string literals, URLs and comments. The `just format` command targets only `./lib/core ./lib/features ./lib/l10n ./test` — it deliberately excludes `lib/generated/`. Do not run `dart format` on `lib/generated/` files.
 
 ## Accessibility identifiers for interactive widgets
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -67,7 +67,8 @@ Some files are produced by `build_runner` (Hive type adapters and JSON serializa
 
 ## Code style and tests
 
-- 120-character line width (configured in `analysis_options.yaml`).
+- 80-character line width — `dart format`'s own default. `just format` passes no
+  `--line-length`, and nothing in the repo configures one.
 - Format with `just format` before committing — this targets only `lib/core`, `lib/features`, `lib/l10n`, and `test` and deliberately skips `lib/generated/`.
 - Run `flutter analyze` and `just test` locally before opening the PR.
 - `just ci` runs the full CI pipeline (install, format check, l10n generation and completeness, build, analyze, test) and is the closest thing to a one-shot pre-flight check.


### PR DESCRIPTION
## Summary

`AGENTS.md` and `CONTRIBUTING.md` both document a **120-character line width "configured in `analysis_options.yaml`"**. Neither half is true, and the mismatch actively misleads: a contributor writing to 120 gets rejected by `just ci`'s `format --set-exit-if-changed`.

## Type of change
- [x] Documentation
- [ ] Bug fix / New feature / Refactor / CI / Localization / Other

## Changes

**Nothing configures a width anywhere.** `analysis_options.yaml` includes `flutter_lints`, excludes `lib/generated/intl` from the analyzer, and leaves the `linter: rules:` block empty. There is no `.editorconfig`. `pubspec.yaml` has no formatter section. `just format` runs `dart format` with **no `--line-length`**.

So the width actually enforced is `dart format`'s own default: **80**.

**The code agrees.** Across `lib/core`, `lib/features`, `lib/l10n` and `test` — the exact four directories `just format` targets — 116,728 lines:

| | |
|---|---|
| ≤ 80 columns | **98.3%** |
| over 80 | 1,940 (1.7%) |
| over 120 | 41 (0.04%) |

The 1.7% past 80 are lines `dart format` will not break — long string literals, URLs, comments. That is the shape of a default-width codebase, not a 120-column one. If 120 were configured and enforced, that 1.7% would be far larger and the 41 outliers would be violations rather than unbreakable lines.

## Test plan
- [x] Described steps below were followed locally
- [ ] Unit / widget tests added or updated (n/a — documentation only)
- [ ] Manual check on Android (n/a)
- [ ] Manual check on iOS (n/a)

### Steps
1. `cat analysis_options.yaml` — no width key anywhere.
2. `ls .editorconfig` — absent. `grep -n "page_width\|line_length" pubspec.yaml` — nothing.
3. `grep -n format justfile` — `dart format {{OPTIONS}} ./lib/core ./lib/features ./lib/l10n ./test`, no `--line-length`.
4. Measured line lengths across those four directories, excluding `lib/generated/`: 98.3% ≤ 80, 41 lines over 120.

## Checklist
- [x] Code follows project style — n/a, markdown only
- [x] New interactive widgets include `Semantics(identifier: '...')` where needed — n/a
- [x] Localization updated in ARBs — n/a, no user-facing strings
- [x] Codegen ran if DBOs/DTOs/env changed — n/a
- [x] No secrets or `.env` values committed
- [x] PR title follows conventional commit style

## Notes

**On the path gate.** This PR was originally meant to demonstrate #1043's gate by touching only markdown. It cannot: a PR based on the gating branch matches none of `pull_request.branches` (`main`, `develop`, `feature/**`, `release/**`) and so gets **no checks at all** while still reporting mergeable — exactly the silent failure the `feature/**` entry's own comment warns about. And a PR based on `develop` has no gate yet. **The gate can only be demonstrated after #1043 merges**, by a docs-only PR against `develop`; this branch is the right shape for that re-run. See the closed #1046.

**`.github/PULL_REQUEST_TEMPLATE.md:33` repeats the same claim** and is deliberately untouched here, because #1045 already edits that file. Worth folding into whichever of the two lands second.
