### PR TITLE
ci(github-release): give it the branch policy its siblings got

### DIFF
--- a/.github/workflows/default_workflow.yml
+++ b/.github/workflows/default_workflow.yml
@@ -1137,6 +1137,23 @@ jobs:
       - ios-build
       - android-build
       - android-integration-tests
+    # Three environments, and the line between them is which CREDENTIALS a job
+    # holds, not what it is called (#1055, #1057):
+    #
+    #   release-build    local signing material only. Branch policy, no
+    #                    reviewer — there is nothing here a wrong branch could
+    #                    spend. `android-package` holds the keystore.
+    #   release-ship     STORE credentials. Branch policy AND an approval,
+    #                    because these can consume a Play versionCode or a
+    #                    TestFlight build number, and neither is refundable.
+    #   release-publish  no secrets at all, but it publishes. Branch policy,
+    #                    no reviewer. See `github-release`.
+    #
+    # So this job is on `release-ship` and its Android counterpart is not,
+    # even though both only package: `fastlane ios build` runs `match`, which
+    # authenticates to App Store Connect, so iOS packaging holds store
+    # credentials and Android packaging holds a local keystore. The asymmetry
+    # is the rule being applied, not an oversight.
     environment: release-ship
     runs-on: macos-26
     permissions:
@@ -1740,6 +1757,21 @@ jobs:
       - release-gate
       - ios-deploy
       - android-deploy
+    # #1057. This job holds no secrets, so an approval here would guard
+    # nothing — and it could not be a real decision anyway: by the time it
+    # runs, both stores already have the build, and declining would leave them
+    # shipped with no release to point at. What it needs is the other half of
+    # what `release-ship` provides.
+    #
+    # The branch policy is the half that matters. This job publishes the one
+    # artifact nobody can quietly take back — a `v*` tag and three binaries,
+    # whose assets GitHub does not version — and until now its only protection
+    # was the `if:` below. That is the mechanism with a track record here: run
+    # 26086317616 was a `workflow_dispatch` from a topic branch and carried
+    # this job to success, cutting a real tag. A branch policy pinned to `main`
+    # would have stopped it whatever the expression said, which is the whole
+    # point of having a second one.
+    environment: release-publish
     runs-on: ubuntu-latest
     permissions:
       contents: write
@@ -1913,6 +1945,10 @@ jobs:
   #
   # It never fails a run that was not meant to ship. A docs merge to `main`
   # leaves `deploy` and `publish` both false, and this job says so and exits 0.
+  # Deliberately in NO environment. It holds no secrets and publishes nothing,
+  # and a branch policy here would be worse than useless: this is the job that
+  # reports when a release did not happen, so anything able to stop it running
+  # defeats it. The three environments above are for jobs that spend something.
   release-summary:
     if: |
       github.ref == 'refs/heads/main' &&

--- a/docs/RELEASING.md
+++ b/docs/RELEASING.md
@@ -13,7 +13,8 @@ the ones that are otherwise remembered, or not.
 
 ## What happens on its own
 
