### PR TITLE
chore(l10n): add a retry string for the search screen

### DIFF
--- a/lib/l10n/intl_cs.arb
+++ b/lib/l10n/intl_cs.arb
@@ -118,29 +118,101 @@
   "foodSourcesHelpText": "Výsledky vyhledávání pocházejí z těchto databází potravin. Open Food Facts pohání vyhledávání produktů a čárových kódů a je vždy zapnutá.",
   "machineTranslatedNameHint": "Název byl přeložen automaticky",
   "measureUnitBar": "{count, plural, one{tyčinka} few{tyčinky} other{tyčinek}}",
-  "@measureUnitBar": {"placeholders": {"count": {"type": "num"}}},
+  "@measureUnitBar": {
+    "placeholders": {
+      "count": {
+        "type": "num"
+      }
+    }
+  },
   "measureUnitBottle": "{count, plural, one{láhev} few{láhve} other{lahví}}",
-  "@measureUnitBottle": {"placeholders": {"count": {"type": "num"}}},
+  "@measureUnitBottle": {
+    "placeholders": {
+      "count": {
+        "type": "num"
+      }
+    }
+  },
   "measureUnitCan": "{count, plural, one{plechovka} few{plechovky} other{plechovek}}",
-  "@measureUnitCan": {"placeholders": {"count": {"type": "num"}}},
+  "@measureUnitCan": {
+    "placeholders": {
+      "count": {
+        "type": "num"
+      }
+    }
+  },
   "measureUnitCup": "{count, plural, one{šálek} few{šálky} other{šálků}}",
-  "@measureUnitCup": {"placeholders": {"count": {"type": "num"}}},
+  "@measureUnitCup": {
+    "placeholders": {
+      "count": {
+        "type": "num"
+      }
+    }
+  },
   "measureUnitEgg": "{count, plural, one{vejce} few{vejce} other{vajec}}",
-  "@measureUnitEgg": {"placeholders": {"count": {"type": "num"}}},
+  "@measureUnitEgg": {
+    "placeholders": {
+      "count": {
+        "type": "num"
+      }
+    }
+  },
   "measureUnitPackage": "{count, plural, one{balení} few{balení} other{balení}}",
-  "@measureUnitPackage": {"placeholders": {"count": {"type": "num"}}},
+  "@measureUnitPackage": {
+    "placeholders": {
+      "count": {
+        "type": "num"
+      }
+    }
+  },
   "measureUnitPiece": "{count, plural, one{kus} few{kusy} other{kusů}}",
-  "@measureUnitPiece": {"placeholders": {"count": {"type": "num"}}},
+  "@measureUnitPiece": {
+    "placeholders": {
+      "count": {
+        "type": "num"
+      }
+    }
+  },
   "measureUnitPortion": "{count, plural, one{porce} few{porce} other{porcí}}",
-  "@measureUnitPortion": {"placeholders": {"count": {"type": "num"}}},
+  "@measureUnitPortion": {
+    "placeholders": {
+      "count": {
+        "type": "num"
+      }
+    }
+  },
   "measureUnitServing": "{count, plural, one{porce} few{porce} other{porcí}}",
-  "@measureUnitServing": {"placeholders": {"count": {"type": "num"}}},
+  "@measureUnitServing": {
+    "placeholders": {
+      "count": {
+        "type": "num"
+      }
+    }
+  },
   "measureUnitSlice": "{count, plural, one{plátek} few{plátky} other{plátků}}",
-  "@measureUnitSlice": {"placeholders": {"count": {"type": "num"}}},
+  "@measureUnitSlice": {
+    "placeholders": {
+      "count": {
+        "type": "num"
+      }
+    }
+  },
   "measureUnitTablespoon": "{count, plural, one{lžíce} few{lžíce} other{lžic}}",
-  "@measureUnitTablespoon": {"placeholders": {"count": {"type": "num"}}},
+  "@measureUnitTablespoon": {
+    "placeholders": {
+      "count": {
+        "type": "num"
+      }
+    }
+  },
   "measureUnitTeaspoon": "{count, plural, one{lžička} few{lžičky} other{lžiček}}",
-  "@measureUnitTeaspoon": {"placeholders": {"count": {"type": "num"}}},
+  "@measureUnitTeaspoon": {
+    "placeholders": {
+      "count": {
+        "type": "num"
+      }
+    }
+  },
   "settingsFoodSourcesLabel": "Databáze potravin",
   "settingsFoodSourcesSubtitle": "Vyberte, odkud pocházejí výsledky vyhledávání",
   "onboardingOtherOptionsLabel": "Další možnosti",
@@ -1058,26 +1130,40 @@
   "customMealsMergeConfirmContent": "Tímto se všechny záznamy zapsané s {loser} nahradí, aby se zobrazovaly jako {winner}, a {loser} bude odstraněna z vašich vlastních potravin. Tuto akci nelze vrátit zpět.",
   "@customMealsMergeConfirmContent": {
     "placeholders": {
-      "loser": { "type": "String" },
-      "winner": { "type": "String" }
+      "loser": {
+        "type": "String"
+      },
+      "winner": {
+        "type": "String"
+      }
     }
   },
   "customMealsMergeConfirmAction": "Sloučit",
   "customMealsMergeSuccessSnackbarOne": "Sloučeno — {winner} má nyní 1 záznam.",
   "@customMealsMergeSuccessSnackbarOne": {
-    "placeholders": { "winner": { "type": "String" } }
+    "placeholders": {
+      "winner": {
+        "type": "String"
+      }
+    }
   },
   "customMealsMergeSuccessSnackbarOther": "Sloučeno — {winner} má nyní {count} záznamů.",
   "@customMealsMergeSuccessSnackbarOther": {
     "placeholders": {
-      "count": { "type": "int" },
-      "winner": { "type": "String" }
+      "count": {
+        "type": "int"
+      },
+      "winner": {
+        "type": "String"
+      }
     }
   },
   "fastingHomeChipBody": "Půst · zbývá {remaining}",
   "@fastingHomeChipBody": {
     "placeholders": {
-      "remaining": { "type": "String" }
+      "remaining": {
+        "type": "String"
+      }
     }
   },
   "fastingNotificationChannelName": "Časovač půstu",
@@ -1145,9 +1231,21 @@
   "aiAssistEndpointFieldLabel": "Adresa serveru",
   "aiAssistModelFieldLabel": "Název modelu",
   "aiAssistDisclosureOwnServerSecure": "S uloženou adresou se text, který zadáte na obrazovce hromadného přidávání, a každá fotografie, kterou si tam necháte přečíst, odesílá na {host} — server, který provozujete vy. Nezískává jej žádná třetí strana a projekt nemá k tomuto stroji žádný vztah a nemůže nic slíbit o tom, co si uchovává. Spojení je šifrované.",
-  "@aiAssistDisclosureOwnServerSecure": {"placeholders": {"host": {"type": "String"}}},
+  "@aiAssistDisclosureOwnServerSecure": {
+    "placeholders": {
+      "host": {
+        "type": "String"
+      }
+    }
+  },
   "aiAssistDisclosureOwnServerPlaintext": "S uloženou adresou se text, který zadáte na obrazovce hromadného přidávání, a každá fotografie, kterou si tam necháte přečíst, odesílá na {host} — server, který provozujete vy. Nezískává jej žádná třetí strana a projekt nemá k tomuto stroji žádný vztah a nemůže nic slíbit o tom, co si uchovává. Tato adresa je prosté HTTP, spojení tedy není šifrované: cokoli v síti mezi tímto telefonem a oním serverem si může přečíst, co se odesílá.",
-  "@aiAssistDisclosureOwnServerPlaintext": {"placeholders": {"host": {"type": "String"}}},
+  "@aiAssistDisclosureOwnServerPlaintext": {
+    "placeholders": {
+      "host": {
+        "type": "String"
+      }
+    }
+  },
   "aiAssistEndpointInvalidLabel": "Zadejte adresu začínající na http:// nebo https://",
   "aiAssistModelRequiredLabel": "Zadejte název modelu, který má tento server použít.",
   "aiAssistEndpointPublicPlaintextLabel": "Tato adresa je veřejná a nešifrovaná, proto jsou požadavky na ni odmítány. Použijte https nebo privátní adresu.",
@@ -1215,5 +1313,6 @@
   "healthSyncDisclosureContinueAction": "Pokračovat",
   "healthSyncUnavailableLabel": "Zdravotní data nejsou na tomto zařízení dostupná. Import tréninků vyžaduje Health Connect v Androidu nebo Apple Health v iOS.",
   "sourcesEnergyCompensationTitle": "Započítání kalorií z tréninku",
-  "sourcesEnergyCompensationDescription": "Importované tréninky se započítávají s nižší energií, než jakou hlásí zařízení. Lidé cvičení kompenzují tím, že po zbytek dne spálí méně kalorií – v průměru asi 28 %, při vyšším podílu tělesného tuku více. Doporučená hodnota vychází z tohoto výzkumu a lze ji změnit v Nastavení → Synchronizace zdravotních dat. Samotnou energii hlásí aplikace nebo zařízení, které trénink zaznamenalo; nepočítá se vzorcem MET v aplikaci."
+  "sourcesEnergyCompensationDescription": "Importované tréninky se započítávají s nižší energií, než jakou hlásí zařízení. Lidé cvičení kompenzují tím, že po zbytek dne spálí méně kalorií – v průměru asi 28 %, při vyšším podílu tělesného tuku více. Doporučená hodnota vychází z tohoto výzkumu a lze ji změnit v Nastavení → Synchronizace zdravotních dat. Samotnou energii hlásí aplikace nebo zařízení, které trénink zaznamenalo; nepočítá se vzorcem MET v aplikaci.",
+  "searchRetryAfterConnectionLost": "Retry search"
 }

--- a/lib/l10n/intl_de.arb
+++ b/lib/l10n/intl_de.arb
@@ -149,29 +149,101 @@
   "foodSourcesHelpText": "Suchergebnisse stammen aus diesen Lebensmitteldatenbanken. Open Food Facts liefert die Produkt- und Barcode-Suche und ist immer aktiviert.",
   "machineTranslatedNameHint": "Name automatisch übersetzt",
   "measureUnitBar": "{count, plural, one{Riegel} other{Riegel}}",
-  "@measureUnitBar": {"placeholders": {"count": {"type": "num"}}},
+  "@measureUnitBar": {
+    "placeholders": {
+      "count": {
+        "type": "num"
+      }
+    }
+  },
   "measureUnitBottle": "{count, plural, one{Flasche} other{Flaschen}}",
-  "@measureUnitBottle": {"placeholders": {"count": {"type": "num"}}},
+  "@measureUnitBottle": {
+    "placeholders": {
+      "count": {
+        "type": "num"
+      }
+    }
+  },
   "measureUnitCan": "{count, plural, one{Dose} other{Dosen}}",
-  "@measureUnitCan": {"placeholders": {"count": {"type": "num"}}},
+  "@measureUnitCan": {
+    "placeholders": {
+      "count": {
+        "type": "num"
+      }
+    }
+  },
   "measureUnitCup": "{count, plural, one{Tasse} other{Tassen}}",
-  "@measureUnitCup": {"placeholders": {"count": {"type": "num"}}},
+  "@measureUnitCup": {
+    "placeholders": {
+      "count": {
+        "type": "num"
+      }
+    }
+  },
   "measureUnitEgg": "{count, plural, one{Ei} other{Eier}}",
-  "@measureUnitEgg": {"placeholders": {"count": {"type": "num"}}},
+  "@measureUnitEgg": {
+    "placeholders": {
+      "count": {
+        "type": "num"
+      }
+    }
+  },
   "measureUnitPackage": "{count, plural, one{Packung} other{Packungen}}",
-  "@measureUnitPackage": {"placeholders": {"count": {"type": "num"}}},
+  "@measureUnitPackage": {
+    "placeholders": {
+      "count": {
+        "type": "num"
+      }
+    }
+  },
   "measureUnitPiece": "{count, plural, one{Stück} other{Stück}}",
-  "@measureUnitPiece": {"placeholders": {"count": {"type": "num"}}},
+  "@measureUnitPiece": {
+    "placeholders": {
+      "count": {
+        "type": "num"
+      }
+    }
+  },
   "measureUnitPortion": "{count, plural, one{Portion} other{Portionen}}",
-  "@measureUnitPortion": {"placeholders": {"count": {"type": "num"}}},
+  "@measureUnitPortion": {
+    "placeholders": {
+      "count": {
+        "type": "num"
+      }
+    }
+  },
   "measureUnitServing": "{count, plural, one{Portion} other{Portionen}}",
-  "@measureUnitServing": {"placeholders": {"count": {"type": "num"}}},
+  "@measureUnitServing": {
+    "placeholders": {
+      "count": {
+        "type": "num"
+      }
+    }
+  },
   "measureUnitSlice": "{count, plural, one{Scheibe} other{Scheiben}}",
