### PR TITLE
docs: correct two claims about Play's Data safety form

### DIFF
--- a/docs/ai-legal-constraints.md
+++ b/docs/ai-legal-constraints.md
@@ -798,11 +798,30 @@ itself transmits nothing to the developer?" is: **it changes the *sharing* answe
 not the *collection* answers.**
 
 - **Collection.** Yes, tiers 1–2 collect in Play's sense, because "collect" means
-  transmitting off device — irrespective of destination. Photos and the meal
-  description (which Play would treat under "Health and fitness" and "Photos and
-  videos") must be declared as collected, marked **optional** (the user can use the
-  entire app without ever enabling the feature), with purpose "App functionality".
-  Tier 0 collects nothing new.
+  transmitting off device — irrespective of destination. The meal photo and the
+  typed meal description must both be declared as collected, marked **optional**
+  (the user can use the entire app without ever enabling the feature), with
+  purpose "App functionality". Tier 0 collects nothing new.
+
+  **Corrected 2026-09-04.** This bullet previously said Play "would treat" the two
+  under *Health and fitness* and *Photos and videos*. The second is right; the
+  first is not, and nothing was cited for it. Play's only two types under that
+  heading are **Health info** — *"Information about a user's health, such as
+  medical records or symptoms"* — and **Fitness info** — *"Information about a
+  user's fitness, such as exercise or other physical activity"*. A meal
+  description is neither. It belongs under **App activity → Other user-generated
+  content**: *"Any other user-generated content not listed here, or in any
+  section. For example, user bios, notes, or open-ended responses."* So the pair
+  is **Photos and videos → Photos** and **App activity → Other user-generated
+  content**, and no Health and fitness entry arises from the AI path.
+
+  Nor from workout import, for a separate reason:
+  [#937](https://github.com/simonoppowa/OpenNutriTracker/issues/937) found that
+  data read from Health Connect and never transmitted falls under Google's
+  carve-out — *"User data accessed by your app that is only processed locally on
+  the user's device and not sent off device does not need to be disclosed."* Two
+  unrelated reasons for the same empty answer; neither covers the other. The live
+  form is [#1050](https://github.com/simonoppowa/OpenNutriTracker/issues/1050).
 - **Sharing.** The user-initiated-action exception is a strong fit — the user
   pastes an endpoint, then taps a button to send a specific photo or sentence. On
   the strict reading you need not declare sharing. Declare it anyway: it costs

--- a/docs/ai-play-encryption-declaration.md
+++ b/docs/ai-play-encryption-declaration.md
@@ -51,6 +51,19 @@ Health Connect or HealthKit integration. So today the declaration is honest, and
 user-typed `http://` address under [#758](https://github.com/simonoppowa/OpenNutriTracker/issues/758)
 would be the app's only plaintext path.
 
+> **Update, 2026-09-04.** Two facts in the paragraph above have expired, and the
+> findings are left as read on 2026-08-22 rather than rewritten. **#758 shipped**,
+> so the conditional in the last sentence is no longer conditional: the app permits
+> plaintext to a private address, which is the only plaintext path and it now
+> exists. *"Today the declaration is honest"* should not be carried forward — the
+> live form still answers **Yes**, and reconciling that is an acceptance criterion
+> on [#1050](https://github.com/simonoppowa/OpenNutriTracker/issues/1050). Section 3
+> below is the part that still holds and is the reason it needs a decision rather
+> than an edit. Separately, **2.2.0 added workout import**, so "there is no Health
+> Connect or HealthKit integration" is out of date; it does not change this
+> question, and what it does change for the Data safety form is
+> [#937](https://github.com/simonoppowa/OpenNutriTracker/issues/937).
+
 ## 3. Can a conditional truth be expressed?
 
 **No.** Google is explicit that the declaration is all-or-nothing:

--- a/docs/privacy-policy-gaps.md
+++ b/docs/privacy-policy-gaps.md
@@ -355,10 +355,21 @@ and 14 do not bite. It is *not* an argument for silence, for three reasons:
 1. The policy's opening list is presented as complete — *"Among the types of
    Personal Data that this Application collects […]"* — and a reader who
    turns on workout import is entitled to find it there.
-2. Google Play's Data safety declaration must cover data the app *accesses*
-   off its own storage regardless of where it ends up, and Google is explicit
-   that *"You alone are responsible for making complete and accurate
-   declarations"*. Health and fitness is a declarable category.
+2. Google's broader *accesses* standard lands on the **privacy policy**, the
+   in-app disclosure and the Health apps declaration — which is this finding —
+   and Google is explicit that *"You alone are responsible for making complete
+   and accurate declarations"*. Health and fitness is a declarable category
+   there.
+
+   *Corrected 2026-09-04:* this point previously said the **Data safety form**
+   must cover data the app accesses "regardless of where it ends up". It does
+   not, and [#937](https://github.com/simonoppowa/OpenNutriTracker/issues/937)
+   settled it the other way: that form is scoped to collection and sharing,
+   "collect" means transmitting off device, and *"User data accessed by your app
+   that is only processed locally on the user's device and not sent off device
+   does not need to be disclosed."* The correction strengthens this finding
+   rather than weakening it — the duty the access standard creates is precisely
+   the policy text this section is asking for.
 3. Finding 1 is the concrete counter-example to "on-device means out of
    scope": until `enablePrintBreadcrumbs = false` ships, on-device values do
    leave, through Sentry, in the released build.


### PR DESCRIPTION
Groundwork for [#1050](https://github.com/simonoppowa/OpenNutriTracker/issues/1050). Two documents state things about Play's Data safety form that Google's own text contradicts, and neither cited a source. They would have been acted on — the first one nearly was.

## `docs/ai-legal-constraints.md`

Said Play *"would treat"* the meal description under **Health and fitness**. It would not. The only two types under that heading are **Health info** — *"Information about a user's health, such as medical records or symptoms"* — and **Fitness info** — *"Information about a user's fitness, such as exercise or other physical activity"*. A meal description is neither.

It is an open-ended response, which is exactly what **App activity → Other user-generated content** is for: *"Any other user-generated content not listed here, or in any section. For example, user bios, notes, or open-ended responses."*

So the pair to declare is **Photos and videos → Photos** and **App activity → Other user-generated content**. The *Photos and videos* half of the original claim was right and is unchanged.

The bullet now also records that no Health and fitness entry arises from workout import either, for an unrelated reason — [#937](https://github.com/simonoppowa/OpenNutriTracker/issues/937)'s carve-out for data read but never transmitted — so a later reader does not take one reason as covering both.

## `docs/privacy-policy-gaps.md`

Said the Data safety form *"must cover data the app accesses off its own storage regardless of where it ends up"*. It must not. That form is scoped to collection and sharing; *"collect" means transmitting off device*; and *"User data accessed by your app that is only processed locally on the user's device and not sent off device does not need to be disclosed."*

The broader access standard is real, but it lands on the privacy policy, the in-app disclosure and the Health apps declaration — which is the finding that bullet exists to argue for. The correction strengthens the point rather than weakening it.

## `docs/ai-play-encryption-declaration.md`

A dated note, not an edit. Its findings hold as read on 2026-08-22; two facts under them have expired. [#758](https://github.com/simonoppowa/OpenNutriTracker/issues/758) shipped, so the plaintext path it called hypothetical now exists and *"today the declaration is honest"* must not be carried forward — the live form still answers **Yes**, which is an acceptance criterion on #1050. And 2.2.0 added workout import, so *"there is no Health Connect or HealthKit integration"* is out of date.

## Convention

Corrections are marked and dated in place rather than rewritten away. These pages are read as a record of what was checked and when, so a silent edit would destroy the thing that makes them worth keeping — and it is the second time this week a plausible in-repo claim has been overturned by going to the primary source.