### PR TITLE
docs(readme): the own-server row promises a rule the code does not keep

### DIFF
--- a/README.md
+++ b/README.md
@@ -142,7 +142,7 @@ No account, no sign-in, no analytics, no ads. Your profile, diary, activities, w
 
 | Destination | When | What is sent |
 | :-- | :-- | :-- |
-| **The address you entered, and nothing else** | **Only if you save a server address in Settings** — when you press *Load models*, and each time a meal line or photo is read | The meal line or the photo, your app language, and the model name you typed |
+| **The address you entered, and nothing else** | **From the moment you type a server address in Settings, not from when you save it** — when you change the address and leave the field, when you press *Load models*, when you save (the setup check), and each time a meal line or photo is read | The meal line or the photo, your app language, and the model name you typed |
 
 This is the one row you can falsify yourself: your own server's access log settles it, where no user can ever settle a claim about a vendor's retention. **No third party receives anything on this path** — which is not the same as the data staying put. It does leave the device, to the address you named, and the app will not send it in the clear to anything that is not a private address.
 


### PR DESCRIPTION
## Summary

The own-server row of *What leaves your device* promises a rule the code does not keep. Corrected here rather than asked of the contributor who surfaced it, because the sentence is not theirs — it is unchanged from `develop`.

Refs #1010.

## Type of change
- [x] Documentation
- [ ] Bug fix / New feature / Refactor / CI / Localization / Other

## The inaccuracy

The row said requests go out **"Only if you save a server address in Settings"**. They go out before that.

`_endpointCommitted` is wired to the address field's focus listener (`ai_assist_dialog.dart:239`) and to `onSubmitted` (`:889`). It returns early when the route is no longer current — so Cancel, OK and the back button send nothing, which is the case the guard at `:443` was written for — and again when the resolved address is unchanged (`:448`). **Neither guard covers moving focus to another field inside the open dialog.** Change the address, tab away, and it reaches `_loadModels()` at `:457` and contacts the machine. Press Cancel afterwards and nothing was ever saved.

The save-time setup check (#780) was also undisclosed.

## Why this row in particular

The paragraph above it sets this row apart *because* it "states a **rule** rather than a party", and the paragraph below invites the reader to falsify it against their own server's access log:

> This is the one row you can falsify yourself: your own server's access log settles it, where no user can ever settle a claim about a vendor's retention.

A reader who took that invitation would find a request the rule said could not be there. Of every claim in that table, this is the one where being wrong is most visible and least defensible.

## The change

| | |
|---|---|
| before | **Only if you save a server address in Settings** — when you press *Load models*, and each time a meal line or photo is read |
| after | **From the moment you type a server address in Settings, not from when you save it** — when you change the address and leave the field, when you press *Load models*, when you save (the setup check), and each time a meal line or photo is read |

"Leave the field" covers both triggers (focus loss and *done*), and "change the address" is exact — re-focusing without editing sends nothing, per the `resolved == _lastEndpoint` guard.

## Test plan
- [x] Described steps below were followed
- [ ] Unit / widget tests (n/a — documentation)
- [ ] Manual check on Android / iOS (n/a)

### Steps
1. Traced every call site of `_endpointCommitted` (`:239` focus listener, `:889` `onSubmitted`) and each early return (`:432` mounted/provider, `:443` route currency, `:448` unchanged address) through to `_loadModels()` at `:457`.
2. Confirmed the exit paths genuinely do not fire, so the correction does not overstate in the other direction.

## Checklist
- [x] Code follows project style — n/a, markdown
- [x] New interactive widgets include `Semantics(identifier: '...')` — n/a
- [x] Localization updated in every ARB — n/a
- [x] Codegen ran if DBOs/DTOs/env changed — n/a
- [x] No secrets or `.env` values committed
- [x] PR title follows conventional commit style

## Note on #1010

That PR edits the same table cell, so it will conflict once this lands. The resolution is to keep this bold phrase and their trigger list — the two changes are complementary, and I have said so on their PR so it does not arrive as a surprise.