-  "@measureUnitSlice": {"placeholders": {"count": {"type": "num"}}},
+  "@measureUnitSlice": {
+    "placeholders": {
+      "count": {
+        "type": "num"
+      }
+    }
+  },
   "measureUnitTablespoon": "{count, plural, one{Esslöffel} other{Esslöffel}}",
-  "@measureUnitTablespoon": {"placeholders": {"count": {"type": "num"}}},
+  "@measureUnitTablespoon": {
+    "placeholders": {
+      "count": {
+        "type": "num"
+      }
+    }
+  },
   "measureUnitTeaspoon": "{count, plural, one{Teelöffel} other{Teelöffel}}",
-  "@measureUnitTeaspoon": {"placeholders": {"count": {"type": "num"}}},
+  "@measureUnitTeaspoon": {
+    "placeholders": {
+      "count": {
+        "type": "num"
+      }
+    }
+  },
   "settingsFoodSourcesLabel": "Lebensmitteldatenbanken",
   "settingsFoodSourcesSubtitle": "Wähle, woher die Suchergebnisse stammen",
   "onboardingOtherOptionsLabel": "Weitere Optionen",
@@ -1089,26 +1161,40 @@
   "customMealsMergeConfirmContent": "Dadurch werden alle Einträge, die mit {loser} protokolliert wurden, ersetzt, sodass sie {winner} anzeigen. Außerdem wird {loser} aus deinen eigenen Mahlzeiten entfernt. Das kann nicht rückgängig gemacht werden.",
   "@customMealsMergeConfirmContent": {
     "placeholders": {
-      "loser": { "type": "String" },
-      "winner": { "type": "String" }
+      "loser": {
+        "type": "String"
+      },
+      "winner": {
+        "type": "String"
+      }
     }
   },
   "customMealsMergeConfirmAction": "Zusammenführen",
   "customMealsMergeSuccessSnackbarOne": "Zusammengeführt — {winner} hat jetzt 1 Eintrag.",
   "@customMealsMergeSuccessSnackbarOne": {
-    "placeholders": { "winner": { "type": "String" } }
+    "placeholders": {
+      "winner": {
+        "type": "String"
+      }
+    }
   },
   "customMealsMergeSuccessSnackbarOther": "Zusammengeführt — {winner} hat jetzt {count} Einträge.",
   "@customMealsMergeSuccessSnackbarOther": {
     "placeholders": {
-      "count": { "type": "int" },
-      "winner": { "type": "String" }
+      "count": {
+        "type": "int"
+      },
+      "winner": {
+        "type": "String"
+      }
     }
   },
   "fastingHomeChipBody": "Fasten · noch {remaining}",
   "@fastingHomeChipBody": {
     "placeholders": {
-      "remaining": { "type": "String" }
+      "remaining": {
+        "type": "String"
+      }
     }
   },
   "fastingNotificationChannelName": "Fasten-Timer",
@@ -1176,9 +1262,21 @@
   "aiAssistEndpointFieldLabel": "Serveradresse",
   "aiAssistModelFieldLabel": "Modellname",
   "aiAssistDisclosureOwnServerSecure": "Mit gespeicherter Adresse wird der Text, den du auf dem Mehrfach-Hinzufügen-Bildschirm eingibst, und jedes Foto, das du dort auslesen lässt, an {host} gesendet — einen Server, den du selbst betreibst. Niemand Drittes erhält ihn, und das Projekt hat keine Beziehung zu dieser Maschine und kann nichts darüber zusagen, was sie aufbewahrt. Die Verbindung ist verschlüsselt.",
-  "@aiAssistDisclosureOwnServerSecure": {"placeholders": {"host": {"type": "String"}}},
+  "@aiAssistDisclosureOwnServerSecure": {
+    "placeholders": {
+      "host": {
+        "type": "String"
+      }
+    }
+  },
   "aiAssistDisclosureOwnServerPlaintext": "Mit gespeicherter Adresse wird der Text, den du auf dem Mehrfach-Hinzufügen-Bildschirm eingibst, und jedes Foto, das du dort auslesen lässt, an {host} gesendet — einen Server, den du selbst betreibst. Niemand Drittes erhält ihn, und das Projekt hat keine Beziehung zu dieser Maschine und kann nichts darüber zusagen, was sie aufbewahrt. Diese Adresse ist einfaches HTTP, die Verbindung ist also nicht verschlüsselt: Alles im Netzwerk zwischen diesem Telefon und dem Server kann mitlesen, was gesendet wird.",
-  "@aiAssistDisclosureOwnServerPlaintext": {"placeholders": {"host": {"type": "String"}}},
+  "@aiAssistDisclosureOwnServerPlaintext": {
+    "placeholders": {
+      "host": {
+        "type": "String"
+      }
+    }
+  },
   "aiAssistEndpointInvalidLabel": "Gib eine Adresse ein, die mit http:// oder https:// beginnt.",
   "aiAssistModelRequiredLabel": "Gib den Namen des Modells an, das dieser Server verwenden soll.",
   "aiAssistEndpointPublicPlaintextLabel": "Diese Adresse ist öffentlich und unverschlüsselt, deshalb werden Anfragen dorthin abgelehnt. Nimm https oder eine private Adresse.",
@@ -1246,5 +1344,6 @@
   "healthSyncDisclosureContinueAction": "Weiter",
   "healthSyncUnavailableLabel": "Gesundheitsdaten sind auf diesem Gerät nicht verfügbar. Der Trainingsimport benötigt Health Connect unter Android oder Apple Health unter iOS.",
   "sourcesEnergyCompensationTitle": "Anrechnung von Trainingskalorien",
-  "sourcesEnergyCompensationDescription": "Importierte Trainings werden mit weniger Energie angerechnet, als dein Gerät meldet. Menschen gleichen Sport aus, indem sie den Rest des Tages weniger Kalorien verbrennen – im Mittel etwa 28 %, bei höherem Körperfettanteil mehr. Der Vorschlag stammt aus dieser Forschung und lässt sich unter Einstellungen → Gesundheitsdaten-Sync ändern. Die Energie selbst meldet die App oder das Gerät, das das Training aufgezeichnet hat; sie wird nicht mit der MET-Formel der App berechnet."
+  "sourcesEnergyCompensationDescription": "Importierte Trainings werden mit weniger Energie angerechnet, als dein Gerät meldet. Menschen gleichen Sport aus, indem sie den Rest des Tages weniger Kalorien verbrennen – im Mittel etwa 28 %, bei höherem Körperfettanteil mehr. Der Vorschlag stammt aus dieser Forschung und lässt sich unter Einstellungen → Gesundheitsdaten-Sync ändern. Die Energie selbst meldet die App oder das Gerät, das das Training aufgezeichnet hat; sie wird nicht mit der MET-Formel der App berechnet.",
+  "searchRetryAfterConnectionLost": "Retry search"
 }

--- a/lib/l10n/intl_en.arb
+++ b/lib/l10n/intl_en.arb
@@ -204,34 +204,112 @@
   "additionalInfoLabelCustom": "Custom Meal Item",
   "additionalInfoLabelFDC": "More Information at\nFoodData Central",
   "additionalInfoLabelSource": "More Information at\n{sourceName}",
-  "@additionalInfoLabelSource": {"placeholders": {"sourceName": {"type": "String"}}},
+  "@additionalInfoLabelSource": {
+    "placeholders": {
+      "sourceName": {
+        "type": "String"
+      }
+    }
+  },
   "foodSourcesAlwaysEnabledLabel": "Always enabled",
   "foodSourcesHelpText": "Search results come from these food databases. Open Food Facts powers the product and barcode search and is always enabled.",
   "machineTranslatedNameHint": "Name translated automatically",
   "measureUnitBar": "{count, plural, one{bar} other{bars}}",
-  "@measureUnitBar": {"placeholders": {"count": {"type": "num"}}},
+  "@measureUnitBar": {
+    "placeholders": {
+      "count": {
+        "type": "num"
+      }
+    }
+  },
   "measureUnitBottle": "{count, plural, one{bottle} other{bottles}}",
-  "@measureUnitBottle": {"placeholders": {"count": {"type": "num"}}},
+  "@measureUnitBottle": {
+    "placeholders": {
+      "count": {
+        "type": "num"
+      }
+    }
+  },
   "measureUnitCan": "{count, plural, one{can} other{cans}}",
-  "@measureUnitCan": {"placeholders": {"count": {"type": "num"}}},
+  "@measureUnitCan": {
+    "placeholders": {
+      "count": {
+        "type": "num"
+      }
+    }
+  },
   "measureUnitCup": "{count, plural, one{cup} other{cups}}",
-  "@measureUnitCup": {"placeholders": {"count": {"type": "num"}}},
+  "@measureUnitCup": {
+    "placeholders": {
+      "count": {
+        "type": "num"
+      }
+    }
+  },
   "measureUnitEgg": "{count, plural, one{egg} other{eggs}}",
-  "@measureUnitEgg": {"placeholders": {"count": {"type": "num"}}},
+  "@measureUnitEgg": {
+    "placeholders": {
+      "count": {
+        "type": "num"
+      }
+    }
+  },
   "measureUnitPackage": "{count, plural, one{package} other{packages}}",
-  "@measureUnitPackage": {"placeholders": {"count": {"type": "num"}}},
+  "@measureUnitPackage": {
+    "placeholders": {
+      "count": {
+        "type": "num"
+      }
+    }
+  },
   "measureUnitPiece": "{count, plural, one{piece} other{pieces}}",
-  "@measureUnitPiece": {"placeholders": {"count": {"type": "num"}}},
+  "@measureUnitPiece": {
+    "placeholders": {
+      "count": {
+        "type": "num"
+      }
+    }
+  },
   "measureUnitPortion": "{count, plural, one{portion} other{portions}}",
-  "@measureUnitPortion": {"placeholders": {"count": {"type": "num"}}},
+  "@measureUnitPortion": {
+    "placeholders": {
+      "count": {
+        "type": "num"
+      }
+    }
+  },
   "measureUnitServing": "{count, plural, one{serving} other{servings}}",
-  "@measureUnitServing": {"placeholders": {"count": {"type": "num"}}},
+  "@measureUnitServing": {
+    "placeholders": {
+      "count": {
+        "type": "num"
+      }
+    }
+  },
   "measureUnitSlice": "{count, plural, one{slice} other{slices}}",
-  "@measureUnitSlice": {"placeholders": {"count": {"type": "num"}}},
+  "@measureUnitSlice": {
+    "placeholders": {
+      "count": {
+        "type": "num"
+      }
+    }
+  },
   "measureUnitTablespoon": "{count, plural, one{tablespoon} other{tablespoons}}",
-  "@measureUnitTablespoon": {"placeholders": {"count": {"type": "num"}}},
+  "@measureUnitTablespoon": {
+    "placeholders": {
+      "count": {
+        "type": "num"
+      }
+    }
+  },
   "measureUnitTeaspoon": "{count, plural, one{teaspoon} other{teaspoons}}",
-  "@measureUnitTeaspoon": {"placeholders": {"count": {"type": "num"}}},
+  "@measureUnitTeaspoon": {
+    "placeholders": {
+      "count": {
+        "type": "num"
+      }
+    }
+  },
   "settingsFoodSourcesLabel": "Food databases",
   "settingsFoodSourcesSubtitle": "Choose where food search results come from",
   "onboardingOtherOptionsLabel": "Other options",
@@ -246,7 +324,13 @@
   "appLicenseLabel": "GPL-3.0 license",
   "appTitle": "OpenNutriTracker",
   "appVersionName": "Version {versionNumber}",
-  "@appVersionName": {"placeholders": {"versionNumber": {"type": "String"}}},
+  "@appVersionName": {
+    "placeholders": {
+      "versionNumber": {
+        "type": "String"
+      }
+    }
+  },
   "barcodeInvalidEan13CheckDigit": "This 13-digit barcode looks miskeyed: its last digit doesn't match the rest",
   "baseQuantityLabel": "Nutrition is per",
   "bmiInfo": "Body Mass Index (BMI) is a index to classify overweight and obesity in adults. It is defined as weight in kilograms divided by the square of height in meters (kg/m²).\n\nBMI does not differentiate between fat and muscle mass and can be misleading for some individuals.",
@@ -265,7 +349,13 @@
   "calciumLabel": "calcium",
   "calculationsMacronutrientsDistributionLabel": "Macros distribution",
   "calculationsMacrosDistribution": "{pctCarbs}% carbs, {pctFats}% fats, {pctProteins}% proteins",
-  "@calculationsMacrosDistribution": {"placeholders": {"pctCarbs": {}, "pctFats": {}, "pctProteins": {}}},
+  "@calculationsMacrosDistribution": {
+    "placeholders": {
+      "pctCarbs": {},
+      "pctFats": {},
+      "pctProteins": {}
+    }
+  },
   "calculationsRecommendedLabel": "(recommended)",
   "calculationsTDEEIOM2006Label": "Institute of Medicine Equation (2005)",
   "calculationsTDEELabel": "TDEE equation",
