### PR TITLE
docs: two review rules the last two reviews earned

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -14,11 +14,15 @@ Reviews are advisory and cannot block a merge. Most PRs come from outside contri
 
 Never assert a count, or an "every locale" claim, you have not computed from this PR's own diff — not from the PR description, which has been wrong before. Don't restate what CI already failed on: `linux-checks` runs `just check_agents_md`, `just check_l10n`, `just build`, `flutter analyze`, `just test` — it deliberately does **not** run the format check. Don't comment on the target branch; a maintainer repoints those.
 
+When a diff edits prose that already existed, separate what it introduced from what it inherited, and say which. Never ask for a fix to text the PR did not touch — on a documentation-correction PR that is the whole difference between useful feedback and asking someone to repair another person's mistake.
+
 ### 1. Untranslated ARB values — the one check CI cannot do
 
 `just check_l10n` fails only on *missing* keys, so a key present in every locale with the English text still in it ships green. For each key **this PR adds or changes** under `lib/l10n/`, compare its value across the locale files.
 
 Report a key left byte-identical to English in every, or nearly every, non-English ARB. `CONTRIBUTING.md` forbids leaving English in as a placeholder, machine translation is the accepted floor, and no Weblate/Crowdin pipeline exists here — so "translations land later" is not an exemption. Name the key and its locales once.
+
+Before reporting one, search the ARBs for a key that already says the same thing — this app has shipped a while and often does. A second phrasing for one action is worse than a late translation: name the existing key and ask for its values to be copied.
 
 Identical is legitimate, and silent, for brand and platform names, units and symbols, acronyms, and placeholder-only strings (`{hour}:00`). A value identical in only one or two locales is usually a real cognate (German `Protein`, Italian `golf`) — leave those. Never audit keys the PR did not touch; that backlog is not this contributor's debt.
 


### PR DESCRIPTION
## Summary

Two rules for `## Code Review Rules`, each earned by a finding from the last two reviews rather than invented.

Refs #1054.

## Type of change
- [x] Documentation
- [ ] Bug fix / New feature / Refactor / CI / Localization / Other

## Changes

**Attribution — separate what a diff introduced from what it inherited.**

On [#1010](https://github.com/simonoppowa/OpenNutriTracker/pull/1010) the automated review went 2-for-4, and not through hallucination — every code claim it made was true. It failed on *aim*: it flagged an own-server disclosure as self-contradicting, which it is, without noticing that sentence is unchanged from `develop`. On a documentation-correction PR that is the whole difference between useful feedback and asking a contributor to repair someone else's mistake. A fourth finding was refuted outright — that PR had *fixed* the area rather than broken it.

**Precedent — check whether the app already says it before reporting a missing translation.**

[#995](https://github.com/simonoppowa/OpenNutriTracker/pull/995) added a key meaning "Scan barcode" and left it English in eight locales. The useful finding was not that it needed translating: `customMealBarcodeScanButton` is *already* exactly `"Scan barcode"` and already translated in all nine locales. Neither the automated review nor the hand-run one in #1035 spotted the duplicate — it surfaced only from deliberately hunting precedents before proposing translations. A second phrasing for one action is a worse outcome than a late translation, and unlike the translation it is the part a reviewer can actually prevent.

## Test plan
- [x] Described steps below were followed locally
- [ ] Unit / widget tests (n/a — documentation)
- [ ] Manual check on Android / iOS (n/a)

### Steps
1. `just check_agents_md` conditions checked against the edited file: **28,705 bytes**, 2,295 under the 31,000 guard and 4,063 under Codex's 32 KiB cap; `## Code Review Rules` still at byte 653, well inside the 12,000 head limit.
2. Both additions sit inside that section, so they land in the head that survives truncation.

## Checklist
- [x] Code follows project style — n/a, markdown
- [x] New interactive widgets include `Semantics(identifier: '...')` — n/a
- [x] Localization updated in every ARB — n/a
- [x] Codegen ran if DBOs/DTOs/env changed — n/a
- [x] No secrets or `.env` values committed
- [x] PR title follows conventional commit style

## Note

Neither rule would have changed a verdict on those two PRs — both reviews were still net useful. They change the *aim*: two of #1010's four findings would have been suppressed as inherited, and #995's would have pointed at an existing key instead of asking for eight translations.
