### PR TITLE
ci: put the release jobs behind two environments, split at the store

### DIFF
--- a/.github/workflows/default_workflow.yml
+++ b/.github/workflows/default_workflow.yml
@@ -1135,6 +1135,7 @@ jobs:
       - ios-build
       - android-build
       - android-integration-tests
+    environment: release-ship
     runs-on: macos-26
     permissions:
       contents: read
@@ -1260,6 +1261,7 @@ jobs:
     # ubuntu it failed with "No such file or directory @ dir_chdir0" as the
     # transporter couldn't resolve its working directory. The IPA is built
     # in ios-package and handed off as an artifact, so this job only uploads.
+    environment: release-ship
     runs-on: macos-26
     permissions:
       # Widened from `read` for the ledger step at the end of this job,
@@ -1396,6 +1398,7 @@ jobs:
       - ios-build
       - android-build
       - android-integration-tests
+    environment: release-build
     runs-on: ubuntu-latest
     permissions:
       contents: read
@@ -1535,6 +1538,7 @@ jobs:
       - release-gate
       - android-package
       - ios-package
+    environment: release-ship
     runs-on: ubuntu-latest
     permissions:
       # Widened from `read` for the ledger step at the end of this job,


### PR DESCRIPTION
## Summary

Step 1 of #1054, and the prerequisite for installing any write-capable GitHub App. Puts every job that touches signing material or a store behind an environment.

The two environments **already exist** — created and verified before this PR, so merging wires jobs to real targets rather than creating implicit unprotected ones:

```
release-build   branches: main   reviewers: none
release-ship    branches: main   reviewers: simonoppowa (required)
```

## Type of change
- [x] CI / tooling
- [ ] Bug fix / New feature / Refactor / Documentation / Localization / Other

## Changes

| job | environment | why |
|---|---|---|
| `android-package` | `release-build` | signs an artifact; nothing leaves the machine |
| `ios-package` | `release-ship` | its `fastlane ios build` lane calls `sync_signing` → `match`, so it genuinely needs App Store Connect credentials |
| `ios-deploy` | `release-ship` | uploads to TestFlight |
| `android-deploy` | `release-ship` | uploads to Play |

**The split is at the point work leaves for a store**, because that is where the irreversible step is. A signed Android artifact can still be produced unattended; nothing reaches a store, and no iOS artifact is signed, without an approval a human has to give.

**That last property is the whole point.** Scoping secrets alone buys nothing against an actor holding `workflows: write` — it can add `environment:` to a job it writes. A required reviewer is the control that survives, because **a GitHub App cannot approve a deployment gated on a human.** This is why it lands before any such app is installed.

## What this costs

- **Two to three approval clicks per release run** — `ios-package`, `ios-deploy` and `android-deploy` reach `release-ship` at different points. On top of the Play upload already done by hand.
- **iOS cannot build unattended.** Provisioning a second, role-scoped App Store Connect key was the alternative; gating the build was judged cheaper.

## Staying repo-level, deliberately

`SENTRY_DNS`, `SUPABASE_PROJECT_URL`, `SUPABASE_PROJECT_ANON_KEY` ship **inside the app binary** — `envied` obfuscates them at compile time but they are extractable, and the anon key is public by design. Protecting them would be theatre, and jobs in both environments need them. `PROJECTS_TOKEN` is used only by `add-issues-to-projects.yml`, which triggers on `issues` and never on a pull request.

## Test plan
- [x] Described steps below were followed
- [ ] Unit / widget tests (n/a — CI config)
- [ ] Manual check on Android / iOS (n/a)

### Steps
1. Both environments created via the API and verified: `release-ship` reports `required_reviewers (simonoppowa)` + `branch_policy`; `release-build` reports `branch_policy` only; both restricted to `main`; **both hold 0 secrets**.
2. `yaml.safe_load` parses the workflow — 16 jobs.
3. Confirmed each `environment:` key sits in the correct job header.

### What to check after merge
- A **pull request** still passes unchanged. PR jobs use the stubs from `.github/actions/write-env-file` and reference no environment, so nothing here can affect them.
- A **push to `main`** pauses for approval before `ios-package`.

## Not in this PR — needs the maintainer

**The secrets have not been moved.** GitHub never reveals a stored value, so each must be re-entered from its original source (Play Console, App Store Connect, the match repo, the keystore). Until then both environments hold nothing and the jobs read the existing repo-level secrets, which still works — the approval gate is live either way.

Order from #1054: add the secrets to the environments → verify a release run is green end to end → **only then** delete the 11 orphaned repo-level secrets (`AWS_*`, `CLOUDFLARE_*`, `R2_*`, `TF_*`, `CATALOG_ACCESS_TOKEN`), which have no consumer in this repository at all.

## Checklist
- [x] Code follows project style — n/a, YAML
- [x] New interactive widgets include `Semantics(identifier: '...')` — n/a
- [x] Localization updated in every ARB — n/a
- [x] Codegen ran if DBOs/DTOs/env changed — n/a
- [x] No secrets or `.env` values committed
- [x] PR title follows conventional commit style
