### PR TITLE
test: round-trip one-off meal photo in JSON export #1061

### DIFF
--- a/lib/features/settings/domain/usecase/export_data_usecase.dart
+++ b/lib/features/settings/domain/usecase/export_data_usecase.dart
@@ -66,6 +66,60 @@ class ExportDataUsecase {
     String userIntakeCsvFileName = 'user_intake.csv',
     String trackedDayCsvFileName = 'user_tracked_day.csv',
   }) async {
+    final archive = await assembleArchive(
+      format: format,
+      userActivityJsonFileName: userActivityJsonFileName,
+      userIntakeJsonFileName: userIntakeJsonFileName,
+      trackedDayJsonFileName: trackedDayJsonFileName,
+      recipeJsonFileName: recipeJsonFileName,
+      weightLogJsonFileName: weightLogJsonFileName,
+      customActivityTemplateJsonFileName: customActivityTemplateJsonFileName,
+      userActivityCsvFileName: userActivityCsvFileName,
+      userIntakeCsvFileName: userIntakeCsvFileName,
+      trackedDayCsvFileName: trackedDayCsvFileName,
+    );
+
+    // Save the zip file to the user-specified location
+    final zipBytes = ZipEncoder().encode(archive);
+    if (zipBytes.isEmpty) {
+      // We built the archive ourselves a few lines up, so this should be
+      // unreachable — but if it ever happens, fail loudly rather than
+      // handing FilePicker.saveFile an empty payload and calling that
+      // a successful export.
+      throw StateError('Export archive was empty, refusing to save it');
+    }
+
+    final result = await FilePicker.saveFile(
+      fileName: exportZipFileName,
+      type: FileType.custom,
+      allowedExtensions: ['zip'],
+      bytes: Uint8List.fromList(zipBytes),
+    );
+
+    if (result == null || result.isEmpty) {
+      // User cancelled the save dialog.
+      return false;
+    }
+
+    ExportWriteVerifier.verify(result, zipBytes.length);
+    return true;
+  }
+
+  /// Builds the export archive without prompting for a save location.
+  /// [exportData] zips this and hands it to FilePicker; tests call it
+  /// directly so a one-off meal photo can be asserted without a dialog.
+  Future<Archive> assembleArchive({
+    required ExportFormat format,
+    required String userActivityJsonFileName,
+    required String userIntakeJsonFileName,
+    required String trackedDayJsonFileName,
+    required String recipeJsonFileName,
+    required String weightLogJsonFileName,
+    required String customActivityTemplateJsonFileName,
+    String userActivityCsvFileName = 'user_activity.csv',
+    String userIntakeCsvFileName = 'user_intake.csv',
+    String trackedDayCsvFileName = 'user_tracked_day.csv',
+  }) async {
     final archive = Archive();
 
     // Activity dataset
@@ -169,30 +223,7 @@ class ExportDataUsecase {
       );
     }
 
-    // Save the zip file to the user-specified location
-    final zipBytes = ZipEncoder().encode(archive);
-    if (zipBytes.isEmpty) {
-      // We built the archive ourselves a few lines up, so this should be
-      // unreachable — but if it ever happens, fail loudly rather than
-      // handing FilePicker.saveFile an empty payload and calling that
-      // a successful export.
-      throw StateError('Export archive was empty, refusing to save it');
-    }
-
-    final result = await FilePicker.saveFile(
-      fileName: exportZipFileName,
-      type: FileType.custom,
-      allowedExtensions: ['zip'],
-      bytes: Uint8List.fromList(zipBytes),
-    );
-
-    if (result == null || result.isEmpty) {
-      // User cancelled the save dialog.
-      return false;
-    }
-
-    ExportWriteVerifier.verify(result, zipBytes.length);
-    return true;
+    return archive;
   }
 
   /// The relative slug of every user-attached photo that belongs in a JSON

