### PR TITLE
ci(play): reject a truncated PNG instead of crashing on it

### DIFF
--- a/.github/workflows/play-screenshots.yml
+++ b/.github/workflows/play-screenshots.yml
@@ -126,6 +126,13 @@ jobs:
               if head[:8] != b'\x89PNG\r\n\x1a\n':
                   bad.append(f'{name}: not a PNG')
                   continue
+              # A file can carry the signature and still be too short to hold
+              # an IHDR — a truncated write, an interrupted download, an
+              # unexpanded LFS pointer. Say so, rather than dying in
+              # struct.unpack and leaving a traceback as the whole diagnosis.
+              if len(head) < 26:
+                  bad.append(f'{name}: truncated PNG — {len(head)} bytes, too short to contain an IHDR header')
+                  continue
               w, h, depth, colour = struct.unpack('>IIBB', head[16:26])
               short, long_ = min(w, h), max(w, h)
               ratio = long_ / short

--- a/android/fastlane/Fastfile
+++ b/android/fastlane/Fastfile
@@ -70,6 +70,14 @@ platform :android do
         problems << "#{name}: not a PNG"
         next
       end
+      # A file can carry the signature and still be too short to hold an
+      # IHDR — a truncated write, an interrupted download, an unexpanded LFS
+      # pointer. Say so, rather than unpacking nil and failing with a
+      # NoMethodError that diagnoses nothing.
+      if head.bytesize < 26
+        problems << "#{name}: truncated PNG — #{head.bytesize} bytes, too short to contain an IHDR header"
+        next
+      end
       width, height, depth, colour_type = head[16, 10].unpack('NNCC')
       short = [width, height].min
       long  = [width, height].max


### PR DESCRIPTION
Develop half of a hotfix pair with [#1090](https://github.com/simonoppowa/OpenNutriTracker/pull/1090). Identical commit; both must land.

Copilot flagged it on the main-bound PR: both PNG validators read 26 bytes and unpacked the IHDR without checking they got 26. A file carrying the PNG signature but truncated below that — an interrupted write, a half-finished download, an unexpanded LFS pointer — died in `struct.unpack` on the Python side, and would have unpacked `nil` on the Ruby side.

Fail-safe either way, since both exit non-zero, so nothing unsafe could reach Play. But the diagnosis was a traceback rather than a sentence, and the entire point of validating locally is that the failure explains itself — which makes it a real defect even though the outcome was already safe.

Both now report the byte count and name what is missing:

```
Rejected:
  a.png: truncated PNG — 20 bytes, too short to contain an IHDR header
```

Verified against a 20-byte truncated PNG, a zero-byte file (still `not a PNG`, the signature check catches it first), and the real six-file set, which still passes.

The guard code landed on develop in [#1085](https://github.com/simonoppowa/OpenNutriTracker/pull/1085); this keeps develop and main identical rather than letting the two copies drift.

Refs #1090, #1085.