### PR TITLE
docs(releasing): ask which lines main has, not which commits

### DIFF
--- a/docs/RELEASING.md
+++ b/docs/RELEASING.md
@@ -204,6 +204,40 @@ Before backporting anything, check whether its content is already present — a 
 both branches, or a paragraph already corrected — rather than trusting the commit list. Only two of
 the four entries it printed in August 2026 were real gaps.
 
+**Ask which lines, not which commits.** The command above answers "which commits", which is the
+wrong question under squash merging — `main` carries a release as one commit that `develop` will
+never contain. The useful question is which *lines* `main` has that `develop` does not:
+
+```bash
+git diff --name-only origin/develop origin/main | while read -r f; do
+  n=$(git diff origin/develop origin/main -- "$f" | grep -cE '^\+[^+]')
+  if [ "$n" -gt 0 ]; then printf '%4d  %s\n' "$n" "$f"; fi
+done
+```
+
+Then judge each file it prints. A line is a gap only if `develop` has no newer version of it. Most
+will be neither: text `develop` has since rewritten, or a file it deleted deliberately, both of
+which look identical to a gap in a commit listing.
+
+Run on **2026-09-04**, with `main` at 2.2.0 and `develop` seventeen commits past it, eleven files
+had `main`-only lines and **not one was a gap**:
+
+| `main`-only lines | Why it was not a gap |
+| --: | :-- |
+| 31 in `default_workflow.yml` | superseded by the `changes` job in #1043, which gates more than the inline version it replaced |
+| 25 in `docs/export-format.md` | superseded by #999 |
+| 15 in `full_description.txt`, 5 in `ai-legal-constraints.md`, 1 in `Info.plist` | superseded by #1049 and #1051 |
+| 4 in `docs/supabase-self-hosting.md` | superseded by #1000 |
+| 4 in `docs/supabase-fdc-self-hosting.md` | `develop` deleted the file on purpose in #997 |
+| 1 each in `README.md`, `ai-architecture.md`, `AGENTS.md`, `CONTRIBUTING.md` | superseded by #1003, #996 and #1047 |
+| 0 in `docs/RELEASING.md` | `develop` is a strict superset |
+
+The specific answer expires; the shape of it does not. `develop` is uniformly newer wherever the
+two differ, so the conflicts a release PR raises resolve to `develop`'s side — they are not a debt
+that grows between releases, and there is nothing to bring down in the meantime. If a run of the
+command above ever *does* print a real gap, cherry-pick it; do not reach for a merge, for the
+reason in the paragraph above.
+
 ## Documentation
 
 The step this page exists for. These have no automation at all, and nothing fails if they are


### PR DESCRIPTION
The back-merge section already warns that most of `git log develop..main` is expected and must not be backported. It does not say how to tell the exception from the rule — so the check gets redone by hand each release, and the answer is only as good as whoever squinted at the commit list.

## What this adds

The per-file question, which is the one that actually decides it: **which _lines_ does `main` have that `develop` does not?** Under squash merging `main` carries a release as a single commit `develop` will never contain, so a commit listing cannot answer it.

The snippet is four lines and its output is judged file by file. A line is a gap only if `develop` has no newer version of it — and most will be text `develop` has since rewritten, or a file it deleted deliberately. **Both look identical to a gap in a commit listing.** That is the trap the section warns about, now with an instrument for it.

## And the result of running it

On 2026-09-04, with `main` at 2.2.0 and `develop` seventeen commits past it: **eleven files had `main`-only lines and not one was a gap.** The table names each and what superseded it — #1043's `changes` job, #999, #1000, #997's deliberate deletion, #1049, #1051, #1003, #996, #1047.

## Why it is worth writing down

I assumed the opposite this morning and said so twice: that the divergence was a growing debt and the fix was to back-merge `main` into `develop` now, while it was small. Both halves were wrong. There was nothing to bring down, and a merge is what the section immediately above this one forbids — `main`'s copy of 2.2.0 is one squashed commit of 117 files and +32,640 lines, and git cannot tell "older text" from "text to restore" inside it.

The durable part is the shape rather than the answer: `develop` is uniformly newer wherever the two differ, so a release PR's conflicts resolve to `develop`'s side. They are not a debt that accumulates between releases, and there is nothing to do about them in the meantime.

## Verification

`test/unit_test/releasing_doc_test.dart` passes — it checks every file and heading link in this document resolves. The snippet was run as written and exits 0; its output is exactly the eleven rows in the table.