--- a/test/unit_test/export_one_off_meal_photo_test.dart
+++ b/test/unit_test/export_one_off_meal_photo_test.dart
@@ -1,0 +1,216 @@
+import 'dart:io';
+import 'dart:typed_data';
+
+import 'package:archive/archive.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:opennutritracker/core/data/data_source/custom_activity_template_data_source.dart';
+import 'package:opennutritracker/core/data/data_source/custom_meal_data_source.dart';
+import 'package:opennutritracker/core/data/data_source/intake_data_source.dart';
+import 'package:opennutritracker/core/data/data_source/recipe_data_source.dart';
+import 'package:opennutritracker/core/data/data_source/tracked_day_data_source.dart';
+import 'package:opennutritracker/core/data/data_source/user_activity_data_source.dart';
+import 'package:opennutritracker/core/data/data_source/weight_log_data_source.dart';
+import 'package:opennutritracker/core/data/dbo/intake_dbo.dart';
+import 'package:opennutritracker/core/data/dbo/intake_type_dbo.dart';
+import 'package:opennutritracker/core/data/dbo/meal_dbo.dart';
+import 'package:opennutritracker/core/data/dbo/meal_nutriments_dbo.dart';
+import 'package:opennutritracker/core/data/dbo/recipe_dbo.dart';
+import 'package:opennutritracker/core/data/dbo/tracked_day_dbo.dart';
+import 'package:opennutritracker/core/data/data_source/user_activity_dbo.dart';
+import 'package:opennutritracker/core/data/dbo/weight_log_dbo.dart';
+import 'package:opennutritracker/core/data/data_source/custom_activity_template_dbo.dart';
+import 'package:opennutritracker/core/data/repository/custom_activity_template_repository.dart';
+import 'package:opennutritracker/core/data/repository/intake_repository.dart';
+import 'package:opennutritracker/core/data/repository/recipe_repository.dart';
+import 'package:opennutritracker/core/data/repository/tracked_day_repository.dart';
+import 'package:opennutritracker/core/data/repository/user_activity_repository.dart';
+import 'package:opennutritracker/core/data/repository/weight_log_repository.dart';
+import 'package:opennutritracker/core/utils/user_image_storage.dart';
+import 'package:opennutritracker/features/settings/domain/usecase/export_data_usecase.dart';
+import 'package:path_provider_platform_interface/path_provider_platform_interface.dart';
+import 'package:plugin_platform_interface/plugin_platform_interface.dart';
+
+import '../helpers/fake_hive_db_provider.dart';
+
+class _FakePathProvider extends PathProviderPlatform
+    with MockPlatformInterfaceMixin {
+  _FakePathProvider(this.root);
+
+  final String root;
+
+  @override
+  Future<String?> getApplicationDocumentsPath() async => root;
+}
+
+class _StubUserActivityRepository extends UserActivityRepository {
+  _StubUserActivityRepository()
+    : super(UserActivityDataSource(FakeHiveDBProvider()));
+
+  @override
+  Future<List<UserActivityDBO>> getAllUserActivityDBO() async => [];
+}
+
+class _StubIntakeRepository extends IntakeRepository {
+  _StubIntakeRepository(this._intakes)
+    : super(IntakeDataSource(FakeHiveDBProvider()));
+
+  final List<IntakeDBO> _intakes;
+
+  @override
+  Future<List<IntakeDBO>> getAllIntakesDBO() async => _intakes;
+}
+
+class _StubTrackedDayRepository extends TrackedDayRepository {
+  _StubTrackedDayRepository()
+    : super(TrackedDayDataSource(FakeHiveDBProvider()));
+
+  @override
+  Future<List<TrackedDayDBO>> getAllTrackedDaysDBO() async => [];
+}
+
+class _StubRecipeRepository extends RecipeRepository {
+  _StubRecipeRepository() : super(RecipeDataSource(FakeHiveDBProvider()));
+
+  @override
+  List<RecipeDBO> getAllRecipesDBO() => [];
+}
+
+class _StubCustomMealDataSource extends CustomMealDataSource {
+  _StubCustomMealDataSource(this._meals) : super(FakeHiveDBProvider());
+
+  final List<MealDBO> _meals;
+
+  @override
+  List<MealDBO> getAllCustomMeals() => _meals;
+}
+
+class _StubWeightLogRepository extends WeightLogRepository {
+  _StubWeightLogRepository() : super(WeightLogDataSource(FakeHiveDBProvider()));
+
+  @override
+  Future<List<WeightLogDBO>> getAllEntriesDBO() async => [];
+}
+
+class _StubTemplateRepository extends CustomActivityTemplateRepository {
+  _StubTemplateRepository()
+    : super(CustomActivityTemplateDataSource(FakeHiveDBProvider()));
+
+  @override
+  Future<List<CustomActivityTemplateDBO>> allTemplateDBOs() async => [];
+}
+
+MealDBO _meal({required String id, String? localImagePath}) {
+  return MealDBO(
+    code: id,
+    name: 'One-off soup',
+    brands: null,
+    thumbnailImageUrl: null,
+    mainImageUrl: null,
+    url: null,
+    mealQuantity: '100',
+    mealUnit: 'g',
+    servingQuantity: 100,
+    servingUnit: 'g',
+    servingSize: '100 g',
+    nutriments: MealNutrimentsDBO(
+      energyKcal100: 40,
+      carbohydrates100: 5,
+      fat100: 1,
+      proteins100: 2,
+      sugars100: 1,
+      saturatedFat100: 0,
+      fiber100: 0,
+    ),
+    source: MealSourceDBO.custom,
+    localImagePath: localImagePath,
+  );
+}
+
+void main() {
+  TestWidgetsFlutterBinding.ensureInitialized();
+
+  late Directory tempRoot;
+
+  setUp(() async {
+    tempRoot = await Directory.systemTemp.createTemp('ont_export_photo_');
+    PathProviderPlatform.instance = _FakePathProvider(tempRoot.path);
+  });
+
+  tearDown(() async {
+    if (await tempRoot.exists()) {
+      await tempRoot.delete(recursive: true);
+    }
+  });
+
+  test(
+    'JSON export includes a one-off custom meal photo and import restores it',
+    () async {
+      const slug = 'meal_images/one-off.webp';
+      final photoBytes = Uint8List.fromList([1, 2, 3, 4, 5]);
+      final mealDir = Directory('${tempRoot.path}/meal_images');
+      await mealDir.create(recursive: true);
+      final original = File('${tempRoot.path}/$slug');
+      await original.writeAsBytes(photoBytes, flush: true);
+
+      final intake = IntakeDBO(
+        id: 'intake-1',
+        unit: 'g',
+        amount: 150,
+        type: IntakeTypeDBO.lunch,
+        meal: _meal(id: 'one-off', localImagePath: slug),
+        dateTime: DateTime(2026, 9, 4),
+      );
+
+      final usecase = ExportDataUsecase(
+        _StubUserActivityRepository(),
+        _StubIntakeRepository([intake]),
+        _StubTrackedDayRepository(),
+        _StubRecipeRepository(),
+        _StubCustomMealDataSource([]),
+        _StubWeightLogRepository(),
+        _StubTemplateRepository(),
+      );
+
+      final archive = await usecase.assembleArchive(
+        format: ExportFormat.json,
+        userActivityJsonFileName: 'user_activity.json',
+        userIntakeJsonFileName: 'user_intake.json',
+        trackedDayJsonFileName: 'user_tracked_day.json',
+        recipeJsonFileName: 'user_recipes.json',
+        weightLogJsonFileName: 'weight_log.json',
+        customActivityTemplateJsonFileName: 'custom_activity_templates.json',
+      );
+
+      final photoEntry = archive.findFile(slug);
+      expect(
+        photoEntry,
+        isNotNull,
+        reason: 'one-off intake photo must be in the JSON zip',
+      );
+      expect(photoEntry!.content as List<int>, equals(photoBytes));
+
+      // Round-trip: drop the on-disk file, then restore the way
+      // ImportDataUsecase writes meal_images/ entries.
+      await original.delete();
+      expect(original.existsSync(), isFalse);
+
+      final zipBytes = ZipEncoder().encode(archive);
+      final restored = ZipDecoder().decodeBytes(zipBytes);
+      final mealOut = await UserImageStorage.ensureDirectory(
+        UserImageKind.meal,
+      );
+      for (final entry in restored.files) {
+        if (!entry.isFile) continue;
+        final sanitized = UserImageStorage.sanitizeRelative(entry.name);
+        if (sanitized == null) continue;
+        final parts = sanitized.split('/');
+        if (parts[0] != UserImageKind.meal.subdir) continue;
+        final dest = File('${mealOut.path}/${parts[1]}');
+        await dest.writeAsBytes(entry.content as List<int>, flush: true);
+      }
+
+      expect(original.existsSync(), isTrue);
+      expect(await original.readAsBytes(), equals(photoBytes));
+    },
+  );
+}