@@ -565,7 +655,13 @@
   "nutritionalStatusRiskAverage": "Average",
   "nutritionalStatusRiskIncreased": "Increased",
   "nutritionalStatusRiskLabel": "Risk of comorbidities: {riskValue}",
-  "@nutritionalStatusRiskLabel": {"placeholders": {"riskValue": {"type": "String"}}},
+  "@nutritionalStatusRiskLabel": {
+    "placeholders": {
+      "riskValue": {
+        "type": "String"
+      }
+    }
+  },
   "nutritionalStatusRiskLow": "Low \n(but risk of other \nclinical problems increased)",
   "nutritionalStatusRiskModerate": "Moderate",
   "nutritionalStatusRiskSevere": "Severe",
@@ -587,26 +683,71 @@
   "onboardingGenderQuestionSubtitle": "What's your gender?",
   "onboardingGoalQuestionSubtitle": "What's your current weight goal?",
   "onboardingFoodSourcesEnabledCount": "{enabled} of {total} enabled",
-  "@onboardingFoodSourcesEnabledCount": {"placeholders": {"enabled": {"type": "int"}, "total": {"type": "int"}}},
+  "@onboardingFoodSourcesEnabledCount": {
+    "placeholders": {
+      "enabled": {
+        "type": "int"
+      },
+      "total": {
+        "type": "int"
+      }
+    }
+  },
   "onboardingGoalSuggestedBadge": "Suggested",
   "onboardingGoalSuggestionBmi": "Your BMI is {bmi} — WHO: {status}.",
-  "@onboardingGoalSuggestionBmi": {"placeholders": {"bmi": {"type": "String"}, "status": {"type": "String"}}},
+  "@onboardingGoalSuggestionBmi": {
+    "placeholders": {
+      "bmi": {
+        "type": "String"
+      },
+      "status": {
+        "type": "String"
+      }
+    }
+  },
   "onboardingGoalSuggestionTarget": "Based on the target weight you entered.",
   "onboardingHeightExampleHintCm": "e.g. 170",
   "onboardingHeightExampleHintFt": "e.g. 5.8",
   "onboardingHeightQuestionSubtitle": "What's your current height?",
   "onboardingHealthyRangeApply": "Use {weight}",
-  "@onboardingHealthyRangeApply": {"placeholders": {"weight": {"type": "String"}}},
+  "@onboardingHealthyRangeApply": {
+    "placeholders": {
+      "weight": {
+        "type": "String"
+      }
+    }
+  },
   "onboardingHealthyRangeLabel": "Healthy range for {height}: {range}",
-  "@onboardingHealthyRangeLabel": {"placeholders": {"height": {"type": "String"}, "range": {"type": "String"}}},
+  "@onboardingHealthyRangeLabel": {
+    "placeholders": {
+      "height": {
+        "type": "String"
+      },
+      "range": {
+        "type": "String"
+      }
+    }
+  },
   "onboardingHealthyRangeSource": "WHO, BMI 18.5–24.9",
   "onboardingImplausibleChange": "Change",
   "onboardingImplausibleHeightBody": "{value} is an unusual height. Keep it?",
-  "@onboardingImplausibleHeightBody": {"placeholders": {"value": {"type": "String"}}},
+  "@onboardingImplausibleHeightBody": {
+    "placeholders": {
+      "value": {
+        "type": "String"
+      }
+    }
+  },
   "onboardingImplausibleKeep": "Keep",
   "onboardingImplausibleTitle": "Double-check this value",
   "onboardingImplausibleWeightBody": "{value} is an unusual weight. Keep it?",
-  "@onboardingImplausibleWeightBody": {"placeholders": {"value": {"type": "String"}}},
+  "@onboardingImplausibleWeightBody": {
+    "placeholders": {
+      "value": {
+        "type": "String"
+      }
+    }
+  },
   "onboardingIntroDescription": "To start, the app needs some information about you to calculate your daily calorie goal.\nAll information about you is stored securely on your device.",
   "onboardingIntroSourcesLinkLabel": "Read our medical calculation sources",
   "onboardingKcalPerDayLabel": "kcal per day",
@@ -1089,7 +1230,13 @@
   "weightHistoryWeightLabel": "Weight",
   "weightLabel": "Weight",
   "yearsLabel": "{age} years",
-  "@yearsLabel": {"placeholders": {"age": {"type": "int"}}},
+  "@yearsLabel": {
+    "placeholders": {
+      "age": {
+        "type": "int"
+      }
+    }
+  },
   "logWaterAmountLabel": "Add {amount} ml",
   "logWaterDialogTitle": "Log water intake",
   "logWaterNothingToUndoLabel": "Nothing to undo",
@@ -1142,26 +1289,40 @@
   "customMealsMergeConfirmContent": "This will replace all entries logged with {loser} so they show {winner} instead, and remove {loser} from your custom foods. This can't be undone.",
   "@customMealsMergeConfirmContent": {
     "placeholders": {
-      "loser": { "type": "String" },
-      "winner": { "type": "String" }
+      "loser": {
+        "type": "String"
+      },
+      "winner": {
+        "type": "String"
+      }
     }
   },
   "customMealsMergeConfirmAction": "Merge",
   "customMealsMergeSuccessSnackbarOne": "Merged — {winner} now has 1 logged entry.",
   "@customMealsMergeSuccessSnackbarOne": {
-    "placeholders": { "winner": { "type": "String" } }
+    "placeholders": {
+      "winner": {
+        "type": "String"
+      }
+    }
   },
   "customMealsMergeSuccessSnackbarOther": "Merged — {winner} now has {count} logged entries.",
   "@customMealsMergeSuccessSnackbarOther": {
     "placeholders": {
-      "count": { "type": "int" },
-      "winner": { "type": "String" }
+      "count": {
+        "type": "int"
+      },
+      "winner": {
+        "type": "String"
+      }
     }
   },
   "fastingHomeChipBody": "Fasting · {remaining} left",
   "@fastingHomeChipBody": {
     "placeholders": {
-      "remaining": { "type": "String" }
+      "remaining": {
+        "type": "String"
+      }
     }
   },
   "fastingNotificationChannelName": "Fasting timer",
@@ -1203,35 +1364,41 @@
   "bulkAddChooseFoodLabel": "Choose another food",
   "bulkAddNothingToLogLabel": "Nothing to log yet",
   "bulkAddSearchFailedLabel": "Couldn't search for these foods",
