### PR TITLE
fix(bulk-add): notice an own-server probe that lands after the user is back

### DIFF
--- a/lib/features/add_meal/presentation/screens/bulk_add_screen.dart
+++ b/lib/features/add_meal/presentation/screens/bulk_add_screen.dart
@@ -9,6 +9,7 @@ import 'package:logging/logging.dart';
 import 'package:flutter_bloc/flutter_bloc.dart';
 import 'package:opennutritracker/core/domain/entity/intake_type_entity.dart';
 import 'package:opennutritracker/core/utils/ai_credential_storage.dart';
+import 'package:opennutritracker/features/add_meal/domain/usecase/run_ai_endpoint_probe_usecase.dart';
 import 'package:opennutritracker/core/utils/ai_model_catalogue.dart';
 import 'package:opennutritracker/core/utils/energy_display.dart';
 import 'package:opennutritracker/core/utils/locator.dart';
@@ -208,12 +209,49 @@ class _BulkAddScreenState extends State<BulkAddScreen> {
       context,
     ).pushNamed(NavigationOptions.settingsRoute, arguments: arguments);
     if (!mounted) return;
+    _resolveAiAnswers();
+    await _resolveAgainWhenProbeLands();
+  }
+
+  void _resolveAiAnswers() {
     setState(() {
       // Destination first: the availability answer awaits this field.
       _photoDestination = _resolvePhotoDestination();
       _photoAvailable = _resolvePhotoAvailable();
       _modelUnknown = _resolveModelUnknown();
     });
+  }
+
+  /// A second trigger, for the one answer that is not ready when the user
+  /// comes back. #1089.
+  ///
+  /// Saving an own-server address starts a capability probe **without
+  /// awaiting it**, and it takes long enough that returning promptly reads
+  /// the verdict as `unknown`. `_ownServerDestination` requires
+  /// `photo == passed`, so the camera stays hidden — and the route pop was
+  /// the only thing that would have re-read it, and has already happened.
+  ///
+  /// The waiting itself is deliberate and stays: the camera is offered only
+  /// once a photograph has actually been read (#735). What was missing is
+  /// that nothing told the screen the verdict had arrived.
+  ///
+  /// Own-server only, because it is the only provider whose availability
+  /// depends on a probe. `current` is null between one probe finishing and
+  /// its replacement registering — two keystore reads wide, documented on
+  /// the runner — and this returns rather than polling: the answer it would
+  /// have waited for is already stored, so the re-resolve above read it.
+  Future<void> _resolveAgainWhenProbeLands() async {
+    const provider = AiProvider.ownServer;
+    if (await locator<AiCredentialStorage>().activeProvider() != provider) {
+      return;
+    }
+
+    final running = locator<AiEndpointProbeRunner>().current(provider);
+    if (running == null) return;
+
+    await running;
+    if (!mounted) return;
+    _resolveAiAnswers();
   }
 
   @override
@@ -280,7 +318,10 @@ class _BulkAddScreenState extends State<BulkAddScreen> {
                 // at large text scales would take multi-line entry away from
                 // exactly the users who need the biggest text, on a screen
                 // that exists for typing several items at once.
-                _buildInput(context, maxFieldHeight: constraints.maxHeight * 0.3),
+                _buildInput(
+                  context,
+                  maxFieldHeight: constraints.maxHeight * 0.3,
+                ),
                 const Divider(height: 1),
                 Expanded(child: _buildBody(context, state)),
                 if (state is BulkAddLoadedState)
@@ -384,8 +425,10 @@ class _BulkAddScreenState extends State<BulkAddScreen> {
     },
   );
 