-Everything below fires from `push` on `main`, so it needs no action beyond the merge.
+Everything below fires from `push` on `main`. **It does not run to completion unattended** — the
+jobs holding store credentials pause for an approval, see [Environments](#environments-and-the-approval-pause).
 
 | Job | What it does |
 |---|---|
@@ -21,6 +22,7 @@ Everything below fires from `push` on `main`, so it needs no action beyond the m
 | `ios-package` / `android-package` | build the IPA, AAB and APK |
 | `ios-deploy` / `android-deploy` | upload to **TestFlight**, and *attempt* the Play **`internal`** track — see [the Android upload](#the-android-upload-usually-needs-a-hand) |
 | `github-release` | tag, attach the IPA/AAB/APK, and generate release notes from merged PRs |
+| `release-summary` | last job; asserts the run produced what `release-gate` promised, and says so on the run page |
 
 Two properties are deliberate and worth knowing:
 
@@ -29,6 +31,32 @@ Two properties are deliberate and worth knowing:
 - **Store metadata is not uploaded.** `skip_upload_metadata: true` on the Play lane, and the
   TestFlight `changelog` is commented out. Listing text and "what's new" are edited in the
   consoles, by a person.
+
+### Environments and the approval pause
+
+Three deployment environments, split by which **credentials** a job holds rather than by what it
+is called. All three are pinned to `main` by a deployment branch policy, which is a guard
+independent of the `if:` expressions — the expression is the mechanism that has already failed
+here once, when a `workflow_dispatch` from a topic branch cut a real tag.
+
+| Environment | Jobs | Protection |
+| :-- | :-- | :-- |
+| `release-build` | `android-package` | branch policy |
+| `release-ship` | `ios-package`, `ios-deploy`, `android-deploy` | branch policy **and an approval** |
+| `release-publish` | `github-release` | branch policy |
+
+**A release stops and waits for you.** The `release-ship` jobs sit in *Review pending deployments*
+until approved, so a merge to `main` does not finish on its own. Approving is the decision point:
+those jobs can consume a Play `versionCode` and a TestFlight build number, and neither is
+refundable.
+
+Declining is a real option and behaves sanely — a rejected job reports `failure`, so
+`github-release` (which needs both deploys green) never runs, and no build number is spent.
+`release-summary` will fail the run and say the build can be retried as it stands, which it can.
+
+`ios-package` is on `release-ship` and `android-package` is not, though both only package:
+`fastlane ios build` runs `match`, which authenticates to App Store Connect, so iOS packaging
+holds store credentials where Android packaging holds only a local keystore.
 
 ### The Android upload usually needs a hand
 


### PR DESCRIPTION
Closes #1057.

#1055 put the release jobs behind environments and split them at the store. `github-release` was left out, so it became the only job on the release path guarded by an `if:` expression alone — and it is the one that publishes the artifact nobody can quietly take back: a `v*` tag and three binaries, whose assets GitHub does not version.

**The environment already exists.** `release-publish` was created and pinned to `main` before this PR, because merging the YAML first would have made GitHub auto-create an *unprotected* environment of the same name — which looks protected and is not.

| Environment | Jobs | Protection |
| :-- | :-- | :-- |
| `release-build` | `android-package` | branch policy |
| `release-ship` | `ios-package`, `ios-deploy`, `android-deploy` | branch policy **and an approval** |
| `release-publish` | `github-release` | branch policy |

## Why a branch policy and not an approval

An approval here would guard nothing — this job holds **no secrets at all**, unlike its siblings — and it could not be a real decision anyway. By the time it runs, both stores already have the build; declining would leave them shipped with no release to point at. It would be a prompt with no answer behind it.

The branch policy is the half that matters, and the file records why: run `26086317616` was a `workflow_dispatch` from a topic branch and carried this job to success, cutting a real tag. The fix then ([#1011](https://github.com/simonoppowa/OpenNutriTracker/issues/1011)) was to add a conjunct — making the same single mechanism more careful. A policy pinned to `main` would have stopped that run whatever the expression said. That is the point of having a second, independent one.

## The asymmetry was the rule, not an oversight

The issue asked whether `ios-package` on `release-ship` and `android-package` on `release-build` was deliberate. It is, and the secrets show it:

```
ios-package      APP_STORE_CONNECT_API_KEY_*, MATCH_*, ...
android-package  ANDROID_KEYSTORE_*, ...
github-release   (none)
```

`fastlane ios build` runs `match`, which authenticates to App Store Connect — so iOS *packaging* holds store credentials where Android packaging holds only a local keystore. The line between the environments is **which credentials a job holds**, not what it is called. That rule is now written down where the environments are declared, so the next reader does not read it as an inconsistency to tidy up.

`release-summary` stays in no environment and now says why: it is the job that reports when a release did not happen, so anything able to stop it running defeats it.

## A documentation gap this uncovered

`docs/RELEASING.md` opened with *"Everything below fires from `push` on `main`, so it needs no action beyond the merge."* Since #1055 that has been **false** — the `release-ship` jobs sit in *Review pending deployments* and a release does not finish unattended. That was the first sentence an operator reads.

It now documents the three environments, the pause, and what declining does: a rejected job reports `failure`, so `github-release` never runs, no build number is spent, and `release-summary` fails the run saying the build can be retried as it stands — which it can.

## Verification

YAML parses, 17 jobs, each mapped to the environment above. `docs/RELEASING.md` re-checked the way `test/unit_test/releasing_doc_test.dart` does — every relative link resolves and every heading anchor exists, including the new one.

Built in a separate git worktree, because the primary working directory holds an unrelated staged changeset that I was asked to leave untouched.