-  "@bulkAddSubmitLabel": {"placeholders": {"count": {"type": "int"}}},
+  "@bulkAddSubmitLabel": {
+    "placeholders": {
+      "count": {
+        "type": "int"
+      }
+    }
+  },
   "bulkAddCheckAmountLabel": "Check the unit for this amount",
   "bulkAddDefaultAmountLabel": "Amount not stated",
   "bulkAddErrorInvalidName": "Item {number}: not a valid food name",
   "@bulkAddErrorInvalidName": {
-      "placeholders": {
-          "number": {
-              "type": "int"
-          }
+    "placeholders": {
+      "number": {
+        "type": "int"
       }
+    }
   },
   "bulkAddErrorQuantityTooSmall": "Item {number}: quantity must be greater than 0",
   "@bulkAddErrorQuantityTooSmall": {
-      "placeholders": {
-          "number": {
-              "type": "int"
-          }
+    "placeholders": {
+      "number": {
+        "type": "int"
       }
+    }
   },
   "bulkAddErrorQuantityTooLarge": "Item {number}: quantity must be {bound} or less",
   "@bulkAddErrorQuantityTooLarge": {
-      "placeholders": {
-          "number": {
-              "type": "int"
-          },
-          "bound": {
-              "type": "int"
-          }
+    "placeholders": {
+      "number": {
+        "type": "int"
+      },
+      "bound": {
+        "type": "int"
       }
+    }
   },
   "settingsAiAssistLabel": "AI meal assistance",
   "settingsAiAssistNotConfiguredLabel": "Off — no key saved",
@@ -1244,7 +1411,7 @@
   "bulkAddModelHintLabel": "A model can read this for you",
   "bulkAddModelHintKeyLabel": "With your own API key",
   "aiConsentChangeProviderNote": "You can change provider later. Each provider's terms are shown in Settings, and nothing you type or photograph is sent until you use the feature.",
-  "aiConsentOwnServerCheckNote": "Saving your server's address also asks it which models it offers, and runs one setup check \u2014 a fixed example line and a sample photograph of ours, never anything of yours.",
+  "aiConsentOwnServerCheckNote": "Saving your server's address also asks it which models it offers, and runs one setup check — a fixed example line and a sample photograph of ours, never anything of yours.",
   "aiConsentAgreeLabel": "I UNDERSTAND",
   "aiAssistDisclosureCommon": "Your diary and your profile are never sent. Nutrition values always come from the food databases, never from the model. The key is stored on this device only: OpenNutriTracker never sees it and does not pay for its use.",
   "aiAssistDisclosureAnthropic": "With a key saved, the text you type on the multi-item add screen — and any photo you choose to read there — is sent to Anthropic. Photos are sent for that one request and never saved.",
@@ -1254,15 +1421,33 @@
   "aiAssistEndpointFieldLabel": "Server address",
   "aiAssistModelFieldLabel": "Model name",
   "aiAssistDisclosureOwnServerSecure": "With an address saved, the text you type on the multi-item add screen, and any photo you choose to read there, is sent to {host} — a server you run. No third party receives it, and the project has no relationship with that machine and can promise nothing about what it keeps. The connection is encrypted.",
-  "@aiAssistDisclosureOwnServerSecure": {"placeholders": {"host": {"type": "String"}}},
+  "@aiAssistDisclosureOwnServerSecure": {
+    "placeholders": {
+      "host": {
+        "type": "String"
+      }
+    }
+  },
   "aiAssistDisclosureOwnServerPlaintext": "With an address saved, the text you type on the multi-item add screen, and any photo you choose to read there, is sent to {host} — a server you run. No third party receives it, and the project has no relationship with that machine and can promise nothing about what it keeps. This address is plain HTTP, so the connection is not encrypted: anything on the network between this phone and that server can read what is sent.",
-  "@aiAssistDisclosureOwnServerPlaintext": {"placeholders": {"host": {"type": "String"}}},
+  "@aiAssistDisclosureOwnServerPlaintext": {
+    "placeholders": {
+      "host": {
+        "type": "String"
+      }
+    }
+  },
   "aiAssistEndpointInvalidLabel": "Enter an address starting with http:// or https://",
   "aiAssistModelRequiredLabel": "Name the model this server should use.",
   "aiAssistEndpointPublicPlaintextLabel": "That address is public and unencrypted, so requests to it are refused. Use https, or a private address.",
   "aiAssistProbeSectionLabel": "Setup check",
   "aiAssistProbeRunningLabel": "Checking this server. The two checks run one after the other, so allow up to {minutes, plural, one{a minute} other{{minutes} minutes}} — you can close this, and the answer will be here when you come back.",
-  "@aiAssistProbeRunningLabel": {"placeholders": {"minutes": {"type": "int"}}},
+  "@aiAssistProbeRunningLabel": {
+    "placeholders": {
+      "minutes": {
+        "type": "int"
+      }
+    }
+  },
   "aiAssistProbeCheckLabel": "Check this server",
   "aiAssistProbeTextLabel": "Meal text",
   "aiAssistProbePhotoLabel": "Photos",
@@ -1274,23 +1459,53 @@
   "aiAssistLoadModelsLabel": "Load models",
   "aiAssistPickModelLabel": "Choose a model",
   "aiAssistModelsUnreachableLabel": "Could not reach {host}. It may be asleep, on another network, or behind a VPN — type the model name instead.",
-  "@aiAssistModelsUnreachableLabel": {"placeholders": {"host": {"type": "String"}}},
+  "@aiAssistModelsUnreachableLabel": {
+    "placeholders": {
+      "host": {
+        "type": "String"
+      }
+    }
+  },
   "aiAssistModelsEmptyLabel": "{host} answered, and lists no models. Type the model name instead.",
-  "@aiAssistModelsEmptyLabel": {"placeholders": {"host": {"type": "String"}}},
+  "@aiAssistModelsEmptyLabel": {
+    "placeholders": {
+      "host": {
+        "type": "String"
+      }
+    }
+  },
   "aiAssistModelsRejectedLabel": "{host} answered, but not with a model list. Check the address, or type the model name instead.",
-  "@aiAssistModelsRejectedLabel": {"placeholders": {"host": {"type": "String"}}},
+  "@aiAssistModelsRejectedLabel": {
+    "placeholders": {
+      "host": {
+        "type": "String"
+      }
+    }
+  },
   "aiAssistModelsInsecureLabel": "Nothing was sent: that address is public and unencrypted. Use https, or type the model name instead.",
   "aiAssistProviderLabel": "Provider",
   "aiAssistModelLabel": "Model",
   "aiAssistServedByLabel": "Served by {provider}",
-  "@aiAssistServedByLabel": {"placeholders": {"provider": {"type": "String"}}},
+  "@aiAssistServedByLabel": {
+    "placeholders": {
+      "provider": {
+        "type": "String"
+      }
+    }
+  },
   "aiAssistModelRecommendedLabel": "Recommended",
   "aiAssistModelCheaperLabel": "Cheaper, and weaker on poor-quality photos",
   "aiAssistModelMoreItemsLabel": "Lists more items from a photo",
   "aiAssistModelCheapestLabel": "Cheapest on this list",
   "aiAssistNoKeyForProviderLabel": "No key saved for this provider.",
   "aiAssistKeyFieldLabel": "{provider} API key",
-  "@aiAssistKeyFieldLabel": {"placeholders": {"provider": {"type": "String"}}},
+  "@aiAssistKeyFieldLabel": {
+    "placeholders": {
+      "provider": {
+        "type": "String"
+      }
+    }
+  },
   "aiAssistKeySavedLabel": "Key saved",
   "aiAssistRemoveKeyLabel": "Remove key",
   "bulkAddReadByModelLabel": "Read by AI — check each row",
@@ -1303,10 +1518,22 @@
   "bulkAddPhotoDisclosureCommon": "OpenNutriTracker keeps no copy of its own, and it is never included in your exports.",
   "bulkAddPhotoDisclosureAnthropic": "The photo is sent to Anthropic to identify the foods in it.",
   "bulkAddPhotoDisclosureOpenRouter": "The photo is sent to OpenRouter, which forwards it to {provider} to identify the foods in it.",
-  "@bulkAddPhotoDisclosureOpenRouter": {"placeholders": {"provider": {"type": "String"}}},
+  "@bulkAddPhotoDisclosureOpenRouter": {
+    "placeholders": {
+      "provider": {
+        "type": "String"
+      }
+    }
+  },
   "bulkAddPhotoDisclosureOpenAI": "The photo is sent to OpenAI to identify the foods in it. OpenAI keeps it for up to 30 days to monitor for abuse, and longer if the law requires it or it is reasonably necessary to protect its services or a third party from harm.",
   "bulkAddPhotoDisclosureOwnServer": "The photo is sent to {host} to identify the foods in it.",
-  "@bulkAddPhotoDisclosureOwnServer": {"placeholders": {"host": {"type": "String"}}},
+  "@bulkAddPhotoDisclosureOwnServer": {
+    "placeholders": {
+      "host": {
+        "type": "String"
+      }
+    }
+  },
   "bulkAddReadFromPhotoLabel": "Read from a photo — check every food and amount",
   "bulkAddPhotoUnavailableLabel": "Turn on AI meal assistance in Settings to read photos",
   "bulkAddPhotoKeyRejectedLabel": "Your API key was rejected. Check it in Settings.",
@@ -1318,27 +1545,79 @@
   "bulkAddPhotoNoFoodLabel": "No food found in that photo. Try another photo, or type the items instead.",
   "settingsHealthSyncSubtitle": "Import workouts",
   "healthSyncAutoImportLabel": "Automatically import workouts from {platform}",
-  "@healthSyncAutoImportLabel": {"placeholders": {"platform": {"type": "String"}}},
+  "@healthSyncAutoImportLabel": {
+    "placeholders": {
+      "platform": {
+        "type": "String"
+      }
+    }
+  },
   "healthSyncKcalMultiplierLabel": "Workout calorie credit",
   "healthSyncKcalMultiplierSubtitle": "Your body typically compensates for exercise by burning fewer calories the rest of the day. 100% credits every workout calorie toward your daily goal.",
   "healthSyncKcalMultiplierValueLabel": "{percent}%",
-  "@healthSyncKcalMultiplierValueLabel": {"placeholders": {"percent": {"type": "int"}}},
+  "@healthSyncKcalMultiplierValueLabel": {
+    "placeholders": {
+      "percent": {
+        "type": "int"
+      }
+    }
+  },
   "healthSyncSuggestedLabel": "Suggested for you: {percent}%",
-  "@healthSyncSuggestedLabel": {"placeholders": {"percent": {"type": "int"}}},
+  "@healthSyncSuggestedLabel": {
+    "placeholders": {
+      "percent": {
+        "type": "int"
+      }
+    }
+  },
   "healthSyncImportNowLabel": "Import now",
   "healthSyncLastImportLabel": "Last import: {time}",
-  "@healthSyncLastImportLabel": {"placeholders": {"time": {"type": "String"}}},
+  "@healthSyncLastImportLabel": {
+    "placeholders": {
+      "time": {
+        "type": "String"
+      }
+    }
+  },
   "healthSyncNeverImportedLabel": "No workouts imported yet",
   "healthSyncImportedCountLabel": "{count, plural, =0{No new workouts} one{1 workout imported} other{{count} workouts imported}}",
-  "@healthSyncImportedCountLabel": {"placeholders": {"count": {"type": "num"}}},
+  "@healthSyncImportedCountLabel": {
+    "placeholders": {
+      "count": {
+        "type": "num"
+      }
+    }
+  },
   "healthSyncPermissionDeniedLabel": "{platform} access was not granted. Allow OpenNutriTracker to read workouts and body fat to import them.",
-  "@healthSyncPermissionDeniedLabel": {"placeholders": {"platform": {"type": "String"}}},
+  "@healthSyncPermissionDeniedLabel": {
+    "placeholders": {
+      "platform": {
+        "type": "String"
+      }
+    }
+  },
   "healthSyncDisclosureTitle": "Import workouts from {platform}?",
-  "@healthSyncDisclosureTitle": {"placeholders": {"platform": {"type": "String"}}},
+  "@healthSyncDisclosureTitle": {
+    "placeholders": {
+      "platform": {
+        "type": "String"
+      }
+    }
+  },
   "healthSyncDisclosureBody": "OpenNutriTracker will read your finished workouts from {platform} — their type, when they happened, how long they lasted and the energy they report — and the most recent body fat percentage it holds.\n\nWorkouts are filed in your diary as activities you can edit or delete, and the energy they report raises that day's calorie goal by a share you choose. The body fat reading is used to suggest what that share should be.\n\nNothing is written back to {platform}, and none of it is sent anywhere — it stays on this device.\n\nYou can turn this off at any time, and doing so stops any further reading.",
-  "@healthSyncDisclosureBody": {"placeholders": {"platform": {"type": "String"}}},
+  "@healthSyncDisclosureBody": {
+    "placeholders": {
+      "platform": {
+        "type": "String"
+      }
+    }
+  },
   "healthSyncDisclosureContinueAction": "Continue",
   "healthSyncUnavailableLabel": "Health data is not available on this device. Workout import needs Health Connect on Android or Apple Health on iOS.",
   "sourcesEnergyCompensationTitle": "Workout calorie credit",
-  "sourcesEnergyCompensationDescription": "Imported workouts are credited with less than the energy your device reports. People compensate for exercise by burning fewer calories through the rest of the day — about 28% on average, and more at a higher body fat percentage. The suggested credit comes from that research and you can override it under Settings → Health sync. The energy itself is reported by the app or device that recorded the workout, not calculated with the app’s MET formula."
+  "sourcesEnergyCompensationDescription": "Imported workouts are credited with less than the energy your device reports. People compensate for exercise by burning fewer calories through the rest of the day — about 28% on average, and more at a higher body fat percentage. The suggested credit comes from that research and you can override it under Settings → Health sync. The energy itself is reported by the app or device that recorded the workout, not calculated with the app’s MET formula.",
+  "searchRetryAfterConnectionLost": "Retry search",
+  "@searchRetryAfterConnectionLost": {
+    "description": "Button on the food search screen, shown after the connection dropped."
+  }
 }

--- a/lib/l10n/intl_it.arb
+++ b/lib/l10n/intl_it.arb
@@ -118,29 +118,101 @@
   "foodSourcesHelpText": "I risultati di ricerca provengono da questi database alimentari. Open Food Facts alimenta la ricerca di prodotti e codici a barre ed è sempre attivo.",
   "machineTranslatedNameHint": "Nome tradotto automaticamente",
   "measureUnitBar": "{count, plural, one{barretta} other{barrette}}",
-  "@measureUnitBar": {"placeholders": {"count": {"type": "num"}}},
+  "@measureUnitBar": {
+    "placeholders": {
+      "count": {
+        "type": "num"
+      }
+    }
+  },
   "measureUnitBottle": "{count, plural, one{bottiglia} other{bottiglie}}",
-  "@measureUnitBottle": {"placeholders": {"count": {"type": "num"}}},
+  "@measureUnitBottle": {
+    "placeholders": {
+      "count": {
+        "type": "num"
+      }
+    }
+  },
   "measureUnitCan": "{count, plural, one{lattina} other{lattine}}",
-  "@measureUnitCan": {"placeholders": {"count": {"type": "num"}}},
+  "@measureUnitCan": {
+    "placeholders": {
+      "count": {
+        "type": "num"
+      }
+    }
+  },
   "measureUnitCup": "{count, plural, one{tazza} other{tazze}}",
-  "@measureUnitCup": {"placeholders": {"count": {"type": "num"}}},
+  "@measureUnitCup": {
+    "placeholders": {
+      "count": {
+        "type": "num"
+      }
+    }
+  },
   "measureUnitEgg": "{count, plural, one{uovo} other{uova}}",
-  "@measureUnitEgg": {"placeholders": {"count": {"type": "num"}}},
+  "@measureUnitEgg": {
+    "placeholders": {
+      "count": {
+        "type": "num"
+      }
+    }
+  },
   "measureUnitPackage": "{count, plural, one{confezione} other{confezioni}}",
-  "@measureUnitPackage": {"placeholders": {"count": {"type": "num"}}},
+  "@measureUnitPackage": {
+    "placeholders": {
+      "count": {
+        "type": "num"
+      }
+    }
+  },
   "measureUnitPiece": "{count, plural, one{pezzo} other{pezzi}}",
-  "@measureUnitPiece": {"placeholders": {"count": {"type": "num"}}},
+  "@measureUnitPiece": {
+    "placeholders": {
+      "count": {
+        "type": "num"
+      }
+    }
+  },
   "measureUnitPortion": "{count, plural, one{porzione} other{porzioni}}",
-  "@measureUnitPortion": {"placeholders": {"count": {"type": "num"}}},
+  "@measureUnitPortion": {
+    "placeholders": {
+      "count": {
+        "type": "num"
+      }
+    }
+  },
   "measureUnitServing": "{count, plural, one{porzione} other{porzioni}}",
-  "@measureUnitServing": {"placeholders": {"count": {"type": "num"}}},
+  "@measureUnitServing": {
+    "placeholders": {
+      "count": {
+        "type": "num"
+      }
+    }
+  },
   "measureUnitSlice": "{count, plural, one{fetta} other{fette}}",
-  "@measureUnitSlice": {"placeholders": {"count": {"type": "num"}}},
+  "@measureUnitSlice": {
+    "placeholders": {
+      "count": {
+        "type": "num"
+      }
+    }
+  },
   "measureUnitTablespoon": "{count, plural, one{cucchiaio} other{cucchiai}}",
-  "@measureUnitTablespoon": {"placeholders": {"count": {"type": "num"}}},
+  "@measureUnitTablespoon": {
+    "placeholders": {
+      "count": {
+        "type": "num"
+      }
+    }
+  },
   "measureUnitTeaspoon": "{count, plural, one{cucchiaino} other{cucchiaini}}",
-  "@measureUnitTeaspoon": {"placeholders": {"count": {"type": "num"}}},
+  "@measureUnitTeaspoon": {
+    "placeholders": {
+      "count": {
+        "type": "num"
+      }
+    }
+  },
   "settingsFoodSourcesLabel": "Database alimentari",
   "settingsFoodSourcesSubtitle": "Scegli da dove provengono i risultati di ricerca",
   "onboardingOtherOptionsLabel": "Altre opzioni",
@@ -1058,26 +1130,40 @@
   "customMealsMergeConfirmContent": "Tutte le voci registrate con {loser} verranno sostituite e mostrate come {winner}, e {loser} sarà rimosso dai tuoi alimenti personalizzati. Questa operazione non può essere annullata.",
   "@customMealsMergeConfirmContent": {
     "placeholders": {
-      "loser": { "type": "String" },
-      "winner": { "type": "String" }
+      "loser": {
+        "type": "String"
+      },
+      "winner": {
+        "type": "String"
+      }
     }
   },
   "customMealsMergeConfirmAction": "Unisci",
   "customMealsMergeSuccessSnackbarOne": "Unito — {winner} ora ha 1 voce registrata.",
   "@customMealsMergeSuccessSnackbarOne": {
-    "placeholders": { "winner": { "type": "String" } }
+    "placeholders": {
+      "winner": {
+        "type": "String"
+      }
+    }
   },
   "customMealsMergeSuccessSnackbarOther": "Unito — {winner} ora ha {count} voci registrate.",
   "@customMealsMergeSuccessSnackbarOther": {
     "placeholders": {
-      "count": { "type": "int" },
-      "winner": { "type": "String" }
+      "count": {
+        "type": "int"
+      },
+      "winner": {
+        "type": "String"
+      }
     }
   },
   "fastingHomeChipBody": "Digiuno · {remaining} rimanenti",
   "@fastingHomeChipBody": {
     "placeholders": {
-      "remaining": { "type": "String" }
+      "remaining": {
+        "type": "String"
+      }
     }
   },
   "fastingNotificationChannelName": "Timer del digiuno",
@@ -1145,9 +1231,21 @@
   "aiAssistEndpointFieldLabel": "Indirizzo del server",
   "aiAssistModelFieldLabel": "Nome del modello",
   "aiAssistDisclosureOwnServerSecure": "Con un indirizzo salvato, il testo che digiti nella schermata di aggiunta multipla, e ogni foto che scegli di far leggere lì, viene inviato a {host} — un server gestito da te. Nessuna terza parte lo riceve, e il progetto non ha alcun rapporto con quella macchina e non può promettere nulla su ciò che conserva. La connessione è cifrata.",
-  "@aiAssistDisclosureOwnServerSecure": {"placeholders": {"host": {"type": "String"}}},
+  "@aiAssistDisclosureOwnServerSecure": {
+    "placeholders": {
+      "host": {
+        "type": "String"
+      }
+    }
+  },
   "aiAssistDisclosureOwnServerPlaintext": "Con un indirizzo salvato, il testo che digiti nella schermata di aggiunta multipla, e ogni foto che scegli di far leggere lì, viene inviato a {host} — un server gestito da te. Nessuna terza parte lo riceve, e il progetto non ha alcun rapporto con quella macchina e non può promettere nulla su ciò che conserva. Questo indirizzo è HTTP in chiaro, quindi la connessione non è cifrata: qualsiasi cosa sulla rete fra questo telefono e quel server può leggere ciò che viene inviato.",
-  "@aiAssistDisclosureOwnServerPlaintext": {"placeholders": {"host": {"type": "String"}}},
+  "@aiAssistDisclosureOwnServerPlaintext": {
+    "placeholders": {
+      "host": {
+        "type": "String"
+      }
+    }
+  },
   "aiAssistEndpointInvalidLabel": "Inserisci un indirizzo che inizi con http:// o https://",
   "aiAssistModelRequiredLabel": "Indica il nome del modello che questo server deve usare.",
   "aiAssistEndpointPublicPlaintextLabel": "Questo indirizzo è pubblico e non cifrato, quindi le richieste verso di esso vengono rifiutate. Usa https o un indirizzo privato.",
@@ -1215,5 +1313,6 @@
   "healthSyncDisclosureContinueAction": "Continua",
   "healthSyncUnavailableLabel": "I dati sulla salute non sono disponibili su questo dispositivo. L’importazione degli allenamenti richiede Health Connect su Android o Apple Health su iOS.",
   "sourcesEnergyCompensationTitle": "Credito calorico degli allenamenti",
-  "sourcesEnergyCompensationDescription": "Gli allenamenti importati vengono accreditati con un’energia inferiore a quella riportata dal dispositivo. Le persone compensano l’attività fisica bruciando meno calorie nel resto della giornata: in media circa il 28%, di più con una massa grassa elevata. Il valore consigliato deriva da questa ricerca e puoi modificarlo in Impostazioni → Sincronizzazione salute. L’energia è quella riportata dall’app o dal dispositivo che ha registrato l’allenamento, non è calcolata con la formula MET dell’app."
+  "sourcesEnergyCompensationDescription": "Gli allenamenti importati vengono accreditati con un’energia inferiore a quella riportata dal dispositivo. Le persone compensano l’attività fisica bruciando meno calorie nel resto della giornata: in media circa il 28%, di più con una massa grassa elevata. Il valore consigliato deriva da questa ricerca e puoi modificarlo in Impostazioni → Sincronizzazione salute. L’energia è quella riportata dall’app o dal dispositivo che ha registrato l’allenamento, non è calcolata con la formula MET dell’app.",
+  "searchRetryAfterConnectionLost": "Retry search"
 }

--- a/lib/l10n/intl_pl.arb
+++ b/lib/l10n/intl_pl.arb
@@ -118,29 +118,101 @@
   "foodSourcesHelpText": "Wyniki wyszukiwania pochodzą z tych baz danych żywności. Open Food Facts obsługuje wyszukiwanie produktów i kodów kreskowych i jest zawsze włączona.",
   "machineTranslatedNameHint": "Nazwa przetłumaczona automatycznie",
   "measureUnitBar": "{count, plural, one{baton} few{batony} many{batonów} other{batona}}",
-  "@measureUnitBar": {"placeholders": {"count": {"type": "num"}}},
+  "@measureUnitBar": {
+    "placeholders": {
+      "count": {
+        "type": "num"
+      }
+    }
+  },
   "measureUnitBottle": "{count, plural, one{butelka} few{butelki} many{butelek} other{butelki}}",
-  "@measureUnitBottle": {"placeholders": {"count": {"type": "num"}}},
+  "@measureUnitBottle": {
+    "placeholders": {
+      "count": {
+        "type": "num"
+      }
+    }
+  },
   "measureUnitCan": "{count, plural, one{puszka} few{puszki} many{puszek} other{puszki}}",
-  "@measureUnitCan": {"placeholders": {"count": {"type": "num"}}},
+  "@measureUnitCan": {
+    "placeholders": {
+      "count": {
+        "type": "num"
+      }
+    }
+  },
   "measureUnitCup": "{count, plural, one{filiżanka} few{filiżanki} many{filiżanek} other{filiżanki}}",
-  "@measureUnitCup": {"placeholders": {"count": {"type": "num"}}},
+  "@measureUnitCup": {
+    "placeholders": {
+      "count": {
+        "type": "num"
+      }
+    }
+  },
   "measureUnitEgg": "{count, plural, one{jajko} few{jajka} many{jajek} other{jajka}}",
-  "@measureUnitEgg": {"placeholders": {"count": {"type": "num"}}},
+  "@measureUnitEgg": {
+    "placeholders": {
+      "count": {
+        "type": "num"
+      }
+    }
+  },
   "measureUnitPackage": "{count, plural, one{opakowanie} few{opakowania} many{opakowań} other{opakowania}}",
-  "@measureUnitPackage": {"placeholders": {"count": {"type": "num"}}},
+  "@measureUnitPackage": {
+    "placeholders": {
+      "count": {
+        "type": "num"
+      }
+    }
+  },
   "measureUnitPiece": "{count, plural, one{kawałek} few{kawałki} many{kawałków} other{kawałka}}",
-  "@measureUnitPiece": {"placeholders": {"count": {"type": "num"}}},
+  "@measureUnitPiece": {
+    "placeholders": {
+      "count": {
+        "type": "num"
+      }
+    }
+  },
   "measureUnitPortion": "{count, plural, one{porcja} few{porcje} many{porcji} other{porcji}}",
-  "@measureUnitPortion": {"placeholders": {"count": {"type": "num"}}},
+  "@measureUnitPortion": {
+    "placeholders": {
+      "count": {
+        "type": "num"
+      }
+    }
+  },
   "measureUnitServing": "{count, plural, one{porcja} few{porcje} many{porcji} other{porcji}}",
-  "@measureUnitServing": {"placeholders": {"count": {"type": "num"}}},
+  "@measureUnitServing": {
+    "placeholders": {
+      "count": {
+        "type": "num"
+      }
+    }
+  },
   "measureUnitSlice": "{count, plural, one{plasterek} few{plasterki} many{plasterków} other{plasterka}}",
-  "@measureUnitSlice": {"placeholders": {"count": {"type": "num"}}},
+  "@measureUnitSlice": {
+    "placeholders": {
+      "count": {
+        "type": "num"
+      }
+    }
+  },
   "measureUnitTablespoon": "{count, plural, one{łyżka} few{łyżki} many{łyżek} other{łyżki}}",
-  "@measureUnitTablespoon": {"placeholders": {"count": {"type": "num"}}},
+  "@measureUnitTablespoon": {
+    "placeholders": {
+      "count": {
+        "type": "num"
+      }
+    }
+  },
   "measureUnitTeaspoon": "{count, plural, one{łyżeczka} few{łyżeczki} many{łyżeczek} other{łyżeczki}}",
-  "@measureUnitTeaspoon": {"placeholders": {"count": {"type": "num"}}},
+  "@measureUnitTeaspoon": {
+    "placeholders": {
+      "count": {
+        "type": "num"
+      }
+    }
+  },
   "settingsFoodSourcesLabel": "Bazy danych żywności",
   "settingsFoodSourcesSubtitle": "Wybierz, skąd pochodzą wyniki wyszukiwania",
   "onboardingOtherOptionsLabel": "Inne opcje",
@@ -1058,26 +1130,40 @@
   "customMealsMergeConfirmContent": "Spowoduje to zastąpienie wszystkich wpisów zarejestrowanych z {loser}, tak by pokazywały {winner}, oraz usunie {loser} z Twoich własnych produktów. Tej operacji nie można cofnąć.",
   "@customMealsMergeConfirmContent": {
     "placeholders": {
-      "loser": { "type": "String" },
-      "winner": { "type": "String" }
+      "loser": {
+        "type": "String"
+      },
+      "winner": {
+        "type": "String"
+      }
     }
   },
   "customMealsMergeConfirmAction": "Połącz",
   "customMealsMergeSuccessSnackbarOne": "Połączono — {winner} ma teraz 1 wpis.",
   "@customMealsMergeSuccessSnackbarOne": {
-    "placeholders": { "winner": { "type": "String" } }
+    "placeholders": {
+      "winner": {
+        "type": "String"
+      }
+    }
   },
   "customMealsMergeSuccessSnackbarOther": "Połączono — {winner} ma teraz {count} wpisów.",
   "@customMealsMergeSuccessSnackbarOther": {
     "placeholders": {
-      "count": { "type": "int" },
-      "winner": { "type": "String" }
+      "count": {
+        "type": "int"
+      },
+      "winner": {
+        "type": "String"
+      }
     }
   },
   "fastingHomeChipBody": "Post · pozostało {remaining}",
   "@fastingHomeChipBody": {
     "placeholders": {
-      "remaining": { "type": "String" }
+      "remaining": {
+        "type": "String"
+      }
     }
   },
   "fastingNotificationChannelName": "Minutnik postu",
@@ -1145,9 +1231,21 @@
   "aiAssistEndpointFieldLabel": "Adres serwera",
   "aiAssistModelFieldLabel": "Nazwa modelu",
   "aiAssistDisclosureOwnServerSecure": "Po zapisaniu adresu tekst wpisywany na ekranie dodawania wielu pozycji oraz każde zdjęcie, które każesz tam odczytać, jest wysyłany do {host} — serwera, który sam prowadzisz. Nie otrzymuje go żadna strona trzecia, a projekt nie ma relacji z tą maszyną i nie może niczego obiecać co do tego, co ona przechowuje. Połączenie jest szyfrowane.",
-  "@aiAssistDisclosureOwnServerSecure": {"placeholders": {"host": {"type": "String"}}},
+  "@aiAssistDisclosureOwnServerSecure": {
+    "placeholders": {
+      "host": {
+        "type": "String"
+      }
+    }
+  },
   "aiAssistDisclosureOwnServerPlaintext": "Po zapisaniu adresu tekst wpisywany na ekranie dodawania wielu pozycji oraz każde zdjęcie, które każesz tam odczytać, jest wysyłany do {host} — serwera, który sam prowadzisz. Nie otrzymuje go żadna strona trzecia, a projekt nie ma relacji z tą maszyną i nie może niczego obiecać co do tego, co ona przechowuje. Ten adres to zwykły HTTP, więc połączenie nie jest szyfrowane: wszystko w sieci między tym telefonem a tym serwerem może odczytać to, co jest wysyłane.",
-  "@aiAssistDisclosureOwnServerPlaintext": {"placeholders": {"host": {"type": "String"}}},
+  "@aiAssistDisclosureOwnServerPlaintext": {
+    "placeholders": {
+      "host": {
+        "type": "String"
+      }
+    }
+  },
   "aiAssistEndpointInvalidLabel": "Podaj adres zaczynający się od http:// lub https://",
   "aiAssistModelRequiredLabel": "Podaj nazwę modelu, którego ma użyć ten serwer.",
   "aiAssistEndpointPublicPlaintextLabel": "Ten adres jest publiczny i nieszyfrowany, więc żądania do niego są odrzucane. Użyj https albo adresu prywatnego.",
@@ -1215,5 +1313,6 @@
   "healthSyncDisclosureContinueAction": "Dalej",
   "healthSyncUnavailableLabel": "Dane zdrowotne nie są dostępne na tym urządzeniu. Import treningów wymaga Health Connect na Androidzie lub Apple Health na iOS.",
   "sourcesEnergyCompensationTitle": "Zaliczanie kalorii z treningu",
-  "sourcesEnergyCompensationDescription": "Zaimportowane treningi są zaliczane z mniejszą energią, niż raportuje urządzenie. Ludzie kompensują wysiłek, spalając mniej kalorii przez resztę dnia — średnio około 28%, a przy wyższej zawartości tkanki tłuszczowej więcej. Sugerowana wartość pochodzi z tych badań i możesz ją zmienić w Ustawieniach → Synchronizacja zdrowia. Sama energia pochodzi z aplikacji lub urządzenia, które zarejestrowało trening, i nie jest obliczana wzorem MET w aplikacji."
+  "sourcesEnergyCompensationDescription": "Zaimportowane treningi są zaliczane z mniejszą energią, niż raportuje urządzenie. Ludzie kompensują wysiłek, spalając mniej kalorii przez resztę dnia — średnio około 28%, a przy wyższej zawartości tkanki tłuszczowej więcej. Sugerowana wartość pochodzi z tych badań i możesz ją zmienić w Ustawieniach → Synchronizacja zdrowia. Sama energia pochodzi z aplikacji lub urządzenia, które zarejestrowało trening, i nie jest obliczana wzorem MET w aplikacji.",
+  "searchRetryAfterConnectionLost": "Retry search"
 }

