### PR TITLE
fix(export): gather meal photos from entries, not only from templates

### DIFF
--- a/docs/export-format.md
+++ b/docs/export-format.md
@@ -37,10 +37,16 @@ next to its CSV counterpart will not find one.
 | `user_activity.csv`     | Flat activities.                                             |
 | `user_tracked_day.csv`  | Flat tracked days — **lossy, see [Round-trip guarantee](#round-trip-guarantee)**. |
 
-**Photos travel with the JSON bundle only.** Any user-attached recipe and custom-meal images are
-added under `recipe_images/` and `meal_images/` when you export as JSON. A CSV export carries
-none, and the CSV importer does not restore them — another reason to use JSON for anything you
-intend to restore from.
+**Photos travel with the JSON bundle only.** User-attached photos are added under
+`recipe_images/` and `meal_images/` when you export as JSON, gathered from three places: recipes,
+saved custom meals, and **the diary entries themselves**. That third source is not redundant — a
+custom meal logged with *Save for next time* off keeps its photo on the entry without leaving a
+saved meal behind, so gathering only from the first two put the filename in the JSON and left the
+bytes out of the zip ([#1061](https://github.com/simonoppowa/OpenNutriTracker/issues/1061)). A
+photo reachable from any of the three is in the bundle exactly once.
+
+A CSV export carries none, and the CSV importer does not restore them — another reason to use
+JSON for anything you intend to restore from.
 
 The **profile box** — height, birthday, PAL, goal — is intentionally not
 included; see `lib/core/data/data_source/user_data_source.dart`. Note this is the

--- a/lib/features/settings/domain/usecase/export_data_usecase.dart
+++ b/lib/features/settings/domain/usecase/export_data_usecase.dart
@@ -4,7 +4,11 @@ import 'dart:typed_data';
 
 import 'package:archive/archive_io.dart';
 import 'package:file_picker/file_picker.dart';
+import 'package:meta/meta.dart';
 import 'package:opennutritracker/core/data/data_source/custom_meal_data_source.dart';
+import 'package:opennutritracker/core/data/dbo/intake_dbo.dart';
+import 'package:opennutritracker/core/data/dbo/meal_dbo.dart';
+import 'package:opennutritracker/core/data/dbo/recipe_dbo.dart';
 import 'package:opennutritracker/core/data/repository/custom_activity_template_repository.dart';
 import 'package:opennutritracker/core/data/repository/intake_repository.dart';
 import 'package:opennutritracker/core/data/repository/recipe_repository.dart';
@@ -65,12 +69,12 @@ class ExportDataUsecase {
     final archive = Archive();
 
     // Activity dataset
-    final fullUserActivity =
-        await _userActivityRepository.getAllUserActivityDBO();
+    final fullUserActivity = await _userActivityRepository
+        .getAllUserActivityDBO();
     if (format == ExportFormat.json) {
-      final bytes = utf8.encode(jsonEncode(
-        fullUserActivity.map((a) => a.toJson()).toList(),
-      ));
+      final bytes = utf8.encode(
+        jsonEncode(fullUserActivity.map((a) => a.toJson()).toList()),
+      );
       archive.addFile(
         ArchiveFile(userActivityJsonFileName, bytes.length, bytes),
       );
@@ -86,35 +90,27 @@ class ExportDataUsecase {
     // Intake dataset
     final fullIntake = await _intakeRepository.getAllIntakesDBO();
     if (format == ExportFormat.json) {
-      final bytes = utf8.encode(jsonEncode(
-        fullIntake.map((i) => i.toJson()).toList(),
-      ));
-      archive.addFile(
-        ArchiveFile(userIntakeJsonFileName, bytes.length, bytes),
+      final bytes = utf8.encode(
+        jsonEncode(fullIntake.map((i) => i.toJson()).toList()),
       );
+      archive.addFile(ArchiveFile(userIntakeJsonFileName, bytes.length, bytes));
     } else {
       final bytes = utf8.encode(CsvDataExporter.intakesToCsv(fullIntake));
-      archive.addFile(
-        ArchiveFile(userIntakeCsvFileName, bytes.length, bytes),
-      );
+      archive.addFile(ArchiveFile(userIntakeCsvFileName, bytes.length, bytes));
     }
 
     // Tracked day dataset
     final fullTrackedDay = await _trackedDayRepository.getAllTrackedDaysDBO();
     if (format == ExportFormat.json) {
-      final bytes = utf8.encode(jsonEncode(
-        fullTrackedDay.map((d) => d.toJson()).toList(),
-      ));
-      archive.addFile(
-        ArchiveFile(trackedDayJsonFileName, bytes.length, bytes),
+      final bytes = utf8.encode(
+        jsonEncode(fullTrackedDay.map((d) => d.toJson()).toList()),
       );
+      archive.addFile(ArchiveFile(trackedDayJsonFileName, bytes.length, bytes));
     } else {
       final bytes = utf8.encode(
         CsvDataExporter.trackedDaysToCsv(fullTrackedDay),
       );
-      archive.addFile(
-        ArchiveFile(trackedDayCsvFileName, bytes.length, bytes),
-      );
+      archive.addFile(ArchiveFile(trackedDayCsvFileName, bytes.length, bytes));
     }
 
     // Recipes, photos, weight log and Custom activity templates — JSON
@@ -126,33 +122,30 @@ class ExportDataUsecase {
     // CSV path under Import Custom Food Data.
     if (format == ExportFormat.json) {
       final fullRecipes = _recipeRepository.getAllRecipesDBO();
-      final recipeBytes = utf8.encode(jsonEncode(
-        fullRecipes.map((r) => r.toJson()).toList(),
-      ));
+      final recipeBytes = utf8.encode(
+        jsonEncode(fullRecipes.map((r) => r.toJson()).toList()),
+      );
       archive.addFile(
         ArchiveFile(recipeJsonFileName, recipeBytes.length, recipeBytes),
       );
 
-      // Include any user-attached recipe photos under their relative
-      // slug (e.g. `recipe_images/<id>.webp`). The slug matches what
-      // we persist on RecipeDBO.imagePath, so import can drop the
-      // bytes back into place without translating filenames.
-      for (final recipe in fullRecipes) {
-        await _addUserImageIfPresent(archive, recipe.imagePath);
-      }
-
-      // Custom-meal photos travel through the same `meal_images/`
-      // subdirectory their relative slug names.
-      final customMeals = _customMealDataSource.getAllCustomMeals();
-      for (final meal in customMeals) {
-        await _addUserImageIfPresent(archive, meal.localImagePath);
+      // Every user-attached photo, under its relative slug (e.g.
+      // `recipe_images/<id>.webp`). The slug matches what we persist on
+      // the DBO, so import can drop the bytes back into place without
+      // translating filenames.
+      for (final path in userImagePaths(
+        recipes: fullRecipes,
+        customMeals: _customMealDataSource.getAllCustomMeals(),
+        intakes: fullIntake,
+      )) {
+        await _addUserImage(archive, path);
       }
 
       // Weight-log dataset
       final fullWeightLog = await _weightLogRepository.getAllEntriesDBO();
-      final weightLogBytes = utf8.encode(jsonEncode(
-        fullWeightLog.map((entry) => entry.toJson()).toList(),
-      ));
+      final weightLogBytes = utf8.encode(
+        jsonEncode(fullWeightLog.map((entry) => entry.toJson()).toList()),
+      );
       archive.addFile(
         ArchiveFile(
           weightLogJsonFileName,
@@ -162,11 +155,11 @@ class ExportDataUsecase {
       );
 
       // Custom activity templates (#70 follow-up)
-      final fullTemplates =
-          await _customActivityTemplateRepository.allTemplateDBOs();
-      final templatesBytes = utf8.encode(jsonEncode(
-        fullTemplates.map((template) => template.toJson()).toList(),
-      ));
+      final fullTemplates = await _customActivityTemplateRepository
+          .allTemplateDBOs();
+      final templatesBytes = utf8.encode(
+        jsonEncode(fullTemplates.map((template) => template.toJson()).toList()),
+      );
       archive.addFile(
         ArchiveFile(
           customActivityTemplateJsonFileName,
@@ -202,13 +195,56 @@ class ExportDataUsecase {
     return true;
   }
 
-  Future<void> _addUserImageIfPresent(
-    Archive archive,
-    String? relativePath,
-  ) async {
-    if (relativePath == null) return;
-    final sanitized = UserImageStorage.sanitizeRelative(relativePath);
-    if (sanitized == null) return;
+  /// The relative slug of every user-attached photo that belongs in a JSON
+  /// bundle, in archive order and without repeats.
+  ///
+  /// **Intakes are a source in their own right, not a duplicate of the
+  /// templates.** A custom meal logged with *Save for next time* off writes
+  /// no custom-meal record ([`edit_meal_screen`], #249), but the intake keeps
+  /// its `localImagePath` and the diary card renders it. Gathering only from
+  /// recipes and custom meals therefore put the reference in the JSON and
+  /// left the bytes out of the zip, so a restore lost the photo with nothing
+  /// failing anywhere (#1061).
+  ///
+  /// Deduplicated because the ordinary case — a saved custom meal that has
+  /// also been logged — reaches this twice, and two archive entries with one
+  /// name would double the bundle for every photographed meal.
+  ///
+  /// Pure, and separated from the file reads for that reason: which photos
+  /// belong in the bundle is the part worth testing, and it needs no
+  /// filesystem to answer.
+  @visibleForTesting
+  static List<String> userImagePaths({
+    required Iterable<RecipeDBO> recipes,
+    required Iterable<MealDBO> customMeals,
+    required Iterable<IntakeDBO> intakes,
+  }) {
+    final seen = <String>{};
+    final paths = <String>[];
+
+    void add(String? relativePath) {
+      if (relativePath == null) return;
+      final sanitized = UserImageStorage.sanitizeRelative(relativePath);
+      if (sanitized == null || !seen.add(sanitized)) return;
+      paths.add(sanitized);
+    }
+
+    for (final recipe in recipes) {
+      add(recipe.imagePath);
+    }
+    for (final meal in customMeals) {
+      add(meal.localImagePath);
+    }
+    for (final intake in intakes) {
+      add(intake.meal.localImagePath);
+    }
+    return paths;
+  }
+
+  /// Adds the bytes for one already-sanitized slug, if the file is still
+  /// there. A missing file is not an error: the photo may have been cleared
+  /// by the OS, and losing one image is not worth failing an export over.
+  Future<void> _addUserImage(Archive archive, String sanitized) async {
     final absolute = await UserImageStorage.absolutePath(sanitized);
     final file = File(absolute);
     if (!await file.exists()) return;

--- a/test/unit_test/export_user_image_paths_test.dart
+++ b/test/unit_test/export_user_image_paths_test.dart
@@ -1,0 +1,167 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:opennutritracker/core/data/dbo/intake_dbo.dart';
+import 'package:opennutritracker/core/data/dbo/intake_type_dbo.dart';
+import 'package:opennutritracker/core/data/dbo/meal_dbo.dart';
+import 'package:opennutritracker/core/data/dbo/meal_nutriments_dbo.dart';
+import 'package:opennutritracker/core/data/dbo/recipe_dbo.dart';
+import 'package:opennutritracker/features/settings/domain/usecase/export_data_usecase.dart';
+
+/// Which user photos belong in a JSON bundle (#1061).
+///
+/// Export used to gather meal photos from the custom-meal box alone. A meal
+/// logged with *Save for next time* off writes no custom-meal record (#249)
+/// but keeps `localImagePath` on the intake, so the JSON carried a reference
+/// to `meal_images/<id>.webp` that the archive did not contain. Nothing
+/// failed — the photo was simply gone after a restore, which is the worst
+/// shape for a backup to fail in.
+void main() {
+  group('ExportDataUsecase.userImagePaths', () {
+    // The regression. This is the only source that reaches a one-off entry.
+    test('collects a photo that exists only on an intake', () {
+      final paths = ExportDataUsecase.userImagePaths(
+        recipes: const [],
+        customMeals: const [],
+        intakes: [_intake(imagePath: 'meal_images/one-off.webp')],
+      );
+
+      expect(paths, ['meal_images/one-off.webp']);
+    });
+
+    test('collects recipe and custom-meal photos as before', () {
+      final paths = ExportDataUsecase.userImagePaths(
+        recipes: [_recipe(imagePath: 'recipe_images/r.webp')],
+        customMeals: [_meal(imagePath: 'meal_images/saved.webp')],
+        intakes: const [],
+      );
+
+      expect(paths, ['recipe_images/r.webp', 'meal_images/saved.webp']);
+    });
+
+    // The ordinary case — a saved custom meal that has also been logged —
+    // reaches this from two sources. Two archive entries under one name
+    // would double the bundle for every photographed meal.
+    test('a saved meal that was also logged is collected once', () {
+      const shared = 'meal_images/saved.webp';
+      final paths = ExportDataUsecase.userImagePaths(
+        recipes: const [],
+        customMeals: [_meal(imagePath: shared)],
+        intakes: [_intake(imagePath: shared)],
+      );
+
+      expect(paths, [shared]);
+    });
+
+    test('two intakes of the same meal contribute one entry', () {
+      const shared = 'meal_images/same.webp';
+      final paths = ExportDataUsecase.userImagePaths(
+        recipes: const [],
+        customMeals: const [],
+        intakes: [
+          _intake(imagePath: shared),
+          _intake(imagePath: shared),
+        ],
+      );
+
+      expect(paths, [shared]);
+    });
+
+    test('meals and recipes without a photo contribute nothing', () {
+      final paths = ExportDataUsecase.userImagePaths(
+        recipes: [_recipe(imagePath: null)],
+        customMeals: [_meal(imagePath: null)],
+        intakes: [_intake(imagePath: null)],
+      );
+
+      expect(paths, isEmpty);
+    });
+
+    // `sanitizeRelative` is what keeps a crafted path from escaping the
+    // documents directory on import. Filtering here rather than at the file
+    // read keeps that single gate in front of every source.
+    test('paths that are not a known image slug are dropped', () {
+      final paths = ExportDataUsecase.userImagePaths(
+        recipes: const [],
+        customMeals: const [],
+        intakes: [
+          _intake(imagePath: '../../etc/passwd'),
+          _intake(imagePath: 'meal_images/../../escape.webp'),
+          _intake(imagePath: 'not_an_image_dir/x.webp'),
+          _intake(imagePath: 'meal_images/'),
+          _intake(imagePath: 'meal_images/ok.webp'),
+        ],
+      );
+
+      expect(paths, ['meal_images/ok.webp']);
+    });
+
+    test('order is recipes, then custom meals, then intakes', () {
+      final paths = ExportDataUsecase.userImagePaths(
+        recipes: [_recipe(imagePath: 'recipe_images/r.webp')],
+        customMeals: [_meal(imagePath: 'meal_images/m.webp')],
+        intakes: [_intake(imagePath: 'meal_images/i.webp')],
+      );
+
+      expect(paths, [
+        'recipe_images/r.webp',
+        'meal_images/m.webp',
+        'meal_images/i.webp',
+      ]);
+    });
+  });
+}
+
+IntakeDBO _intake({required String? imagePath}) => IntakeDBO(
+  id: 'intake-1',
+  unit: 'g',
+  amount: 100,
+  type: IntakeTypeDBO.snack,
+  meal: _meal(imagePath: imagePath),
+  dateTime: DateTime.utc(2026, 1, 1),
+);
+
+MealDBO _meal({required String? imagePath}) => MealDBO(
+  code: null,
+  name: 'Sample meal',
+  brands: null,
+  thumbnailImageUrl: null,
+  mainImageUrl: null,
+  url: null,
+  mealQuantity: '100',
+  mealUnit: 'g',
+  servingQuantity: null,
+  servingUnit: null,
+  servingSize: null,
+  source: MealSourceDBO.custom,
+  nutriments: MealNutrimentsDBO(
+    energyKcal100: 100,
+    carbohydrates100: null,
+    fat100: null,
+    proteins100: null,
+    sugars100: null,
+    saturatedFat100: null,
+    fiber100: null,
+  ),
+  localImagePath: imagePath,
+);
+
+RecipeDBO _recipe({required String? imagePath}) => RecipeDBO(
+  id: 'recipe-1',
+  name: 'Sample recipe',
+  description: null,
+  ingredients: const [],
+  totalWeightG: 100,
+  aggregatedNutrimentsPer100: MealNutrimentsDBO(
+    energyKcal100: 100,
+    carbohydrates100: null,
+    fat100: null,
+    proteins100: null,
+    sugars100: null,
+    saturatedFat100: null,
+    fiber100: null,
+  ),
+  createdAt: DateTime.utc(2026, 1, 1),
+  updatedAt: DateTime.utc(2026, 1, 1),
+  servingsCount: null,
+  tags: null,
+  imagePath: imagePath,
+);


### PR DESCRIPTION
Closes #1061. Option **B** from the issue — fix the export rather than qualify the docs.

## The defect

A custom meal logged with **Save for next time** off writes no custom-meal record (#249), but the intake keeps its `localImagePath` and the diary card renders it (`intake_card.dart:123`). Export gathered meal photos from `getAllCustomMeals()` alone, so the JSON carried a reference to `meal_images/<id>.webp` that the archive did not contain.

**Nothing failed.** No error, no warning, and the export looked complete — the photo was simply gone after a restore. For a backup, that is the worst available failure shape.

## Why B rather than A

That photo is durable user data everywhere else in the app: it survives on disk, renders in the diary, and is deleted with the intake. Export was the only place it was treated as belonging to a *template* rather than to an *entry*. Qualifying the docs would have made the sentence true while leaving a backup that quietly drops data.

Import needed nothing — it restores by archive entry name, so the bytes now land exactly where the JSON already pointed.

## The shape of the change

Intakes become a third source alongside recipes and saved custom meals, and the three are **deduplicated**. That is not defensive: the ordinary case — a saved meal that has also been logged — reaches the collector twice, and two archive entries under one name would double the bundle for every photographed meal.

The decision of *which* photos belong in a bundle is now a pure static method, with the file reads left outside it. That is the part worth testing and it needs no filesystem to answer; the old code interleaved the two, which is why nothing covered it.

## Verification

Seven tests: the one-off entry (the regression), both older sources, deduplication from two directions, absent paths, the `sanitizeRelative` gate that stops a crafted path escaping the documents directory, and archive order.

Mutation-checked rather than assumed — three regressions introduced one at a time, all three caught:

| mutation | result |
| :-- | :-- |
| drop the intake loop (restore the bug) | 4 tests fail |
| remove the dedup | 2 tests fail |
| skip the `sanitizeRelative` gate | 1 test fails |

Full suite green at **2140** (2133 before, plus these seven).

## Docs

`docs/export-format.md` said *"**Any** user-attached recipe and custom-meal images are added"*. "Any" was the word doing the damage — a universal claim nobody had checked. It now names the three sources and says why the third is not redundant, so the claim is checkable rather than sweeping.

The README needed no change: *"(recipe and custom-meal photos included)"* is true once this lands.

## Provenance

Found by the Codex review on #1010, corrected there, then lost in a later revision. Re-verified against the code before filing as #1061 rather than taken from the review.