### PR TITLE
docs: correct the store declarations 2.2.0 outgrew (#990)

### DIFF
--- a/docs/RELEASING.md
+++ b/docs/RELEASING.md
@@ -117,6 +117,49 @@ This step starts passing on its own once Google fixes the API; nothing here need
       automated.
 - [ ] **Update the store listings** with the "what's new" text, since the pipeline uploads none.
 
+## Store declarations
+
+Four platform-facing declarations live in the repo and are entered by hand in the two consoles.
+The repo copy is the source text; the console is where it takes effect, so they drift silently
+unless this list is walked. All four were corrected for 2.2.0 in
+[#990](https://github.com/simonoppowa/OpenNutriTracker/issues/990), and
+[`test/unit_test/store_declarations_test.dart`](../test/unit_test/store_declarations_test.dart)
+pins them so a later edit cannot quietly undo one.
+
+- [ ] **Paste `fastlane/metadata/android/en-US/full_description.txt` into the Play listing.**
+      `upload_to_play_store` runs with `skip_upload_metadata: true`, so the pipeline never touches
+      the listing and the file and the live description agree only if someone copies it across.
+      The file is held under Play's 4000-character cap by a test; the Console gives no warning
+      until it refuses the text.
+- [ ] **Keep the "not a medical device" sentence in the listing.** Google's
+      [Health Content and Services](https://support.google.com/googleplay/android-developer/answer/12261419)
+      policy requires that exact wording *in the app description* for a health-and-fitness app that
+      is not a declared medical device, plus a reminder to consult a healthcare professional. Both
+      are the last line of `full_description.txt`.
+- [ ] **Answer Play's Health apps declaration.** Required for all developers under the same policy,
+      with nutrition tracking as a declarable feature.
+- [ ] **Make the App Store Connect App Privacy record agree with
+      [`ios/Runner/PrivacyInfo.xcprivacy`](../ios/Runner/PrivacyInfo.xcprivacy).** They are two
+      separate artifacts with no link between them, so they agree only by hand — and Apple
+      validates the manifest on the way in: *"App Store Connect rejects app submissions that
+      include invalid privacy manifest files."* What the manifest declares today, and what the
+      questionnaire therefore has to say:
+
+      | Data type | Linked to user | Tracking | Purpose |
+      | :-- | :-- | :-- | :-- |
+      | Photos or Videos | No | No | App Functionality |
+      | Other User Content | No | No | App Functionality |
+      | Crash Data, Performance Data, Other Diagnostic Data | No | No | App Functionality |
+
+      The first two exist only because of AI meal assistance. Food search terms, HealthKit
+      workouts and locally-attached meal photos are deliberately absent; the manifest says why,
+      beside each one.
+
+Two questions behind these are open rather than answered, and neither blocks a release:
+[#816](https://github.com/simonoppowa/OpenNutriTracker/issues/816) on whether a server the user
+runs counts as collection for Play's Data safety form, and the Apple twin of it noted in the
+privacy manifest. `docs/ai-legal-constraints.md` carries the research both rest on.
+
 ## Hotfixes, and the way back to `develop`
 
 A fix urgent enough to skip the batch can go straight to `main`. Nothing brings it back down, so

--- a/docs/RELEASING.md
+++ b/docs/RELEASING.md
@@ -119,12 +119,21 @@ This step starts passing on its own once Google fixes the API; nothing here need
 
 ## Store declarations
 
-Four platform-facing declarations live in the repo and are entered by hand in the two consoles.
-The repo copy is the source text; the console is where it takes effect, so they drift silently
-unless this list is walked. All four were corrected for 2.2.0 in
-[#990](https://github.com/simonoppowa/OpenNutriTracker/issues/990), and
+These declarations sit in three different places, which is the whole reason they drift apart:
+
+- **In the app bundle.** The iOS purpose strings in `Info.plist`, and the privacy manifest. They
+  ship with a build and are entered nowhere — they are right when the code is right, and App
+  Review reads them straight out of the bundle.
+- **Repo text that a human copies into a console.** The Play listing, and only that.
+- **Console only, with no repo copy at all.** Play's Health apps declaration, and the App Store
+  Connect App Privacy record — which has to agree with the privacy manifest, with nothing
+  anywhere checking that it does.
+
+All of them were corrected for 2.2.0 in
+[#990](https://github.com/simonoppowa/OpenNutriTracker/issues/990).
 [`test/unit_test/store_declarations_test.dart`](../test/unit_test/store_declarations_test.dart)
-pins them so a later edit cannot quietly undo one.
+pins the repo half so a later edit cannot quietly undo one; the console half is the checklist
+below, and nothing but this page will remind you.
 
 - [ ] **Paste `fastlane/metadata/android/en-US/full_description.txt` into the Play listing.**
       `upload_to_play_store` runs with `skip_upload_metadata: true`, so the pipeline never touches

--- a/docs/RELEASING.md
+++ b/docs/RELEASING.md
@@ -155,10 +155,14 @@ pins them so a later edit cannot quietly undo one.
       workouts and locally-attached meal photos are deliberately absent; the manifest says why,
       beside each one.
 
-Two questions behind these are open rather than answered, and neither blocks a release:
+The table is what the AI path made necessary, not a statement that the record is complete. Three
+things behind it are open rather than answered, and none blocks a release:
 [#816](https://github.com/simonoppowa/OpenNutriTracker/issues/816) on whether a server the user
-runs counts as collection for Play's Data safety form, and the Apple twin of it noted in the
-privacy manifest. `docs/ai-legal-constraints.md` carries the research both rest on.
+runs counts as collection for Play's Data safety form; the Apple twin of it noted in the privacy
+manifest; and [#938](https://github.com/simonoppowa/OpenNutriTracker/issues/938) on the coarse
+location the Supabase gateway derives from the caller's IP, whose research concludes both stores
+want it declared and which no manifest entry covers yet. That research sits on the unmerged
+`research/store-declarations` branch; `docs/ai-legal-constraints.md` carries the rest.
 
 ## Hotfixes, and the way back to `develop`
 

--- a/fastlane/metadata/android/en-US/full_description.txt
+++ b/fastlane/metadata/android/en-US/full_description.txt
@@ -1,19 +1,21 @@
-OpenNutriTracker is an open-source mobile application designed to simplify nutritional tracking and management. Whether you are looking to improve your health, lose weight, or simply maintain a balanced diet, OpenNutriTracker provides a minimalistic interface to easily track and analyze your daily nutrition.
+OpenNutriTracker is an open-source calorie and nutrition tracker with a minimalistic interface — for improving your health, losing weight, or keeping a balanced diet.
 
 
-🍎 Nutritional tracking: Log meals and snacks against a large food database — Open Food Facts plus a multi-source reference backend covering USDA FoodData Central and the German Bundeslebensmittelschlüssel (BLS), with the sources selectable in Settings → Food databases. Search, scan, or add straight as a number when you already know the calorie cost.
-📓 Food diary: A calendar-driven diary that breaks the day into Breakfast, Lunch, Dinner, and Snack, with per-meal kcal targets (Standard, OMAD, Five-small, Mediterranean, Two-meal, or a custom share), drag-to-rearrange between meals, and sort by time or by macro contribution.
-📈 Trends: A current and best day-streak card, calories charted against your goal line, daily macro averages, water intake, and weight against target with an estimate of the weeks left to reach it. Switch the window between 7, 30 and 90 days or your whole history.
-🥕 Micronutrient panel: Day and week views for fibre, sodium, saturated fat, sugar, calcium, iron, potassium, vitamin D, vitamin B12, and magnesium, with optional Dietary Reference Intake bars from the IOM tables.
-🍽️ Custom meals & recipes: Build a one-off custom meal or save a reusable recipe with photo, brand, and barcode. The recipe builder has its own ingredient picker with barcode scanning so you can compose meals from real products.
-⚡ Quick add: When you already know roughly how much you ate, skip the search flow entirely — Quick add takes a title plus kcal (and optional macros) and logs it straight to the meal section.
-📷 Barcode scanner: Scan packaged items for instant lookup, paste a barcode manually when the camera struggles, or attach a barcode to a custom meal so future scans recognise your own foods.
-🏃 Activities: Log workouts from a categorised activity catalogue or define your own custom activities with direct kcal entry and reusable templates.
+🍎 Nutritional tracking: Log meals and snacks against a large food database — Open Food Facts plus a reference backend covering USDA FoodData Central and the German BLS, selectable in Settings. Search, scan, or enter a number when you already know the calorie cost.
+📓 Food diary: A calendar-driven diary split into Breakfast, Lunch, Dinner and Snack, with per-meal kcal targets (several presets or a custom share), drag-to-rearrange between meals, and sort by time or macro contribution.
+📈 Trends: Current and best day-streak, calories against your goal line, daily macro averages, water intake, and weight against target. Switch between 7, 30 and 90 days or your whole history.
+🥕 Micronutrient panel: Day and week views for fibre, sodium, saturated fat, sugar, calcium, iron, potassium, vitamin D, vitamin B12 and magnesium, with optional Dietary Reference Intake bars.
+🍽️ Custom meals & recipes: Build a one-off custom meal or save a reusable recipe with photo, brand and barcode. The recipe builder has its own ingredient picker with barcode scanning.
+⚡ Quick add: Skip the search when you already know roughly how much you ate — a title plus kcal (and optional macros), logged straight to the meal.
+🤖 AI meal assistance (experimental, off by default): Describe a meal in one line, or photograph it, and have several items resolved at once. Needs your own API key (Anthropic, OpenAI, OpenRouter) or a server you run — the project never sees either. The model reads language, not nutrition: every calorie still comes from the food databases.
+📷 Barcode scanner: Scan packaged items for instant lookup, paste a barcode manually, or attach a barcode to a custom meal so future scans recognise your own foods.
+🏃 Activities and workout import: Log workouts from a categorised catalogue or define custom activities with direct kcal entry and templates. Optionally import finished workouts from Health Connect — read-only, off by default, nothing is written back, and they stay on your device.
 💧 Water tracker: A water chip on the home screen with quick-add increments, an editable goal, and undo for the last entry.
-⏱️ Fasting timer: Optional intermittent-fasting timer with content-warning gate, a home chip showing time remaining, and a completion notification when you reach your window.
-⚖️ Weight history: Capture weight during onboarding and on demand, see the trend on a chart with a dashed line at your target weight, and optionally taper the calorie goal as you approach it.
-🎨 Material You & theme picker: Adopt the system accent colour on Android 12+, or pick from sixteen built-in presets. The app icon adapts to Android themed icons.
+⏱️ Fasting timer: Optional intermittent-fasting timer with a content-warning gate, a home chip showing time remaining, and a completion notification.
+⚖️ Weight history: Capture weight during onboarding and on demand, see the trend against your target, and optionally taper the calorie goal as you approach it.
+🎨 Material You & themes: Adopt the system accent colour on Android 12+, or pick from sixteen built-in presets.
 🔢 kcal or kJ: Switch the energy unit globally; every diary entry, target, and chart reflects the choice.
-📤 Export & import: Export your diary entries, activities, tracked days, and recipes to a JSON zip, with flat CSV companions so a spreadsheet can read them. Paste a JSON blob to import meals, and share a single meal or activity as a QR code another phone can scan. Your profile, weight log, custom-meal catalogue, water and fasting history stay out of the bundle.
-🔒 Privacy first: All data is AES-encrypted and stored locally. Anonymous crash reporting is opt-in during onboarding and can be turned off at any time.
-🚫💰 No subscriptions, in-app purchases, or ads: OpenNutriTracker is completely free, with no paid tier and no advertising.
+📤 Export & import: Export diary entries, activities, tracked days and recipes to a JSON zip, with flat CSVs a spreadsheet can read. Paste a JSON blob to import meals, or share a meal or activity as a QR code. Your profile, weight log, custom meals, water and fasting history stay out of the bundle.
+🔒 Privacy first: No account, no sign-in, no analytics, no ads. Your diary, profile, weight, custom meals and recipes are stored on your device in AES-256 encrypted databases; photos you attach are ordinary image files beside them. Food search sends the search term, plus your language code to rank results. AI meal assistance sends only the line you type or the photo you take, to the provider you chose — never your diary or history. Crash reporting is opt-in.
+🚫💰 No subscriptions, purchases or ads: completely free, with no paid tier and no advertising.
+⚕️ Not a medical device: OpenNutriTracker is not a medical device and does not diagnose, treat, cure, or prevent any medical condition. Figures are estimates from public databases and published equations. Always consult a healthcare professional for medical advice, diagnosis, or treatment.

--- a/ios/Runner/Info.plist
+++ b/ios/Runner/Info.plist
@@ -60,7 +60,7 @@
 	<key>UIApplicationSupportsIndirectInputEvents</key>
 	<true/>
 	<key>NSCameraUsageDescription</key>
-	<string>Camera permission is used to scan barcodes and to attach a photo to a custom meal so it's easier to recognise in your saved list.</string>
+	<string>Camera permission is used to scan barcodes, to attach a photo to a custom meal so it's easier to recognise in your saved list, and — only if you turn on AI meal assistance — to photograph a meal so the provider you configured can read what is in it. That photo is sent for that one request, is never written to your device, and is not included in your exports.</string>
 	<key>NSPhotoLibraryUsageDescription</key>
     <string>Used to attach a photo to a custom meal so it's easier to recognise in your saved list, and for exporting data.</string>
 	<key>NSHealthShareUsageDescription</key>

--- a/ios/Runner/Info.plist
+++ b/ios/Runner/Info.plist
@@ -60,7 +60,7 @@
 	<key>UIApplicationSupportsIndirectInputEvents</key>
 	<true/>
 	<key>NSCameraUsageDescription</key>
-	<string>Camera permission is used to scan barcodes, to attach a photo to a custom meal so it's easier to recognise in your saved list, and — only if you turn on AI meal assistance — to photograph a meal so the provider you configured can read what is in it. That photo is sent for that one request, is never written to your device, and is not included in your exports.</string>
+	<string>Camera permission is used to scan barcodes, to attach a photo to a custom meal so it's easier to recognise in your saved list, and — only if you turn on AI meal assistance — to photograph a meal so the provider you configured can read what is in it. That photo is sent for that one request; the app saves no copy of its own and deletes the camera's temporary file as soon as it has been encoded, so the photo is not in your saved meals and not in your exports.</string>
 	<key>NSPhotoLibraryUsageDescription</key>
     <string>Used to attach a photo to a custom meal so it's easier to recognise in your saved list, and for exporting data.</string>
 	<key>NSHealthShareUsageDescription</key>

--- a/ios/Runner/PrivacyInfo.xcprivacy
+++ b/ios/Runner/PrivacyInfo.xcprivacy
@@ -80,14 +80,21 @@
              Apple defines "collect" as transmitting data off the device "in a
              way that allows you and/or your third-party partners to access it
              for a period longer than what is necessary to service the
-             transmitted request in real time". Whether a provider the USER
-             contracts with counts as a third-party partner of this project is
-             not answerable in advance — it is the Apple twin of the Play
-             question in #816. Both types are declared anyway: OpenAI documents
-             retaining API inputs for up to 30 days and Anthropic retains
-             flagged content for up to two years, so the data does outlive the
-             request, and under-declaring is the direction that gets a
-             submission rejected.
+             transmitted request in real time", and narrows the second actor to
+             vendors "whose code you've added to your app".
+
+             On the letter of that, neither actor is reached: the project never
+             receives any of this, and no provider SDK is embedded — the app
+             speaks to each provider over its own HTTP client. So this is
+             declared on the conservative reading rather than because the
+             definition plainly bites. It is the Apple twin of the open Play
+             question in #816, and the reason for declaring is the same one
+             recorded there: the data does outlive the request (OpenAI
+             documents retaining API inputs for up to 30 days, Anthropic
+             retains flagged content for up to two years), and against a
+             one-bit public label the cost of over-declaring is a less
+             flattering row while the cost of under-declaring is a rejected
+             submission.
 
              Linked is NO because the app generates no user or device
              identifier and sends none. Tracking is NO because nothing is
@@ -97,7 +104,12 @@
                * Food search terms. They reach Open Food Facts and the Supabase
                  backend only to answer the query. Backend access is RPC-only
                  (#882) precisely so the term stays out of the gateway log, so
-                 nothing retains it past the request.
+                 nothing retains it past the request. That covers the search
+                 TERM and nothing else: whether the coarse location the gateway
+                 derives from the caller's IP is separately collectable is #938
+                 under map #935, whose research answers yes for Apple. This
+                 list is what the AI path does and does not add — not a claim
+                 that the whole manifest is complete.
                * Health and Fitness. Workouts and body fat percentage are read
                  from HealthKit and never transmitted off the device — and
                  "collect" is about transmission, not access.

--- a/ios/Runner/PrivacyInfo.xcprivacy
+++ b/ios/Runner/PrivacyInfo.xcprivacy
@@ -72,6 +72,65 @@
                 <string>NSPrivacyCollectedDataTypePurposeAppFunctionality</string>
             </array>
         </dict>
+        <!-- AI meal assistance (#990). Declared only because of that feature:
+             it is off until the user saves an API key of their own or the
+             address of a server they run, and the app transmits none of this
+             otherwise.
+
+             Apple defines "collect" as transmitting data off the device "in a
+             way that allows you and/or your third-party partners to access it
+             for a period longer than what is necessary to service the
+             transmitted request in real time". Whether a provider the USER
+             contracts with counts as a third-party partner of this project is
+             not answerable in advance — it is the Apple twin of the Play
+             question in #816. Both types are declared anyway: OpenAI documents
+             retaining API inputs for up to 30 days and Anthropic retains
+             flagged content for up to two years, so the data does outlive the
+             request, and under-declaring is the direction that gets a
+             submission rejected.
+
+             Linked is NO because the app generates no user or device
+             identifier and sends none. Tracking is NO because nothing is
+             linked with third-party data or shared with a data broker.
+
+             Deliberately NOT declared, each for a different reason:
+               * Food search terms. They reach Open Food Facts and the Supabase
+                 backend only to answer the query. Backend access is RPC-only
+                 (#882) precisely so the term stays out of the gateway log, so
+                 nothing retains it past the request.
+               * Health and Fitness. Workouts and body fat percentage are read
+                 from HealthKit and never transmitted off the device — and
+                 "collect" is about transmission, not access.
+               * Photos attached to a custom meal or recipe. Those stay on
+                 disk and are never sent anywhere.
+
+             `PhotosorVideos` is Apple's own spelling, lowercase "or"
+             included. It is not a typo and must not be "corrected". -->
+        <dict>
+            <key>NSPrivacyCollectedDataType</key>
+            <string>NSPrivacyCollectedDataTypePhotosorVideos</string>
+            <key>NSPrivacyCollectedDataTypeLinked</key>
+            <false/>
+            <key>NSPrivacyCollectedDataTypeTracking</key>
+            <false/>
+            <key>NSPrivacyCollectedDataTypePurposes</key>
+            <array>
+                <string>NSPrivacyCollectedDataTypePurposeAppFunctionality</string>
+            </array>
+        </dict>
+        <!-- The meal line typed on the multi-item add screen. -->
+        <dict>
+            <key>NSPrivacyCollectedDataType</key>
+            <string>NSPrivacyCollectedDataTypeOtherUserContent</string>
+            <key>NSPrivacyCollectedDataTypeLinked</key>
+            <false/>
+            <key>NSPrivacyCollectedDataTypeTracking</key>
+            <false/>
+            <key>NSPrivacyCollectedDataTypePurposes</key>
+            <array>
+                <string>NSPrivacyCollectedDataTypePurposeAppFunctionality</string>
+            </array>
+        </dict>
     </array>
 </dict>
 </plist>

--- a/test/unit_test/store_declarations_test.dart
+++ b/test/unit_test/store_declarations_test.dart
@@ -44,15 +44,32 @@ void main() {
       expect(camera, contains('custom meal'));
     });
 
-    // The photo path promises this in Settings and in the README, and the
-    // purpose string is the one place Apple reads it.
-    test('does not claim the photo is kept', () {
+    // The picker DOES write a cache file — `ImagePicker.pickImage` hands the
+    // app a temp copy, and `MealPhotoEncoder.encodeAndDiscardSource` deletes
+    // it in a `finally`, best effort. So the string may describe the app
+    // keeping no copy of its own and deleting that file; it may not claim the
+    // photo is never written to the device, which is what this string said
+    // before and is not true. The README has always drawn the line here.
+    test('describes what happens to the photo without over-claiming', () {
       final camera = valueFor('NSCameraUsageDescription')!.toLowerCase();
-      expect(camera, contains('never written to your device'));
+      expect(camera, contains('saves no copy of its own'));
+      expect(camera, contains("deletes the camera's temporary file"));
+      expect(
+        camera,
+        isNot(contains('never written')),
+        reason: 'the picker writes a cache file before it is deleted',
+      );
     });
   });
 
   group('iOS privacy manifest', () {
+    // Greedy `(.*)` on purpose. Each collected-type dictionary contains its
+    // own `NSPrivacyCollectedDataTypePurposes` array, so a lazy `(.*?)` would
+    // stop at the first inner `</array>` and match only the first entry's
+    // purposes — 460 characters instead of 5449, with neither AI type inside
+    // it. This works because `NSPrivacyCollectedDataTypes` is the last key in
+    // the file; if a key is ever added after it, match the outer array some
+    // other way rather than making this lazy.
     String collectedTypes() => RegExp(
       '<key>NSPrivacyCollectedDataTypes</key>\\s*<array>(.*)</array>',
       dotAll: true,

--- a/test/unit_test/store_declarations_test.dart
+++ b/test/unit_test/store_declarations_test.dart
@@ -1,0 +1,138 @@
+import 'dart:io';
+
+import 'package:flutter_test/flutter_test.dart';
+
+/// Pins the platform-facing declarations that 2.2.0 outgrew (#990).
+///
+/// These files are read by Apple's reviewer and Google's policy check, not by
+/// the app, so nothing else in CI looks at them. Every one of them drifted
+/// silently while AI meal assistance and workout import were being built: the
+/// camera purpose string still described an app with no meal photo, the
+/// privacy manifest declared only Sentry's diagnostics, and the Play listing
+/// described neither feature while over-claiming encryption.
+///
+/// The listing is also under a hard 4000-character cap that nothing warns
+/// about until the Play Console rejects the text, which is why the length is
+/// asserted here rather than discovered during a submission.
+void main() {
+  final infoPlist = File('ios/Runner/Info.plist').readAsStringSync();
+  final manifest = File('ios/Runner/PrivacyInfo.xcprivacy').readAsStringSync();
+  final listing = File(
+    'fastlane/metadata/android/en-US/full_description.txt',
+  ).readAsStringSync();
+
+  String? valueFor(String key) => RegExp(
+    '<key>$key</key>\\s*<string>(.*?)</string>',
+    dotAll: true,
+  ).firstMatch(infoPlist)?.group(1);
+
+  group('iOS camera purpose string', () {
+    // Apple requires the string to describe the actual use, and reading a
+    // meal photograph is the use a reviewer will exercise — it is also the
+    // only camera use where the picture leaves the device.
+    test('names reading a meal photo', () {
+      final camera = valueFor('NSCameraUsageDescription')!;
+      expect(camera.toLowerCase(), contains('ai meal assistance'));
+      expect(camera.toLowerCase(), contains('photograph a meal'));
+    });
+
+    // The AI clause was added to a string that already had two purposes.
+    // Neither may be dropped on the way past.
+    test('keeps the barcode and custom-meal purposes', () {
+      final camera = valueFor('NSCameraUsageDescription')!.toLowerCase();
+      expect(camera, contains('barcode'));
+      expect(camera, contains('custom meal'));
+    });
+
+    // The photo path promises this in Settings and in the README, and the
+    // purpose string is the one place Apple reads it.
+    test('does not claim the photo is kept', () {
+      final camera = valueFor('NSCameraUsageDescription')!.toLowerCase();
+      expect(camera, contains('never written to your device'));
+    });
+  });
+
+  group('iOS privacy manifest', () {
+    String collectedTypes() => RegExp(
+      '<key>NSPrivacyCollectedDataTypes</key>\\s*<array>(.*)</array>',
+      dotAll: true,
+    ).firstMatch(manifest)!.group(1)!;
+
+    // Lowercase "or" is Apple's own spelling of this constant. A well-meaning
+    // correction to `PhotosOrVideos` would be silently ignored by Apple.
+    test('declares the meal photo', () {
+      expect(
+        collectedTypes(),
+        contains('<string>NSPrivacyCollectedDataTypePhotosorVideos</string>'),
+      );
+    });
+
+    test('declares the typed meal line', () {
+      expect(
+        collectedTypes(),
+        contains('<string>NSPrivacyCollectedDataTypeOtherUserContent</string>'),
+      );
+    });
+
+    // The app generates no user or device identifier and sends none, so
+    // nothing it declares may be linked to an identity or used for tracking.
+    // A `<true/>` under either key would contradict the README's privacy
+    // table and the App Store Connect record it has to agree with.
+    test('nothing is linked to the user or used for tracking', () {
+      final linked = RegExp(
+        '<key>NSPrivacyCollectedDataTypeLinked</key>\\s*<(true|false)/>',
+      ).allMatches(manifest).map((m) => m.group(1)).toList();
+      final tracking = RegExp(
+        '<key>NSPrivacyCollectedDataTypeTracking</key>\\s*<(true|false)/>',
+      ).allMatches(manifest).map((m) => m.group(1)).toList();
+
+      expect(linked, isNotEmpty);
+      expect(linked, everyElement('false'));
+      expect(tracking, isNotEmpty);
+      expect(tracking, everyElement('false'));
+    });
+  });
+
+  group('Play listing', () {
+    // Play rejects a longer description outright. Nothing in the repo or in
+    // CI checks it, and `upload_to_play_store` runs with
+    // `skip_upload_metadata: true`, so the rejection would arrive during a
+    // manual Console edit rather than from the pipeline.
+    test('is within the 4000-character cap', () {
+      expect(
+        listing.length,
+        lessThanOrEqualTo(4000),
+        reason: 'Play truncates or refuses a longer full description',
+      );
+    });
+
+    test('describes the two features 2.2.0 added', () {
+      expect(listing.toLowerCase(), contains('ai meal assistance'));
+      expect(listing.toLowerCase(), contains('workout import'));
+    });
+
+    // Google's Health Content and Services policy requires this sentence in
+    // the app description, in these words, for a health-and-fitness app that
+    // is not a declared medical device.
+    test('carries the disclaimer Google specifies, verbatim', () {
+      expect(
+        listing,
+        contains(
+          'not a medical device and does not diagnose, treat, cure, '
+          'or prevent any medical condition',
+        ),
+      );
+    });
+
+    test('reminds the reader to consult a professional', () {
+      expect(listing.toLowerCase(), contains('healthcare professional'));
+    });
+
+    // Photos attached to a meal or recipe are stored as ordinary image files,
+    // so the blanket claim was false in the direction that matters.
+    test('does not claim that all data is encrypted', () {
+      expect(listing, isNot(contains('All data is AES-encrypted')));
+      expect(listing, contains('AES-256 encrypted databases'));
+    });
+  });
+}


### PR DESCRIPTION
Closes #990.

2.2.0 is the first release with AI meal assistance and workout import. Five platform-facing
declarations still described the app as it was before, and none of them is read by anything in
CI — the first reader is an App Review engineer or a Play policy check.

## What changed

**`NSCameraUsageDescription` now names reading a meal photo.** The old string covered barcode
scanning and attaching a photo to a custom meal. Neither is the use where a photograph *leaves
the device*, and that is the one a reviewer will exercise. The new string keeps both existing
purposes and adds the AI one.

Its first draft said the photo "is never written to your device". That is false, and Copilot
caught it: `ImagePicker.pickImage` hands the app a cache file and
`MealPhotoEncoder.encodeAndDiscardSource` deletes it in a `finally`, best effort. The README has
always drawn that line carefully — *"the app attempts to delete that as soon as the photo is
encoded … best effort"* — and the purpose string had quietly outrun it. It now describes the
app's own behaviour rather than a state it cannot guarantee: no copy of its own is saved, the
camera's temporary file is deleted once the photo has been encoded, and the photo is in neither
the saved meals nor the exports. Writing an over-claim into a store declaration is the exact
defect class this PR exists to fix, so the test now rejects the old wording by name.

`NSPhotoLibraryUsageDescription` is deliberately unchanged: the AI path is
`ImageSource.camera` only (`bulk_add_screen.dart:1114`), with no gallery option anywhere on that
screen, so the library is not involved.

**`PrivacyInfo.xcprivacy` declares what the AI path transmits.** It previously declared only
Sentry's three diagnostic types. Added `NSPrivacyCollectedDataTypePhotosorVideos` (the meal
photo) and `NSPrivacyCollectedDataTypeOtherUserContent` (the typed meal line), both unlinked,
neither used for tracking, purpose App Functionality.

Apple defines *collect* as transmitting data off the device "in a way that allows you and/or your
third-party partners to access it for a period longer than what is necessary to service the
transmitted request in real time", and narrows the second actor to vendors "whose code you've
added to your app". On the letter of that, **neither actor is reached**: the project never
receives any of this, and no provider SDK is embedded — the app speaks to each provider over its
own HTTP client. So this is declared on the conservative reading rather than because the
definition plainly bites, and the manifest says so. It is the Apple twin of the open Play question
in #816, and the reason for declaring is the one already recorded there: the data does outlive the
request (OpenAI documents retaining API inputs for up to 30 days, Anthropic retains flagged
content for up to two years), and against a one-bit public label the cost of over-declaring is a
less flattering row while the cost of under-declaring is a rejected submission.

Three things are deliberately *not* declared, and the manifest says why beside each: food search
terms (RPC-only per #882, so nothing retains them past the request), HealthKit workouts (read but
never transmitted, and *collect* is about transmission), and photos attached to a custom meal
(they never leave the device). That list is what the AI path adds and does not add — **not** a
claim the manifest is complete. #938's research concludes Apple wants **Coarse Location** declared
for the Supabase gateway logs, no entry covers it, and the manifest now says as much rather than
letting the omission read as settled.

**The Play listing describes the app that shipped.** It gained an AI meal assistance bullet and
workout import, its privacy bullet now names what stays local instead of implying everything
does, and it carries the disclaimer Google's Health Content and Services policy requires.

The old privacy bullet read *"All data is AES-encrypted and stored locally"*. Photos attached to a
meal or recipe are ordinary WebP files on disk, so the claim was false in the direction that
matters. It now says which data is in the encrypted databases, that search sends the search term and the language
code used to rank results, and that AI meal assistance sends only the line you type or the photo
you take.

The listing is under a hard **4000-character cap** with no warning until the Console refuses the
text, and it was at 3571. The additions did not fit, so existing bullets were tightened to make
room — the substance of each is intact, the padding is not. Final: **3952**.

## What this does not do

The **Play Data safety record** is out of scope by the issue's own framing — it is tracked
separately as the one genuinely blocking platform item. #816 (does a server the user runs count as
collection?) stays open, and nothing here pretends to answer it.

Everything here is repo-side text. `upload_to_play_store` runs with `skip_upload_metadata: true`,
so the pipeline never touches the listing, and the App Store Connect App Privacy questionnaire is
a web form. `docs/RELEASING.md` gained a **Store declarations** section listing each console
action and the exact App Privacy answers the manifest now requires, so the two can be kept in
agreement.

## Verification

`test/unit_test/store_declarations_test.dart` — 11 tests pinning all five criteria: the camera
string names the meal photo and keeps its two older purposes, the manifest declares both AI types
with nothing linked or tracking, the listing is within the cap, mentions both features, carries
Google's sentence verbatim, and no longer makes the blanket encryption claim.

Mutation-checked rather than assumed — six regressions were introduced one at a time and every one
was caught: restoring the AES over-claim, deleting the disclaimer, padding the listing past 4000,
reverting the camera string, swapping the photo data type, and flipping `Linked` to true. The
corrected camera assertion was re-checked the same way.

One review suggestion was **not** taken. Making the collected-types regex lazy would break the
test: each entry carries its own `NSPrivacyCollectedDataTypePurposes` array, so `(.*?)` stops at
the first inner `</array>` and matches 460 characters instead of 5449, finding neither AI type.
Measured rather than argued; the greedy match now carries a comment saying so.

`PrivacyInfo.xcprivacy` parses as a plist and every collected-type dictionary has exactly the four
keys TN3184 specifies — Apple rejects submissions containing an invalid manifest, so a malformed
file would fail at upload rather than here.