--- a/lib/l10n/intl_sk.arb
+++ b/lib/l10n/intl_sk.arb
@@ -166,29 +166,101 @@
   "foodSourcesHelpText": "Výsledky vyhľadávania pochádzajú z týchto databáz potravín. Open Food Facts poháňa vyhľadávanie produktov a čiarových kódov a je vždy zapnutá.",
   "machineTranslatedNameHint": "Názov bol preložený automaticky",
   "measureUnitBar": "{count, plural, one{tyčinka} few{tyčinky} other{tyčiniek}}",
-  "@measureUnitBar": {"placeholders": {"count": {"type": "num"}}},
+  "@measureUnitBar": {
+    "placeholders": {
+      "count": {
+        "type": "num"
+      }
+    }
+  },
   "measureUnitBottle": "{count, plural, one{fľaša} few{fľaše} other{fliaš}}",
-  "@measureUnitBottle": {"placeholders": {"count": {"type": "num"}}},
+  "@measureUnitBottle": {
+    "placeholders": {
+      "count": {
+        "type": "num"
+      }
+    }
+  },
   "measureUnitCan": "{count, plural, one{plechovka} few{plechovky} other{plechoviek}}",
-  "@measureUnitCan": {"placeholders": {"count": {"type": "num"}}},
+  "@measureUnitCan": {
+    "placeholders": {
+      "count": {
+        "type": "num"
+      }
+    }
+  },
   "measureUnitCup": "{count, plural, one{šálka} few{šálky} other{šálok}}",
