### PR TITLE
fix(bulk-add): give the photo failure the route its text already names

### DIFF
--- a/lib/features/add_meal/presentation/screens/bulk_add_screen.dart
+++ b/lib/features/add_meal/presentation/screens/bulk_add_screen.dart
@@ -401,6 +401,33 @@ class _BulkAddScreenState extends State<BulkAddScreen> {
         BulkAddPhotoError.insecureDestination =>
           S.of(context).bulkAddModelInsecureServerLabel,
         BulkAddPhotoError.billing => S.of(context).bulkAddPhotoNoCreditLabel,
+      },
+      // #992. Three of these sentences send the user to Settings by name and
+      // the fourth is answered there too, but only the *text* path ever
+      // carried a way in — the photo path said "check it in Settings" and
+      // left the user to find it, which is the hunt #852 already fixed once,
+      // in the same dialog, for the same failures.
+      //
+      // Exhaustive, and deliberately not a `_ => null` default: a ninth photo
+      // failure has to say here whether Settings answers it, rather than
+      // inheriting silence from a case nobody weighed it against.
+      //
+      // The four that get nothing point somewhere else, and a Settings button
+      // under them would send the user to fix the one thing that is not
+      // broken: the camera case is a permission the OS holds, the unreadable
+      // case wants a different photograph, the transient case wants the
+      // connection or another attempt, and the billing case is settled on the
+      // provider's own site — its sentence says so.
+      action: switch (state.error) {
+        BulkAddPhotoError.unavailable ||
+        BulkAddPhotoError.auth ||
+        BulkAddPhotoError.unsupported ||
+        BulkAddPhotoError.insecureDestination =>
+          () => _openAiSettings(context),
+        BulkAddPhotoError.transient ||
+        BulkAddPhotoError.camera ||
+        BulkAddPhotoError.unreadable ||
+        BulkAddPhotoError.billing => null,
       });
     }
     if (state is! BulkAddLoadedState) {
@@ -501,10 +528,7 @@ class _BulkAddScreenState extends State<BulkAddScreen> {
         // does not appear here on purpose: the auth, unsupported, billing,
         // timeout and insecure-destination cases are all fixed in this one
         // dialog, so they all ask for the same thing.
-        action: () => Navigator.of(context).pushNamed(
-          NavigationOptions.settingsRoute,
-          arguments: const SettingsScreenArguments(openAiAssist: true),
-        ),
+        action: () => _openAiSettings(context),
       );
     }
 
@@ -630,9 +654,53 @@ class _BulkAddScreenState extends State<BulkAddScreen> {
     );
   }
 