-  Widget _buildInput(BuildContext context, {required double maxFieldHeight}) =>
-      Padding(
+  Widget _buildInput(
+    BuildContext context, {
+    required double maxFieldHeight,
+  }) => Padding(
     padding: const EdgeInsets.all(16),
     child: Column(
       crossAxisAlignment: CrossAxisAlignment.stretch,
@@ -396,19 +439,19 @@ class _BulkAddScreenState extends State<BulkAddScreen> {
         ConstrainedBox(
           constraints: BoxConstraints(maxHeight: maxFieldHeight),
           child: Semantics(
-          identifier: 'bulk-add-input',
-          child: TextField(
-            controller: _textController,
-            minLines: 2,
-            maxLines: 4,
-            textInputAction: TextInputAction.newline,
-            keyboardType: TextInputType.multiline,
-            decoration: InputDecoration(
-              hintText: S.of(context).bulkAddInputHint,
-              border: const OutlineInputBorder(),
+            identifier: 'bulk-add-input',
+            child: TextField(
+              controller: _textController,
+              minLines: 2,
+              maxLines: 4,
+              textInputAction: TextInputAction.newline,
+              keyboardType: TextInputType.multiline,
+              decoration: InputDecoration(
+                hintText: S.of(context).bulkAddInputHint,
+                border: const OutlineInputBorder(),
+              ),
             ),
           ),
-        ),
         ),
         const SizedBox(height: 12),
         Semantics(
@@ -431,47 +474,52 @@ class _BulkAddScreenState extends State<BulkAddScreen> {
       return _centeredMessage(context, S.of(context).bulkAddSearchFailedLabel);
     }
     if (state is BulkAddPhotoErrorState) {
-      return _centeredMessage(context, switch (state.error) {
-        BulkAddPhotoError.unavailable =>
-          S.of(context).bulkAddPhotoUnavailableLabel,
-        BulkAddPhotoError.auth => S.of(context).bulkAddPhotoKeyRejectedLabel,
-        BulkAddPhotoError.transient => S.of(context).bulkAddPhotoFailedLabel,
-        BulkAddPhotoError.camera => S.of(context).bulkAddPhotoCameraFailedLabel,
-        BulkAddPhotoError.unreadable =>
-          S.of(context).bulkAddPhotoUnreadableLabel,
-        BulkAddPhotoError.unsupported =>
-          S.of(context).bulkAddPhotoUnsupportedLabel,
-        BulkAddPhotoError.insecureDestination =>
-          S.of(context).bulkAddModelInsecureServerLabel,
-        BulkAddPhotoError.billing => S.of(context).bulkAddPhotoNoCreditLabel,
-      },
-      // #992. Three of these sentences send the user to Settings by name and
-      // the fourth is answered there too, but only the *text* path ever
-      // carried a way in — the photo path said "check it in Settings" and
-      // left the user to find it, which is the hunt #852 already fixed once,
-      // in the same dialog, for the same failures.
-      //
-      // Exhaustive, and deliberately not a `_ => null` default: a ninth photo
-      // failure has to say here whether Settings answers it, rather than
-      // inheriting silence from a case nobody weighed it against.
-      //
-      // The four that get nothing point somewhere else, and a Settings button
-      // under them would send the user to fix the one thing that is not
-      // broken: the camera case is a permission the OS holds, the unreadable
-      // case wants a different photograph, the transient case wants the
-      // connection or another attempt, and the billing case is settled on the
-      // provider's own site — its sentence says so.
-      action: switch (state.error) {
-        BulkAddPhotoError.unavailable ||
-        BulkAddPhotoError.auth ||
-        BulkAddPhotoError.unsupported ||
-        BulkAddPhotoError.insecureDestination =>
-          () => _openAiSettings(context),
-        BulkAddPhotoError.transient ||
-        BulkAddPhotoError.camera ||
-        BulkAddPhotoError.unreadable ||
-        BulkAddPhotoError.billing => null,
-      });
+      return _centeredMessage(
+        context,
+        switch (state.error) {
+          BulkAddPhotoError.unavailable =>
+            S.of(context).bulkAddPhotoUnavailableLabel,
+          BulkAddPhotoError.auth => S.of(context).bulkAddPhotoKeyRejectedLabel,
+          BulkAddPhotoError.transient => S.of(context).bulkAddPhotoFailedLabel,
+          BulkAddPhotoError.camera =>
+            S.of(context).bulkAddPhotoCameraFailedLabel,
+          BulkAddPhotoError.unreadable =>
+            S.of(context).bulkAddPhotoUnreadableLabel,
+          BulkAddPhotoError.unsupported =>
+            S.of(context).bulkAddPhotoUnsupportedLabel,
+          BulkAddPhotoError.insecureDestination =>
+            S.of(context).bulkAddModelInsecureServerLabel,
+          BulkAddPhotoError.billing => S.of(context).bulkAddPhotoNoCreditLabel,
+        },
+        // #992. Three of these sentences send the user to Settings by name and
+        // the fourth is answered there too, but only the *text* path ever
+        // carried a way in — the photo path said "check it in Settings" and
+        // left the user to find it, which is the hunt #852 already fixed once,
+        // in the same dialog, for the same failures.
+        //
+        // Exhaustive, and deliberately not a `_ => null` default: a ninth photo
+        // failure has to say here whether Settings answers it, rather than
+        // inheriting silence from a case nobody weighed it against.
+        //
+        // The four that get nothing point somewhere else, and a Settings button
+        // under them would send the user to fix the one thing that is not
+        // broken: the camera case is a permission the OS holds, the unreadable
+        // case wants a different photograph, the transient case wants the
+        // connection or another attempt, and the billing case is settled on the
+        // provider's own site — its sentence says so.
+        action: switch (state.error) {
+          BulkAddPhotoError.unavailable ||
+          BulkAddPhotoError.auth ||
+          BulkAddPhotoError.unsupported ||
+          BulkAddPhotoError.insecureDestination => () => _openAiSettings(
+            context,
+          ),
+          BulkAddPhotoError.transient ||
+          BulkAddPhotoError.camera ||
+          BulkAddPhotoError.unreadable ||
+          BulkAddPhotoError.billing => null,
+        },
+      );
     }
     if (state is! BulkAddLoadedState) {
       // Scrollable because here the line *is* the body and takes a tight
@@ -485,19 +533,19 @@ class _BulkAddScreenState extends State<BulkAddScreen> {
       return _withModelHint(
         context,
         _centeredMessage(context, switch (state) {
-        // A bad segment explains itself; that outranks either generic line.
-        _ when state.parseErrors.isNotEmpty => _parseErrorsText(
-          context,
-          state.parseErrors,
-        ),
-        // The model looked at a photograph and reported no food. "Nothing to
-        // log yet" is true but reads as though nothing happened, and the
-        // notice that would have said a photo was read is not drawn on this
-        // branch — so the one screen where the user most needs to know a
-        // machine answered was the one screen that never said so.
-        _ when state.source == BulkAddReadSource.photo =>
-          S.of(context).bulkAddPhotoNoFoodLabel,
-        _ => S.of(context).bulkAddNothingToLogLabel,
+          // A bad segment explains itself; that outranks either generic line.
+          _ when state.parseErrors.isNotEmpty => _parseErrorsText(
+            context,
+            state.parseErrors,
+          ),
+          // The model looked at a photograph and reported no food. "Nothing to
+          // log yet" is true but reads as though nothing happened, and the
+          // notice that would have said a photo was read is not drawn on this
+          // branch — so the one screen where the user most needs to know a
+          // machine answered was the one screen that never said so.
+          _ when state.source == BulkAddReadSource.photo =>
+            S.of(context).bulkAddPhotoNoFoodLabel,
+          _ => S.of(context).bulkAddNothingToLogLabel,
         }),
       );
     }
@@ -612,87 +660,90 @@ class _BulkAddScreenState extends State<BulkAddScreen> {
     // fraction of it overflows the part that is left.
     return LayoutBuilder(
       builder: (context, constraints) => Column(
-      children: [
-        Semantics(
-          identifier: 'bulk-add-model-notice',
-          child: Container(
-            width: double.infinity,
-            padding: const EdgeInsets.symmetric(horizontal: 16, vertical: 8),
-            color: emphasised
-                ? scheme.errorContainer
-                : scheme.surfaceContainerHighest,
-            // **Bounded, and scrollable rather than clipped.** Dropping the
-            // cap on its own overflowed by 317px at 2x on a 320dp screen —
-            // the notice sits above the rows in a `Column`, so its height
-            // comes straight out of them. A ceiling gives the rows their
-            // share back; scrolling is what stops the ceiling becoming a
-            // second truncation, which is the bug this is fixing.
-            child: ConstrainedBox(
-              constraints: BoxConstraints(
-                maxHeight: constraints.maxHeight * 0.4,
-              ),
-              child: SingleChildScrollView(
-                child: Column(
-              crossAxisAlignment: CrossAxisAlignment.start,
-              mainAxisSize: MainAxisSize.min,
-              children: [
-                Row(
-                  children: [
-                    Icon(
-                      icon,
-                      size: 16,
-                      color: emphasised ? scheme.onErrorContainer : null,
-                    ),
-                    const SizedBox(width: 8),
-                    Expanded(
-                  child: Text(
-                    text,
-                    style: Theme.of(context).textTheme.bodySmall?.copyWith(
-                      color: emphasised ? scheme.onErrorContainer : null,
-                    ),
-                    // **No cap.** There used to be three lines, on the
-                    // reasoning that these run long in German. Measured for
-                    // #777, every one of them overran it — in English too —
-                    // and no cap survives the combination that matters:
-                    // German at 2x on a 320dp screen needed twenty lines,
-                    // which is when the words are needed most. Now that the
-                    // advice is a button, what is left is one sentence: two
-                    // or three lines on a handset, up to eight at 2x on the
-                    // narrowest screen, and never cut off.
-                  ),
+        children: [
+          Semantics(
+            identifier: 'bulk-add-model-notice',
+            child: Container(
+              width: double.infinity,
+              padding: const EdgeInsets.symmetric(horizontal: 16, vertical: 8),
+              color: emphasised
+                  ? scheme.errorContainer
+                  : scheme.surfaceContainerHighest,
+              // **Bounded, and scrollable rather than clipped.** Dropping the
+              // cap on its own overflowed by 317px at 2x on a 320dp screen —
+              // the notice sits above the rows in a `Column`, so its height
+              // comes straight out of them. A ceiling gives the rows their
+              // share back; scrolling is what stops the ceiling becoming a
+              // second truncation, which is the bug this is fixing.
+              child: ConstrainedBox(
+                constraints: BoxConstraints(
+                  maxHeight: constraints.maxHeight * 0.4,
                 ),
-                  ],
-                ),
-                // **Below the sentence, not beside it.** Sharing the row was
-                // measured first and is worse: a button takes about 120px,
-                // which on a 320dp screen leaves the text 144 and pushes
-                // German at 2x back up to twelve lines. Full width for the
-                // words, the control underneath.
-                if (action != null)
-                  Align(
-                    alignment: AlignmentDirectional.centerEnd,
-                    child: Semantics(
-                      identifier: 'bulk-add-notice-action',
-                      child: TextButton(
-                        onPressed: action,
-                        style: TextButton.styleFrom(
-                          foregroundColor: emphasised
-                              ? scheme.onErrorContainer
-                              : null,
-                          visualDensity: VisualDensity.compact,
-                        ),
-                        child: Text(S.of(context).settingsLabel),
+                child: SingleChildScrollView(
+                  child: Column(
+                    crossAxisAlignment: CrossAxisAlignment.start,
+                    mainAxisSize: MainAxisSize.min,
+                    children: [
+                      Row(
+                        children: [
+                          Icon(
+                            icon,
+                            size: 16,
+                            color: emphasised ? scheme.onErrorContainer : null,
+                          ),
+                          const SizedBox(width: 8),
+                          Expanded(
+                            child: Text(
+                              text,
+                              style: Theme.of(context).textTheme.bodySmall
+                                  ?.copyWith(
+                                    color: emphasised
+                                        ? scheme.onErrorContainer
+                                        : null,
+                                  ),
+                              // **No cap.** There used to be three lines, on the
+                              // reasoning that these run long in German. Measured for
+                              // #777, every one of them overran it — in English too —
+                              // and no cap survives the combination that matters:
+                              // German at 2x on a 320dp screen needed twenty lines,
+                              // which is when the words are needed most. Now that the
+                              // advice is a button, what is left is one sentence: two
+                              // or three lines on a handset, up to eight at 2x on the
+                              // narrowest screen, and never cut off.
+                            ),
+                          ),
+                        ],
                       ),
-                    ),
+                      // **Below the sentence, not beside it.** Sharing the row was
+                      // measured first and is worse: a button takes about 120px,
+                      // which on a 320dp screen leaves the text 144 and pushes
+                      // German at 2x back up to twelve lines. Full width for the
+                      // words, the control underneath.
+                      if (action != null)
+                        Align(
+                          alignment: AlignmentDirectional.centerEnd,
+                          child: Semantics(
+                            identifier: 'bulk-add-notice-action',
+                            child: TextButton(
+                              onPressed: action,
+                              style: TextButton.styleFrom(
+                                foregroundColor: emphasised
+                                    ? scheme.onErrorContainer
+                                    : null,
+                                visualDensity: VisualDensity.compact,
+                              ),
+                              child: Text(S.of(context).settingsLabel),
+                            ),
+                          ),
+                        ),
+                    ],
                   ),
-              ],
                 ),
               ),
             ),
           ),
-        ),
-        Expanded(child: list),
-      ],
+          Expanded(child: list),
+        ],
       ),
     );
   }
@@ -711,9 +762,7 @@ class _BulkAddScreenState extends State<BulkAddScreen> {
   /// photo failure action — and only the ones that went through
   /// [_openSettings] noticed a provider configured while they were away.
   void _openAiSettings(BuildContext context) => unawaited(
-    _openSettings(
-      arguments: const SettingsScreenArguments(openAiAssist: true),
-    ),
+    _openSettings(arguments: const SettingsScreenArguments(openAiAssist: true)),
   );
 
   /// A message that fills the body, optionally with something to do about it.
@@ -1099,16 +1148,15 @@ class _BulkAddScreenState extends State<BulkAddScreen> {
 
   /// Says which of the three failures this is. They used to render
   /// identically, as the field's own name.
-  String _quantityErrorText(BuildContext context, BulkAddQuantityError error) =>
-      switch (error) {
-        BulkAddQuantityError.malformed =>
-          S.of(context).bulkAddRowQuantityInvalid,
-        BulkAddQuantityError.tooSmall =>
-          S.of(context).bulkAddRowQuantityTooSmall,
-        BulkAddQuantityError.tooLarge => S
-            .of(context)
-            .bulkAddRowQuantityTooLarge(bulkAddMaxQuantity),
-      };
+  String _quantityErrorText(
+    BuildContext context,
+    BulkAddQuantityError error,
+  ) => switch (error) {
+    BulkAddQuantityError.malformed => S.of(context).bulkAddRowQuantityInvalid,
+    BulkAddQuantityError.tooSmall => S.of(context).bulkAddRowQuantityTooSmall,
+    BulkAddQuantityError.tooLarge =>
+      S.of(context).bulkAddRowQuantityTooLarge(bulkAddMaxQuantity),
+  };
 
   /// What the unit dropdown needs to show its longest unit without clipping
   /// it: the dropdown sizes itself to its widest item, plus its arrow.
@@ -1184,10 +1232,10 @@ class _BulkAddScreenState extends State<BulkAddScreen> {
         UnitDropdownItem.flOz => S.of(context).flOzUnit,
         UnitDropdownItem.serving =>
           householdPortionLabel(
-            row.meal?.servingSize,
-            languageCode: Localizations.localeOf(context).languageCode,
-            textIsLocalized: row.meal?.servingSizeIsLocalized ?? false,
-          ) ??
+                row.meal?.servingSize,
+                languageCode: Localizations.localeOf(context).languageCode,
+                textIsLocalized: row.meal?.servingSizeIsLocalized ?? false,
+              ) ??
               S.of(context).servingLabel,
       };
 
@@ -1429,7 +1477,11 @@ class _BulkAddScreenState extends State<BulkAddScreen> {
       // converted first. Logging the raw amount stores 4 g for 4 oz.
       writes.add((
         row: row,
-        amount: convertQuantityToBaseUnit(quantity, row.effectiveUnit, row.meal!),
+        amount: convertQuantityToBaseUnit(
+          quantity,
+          row.effectiveUnit,
+          row.meal!,
+        ),
       ));
     }
 

--- a/test/features/add_meal/presentation/bulk_add_screen_test.dart
+++ b/test/features/add_meal/presentation/bulk_add_screen_test.dart
@@ -4,6 +4,9 @@ import 'package:flutter/rendering.dart';
 import 'package:flutter_localizations/flutter_localizations.dart';
 import 'package:flutter_secure_storage/flutter_secure_storage.dart';
 import 'package:flutter_test/flutter_test.dart';
+import 'dart:async';
+import 'package:opennutritracker/features/add_meal/domain/usecase/probe_ai_endpoint_usecase.dart';
+import 'package:opennutritracker/features/add_meal/domain/usecase/run_ai_endpoint_probe_usecase.dart';
 import 'package:opennutritracker/core/utils/ai_credential_storage.dart';
 import 'package:opennutritracker/core/utils/ai_model_catalogue.dart';
 import 'package:opennutritracker/features/add_meal/domain/meal_photo_interpreter.dart';
@@ -117,29 +120,28 @@ MealEntity _meal(
   String? mealUnit,
   String? brands,
   List<MealPortionEntity> portions = const [],
-}) =>
-    MealEntity(
-      code: name,
-      name: name,
-      brands: brands,
-      url: null,
-      mealQuantity: null,
-      mealUnit: mealUnit,
-      servingQuantity: servingQuantity,
-      servingUnit: null,
-      servingSize: servingSize,
-      portions: portions,
-      source: MealSourceEntity.off,
-      nutriments: const MealNutrimentsEntity(
-        energyKcal100: 100,
-        carbohydrates100: 0,
-        fat100: 0,
-        proteins100: 0,
-        sugars100: null,
-        saturatedFat100: null,
-        fiber100: null,
-      ),
-    );
+}) => MealEntity(
+  code: name,
+  name: name,
+  brands: brands,
+  url: null,
+  mealQuantity: null,
+  mealUnit: mealUnit,
+  servingQuantity: servingQuantity,
+  servingUnit: null,
+  servingSize: servingSize,
+  portions: portions,
+  source: MealSourceEntity.off,
+  nutriments: const MealNutrimentsEntity(
+    energyKcal100: 100,
+    carbohydrates100: 0,
+    fat100: 0,
+    proteins100: 0,
+    sugars100: null,
+    saturatedFat100: null,
+    fiber100: null,
+  ),
+);
 
 final getIt = GetIt.instance;
 
@@ -297,6 +299,27 @@ class _AlwaysFailsInterpreter implements MealTextInterpreter {
       throw failure;
 }
 
+/// A prober held open, so a probe can be started, left in flight while the
+/// user comes back, and landed on demand. #1089.
+class _GatedProber implements AiEndpointProber {
+  _GatedProber(this.result);
+
+  AiEndpointProbe result;
+  final gate = Completer<void>();
+
+  @override
+  Future<AiEndpointProbe> probe(
+    AiSelection selection, {
+    String? localeCode,
+  }) async {
+    await gate.future;
+    return result;
+  }
+
+  @override
+  dynamic noSuchMethod(Invocation invocation) => super.noSuchMethod(invocation);
+}
+
 class _MapStorage implements FlutterSecureStorage {
   final Map<String, String> values;
 
@@ -320,6 +343,42 @@ class _MapStorage implements FlutterSecureStorage {
     AppleOptions? mOptions,
     WindowsOptions? wOptions,
   }) async => values[key];
+
+  /// Writes land, rather than vanishing into [noSuchMethod].
+  ///
+  /// They used to: only `read` was implemented, so anything the app stored
+  /// during a test was silently dropped and read back as absent. Nothing
+  /// noticed while every test seeded the map and only read from it — but a
+  /// probe verdict written by the runner disappeared, and the symptom was a
+  /// capability that stayed `unknown` with no failure pointing here.
+  @override
+  Future<void> write({
+    required String key,
+    required String? value,
+    AppleOptions? iOptions,
+    AndroidOptions? aOptions,
+    LinuxOptions? lOptions,
+    WebOptions? webOptions,
+    AppleOptions? mOptions,
+    WindowsOptions? wOptions,
+  }) async {
+    if (value == null) {
+      values.remove(key);
+    } else {
+      values[key] = value;
+    }
+  }
+
+  @override
+  Future<void> delete({
+    required String key,
+    AppleOptions? iOptions,
+    AndroidOptions? aOptions,
+    LinuxOptions? lOptions,
+    WebOptions? webOptions,
+    AppleOptions? mOptions,
+    WindowsOptions? wOptions,
+  }) async => values.remove(key);
 
   @override
   dynamic noSuchMethod(Invocation invocation) => super.noSuchMethod(invocation);
@@ -349,55 +408,52 @@ Widget _app({
   bool imperial = false,
   Locale? locale,
   List<RouteSettings>? pushed,
-}) =>
-    ChangeNotifierProvider<EnergyUnitProvider>(
-      create: (_) => EnergyUnitProvider(usesKilojoules: false),
-      child: MaterialApp(
-        localizationsDelegates: const [
-          S.delegate,
-          GlobalMaterialLocalizations.delegate,
-          GlobalWidgetsLocalizations.delegate,
-          GlobalCupertinoLocalizations.delegate,
-        ],
-        supportedLocales: S.supportedLocales,
-        locale: locale,
-        navigatorObservers: [if (pushed != null) _PushRecorder(pushed)],
-        initialRoute: NavigationOptions.mainRoute,
-        onGenerateRoute: (settings) {
-          if (settings.name == NavigationOptions.mainRoute) {
-            return MaterialPageRoute<void>(
-              settings: settings,
-              builder: (_) => const Scaffold(body: SizedBox()),
-            );
-          }
-          // A stand-in for the settings screen, which needs a locator graph
-          // of its own. It keeps the arguments the caller passed — those are
-          // what carries the request to open the AI dialog (#852), and
-          // rewriting them here, as the branch below has to for the screen
-          // under test, would hide the thing being asserted.
-          if (settings.name == NavigationOptions.settingsRoute) {
-            return MaterialPageRoute<void>(
-              settings: settings,
-              builder: (_) => const Scaffold(
-                key: Key('settings-stub'),
-                body: SizedBox(),
-              ),
-            );
-          }
-          return MaterialPageRoute<void>(
-            settings: RouteSettings(
-              name: settings.name,
-              arguments: BulkAddScreenArguments(
-                IntakeTypeEntity.breakfast,
-                DateTime(2026, 8, 10),
-                imperial,
-              ),
-            ),
-            builder: (_) => const BulkAddScreen(),
-          );
-        },
-      ),
-    );
+}) => ChangeNotifierProvider<EnergyUnitProvider>(
+  create: (_) => EnergyUnitProvider(usesKilojoules: false),
+  child: MaterialApp(
+    localizationsDelegates: const [
+      S.delegate,
+      GlobalMaterialLocalizations.delegate,
+      GlobalWidgetsLocalizations.delegate,
+      GlobalCupertinoLocalizations.delegate,
+    ],
+    supportedLocales: S.supportedLocales,
+    locale: locale,
+    navigatorObservers: [if (pushed != null) _PushRecorder(pushed)],
+    initialRoute: NavigationOptions.mainRoute,
+    onGenerateRoute: (settings) {
+      if (settings.name == NavigationOptions.mainRoute) {
+        return MaterialPageRoute<void>(
+          settings: settings,
+          builder: (_) => const Scaffold(body: SizedBox()),
+        );
+      }
+      // A stand-in for the settings screen, which needs a locator graph
+      // of its own. It keeps the arguments the caller passed — those are
+      // what carries the request to open the AI dialog (#852), and
+      // rewriting them here, as the branch below has to for the screen
+      // under test, would hide the thing being asserted.
+      if (settings.name == NavigationOptions.settingsRoute) {
+        return MaterialPageRoute<void>(
+          settings: settings,
+          builder: (_) =>
+              const Scaffold(key: Key('settings-stub'), body: SizedBox()),
+        );
+      }
+      return MaterialPageRoute<void>(
+        settings: RouteSettings(
+          name: settings.name,
+          arguments: BulkAddScreenArguments(
+            IntakeTypeEntity.breakfast,
+            DateTime(2026, 8, 10),
+            imperial,
+          ),
+        ),
+        builder: (_) => const BulkAddScreen(),
+      );
+    },
+  ),
+);
 
 /// Pushes the screen, types [text] and taps Search, then settles.
 Future<void> _parse(WidgetTester tester, String text) async {
@@ -427,13 +483,16 @@ void main() {
     tester.view.devicePixelRatio = 2.625;
     addTearDown(tester.view.reset);
 
-    await _registerWithFailingReader({
-      'toast': [_meal('Toast')],
-    }, const MealInterpreterException(
-      'unauthorized',
-      failure: MealInterpreterFailure.auth,
-      statusCode: 401,
-    ));
+    await _registerWithFailingReader(
+      {
+        'toast': [_meal('Toast')],
+      },
+      const MealInterpreterException(
+        'unauthorized',
+        failure: MealInterpreterFailure.auth,
+        statusCode: 401,
+      ),
+    );
 
     await tester.pumpWidget(_app(locale: const Locale('de')));
     await tester.pumpAndSettle();
@@ -464,13 +523,16 @@ void main() {
     tester.view.devicePixelRatio = 2.625;
     addTearDown(tester.view.reset);
 
-    await _registerWithFailingReader({
-      'toast': [_meal('Toast')],
-    }, const MealInterpreterException(
-      'no credit',
-      failure: MealInterpreterFailure.billing,
-      statusCode: 402,
-    ));
+    await _registerWithFailingReader(
+      {
+        'toast': [_meal('Toast')],
+      },
+      const MealInterpreterException(
+        'no credit',
+        failure: MealInterpreterFailure.billing,
+        statusCode: 402,
+      ),
+    );
 
     await tester.pumpWidget(_app());
     await tester.pumpAndSettle();
@@ -498,12 +560,15 @@ void main() {
     tester.view.devicePixelRatio = 2.625;
     addTearDown(tester.view.reset);
 
-    await _registerWithFailingReader({
-      'toast': [_meal('Toast')],
-    }, const MealInterpreterException(
-      'request timed out',
-      failure: MealInterpreterFailure.timeout,
-    ));
+    await _registerWithFailingReader(
+      {
+        'toast': [_meal('Toast')],
+      },
+      const MealInterpreterException(
+        'request timed out',
+        failure: MealInterpreterFailure.timeout,
+      ),
+    );
 
     await tester.pumpWidget(_app());
     await tester.pumpAndSettle();
@@ -534,12 +599,15 @@ void main() {
     tester.view.devicePixelRatio = 3.0;
     addTearDown(tester.view.reset);
 
-    await _registerWithFailingReader({
-      'toast': [_meal('Toast')],
-    }, const MealInterpreterException(
-      'request timed out',
-      failure: MealInterpreterFailure.timeout,
-    ));
+    await _registerWithFailingReader(
+      {
+        'toast': [_meal('Toast')],
+      },
+      const MealInterpreterException(
+        'request timed out',
+        failure: MealInterpreterFailure.timeout,
+      ),
+    );
 
     await tester.pumpWidget(
       MediaQuery(
@@ -624,7 +692,8 @@ void main() {
     expect(
       tester.getSize(dropdown).width,
       greaterThanOrEqualTo(needed),
-      reason: 'the unit dropdown is narrower than the unit it has to show, '
+      reason:
+          'the unit dropdown is narrower than the unit it has to show, '
           'and a clipped unit reads as a different one',
     );
   });
@@ -677,9 +746,7 @@ void main() {
     // it. Reducing "30 g" to "g" would put a wrong unit on a right number,
     // so the fallback has to hold.
     await _register({
-      'yoghurt': [
-        _meal('Yoghurt', servingQuantity: 125, servingSize: '30 g'),
-      ],
+      'yoghurt': [_meal('Yoghurt', servingQuantity: 125, servingSize: '30 g')],
     });
 
     await tester.pumpWidget(_app());
@@ -704,9 +771,7 @@ void main() {
     final en = lookupS(const Locale('en'));
     expect(find.text(en.bulkAddDefaultAmountLabel), findsOneWidget);
     // Quieter than its siblings: the muted surface colour, not an accent.
-    final marker = tester.widget<Text>(
-      find.text(en.bulkAddDefaultAmountLabel),
-    );
+    final marker = tester.widget<Text>(find.text(en.bulkAddDefaultAmountLabel));
     final scheme = Theme.of(
       tester.element(find.text(en.bulkAddDefaultAmountLabel)),
     ).colorScheme;
@@ -732,19 +797,29 @@ void main() {
     );
   });
 
-  testWidgets('a chosen portion is written as a plain serving', (
-    tester,
-  ) async {
+  testWidgets('a chosen portion is written as a plain serving', (tester) async {
     // #864 decision 3. The dropdown offers "serving#1" so the row can name
     // the slice, but `IntakeDBO.unit` is published in docs/export-format.md
     // and rides in a positional QR array other builds parse, so what gets
     // written has to stay inside the closed set.
     await _register({
       'bread': [
-        _meal('Bread', servingQuantity: 244, portions: const [
-          MealPortionEntity(label: '1 cup', gramWeight: 244, localized: false),
-          MealPortionEntity(label: '1 slice', gramWeight: 38, localized: false),
-        ]),
+        _meal(
+          'Bread',
+          servingQuantity: 244,
+          portions: const [
+            MealPortionEntity(
+              label: '1 cup',
+              gramWeight: 244,
+              localized: false,
+            ),
+            MealPortionEntity(
+              label: '1 slice',
+              gramWeight: 38,
+              localized: false,
+            ),
+          ],
+        ),
       ],
     });
 
@@ -761,10 +836,16 @@ void main() {
     await tester.pumpAndSettle();
 
     final write = _mealDetailBloc.writes.single;
-    expect(write.unit, 'serving',
-        reason: 'the portion suffix must never be written down');
-    expect(double.parse(write.amount), 114,
-        reason: '3 slices at 38 g, not 3 cups at 244 g');
+    expect(
+      write.unit,
+      'serving',
+      reason: 'the portion suffix must never be written down',
+    );
+    expect(
+      double.parse(write.amount),
+      114,
+      reason: '3 slices at 38 g, not 3 cups at 244 g',
+    );
   });
 
   testWidgets('the quantity box holds the largest amount at 2x', (
@@ -820,12 +901,15 @@ void main() {
     tester.view.devicePixelRatio = 3.0;
     addTearDown(tester.view.reset);
 
-    await _registerWithFailingReader({
-      'toast': [_meal('Toast')],
-    }, const MealInterpreterException(
-      'request timed out',
-      failure: MealInterpreterFailure.timeout,
-    ));
+    await _registerWithFailingReader(
+      {
+        'toast': [_meal('Toast')],
+      },
+      const MealInterpreterException(
+        'request timed out',
+        failure: MealInterpreterFailure.timeout,
+      ),
+    );
 
     // Collected rather than asserted away, so the assertion can name what it
     // covers. It began downwards-only: fixing the vertical overflow (#820)
@@ -882,7 +966,6 @@ void main() {
     );
   });
 
-
   testWidgets('the advice is a control, so nothing can truncate it', (
     tester,
   ) async {
@@ -893,12 +976,15 @@ void main() {
     tester.view.devicePixelRatio = 2.625;
     addTearDown(tester.view.reset);
 
-    await _registerWithFailingReader({
-      'toast': [_meal('Toast')],
-    }, const MealInterpreterException(
-      'no credit',
-      failure: MealInterpreterFailure.billing,
-    ));
+    await _registerWithFailingReader(
+      {
+        'toast': [_meal('Toast')],
+      },
+      const MealInterpreterException(
+        'no credit',
+        failure: MealInterpreterFailure.billing,
+      ),
+    );
 
     final pushed = <RouteSettings>[];
     await tester.pumpWidget(_app(pushed: pushed));
@@ -979,12 +1065,15 @@ void main() {
     tester.view.devicePixelRatio = 2.625;
     addTearDown(tester.view.reset);
 
-    await _registerWithFailingReader({
-      'toast': [_meal('Toast')],
-    }, const MealInterpreterException(
-      'request timed out',
-      failure: MealInterpreterFailure.timeout,
-    ));
+    await _registerWithFailingReader(
+      {
+        'toast': [_meal('Toast')],
+      },
+      const MealInterpreterException(
+        'request timed out',
+        failure: MealInterpreterFailure.timeout,
+      ),
+    );
 
     await tester.pumpWidget(_app());
     await tester.pumpAndSettle();
@@ -1015,7 +1104,6 @@ void main() {
     expect(find.bySemanticsIdentifier('bulk-add-submit'), findsOneWidget);
   });
 
-
   testWidgets('a refused destination is not dressed as a network fault', (
     tester,
   ) async {
@@ -1026,12 +1114,15 @@ void main() {
     tester.view.devicePixelRatio = 2.625;
     addTearDown(tester.view.reset);
 
-    await _registerWithFailingReader({
-      'toast': [_meal('Toast')],
-    }, const MealInterpreterException(
-      'plaintext to a public address',
-      failure: MealInterpreterFailure.insecureDestination,
-    ));
+    await _registerWithFailingReader(
+      {
+        'toast': [_meal('Toast')],
+      },
+      const MealInterpreterException(
+        'plaintext to a public address',
+        failure: MealInterpreterFailure.insecureDestination,
+      ),
+    );
 
     await tester.pumpWidget(_app());
     await tester.pumpAndSettle();
@@ -1056,12 +1147,15 @@ void main() {
     tester.view.devicePixelRatio = 2.625;
     addTearDown(tester.view.reset);
 
-    await _registerWithFailingReader({
-      'toast': [_meal('Toast')],
-    }, const MealInterpreterException(
-      'plaintext to a public address',
-      failure: MealInterpreterFailure.insecureDestination,
-    ));
+    await _registerWithFailingReader(
+      {
+        'toast': [_meal('Toast')],
+      },
+      const MealInterpreterException(
+        'plaintext to a public address',
+        failure: MealInterpreterFailure.insecureDestination,
+      ),
+    );
 
     await tester.pumpWidget(_app(locale: const Locale('de')));
     await tester.pumpAndSettle();
@@ -1156,31 +1250,32 @@ void main() {
     expect(find.text(l10n.bulkAddNothingToLogLabel), findsNothing);
   });
 
-  testWidgets('a refused photo destination points at the address, not the model', (
-    tester,
-  ) async {
-    final bloc = await _registerWithPhotoReading(
-      const MealPhotoFailed(MealPhotoFailure.insecureDestination),
-    );
-    await tester.pumpWidget(_app());
-    tester.state<NavigatorState>(find.byType(Navigator)).pushNamed('/bulk');
-    await tester.pumpAndSettle();
+  testWidgets(
+    'a refused photo destination points at the address, not the model',
+    (tester) async {
+      final bloc = await _registerWithPhotoReading(
+        const MealPhotoFailed(MealPhotoFailure.insecureDestination),
+      );
+      await tester.pumpWidget(_app());
+      tester.state<NavigatorState>(find.byType(Navigator)).pushNamed('/bulk');
+      await tester.pumpAndSettle();
 
-    bloc.add(
-      ReadMealPhotoEvent(
-        photo: MealPhoto(
-          bytes: Uint8List.fromList([1, 2, 3]),
-          mediaType: 'image/webp',
+      bloc.add(
+        ReadMealPhotoEvent(
+          photo: MealPhoto(
+            bytes: Uint8List.fromList([1, 2, 3]),
+            mediaType: 'image/webp',
+          ),
+          usesImperialUnits: false,
         ),
-        usesImperialUnits: false,
-      ),
-    );
-    await tester.pumpAndSettle();
+      );
+      await tester.pumpAndSettle();
 
-    final l10n = await S.delegate.load(const Locale('en'));
-    expect(find.text(l10n.bulkAddModelInsecureServerLabel), findsOneWidget);
-    expect(find.text(l10n.bulkAddPhotoUnsupportedLabel), findsNothing);
-  });
+      final l10n = await S.delegate.load(const Locale('en'));
+      expect(find.text(l10n.bulkAddModelInsecureServerLabel), findsOneWidget);
+      expect(find.text(l10n.bulkAddPhotoUnsupportedLabel), findsNothing);
+    },
+  );
 
   // #992. "Your API key was rejected. Check it in Settings." was the whole of
   // the photo path's recovery: it named the place and then left the user to
@@ -1327,7 +1422,8 @@ void main() {
     expect(
       (scrollBox.center.dy - regionBox.center.dy).abs(),
       lessThan(1.0),
-      reason: 'a short message stays centred in its region, not pinned to '
+      reason:
+          'a short message stays centred in its region, not pinned to '
           'the top of the scroll viewport',
     );
   });
@@ -1445,11 +1541,7 @@ void main() {
     /// typed into.
     Finder amountField(int row) => find.byType(TextField).at(row + 1);
 
-    Future<void> typeAmount(
-      WidgetTester tester,
-      int row,
-      String amount,
-    ) async {
+    Future<void> typeAmount(WidgetTester tester, int row, String amount) async {
       await tester.enterText(amountField(row), amount);
       await tester.pumpAndSettle();
     }
@@ -1635,9 +1727,7 @@ void main() {
     expect(_mealDetailBloc.writes.map((w) => w.mealName), ['Toast']);
   });
 
-  testWidgets('choosing a unit lets a flagged row be written', (
-    tester,
-  ) async {
+  testWidgets('choosing a unit lets a flagged row be written', (tester) async {
     // Excluding the row is only defensible because the way back is one tap
     // on the control the warning already points at.
     await _register({
@@ -1828,9 +1918,7 @@ void main() {
     );
   });
 
-  testWidgets('the camera is hidden with no credential at all', (
-    tester,
-  ) async {
+  testWidgets('the camera is hidden with no credential at all', (tester) async {
     // The other half of the gate, and the one a destination-only check let
     // through: an install that has never opened settings resolves a
     // destination anyway, because nothing stored reads as Anthropic (#688)
@@ -2225,12 +2313,15 @@ void main() {
       // The other route out of this screen (#852). Both call sites now carry
       // the same arguments, so this asserts the second one keeps them when it
       // goes through the re-resolving helper.
-      await _registerWithFailingReader({
-        'toast': [_meal('Toast')],
-      }, const MealInterpreterException(
-        'rejected',
-        failure: MealInterpreterFailure.auth,
-      ));
+      await _registerWithFailingReader(
+        {
+          'toast': [_meal('Toast')],
+        },
+        const MealInterpreterException(
+          'rejected',
+          failure: MealInterpreterFailure.auth,
+        ),
+      );
       getIt.unregister<AiCredentialStorage>();
       final stored = _MapStorage(const {});
       getIt.registerLazySingleton<AiCredentialStorage>(
@@ -2268,6 +2359,105 @@ void main() {
 
       expect(find.bySemanticsIdentifier('bulk-add-photo'), findsOneWidget);
       expect(tester.takeException(), isNull);
+    });
+  });
+
+  group('an own-server probe that lands after the user is back (#1089)', () {
+    /// Nothing configured, so the discovery hint is on screen and the route
+    /// out of it is the one this exercises.
+    Future<
+      ({_MapStorage stored, _GatedProber prober, AiEndpointProbeRunner runner})
+    >
+    arrange(WidgetTester tester, AiCapability photo) async {
+      await _register(const {});
+      getIt.unregister<AiCredentialStorage>();
+      final stored = _MapStorage(const {});
+      final storage = AiCredentialStorage(stored);
+      getIt.registerLazySingleton<AiCredentialStorage>(() => storage);
+
+      final prober = _GatedProber(
+        AiEndpointProbe(text: AiCapability.passed, photo: photo, checked: true),
+      );
+      final runner = AiEndpointProbeRunner(storage, prober);
+      getIt.registerLazySingleton<AiEndpointProbeRunner>(() => runner);
+      return (stored: stored, prober: prober, runner: runner);
+    }
+
+    /// What the user does over in settings: saves an address, which starts a
+    /// probe the dialog deliberately does not await (#780).
+    void configureOwnServerAndStartProbe(
+      _MapStorage stored,
+      AiEndpointProbeRunner runner,
+    ) {
+      stored.values['AiProviderTag'] = 'ownServer';
+      stored.values['AiEndpointTag.ownServer'] = 'http://192.168.1.5:11434';
+      stored.values['AiModelTag.ownServer'] = 'gemma3:4b';
+      unawaited(runner.start(AiProvider.ownServer));
+    }
+
+    testWidgets('the camera appears when the verdict arrives', (tester) async {
+      final it = await arrange(tester, AiCapability.passed);
+
+      await tester.pumpWidget(_app());
+      await tester.pumpAndSettle();
+      final navigator = tester.state<NavigatorState>(find.byType(Navigator));
+      navigator.pushNamed('/bulk');
+      await tester.pumpAndSettle();
+
+      final camera = find.bySemanticsIdentifier('bulk-add-photo');
+      expect(camera, findsNothing, reason: 'nothing is configured yet');
+
+      await tester.tap(find.bySemanticsIdentifier('bulk-add-model-hint'));
+      await tester.pumpAndSettle();
+      configureOwnServerAndStartProbe(it.stored, it.runner);
+      await tester.pump();
+
+      navigator.pop();
+      await tester.pumpAndSettle();
+      expect(
+        camera,
+        findsNothing,
+        reason: 'the probe has not landed, so the verdict is still unknown',
+      );
+
+      it.prober.gate.complete();
+      await tester.pumpAndSettle();
+
+      expect(
+        camera,
+        findsOneWidget,
+        reason: 'the screen hears the verdict land without being re-entered',
+      );
+    });
+
+    testWidgets('a probe that finds no photo capability leaves it hidden', (
+      tester,
+    ) async {
+      // Text works, photographs do not — a real llama.cpp answer, and the
+      // reason the camera waits on a probe at all.
+      final it = await arrange(tester, AiCapability.failed);
+
+      await tester.pumpWidget(_app());
+      await tester.pumpAndSettle();
+      final navigator = tester.state<NavigatorState>(find.byType(Navigator));
+      navigator.pushNamed('/bulk');
+      await tester.pumpAndSettle();
+
+      await tester.tap(find.bySemanticsIdentifier('bulk-add-model-hint'));
+      await tester.pumpAndSettle();
+      configureOwnServerAndStartProbe(it.stored, it.runner);
+      await tester.pump();
+      navigator.pop();
+      await tester.pumpAndSettle();
+
+      it.prober.gate.complete();
+      await tester.pumpAndSettle();
+
+      expect(
+        find.bySemanticsIdentifier('bulk-add-photo'),
+        findsNothing,
+        reason: 'a landed verdict is not the same as a passing one',
+      );
     });
   });
 }


### PR DESCRIPTION
Closes #1089.

#1086 gave this screen one trigger for re-reading its AI answers: the settings route popping. **For own-server that fires too early.** Saving an address starts a capability probe without awaiting it (#780), and `_ownServerDestination` requires `photo == passed` — so a user who returns promptly reads the verdict as `unknown`, the camera stays hidden, and the one thing that would have re-read it has already happened.

The waiting itself is deliberate and stays: the camera is offered only once a photograph has actually been read (#735). What was missing is that nothing told the screen the verdict had arrived.

## A second trigger, not a new mechanism

`AiEndpointProbeRunner.current(provider)` already exposes the in-flight probe. So this awaits what is running and re-resolves — own-server only, since it is the only provider whose availability depends on a probe.

`current` is null in the two-keystore-reads gap between one probe finishing and its replacement registering, documented on the runner. This returns rather than polling: the answer it would have waited for is already stored, so the re-resolve on return has read it.

## Verification

Two tests, each failing against a **different** mutation — worth stating because only one of them exercises the new code:

| mutation | fails |
| :-- | :-- |
| drop the second trigger | "the camera appears when the verdict arrives" |
| accept a `failed` verdict as usable | "a probe that finds no photo capability leaves it hidden" |

A landed verdict is not the same as a passing one, and the second test is what keeps those apart.

Full suite green at **2172**; 76 in the screen test file.

## One thing this uncovered

`_MapStorage`, the secure-storage fake in the screen test, implemented only `read`. Everything the app **wrote** during a test vanished into `noSuchMethod` and read back as absent.

Nothing noticed, because every existing test seeds the map and only reads from it. It surfaced here because the probe runner writes its verdict and reads it back, so the capability stayed `unknown` — with no failure pointing anywhere near the fake. It cost me a while: I checked the storage keys, the enabled derivation, the selection, and the prober call count before suspecting the fake itself.

It now stores writes and honours deletes. The rest of the file is unaffected — same 76 tests, all passing — but a storage fake that silently drops writes is a trap for the next test that needs one.