-  "@measureUnitCup": {"placeholders": {"count": {"type": "num"}}},
+  "@measureUnitCup": {
+    "placeholders": {
+      "count": {
+        "type": "num"
+      }
+    }
+  },
   "measureUnitEgg": "{count, plural, one{vajce} few{vajcia} other{vajec}}",
-  "@measureUnitEgg": {"placeholders": {"count": {"type": "num"}}},
+  "@measureUnitEgg": {
+    "placeholders": {
+      "count": {
+        "type": "num"
+      }
+    }
+  },
   "measureUnitPackage": "{count, plural, one{balenie} few{balenia} other{balení}}",
-  "@measureUnitPackage": {"placeholders": {"count": {"type": "num"}}},
+  "@measureUnitPackage": {
+    "placeholders": {
+      "count": {
+        "type": "num"
+      }
+    }
+  },
   "measureUnitPiece": "{count, plural, one{kus} few{kusy} other{kusov}}",
-  "@measureUnitPiece": {"placeholders": {"count": {"type": "num"}}},
+  "@measureUnitPiece": {
+    "placeholders": {
+      "count": {
+        "type": "num"
+      }
+    }
+  },
   "measureUnitPortion": "{count, plural, one{porcia} few{porcie} other{porcií}}",
-  "@measureUnitPortion": {"placeholders": {"count": {"type": "num"}}},
+  "@measureUnitPortion": {
+    "placeholders": {
+      "count": {
+        "type": "num"
+      }
+    }
+  },
   "measureUnitServing": "{count, plural, one{porcia} few{porcie} other{porcií}}",
-  "@measureUnitServing": {"placeholders": {"count": {"type": "num"}}},
+  "@measureUnitServing": {
+    "placeholders": {
+      "count": {
+        "type": "num"
+      }
+    }
+  },
   "measureUnitSlice": "{count, plural, one{plátok} few{plátky} other{plátkov}}",
-  "@measureUnitSlice": {"placeholders": {"count": {"type": "num"}}},
+  "@measureUnitSlice": {
+    "placeholders": {
+      "count": {
+        "type": "num"
+      }
+    }
+  },
   "measureUnitTablespoon": "{count, plural, one{lyžica} few{lyžice} other{lyžíc}}",
-  "@measureUnitTablespoon": {"placeholders": {"count": {"type": "num"}}},
+  "@measureUnitTablespoon": {
+    "placeholders": {
+      "count": {
+        "type": "num"
+      }
+    }
+  },
   "measureUnitTeaspoon": "{count, plural, one{lyžička} few{lyžičky} other{lyžičiek}}",
-  "@measureUnitTeaspoon": {"placeholders": {"count": {"type": "num"}}},
+  "@measureUnitTeaspoon": {
+    "placeholders": {
+      "count": {
+        "type": "num"
+      }
+    }
+  },
   "settingsFoodSourcesLabel": "Databázy potravín",
   "settingsFoodSourcesSubtitle": "Vyberte, odkiaľ pochádzajú výsledky vyhľadávania",
   "onboardingOtherOptionsLabel": "Ďalšie možnosti",
@@ -1089,26 +1161,40 @@
   "customMealsMergeConfirmContent": "Tým sa všetky záznamy zapísané s {loser} nahradia, aby zobrazovali {winner}, a {loser} bude odstránené z vašich vlastných jedál. Túto akciu nemožno vrátiť späť.",
   "@customMealsMergeConfirmContent": {
     "placeholders": {
-      "loser": { "type": "String" },
-      "winner": { "type": "String" }
+      "loser": {
+        "type": "String"
+      },
+      "winner": {
+        "type": "String"
+      }
     }
   },
   "customMealsMergeConfirmAction": "Zlúčiť",
   "customMealsMergeSuccessSnackbarOne": "Zlúčené — {winner} má teraz 1 záznam.",
   "@customMealsMergeSuccessSnackbarOne": {
-    "placeholders": { "winner": { "type": "String" } }
+    "placeholders": {
+      "winner": {
+        "type": "String"
+      }
+    }
   },
   "customMealsMergeSuccessSnackbarOther": "Zlúčené — {winner} má teraz {count} záznamov.",
   "@customMealsMergeSuccessSnackbarOther": {
     "placeholders": {
-      "count": { "type": "int" },
-      "winner": { "type": "String" }
+      "count": {
+        "type": "int"
+      },
+      "winner": {
+        "type": "String"
+      }
     }
   },
   "fastingHomeChipBody": "Pôst · zostáva {remaining}",
   "@fastingHomeChipBody": {
     "placeholders": {
-      "remaining": { "type": "String" }
+      "remaining": {
+        "type": "String"
+      }
     }
   },
   "fastingNotificationChannelName": "Časovač pôstu",
@@ -1176,9 +1262,21 @@
   "aiAssistEndpointFieldLabel": "Adresa servera",
   "aiAssistModelFieldLabel": "Názov modelu",
   "aiAssistDisclosureOwnServerSecure": "S uloženou adresou sa text, ktorý zadáte na obrazovke hromadného pridávania, a každá fotografia, ktorú si tam necháte prečítať, odosiela na {host} — server, ktorý prevádzkujete vy. Nezískava ho žiadna tretia strana a projekt nemá k tomuto stroju žiadny vzťah a nemôže nič sľúbiť o tom, čo si uchováva. Spojenie je šifrované.",
-  "@aiAssistDisclosureOwnServerSecure": {"placeholders": {"host": {"type": "String"}}},
+  "@aiAssistDisclosureOwnServerSecure": {
+    "placeholders": {
+      "host": {
+        "type": "String"
+      }
+    }
+  },
   "aiAssistDisclosureOwnServerPlaintext": "S uloženou adresou sa text, ktorý zadáte na obrazovke hromadného pridávania, a každá fotografia, ktorú si tam necháte prečítať, odosiela na {host} — server, ktorý prevádzkujete vy. Nezískava ho žiadna tretia strana a projekt nemá k tomuto stroju žiadny vzťah a nemôže nič sľúbiť o tom, čo si uchováva. Táto adresa je obyčajné HTTP, takže spojenie nie je šifrované: čokoľvek v sieti medzi týmto telefónom a oným serverom si môže prečítať, čo sa odosiela.",
-  "@aiAssistDisclosureOwnServerPlaintext": {"placeholders": {"host": {"type": "String"}}},
+  "@aiAssistDisclosureOwnServerPlaintext": {
+    "placeholders": {
+      "host": {
+        "type": "String"
+      }
+    }
+  },
   "aiAssistEndpointInvalidLabel": "Zadajte adresu začínajúcu na http:// alebo https://",
   "aiAssistModelRequiredLabel": "Zadajte názov modelu, ktorý má tento server použiť.",
   "aiAssistEndpointPublicPlaintextLabel": "Táto adresa je verejná a nešifrovaná, preto sú požiadavky na ňu odmietané. Použite https alebo privátnu adresu.",
@@ -1246,5 +1344,6 @@
   "healthSyncDisclosureContinueAction": "Pokračovať",
   "healthSyncUnavailableLabel": "Zdravotné údaje nie sú na tomto zariadení dostupné. Import tréningov vyžaduje Health Connect v Androide alebo Apple Health v iOS.",
   "sourcesEnergyCompensationTitle": "Započítanie kalórií z tréningu",
-  "sourcesEnergyCompensationDescription": "Importované tréningy sa započítavajú s nižšou energiou, než akú hlási zariadenie. Ľudia cvičenie kompenzujú tým, že po zvyšok dňa spália menej kalórií – v priemere asi 28 %, pri vyššom podiele telesného tuku viac. Odporúčaná hodnota vychádza z tohto výskumu a môžeš ju zmeniť v Nastaveniach → Synchronizácia zdravotných údajov. Samotnú energiu hlási aplikácia alebo zariadenie, ktoré tréning zaznamenalo; nepočíta sa vzorcom MET v aplikácii."
+  "sourcesEnergyCompensationDescription": "Importované tréningy sa započítavajú s nižšou energiou, než akú hlási zariadenie. Ľudia cvičenie kompenzujú tým, že po zvyšok dňa spália menej kalórií – v priemere asi 28 %, pri vyššom podiele telesného tuku viac. Odporúčaná hodnota vychádza z tohto výskumu a môžeš ju zmeniť v Nastaveniach → Synchronizácia zdravotných údajov. Samotnú energiu hlási aplikácia alebo zariadenie, ktoré tréning zaznamenalo; nepočíta sa vzorcom MET v aplikácii.",
+  "searchRetryAfterConnectionLost": "Retry search"
 }

--- a/lib/l10n/intl_tr.arb
+++ b/lib/l10n/intl_tr.arb
@@ -149,29 +149,101 @@
   "foodSourcesHelpText": "Arama sonuçları bu gıda veritabanlarından gelir. Open Food Facts, ürün ve barkod aramasını sağlar ve her zaman etkindir.",
   "machineTranslatedNameHint": "Ad otomatik olarak çevrildi",
   "measureUnitBar": "{count, plural, other{bar}}",
-  "@measureUnitBar": {"placeholders": {"count": {"type": "num"}}},
+  "@measureUnitBar": {
+    "placeholders": {
+      "count": {
+        "type": "num"
+      }
+    }
+  },
   "measureUnitBottle": "{count, plural, other{şişe}}",
-  "@measureUnitBottle": {"placeholders": {"count": {"type": "num"}}},
+  "@measureUnitBottle": {
+    "placeholders": {
+      "count": {
+        "type": "num"
+      }
+    }
+  },
   "measureUnitCan": "{count, plural, other{kutu}}",
-  "@measureUnitCan": {"placeholders": {"count": {"type": "num"}}},
+  "@measureUnitCan": {
+    "placeholders": {
+      "count": {
+        "type": "num"
+      }
+    }
+  },
   "measureUnitCup": "{count, plural, other{fincan}}",
-  "@measureUnitCup": {"placeholders": {"count": {"type": "num"}}},
+  "@measureUnitCup": {
+    "placeholders": {
+      "count": {
+        "type": "num"
+      }
+    }
+  },
   "measureUnitEgg": "{count, plural, other{yumurta}}",
-  "@measureUnitEgg": {"placeholders": {"count": {"type": "num"}}},
+  "@measureUnitEgg": {
+    "placeholders": {
+      "count": {
+        "type": "num"
+      }
+    }
+  },
   "measureUnitPackage": "{count, plural, other{paket}}",
-  "@measureUnitPackage": {"placeholders": {"count": {"type": "num"}}},
+  "@measureUnitPackage": {
+    "placeholders": {
+      "count": {
+        "type": "num"
+      }
+    }
+  },
   "measureUnitPiece": "{count, plural, other{parça}}",