-  Widget _centeredMessage(BuildContext context, String message) => Padding(
+  /// The one place every "change a setting" recovery on this screen goes.
+  ///
+  /// Shared rather than repeated so the two paths cannot drift: the photo
+  /// failures are answered in the same dialog as the text ones, and the whole
+  /// point of #852 is that the route carries *which* part of Settings to
+  /// open. A second copy of these arguments is a second chance to lose them.
+  void _openAiSettings(BuildContext context) => Navigator.of(context).pushNamed(
+    NavigationOptions.settingsRoute,
+    arguments: const SettingsScreenArguments(openAiAssist: true),
+  );
+
+  /// A message that fills the body, optionally with something to do about it.
+  ///
+  /// [action] is optional because most callers have nothing to offer: a
+  /// failed food search and an empty parse are not fixed anywhere in
+  /// particular, so they stay a sentence and nothing else.
+  Widget _centeredMessage(
+    BuildContext context,
+    String message, {
+    VoidCallback? action,
+  }) => Padding(
     padding: const EdgeInsets.all(24),
-    child: Center(child: Text(message, textAlign: TextAlign.center)),
+    // Scrollable rather than clipped, for the reason #777 settled: this
+    // region takes a tight height from the `Expanded` above, and German at 2x
+    // on a 320dp screen wants 484px more than it has. A bare `Column` there
+    // paints its overflow past the bottom of the screen, and the button is
+    // the last thing in it — so the control this change exists to add would
+    // have been the first thing to go: in the tree, and untappable. Measured,
+    // not assumed; the test pins it.
+    child: Center(
+      child: SingleChildScrollView(
+        child: Column(
+          mainAxisSize: MainAxisSize.min,
+          children: [
+            Text(message, textAlign: TextAlign.center),
+            if (action != null)
+              Semantics(
+                identifier: 'bulk-add-message-action',
+                child: TextButton(
+                  onPressed: action,
+                  child: Text(S.of(context).settingsLabel),
+                ),
+              ),
+          ],
+        ),
+      ),
+    ),
   );
 
   /// The parser reports *what* was wrong with *which* item; the sentence is

--- a/test/features/add_meal/presentation/bulk_add_screen_test.dart
+++ b/test/features/add_meal/presentation/bulk_add_screen_test.dart
@@ -244,6 +244,49 @@ MealInterpreterFailure _throwsFor(MealTextModelFailure kind) => switch (kind) {
     MealInterpreterFailure.insecureDestination,
 };
 
+/// Whether the photo failure [error] is one the AI settings dialog answers.
+///
+/// A switch over the enum for the same reason [_throwsFor] is one: a ninth
+/// photo failure cannot be added without saying here whether Settings is
+/// where its user should be sent, rather than inheriting an answer from a
+/// default it was never weighed against.
+///
+/// The four that say `false` are answered somewhere this app does not own —
+/// the camera permission, a different photograph, the connection, and the
+/// provider's own billing page.
+bool _offersSettings(BulkAddPhotoError error) => switch (error) {
+  BulkAddPhotoError.unavailable ||
+  BulkAddPhotoError.auth ||
+  BulkAddPhotoError.unsupported ||
+  BulkAddPhotoError.insecureDestination => true,
+  BulkAddPhotoError.transient ||
+  BulkAddPhotoError.camera ||
+  BulkAddPhotoError.unreadable ||
+  BulkAddPhotoError.billing => false,
+};
+
+/// Puts the screen in front of the photo failure [error], without a picker
+/// and without a model: the bloc takes the failure as an event, which is how
+/// the camera path reports one anyway.
+Future<void> _photoFailure(
+  WidgetTester tester,
+  BulkAddPhotoError error, {
+  List<RouteSettings>? pushed,
+  Locale? locale,
+  Widget Function(Widget app)? wrap,
+}) async {
+  final bloc = await _registerWithPhotoReading(
+    const MealPhotoFailed(MealPhotoFailure.transient),
+  );
+  final app = _app(pushed: pushed, locale: locale);
+  await tester.pumpWidget(wrap == null ? app : wrap(app));
+  tester.state<NavigatorState>(find.byType(Navigator)).pushNamed('/bulk');
+  await tester.pumpAndSettle();
+
+  bloc.add(ReadMealPhotoFailedEvent(error));
+  await tester.pumpAndSettle();
+}
+
 class _AlwaysFailsInterpreter implements MealTextInterpreter {
   final MealInterpreterException failure;
 
@@ -1137,6 +1180,122 @@ void main() {
     final l10n = await S.delegate.load(const Locale('en'));
     expect(find.text(l10n.bulkAddModelInsecureServerLabel), findsOneWidget);
     expect(find.text(l10n.bulkAddPhotoUnsupportedLabel), findsNothing);
+  });
+
+  // #992. "Your API key was rejected. Check it in Settings." was the whole of
+  // the photo path's recovery: it named the place and then left the user to
+  // find it, four category groups down a list — the same hunt #852 fixed for
+  // the text path, on failures answered in the same dialog. The destination
+  // is asserted the way the text path's is, arguments and all, because
+  // landing at the top of Settings is the bug rather than a detail of it.
+  for (final error in BulkAddPhotoError.values) {
+    testWidgets(
+      _offersSettings(error)
+          ? 'the photo ${error.name} failure opens the AI settings'
+          : 'the photo ${error.name} failure offers no settings button',
+      (tester) async {
+        final pushed = <RouteSettings>[];
+        await _photoFailure(tester, error, pushed: pushed);
+
+        final action = find.bySemanticsIdentifier('bulk-add-message-action');
+        if (!_offersSettings(error)) {
+          expect(
+            action,
+            findsNothing,
+            reason:
+                '${error.name} is not fixed in Settings, and a button that '
+                'sends the user there is a wrong instruction, not a spare one',
+          );
+          return;
+        }
+
+        expect(action, findsOneWidget, reason: '${error.name} names Settings');
+        // The same word the text path's control carries, from the same key:
+        // one action, one label, however the read was started.
+        expect(
+          find.descendant(
+            of: action,
+            matching: find.text(l10nEn.settingsLabel),
+          ),
+          findsOneWidget,
+        );
+
+        await tester.tap(action);
+        await tester.pumpAndSettle();
+
+        final settings = pushed
+            .where((route) => route.name == NavigationOptions.settingsRoute)
+            .toList();
+        expect(settings, hasLength(1));
+        expect(
+          settings.single.arguments,
+          isA<SettingsScreenArguments>().having(
+            (arguments) => arguments.openAiAssist,
+            'openAiAssist',
+            isTrue,
+          ),
+          reason:
+              'the photo path has to land where the text path lands: on the '
+              'AI dialog, not at the top of Settings',
+        );
+        expect(tester.takeException(), isNull);
+      },
+    );
+  }
+
+  testWidgets('the settings button is reachable at 2x in German', (
+    tester,
+  ) async {
+    // The size #777 measured this screen against. The button sits under a
+    // sentence that wants many lines here, and the region is 484px short of
+    // holding both — so "offers the action" is only true if it scrolls. A
+    // plain `Center` paints the control off the bottom of the screen, where
+    // it is findable and untappable.
+    tester.view.physicalSize = const Size(320 * 3, 640 * 3);
+    tester.view.devicePixelRatio = 3.0;
+    addTearDown(tester.view.reset);
+
+    final pushed = <RouteSettings>[];
+    await _photoFailure(
+      tester,
+      BulkAddPhotoError.unsupported,
+      pushed: pushed,
+      locale: const Locale('de'),
+      wrap: (app) => MediaQuery(
+        data: const MediaQueryData(textScaler: TextScaler.linear(2.0)),
+        child: app,
+      ),
+    );
+
+    expect(
+      tester.takeException(),
+      isNull,
+      reason: 'the message and its control must not overflow the body',
+    );
+
+    final action = find.bySemanticsIdentifier('bulk-add-message-action');
+    await tester.ensureVisible(action);
+    await tester.pumpAndSettle();
+    await tester.tap(action);
+    await tester.pumpAndSettle();
+
+    expect(
+      pushed.map((route) => route.name),
+      contains(NavigationOptions.settingsRoute),
+    );
+    expect(tester.takeException(), isNull);
+  });
+
+  testWidgets('a message with nowhere to go stays a sentence', (tester) async {
+    // The centred message's other callers were not given a button by this
+    // change. An empty parse is not fixed in Settings, and sending someone
+    // there for it is the mis-direction #992 fixes, pointed the other way.
+    await _register(const {});
+    await tester.pumpWidget(_app());
+    await _parse(tester, '');
+
+    expect(find.text(l10nEn.bulkAddNothingToLogLabel), findsOneWidget);
+    expect(find.bySemanticsIdentifier('bulk-add-message-action'), findsNothing);
   });
 
   testWidgets('an empty text parse still shows the generic line', (

--- a/test/features/add_meal/presentation/bulk_add_screen_test.dart
+++ b/test/features/add_meal/presentation/bulk_add_screen_test.dart
@@ -1298,6 +1298,40 @@ void main() {
     expect(find.bySemanticsIdentifier('bulk-add-message-action'), findsNothing);
   });
 
+  // Copilot on #1087 read the new `SingleChildScrollView` as breaking the
+  // vertical centring every other caller of `_centeredMessage` relies on.
+  // `Center` passes loose constraints, so the scroll view shrink-wraps its
+  // child rather than filling the viewport — but nothing pinned that, so a
+  // later change could make the claim true without a test noticing.
+  testWidgets('a short message is still vertically centred', (tester) async {
+    await _register(const {});
+    await tester.pumpWidget(_app());
+    await _parse(tester, '');
+
+    final message = find.text(l10nEn.bulkAddNothingToLogLabel);
+    expect(message, findsOneWidget);
+
+    // Compared against the region `_centeredMessage` is given, not the
+    // screen: the input block and divider sit above it, so "centred" means
+    // centred in what is left. The scroll view shrink-wraps the message, so
+    // its box is the message's box — top-aligning it moves this by half the
+    // region, which is what the assertion has to be able to see.
+    final scroller = find.ancestor(
+      of: message,
+      matching: find.byType(SingleChildScrollView),
+    );
+    final region = find.ancestor(of: scroller, matching: find.byType(Padding));
+    final scrollBox = tester.getRect(scroller.first);
+    final regionBox = tester.getRect(region.first);
+
+    expect(
+      (scrollBox.center.dy - regionBox.center.dy).abs(),
+      lessThan(1.0),
+      reason: 'a short message stays centred in its region, not pinned to '
+          'the top of the scroll viewport',
+    );
+  });
+
   testWidgets('an empty text parse still shows the generic line', (
     tester,
   ) async {


### PR DESCRIPTION
Closes item **3** of #992.

The text path's failure notice carries an action to the AI settings. The photo path shows the same words through `_centeredMessage`, which took no action — so a user told to check Settings had to go and find it.

`_centeredMessage` now takes an **optional** action, leaving its other call sites untouched, and the photo failure passes the same label and destination the text path already uses.

**No new string.** The label the text path shows is the one this needed — worth saying because the alternative was nine ARB files for a button that already had a name.

66 tests pass; analyze clean.