### PR DESCRIPTION
## Summary
Rebased onto develop after #1079. Collection already lives in `userImagePaths`, so I dropped that part.

Kept `assembleArchive` and the round-trip test against the merged code — real files, real zip, assertion on the bytes inside.

## Type of change
- [ ] Bug fix
- [ ] New feature
- [x] Refactor / cleanup
- [ ] Documentation
- [ ] CI / tooling
- [ ] Localization
- [ ] Other

## Related issues
Refs #1061

## Changes
- Extract `assembleArchive` so export can be driven without FilePicker
- Round-trip test for a one-off meal photo (empty catalogue, photo on the intake)

## Screenshots / recordings

## Test plan
- [ ] Described steps below were followed locally
- [x] Unit / widget tests added or updated (if applicable)
- [ ] Manual check on Android
- [ ] Manual check on iOS (if applicable)

### Steps
1. `flutter test test/unit_test/export_one_off_meal_photo_test.dart`

## Checklist
- [x] Code follows project style — run `just format` (`dart format`'s default 80-column width; nothing configures a wider one)
- [ ] New interactive widgets include `Semantics(identifier: '...')` where needed
- [ ] Localization updated in **every** `lib/l10n/intl_*.arb` with a real translation, not the English string (`lib/generated/` is gitignored — do not edit or commit it)
- [ ] Codegen ran if DBOs/DTOs/env changed (`just build`)
- [x] No secrets or `.env` values committed
- [x] PR title follows conventional commit style (e.g. `feat:`, `fix:`, `chore:`)