-  "@measureUnitPiece": {"placeholders": {"count": {"type": "num"}}},
+  "@measureUnitPiece": {
+    "placeholders": {
+      "count": {
+        "type": "num"
+      }
+    }
+  },
   "measureUnitPortion": "{count, plural, other{porsiyon}}",
-  "@measureUnitPortion": {"placeholders": {"count": {"type": "num"}}},
+  "@measureUnitPortion": {
+    "placeholders": {
+      "count": {
+        "type": "num"
+      }
+    }
+  },
   "measureUnitServing": "{count, plural, other{porsiyon}}",
-  "@measureUnitServing": {"placeholders": {"count": {"type": "num"}}},
+  "@measureUnitServing": {
+    "placeholders": {
+      "count": {
+        "type": "num"
+      }
+    }
+  },
   "measureUnitSlice": "{count, plural, other{dilim}}",
-  "@measureUnitSlice": {"placeholders": {"count": {"type": "num"}}},
+  "@measureUnitSlice": {
+    "placeholders": {
+      "count": {
+        "type": "num"
+      }
+    }
+  },
   "measureUnitTablespoon": "{count, plural, other{yemek kaşığı}}",
-  "@measureUnitTablespoon": {"placeholders": {"count": {"type": "num"}}},
+  "@measureUnitTablespoon": {
+    "placeholders": {
+      "count": {
+        "type": "num"
+      }
+    }
+  },
   "measureUnitTeaspoon": "{count, plural, other{çay kaşığı}}",
-  "@measureUnitTeaspoon": {"placeholders": {"count": {"type": "num"}}},
+  "@measureUnitTeaspoon": {
+    "placeholders": {
+      "count": {
+        "type": "num"
+      }
+    }
+  },
   "settingsFoodSourcesLabel": "Gıda veritabanları",
   "settingsFoodSourcesSubtitle": "Arama sonuçlarının kaynağını seçin",
   "onboardingOtherOptionsLabel": "Diğer seçenekler",
@@ -1089,26 +1161,40 @@
   "customMealsMergeConfirmContent": "Bu işlem, {loser} ile kaydedilen tüm girdileri değiştirip {winner} olarak gösterir ve {loser} özel yiyeceklerinden kaldırılır. Bu işlem geri alınamaz.",
   "@customMealsMergeConfirmContent": {
     "placeholders": {
-      "loser": { "type": "String" },
-      "winner": { "type": "String" }
+      "loser": {
+        "type": "String"
+      },
+      "winner": {
+        "type": "String"
+      }
     }
   },
   "customMealsMergeConfirmAction": "Birleştir",
   "customMealsMergeSuccessSnackbarOne": "Birleştirildi — {winner} artık 1 kayda sahip.",
   "@customMealsMergeSuccessSnackbarOne": {
-    "placeholders": { "winner": { "type": "String" } }
+    "placeholders": {
+      "winner": {
+        "type": "String"
+      }
+    }
   },
   "customMealsMergeSuccessSnackbarOther": "Birleştirildi — {winner} artık {count} kayda sahip.",
   "@customMealsMergeSuccessSnackbarOther": {
     "placeholders": {
-      "count": { "type": "int" },
-      "winner": { "type": "String" }
+      "count": {
+        "type": "int"
+      },
+      "winner": {
+        "type": "String"
+      }
     }
   },
   "fastingHomeChipBody": "Oruç · {remaining} kaldı",
   "@fastingHomeChipBody": {
     "placeholders": {
-      "remaining": { "type": "String" }
+      "remaining": {
+        "type": "String"
+      }
     }
   },
   "fastingNotificationChannelName": "Oruç zamanlayıcısı",
@@ -1176,9 +1262,21 @@
   "aiAssistEndpointFieldLabel": "Sunucu adresi",
   "aiAssistModelFieldLabel": "Model adı",
   "aiAssistDisclosureOwnServerSecure": "Adres kaydedildiğinde, çoklu ekleme ekranında yazdığınız metin ve orada okutmayı seçtiğiniz her fotoğraf {host} adresine — kendi işlettiğiniz bir sunucuya — gönderilir. Bunu hiçbir üçüncü taraf almaz; projenin o makineyle bir ilişkisi yoktur ve neyi sakladığı konusunda hiçbir söz veremez. Bağlantı şifrelidir.",
-  "@aiAssistDisclosureOwnServerSecure": {"placeholders": {"host": {"type": "String"}}},
+  "@aiAssistDisclosureOwnServerSecure": {
+    "placeholders": {
+      "host": {
+        "type": "String"
+      }
+    }
+  },
   "aiAssistDisclosureOwnServerPlaintext": "Adres kaydedildiğinde, çoklu ekleme ekranında yazdığınız metin ve orada okutmayı seçtiğiniz her fotoğraf {host} adresine — kendi işlettiğiniz bir sunucuya — gönderilir. Bunu hiçbir üçüncü taraf almaz; projenin o makineyle bir ilişkisi yoktur ve neyi sakladığı konusunda hiçbir söz veremez. Bu adres düz HTTP olduğundan bağlantı şifreli değildir: bu telefonla o sunucu arasındaki ağda bulunan her şey gönderilenleri okuyabilir.",
-  "@aiAssistDisclosureOwnServerPlaintext": {"placeholders": {"host": {"type": "String"}}},
+  "@aiAssistDisclosureOwnServerPlaintext": {
+    "placeholders": {
+      "host": {
+        "type": "String"
+      }
+    }
+  },
   "aiAssistEndpointInvalidLabel": "http:// veya https:// ile başlayan bir adres girin.",
   "aiAssistModelRequiredLabel": "Bu sunucunun kullanacağı model adını girin.",
   "aiAssistEndpointPublicPlaintextLabel": "Bu adres herkese açık ve şifresiz olduğundan oraya giden istekler reddedilir. https veya özel bir adres kullanın.",
@@ -1246,5 +1344,6 @@
   "healthSyncDisclosureContinueAction": "Devam",
   "healthSyncUnavailableLabel": "Bu cihazda sağlık verileri kullanılamıyor. Antrenman içe aktarma, Android’de Health Connect veya iOS’ta Apple Health gerektirir.",
   "sourcesEnergyCompensationTitle": "Antrenman kalori payı",
-  "sourcesEnergyCompensationDescription": "İçe aktarılan antrenmanlar, cihazın bildirdiği enerjinin tamamından daha azıyla sayılır. İnsanlar egzersizi, günün geri kalanında daha az kalori yakarak dengeler; ortalama olarak yaklaşık %28, vücut yağ oranı yüksek olanlarda daha fazla. Önerilen pay bu araştırmadan gelir ve Ayarlar → Sağlık senkronizasyonu bölümünden değiştirebilirsin. Enerjinin kendisi antrenmanı kaydeden uygulama veya cihaz tarafından bildirilir; uygulamadaki MET formülüyle hesaplanmaz."
+  "sourcesEnergyCompensationDescription": "İçe aktarılan antrenmanlar, cihazın bildirdiği enerjinin tamamından daha azıyla sayılır. İnsanlar egzersizi, günün geri kalanında daha az kalori yakarak dengeler; ortalama olarak yaklaşık %28, vücut yağ oranı yüksek olanlarda daha fazla. Önerilen pay bu araştırmadan gelir ve Ayarlar → Sağlık senkronizasyonu bölümünden değiştirebilirsin. Enerjinin kendisi antrenmanı kaydeden uygulama veya cihaz tarafından bildirilir; uygulamadaki MET formülüyle hesaplanmaz.",
+  "searchRetryAfterConnectionLost": "Retry search"
 }

--- a/lib/l10n/intl_uk.arb
+++ b/lib/l10n/intl_uk.arb
@@ -118,29 +118,101 @@
   "foodSourcesHelpText": "Результати пошуку надходять із цих баз даних продуктів. Open Food Facts забезпечує пошук продуктів і штрих-кодів і завжди ввімкнена.",
   "machineTranslatedNameHint": "Назву перекладено автоматично",
   "measureUnitBar": "{count, plural, one{батончик} few{батончики} many{батончиків} other{батончика}}",
-  "@measureUnitBar": {"placeholders": {"count": {"type": "num"}}},
+  "@measureUnitBar": {
+    "placeholders": {
+      "count": {
+        "type": "num"
+      }
+    }
+  },
   "measureUnitBottle": "{count, plural, one{пляшка} few{пляшки} many{пляшок} other{пляшки}}",
-  "@measureUnitBottle": {"placeholders": {"count": {"type": "num"}}},
+  "@measureUnitBottle": {
+    "placeholders": {
+      "count": {
+        "type": "num"
+      }
+    }
+  },
   "measureUnitCan": "{count, plural, one{банка} few{банки} many{банок} other{банки}}",
-  "@measureUnitCan": {"placeholders": {"count": {"type": "num"}}},
+  "@measureUnitCan": {
+    "placeholders": {
+      "count": {
+        "type": "num"
+      }
+    }
+  },
   "measureUnitCup": "{count, plural, one{чашка} few{чашки} many{чашок} other{чашки}}",
-  "@measureUnitCup": {"placeholders": {"count": {"type": "num"}}},
+  "@measureUnitCup": {
+    "placeholders": {
+      "count": {
+        "type": "num"
+      }
+    }
+  },
   "measureUnitEgg": "{count, plural, one{яйце} few{яйця} many{яєць} other{яйця}}",
-  "@measureUnitEgg": {"placeholders": {"count": {"type": "num"}}},
+  "@measureUnitEgg": {
+    "placeholders": {
+      "count": {
+        "type": "num"
+      }
+    }
+  },
   "measureUnitPackage": "{count, plural, one{упаковка} few{упаковки} many{упаковок} other{упаковки}}",
-  "@measureUnitPackage": {"placeholders": {"count": {"type": "num"}}},
+  "@measureUnitPackage": {
+    "placeholders": {
+      "count": {
+        "type": "num"
+      }
+    }
+  },
   "measureUnitPiece": "{count, plural, one{шматок} few{шматки} many{шматків} other{шматка}}",
-  "@measureUnitPiece": {"placeholders": {"count": {"type": "num"}}},
+  "@measureUnitPiece": {
+    "placeholders": {
+      "count": {
+        "type": "num"
+      }
+    }
+  },
   "measureUnitPortion": "{count, plural, one{порція} few{порції} many{порцій} other{порції}}",
-  "@measureUnitPortion": {"placeholders": {"count": {"type": "num"}}},
+  "@measureUnitPortion": {
+    "placeholders": {
+      "count": {
+        "type": "num"
+      }
+    }
+  },
   "measureUnitServing": "{count, plural, one{порція} few{порції} many{порцій} other{порції}}",
-  "@measureUnitServing": {"placeholders": {"count": {"type": "num"}}},
+  "@measureUnitServing": {
+    "placeholders": {
+      "count": {
+        "type": "num"
+      }
+    }
+  },
   "measureUnitSlice": "{count, plural, one{скибка} few{скибки} many{скибок} other{скибки}}",
-  "@measureUnitSlice": {"placeholders": {"count": {"type": "num"}}},
+  "@measureUnitSlice": {
+    "placeholders": {
+      "count": {
+        "type": "num"
+      }
+    }
+  },
   "measureUnitTablespoon": "{count, plural, one{столова ложка} few{столові ложки} many{столових ложок} other{столової ложки}}",
-  "@measureUnitTablespoon": {"placeholders": {"count": {"type": "num"}}},
+  "@measureUnitTablespoon": {
+    "placeholders": {
+      "count": {
+        "type": "num"
+      }
+    }
+  },
   "measureUnitTeaspoon": "{count, plural, one{чайна ложка} few{чайні ложки} many{чайних ложок} other{чайної ложки}}",
-  "@measureUnitTeaspoon": {"placeholders": {"count": {"type": "num"}}},
+  "@measureUnitTeaspoon": {
+    "placeholders": {
+      "count": {
+        "type": "num"
+      }
+    }
+  },
   "settingsFoodSourcesLabel": "Бази даних продуктів",
   "settingsFoodSourcesSubtitle": "Виберіть, звідки надходять результати пошуку",
   "onboardingOtherOptionsLabel": "Інші параметри",
@@ -1058,26 +1130,40 @@
   "customMealsMergeConfirmContent": "Це замінить усі записи, додані з {loser}, щоб вони показували {winner}, і видалить {loser} з ваших власних страв. Цю дію не можна скасувати.",
   "@customMealsMergeConfirmContent": {
     "placeholders": {
-      "loser": { "type": "String" },
-      "winner": { "type": "String" }
+      "loser": {
+        "type": "String"
+      },
+      "winner": {
+        "type": "String"
+      }
     }
   },
   "customMealsMergeConfirmAction": "Об’єднати",
   "customMealsMergeSuccessSnackbarOne": "Об'єднано — {winner} тепер має 1 запис.",
   "@customMealsMergeSuccessSnackbarOne": {
-    "placeholders": { "winner": { "type": "String" } }
+    "placeholders": {
+      "winner": {
+        "type": "String"
+      }
+    }
   },
   "customMealsMergeSuccessSnackbarOther": "Об'єднано — {winner} тепер має {count} записів.",
   "@customMealsMergeSuccessSnackbarOther": {
     "placeholders": {
-      "count": { "type": "int" },
-      "winner": { "type": "String" }
+      "count": {
+        "type": "int"
+      },
+      "winner": {
+        "type": "String"
+      }
     }
   },
   "fastingHomeChipBody": "Голодування · залишилось {remaining}",
   "@fastingHomeChipBody": {
     "placeholders": {
-      "remaining": { "type": "String" }
+      "remaining": {
+        "type": "String"
+      }
     }
   },
   "fastingNotificationChannelName": "Таймер голодування",
@@ -1145,9 +1231,21 @@
   "aiAssistEndpointFieldLabel": "Адреса сервера",
   "aiAssistModelFieldLabel": "Назва моделі",
   "aiAssistDisclosureOwnServerSecure": "Зі збереженою адресою текст, який ви вводите на екрані додавання кількох позицій, і будь-яке фото, яке ви даєте прочитати там, надсилається на {host} — сервер, який ви обслуговуєте самі. Його не отримує жодна третя сторона, і проєкт не має стосунку до цієї машини та нічого не може обіцяти щодо того, що вона зберігає. З’єднання зашифроване.",
-  "@aiAssistDisclosureOwnServerSecure": {"placeholders": {"host": {"type": "String"}}},
+  "@aiAssistDisclosureOwnServerSecure": {
+    "placeholders": {
+      "host": {
+        "type": "String"
+      }
+    }
+  },
   "aiAssistDisclosureOwnServerPlaintext": "Зі збереженою адресою текст, який ви вводите на екрані додавання кількох позицій, і будь-яке фото, яке ви даєте прочитати там, надсилається на {host} — сервер, який ви обслуговуєте самі. Його не отримує жодна третя сторона, і проєкт не має стосунку до цієї машини та нічого не може обіцяти щодо того, що вона зберігає. Ця адреса використовує звичайний HTTP, тому з’єднання не зашифроване: усе в мережі між цим телефоном і тим сервером може прочитати те, що надсилається.",
-  "@aiAssistDisclosureOwnServerPlaintext": {"placeholders": {"host": {"type": "String"}}},
+  "@aiAssistDisclosureOwnServerPlaintext": {
+    "placeholders": {
+      "host": {
+        "type": "String"
+      }
+    }
+  },
   "aiAssistEndpointInvalidLabel": "Введіть адресу, що починається з http:// або https://",
   "aiAssistModelRequiredLabel": "Вкажіть назву моделі, яку має використовувати цей сервер.",
   "aiAssistEndpointPublicPlaintextLabel": "Ця адреса публічна й незашифрована, тому запити до неї відхиляються. Використайте https або приватну адресу.",
@@ -1215,5 +1313,6 @@
   "healthSyncDisclosureContinueAction": "Продовжити",
   "healthSyncUnavailableLabel": "Дані про здоров’я недоступні на цьому пристрої. Для імпорту тренувань потрібен Health Connect на Android або Apple Health на iOS.",
   "sourcesEnergyCompensationTitle": "Зарахування калорій за тренування",
-  "sourcesEnergyCompensationDescription": "Імпортовані тренування зараховуються з меншою енергією, ніж повідомляє пристрій. Люди компенсують навантаження, спалюючи менше калорій протягом решти дня — у середньому близько 28%, а за вищого відсотка жиру більше. Рекомендоване значення походить із цього дослідження, і його можна змінити в Налаштуваннях → Синхронізація зі здоров’ям. Саму енергію повідомляє застосунок або пристрій, який записав тренування; вона не обчислюється формулою MET у застосунку."
+  "sourcesEnergyCompensationDescription": "Імпортовані тренування зараховуються з меншою енергією, ніж повідомляє пристрій. Люди компенсують навантаження, спалюючи менше калорій протягом решти дня — у середньому близько 28%, а за вищого відсотка жиру більше. Рекомендоване значення походить із цього дослідження, і його можна змінити в Налаштуваннях → Синхронізація зі здоров’ям. Саму енергію повідомляє застосунок або пристрій, який записав тренування; вона не обчислюється формулою MET у застосунку.",
+  "searchRetryAfterConnectionLost": "Retry search"
 }

--- a/lib/l10n/intl_zh.arb
+++ b/lib/l10n/intl_zh.arb
@@ -119,29 +119,101 @@
   "foodSourcesHelpText": "搜索结果来自这些食品数据库。Open Food Facts 提供产品和条形码搜索，始终处于启用状态。",
   "machineTranslatedNameHint": "名称为自动翻译",
   "measureUnitBar": "{count, plural, other{条}}",
-  "@measureUnitBar": {"placeholders": {"count": {"type": "num"}}},
+  "@measureUnitBar": {
+    "placeholders": {
+      "count": {
+        "type": "num"
+      }
+    }
+  },
   "measureUnitBottle": "{count, plural, other{瓶}}",
-  "@measureUnitBottle": {"placeholders": {"count": {"type": "num"}}},
+  "@measureUnitBottle": {
+    "placeholders": {
+      "count": {
+        "type": "num"
+      }
+    }
+  },
   "measureUnitCan": "{count, plural, other{罐}}",
-  "@measureUnitCan": {"placeholders": {"count": {"type": "num"}}},
+  "@measureUnitCan": {
+    "placeholders": {
+      "count": {
+        "type": "num"
+      }
+    }
+  },
   "measureUnitCup": "{count, plural, other{杯}}",
-  "@measureUnitCup": {"placeholders": {"count": {"type": "num"}}},
+  "@measureUnitCup": {
+    "placeholders": {
+      "count": {
+        "type": "num"
+      }
+    }
+  },
   "measureUnitEgg": "{count, plural, other{个}}",
-  "@measureUnitEgg": {"placeholders": {"count": {"type": "num"}}},
+  "@measureUnitEgg": {
+    "placeholders": {
+      "count": {
+        "type": "num"
+      }
+    }
+  },
   "measureUnitPackage": "{count, plural, other{包}}",
-  "@measureUnitPackage": {"placeholders": {"count": {"type": "num"}}},
+  "@measureUnitPackage": {
+    "placeholders": {
+      "count": {
+        "type": "num"
+      }
+    }
+  },
   "measureUnitPiece": "{count, plural, other{块}}",
-  "@measureUnitPiece": {"placeholders": {"count": {"type": "num"}}},
+  "@measureUnitPiece": {
+    "placeholders": {
+      "count": {
+        "type": "num"
+      }
+    }
+  },
   "measureUnitPortion": "{count, plural, other{份}}",
-  "@measureUnitPortion": {"placeholders": {"count": {"type": "num"}}},
+  "@measureUnitPortion": {
+    "placeholders": {
+      "count": {
+        "type": "num"
+      }
+    }
+  },
   "measureUnitServing": "{count, plural, other{份}}",
-  "@measureUnitServing": {"placeholders": {"count": {"type": "num"}}},
+  "@measureUnitServing": {
+    "placeholders": {
+      "count": {
+        "type": "num"
+      }
+    }
+  },
   "measureUnitSlice": "{count, plural, other{片}}",
-  "@measureUnitSlice": {"placeholders": {"count": {"type": "num"}}},
+  "@measureUnitSlice": {
+    "placeholders": {
+      "count": {
+        "type": "num"
+      }
+    }
+  },
   "measureUnitTablespoon": "{count, plural, other{汤匙}}",
-  "@measureUnitTablespoon": {"placeholders": {"count": {"type": "num"}}},
+  "@measureUnitTablespoon": {
+    "placeholders": {
+      "count": {
+        "type": "num"
+      }
+    }
+  },
   "measureUnitTeaspoon": "{count, plural, other{茶匙}}",
-  "@measureUnitTeaspoon": {"placeholders": {"count": {"type": "num"}}},
+  "@measureUnitTeaspoon": {
+    "placeholders": {
+      "count": {
+        "type": "num"
+      }
+    }
+  },
   "settingsFoodSourcesLabel": "食品数据库",
   "settingsFoodSourcesSubtitle": "选择食品搜索结果的来源",
   "onboardingOtherOptionsLabel": "其他选项",
@@ -1059,26 +1131,40 @@
   "customMealsMergeConfirmContent": "这会把所有用 {loser} 记录的条目改为显示 {winner},并把 {loser} 从你的自定义食物中移除。此操作无法撤销。",
   "@customMealsMergeConfirmContent": {
     "placeholders": {
-      "loser": { "type": "String" },
-      "winner": { "type": "String" }
+      "loser": {
+        "type": "String"
+      },
+      "winner": {
+        "type": "String"
+      }
     }
   },
   "customMealsMergeConfirmAction": "合并",
   "customMealsMergeSuccessSnackbarOne": "已合并 — {winner} 现在有 1 条记录。",
   "@customMealsMergeSuccessSnackbarOne": {
-    "placeholders": { "winner": { "type": "String" } }
+    "placeholders": {
+      "winner": {
+        "type": "String"
+      }
+    }
   },
   "customMealsMergeSuccessSnackbarOther": "已合并 — {winner} 现在有 {count} 条记录。",
   "@customMealsMergeSuccessSnackbarOther": {
     "placeholders": {
-      "count": { "type": "int" },
-      "winner": { "type": "String" }
+      "count": {
+        "type": "int"
+      },
+      "winner": {
+        "type": "String"
+      }
     }
   },
   "fastingHomeChipBody": "禁食中 · 剩余 {remaining}",
   "@fastingHomeChipBody": {
     "placeholders": {
-      "remaining": { "type": "String" }
+      "remaining": {
+        "type": "String"
+      }
     }
   },
   "fastingNotificationChannelName": "断食计时器",
@@ -1146,9 +1232,21 @@
   "aiAssistEndpointFieldLabel": "服务器地址",
   "aiAssistModelFieldLabel": "模型名称",
   "aiAssistDisclosureOwnServerSecure": "保存地址后，您在多项添加界面输入的文本，以及您选择在那里读取的任何照片，会发送到 {host}——由您自己运行的服务器。没有第三方会收到它，本项目与该机器没有任何关系，也无法就其保留内容做出任何承诺。连接是加密的。",
-  "@aiAssistDisclosureOwnServerSecure": {"placeholders": {"host": {"type": "String"}}},
+  "@aiAssistDisclosureOwnServerSecure": {
+    "placeholders": {
+      "host": {
+        "type": "String"
+      }
+    }
+  },
   "aiAssistDisclosureOwnServerPlaintext": "保存地址后，您在多项添加界面输入的文本，以及您选择在那里读取的任何照片，会发送到 {host}——由您自己运行的服务器。没有第三方会收到它，本项目与该机器没有任何关系，也无法就其保留内容做出任何承诺。该地址为明文 HTTP，因此连接未加密：本手机与该服务器之间网络上的任何设备都能读取所发送的内容。",
-  "@aiAssistDisclosureOwnServerPlaintext": {"placeholders": {"host": {"type": "String"}}},
+  "@aiAssistDisclosureOwnServerPlaintext": {
+    "placeholders": {
+      "host": {
+        "type": "String"
+      }
+    }
+  },
   "aiAssistEndpointInvalidLabel": "请输入以 http:// 或 https:// 开头的地址。",
   "aiAssistModelRequiredLabel": "请填写该服务器要使用的模型名称。",
   "aiAssistEndpointPublicPlaintextLabel": "该地址是公网地址且未加密，因此发往它的请求会被拒绝。请使用 https 或私有地址。",
@@ -1216,5 +1314,6 @@
   "healthSyncDisclosureContinueAction": "继续",
   "healthSyncUnavailableLabel": "此设备上无法使用健康数据。导入锻炼需要 Android 上的 Health Connect 或 iOS 上的 Apple Health。",
   "sourcesEnergyCompensationTitle": "锻炼热量计入比例",
-  "sourcesEnergyCompensationDescription": "导入的锻炼计入的热量少于设备报告的数值。人体会在一天中的其余时间少消耗热量来补偿运动，平均约为 28%，体脂率越高补偿越多。建议值来自该研究，你可以在设置 → 健康同步中修改。热量数值由记录该锻炼的应用或设备提供，并非由应用内的 MET 公式计算。"
+  "sourcesEnergyCompensationDescription": "导入的锻炼计入的热量少于设备报告的数值。人体会在一天中的其余时间少消耗热量来补偿运动，平均约为 28%，体脂率越高补偿越多。建议值来自该研究，你可以在设置 → 健康同步中修改。热量数值由记录该锻炼的应用或设备提供，并非由应用内的 MET 公式计算。",
+  "searchRetryAfterConnectionLost": "Retry search"
 }


### PR DESCRIPTION
Adds `searchRetryAfterConnectionLost` to all nine ARBs, with the description on the template.

Scratch PR — standing this up to check a repository automation end to end on a branch that carries the current `develop`. **Not intended to merge**; it will be closed once checked, and nothing here is wired into the UI yet.