### PR TITLE
docs: the console checklist omitted the item that actually blocks

### DIFF
--- a/docs/RELEASING.md
+++ b/docs/RELEASING.md
@@ -182,6 +182,17 @@ below, and nothing but this page will remind you.
       policy requires that exact wording *in the app description* for a health-and-fitness app that
       is not a declared medical device, plus a reminder to consult a healthcare professional. Both
       are the last line of `full_description.txt`.
+- [ ] **Correct Play's Data safety record**, which is the one item here that genuinely blocks
+      promoting the Android build to production. The record omits the meal photo and the typed
+      meal line, and
+      [#1050](https://github.com/simonoppowa/OpenNutriTracker/issues/1050) carries the answer
+      sheet field by field — two types, both collected and shared, both optional, purpose App
+      functionality, ephemeral **No**. It is entered in *App content*, independently of a release.
+
+      This step was missing from the first version of this list, which named the three cosmetic
+      declarations and not the blocking one. The public result is visible only at
+      `play.google.com/store/apps/datasafety?id=…`, and that page renders type-level rows rather
+      than the categories the Console groups them under.
 - [ ] **Answer Play's Health apps declaration.** Required for all developers under the same policy,
       with nutrition tracking as a declarable feature.
 - [ ] **Make the App Store Connect App Privacy record agree with
@@ -200,6 +211,10 @@ below, and nothing but this page will remind you.
       The first two exist only because of AI meal assistance. Food search terms, HealthKit
       workouts and locally-attached meal photos are deliberately absent; the manifest says why,
       beside each one.
+- [ ] **Answer Apple's regulated-medical-device question**
+      ([#1081](https://github.com/simonoppowa/OpenNutriTracker/issues/1081)). It gates Health &
+      Fitness submissions. Existing apps have until early 2027, so it does not block a release
+      today — it is here because a deadline nobody has written down is a deadline nobody meets.
 
 The table is what the AI path made necessary, not a statement that the record is complete. Three
 things behind it are open rather than answered, and none blocks a release:

--- a/docs/privacy-policy-gaps.md
+++ b/docs/privacy-policy-gaps.md
@@ -128,7 +128,14 @@ The project already knows this. `lib/core/utils/sentry_config.dart:7-21` on
 and `:25` fixes it with `options.enablePrintBreadcrumbs = false`. That file
 does not exist at `v2.0.2` — `git show v2.0.2:lib/core/utils/sentry_config.dart`
 returns *"exists on disk, but not in 'v2.0.2'"*. The fix landed in the
-`e53be1bc` / #877 line of work and is not in any release.
+`e53be1bc` / #877 line of work.
+
+> **Update, 2026-09-05.** It has since shipped: `v2.2.0` carries
+> `sentry_config.dart` with `options.enablePrintBreadcrumbs = false`. The
+> finding above is left as audited against `v2.0.2`, which is what it was
+> written about and what the published policy was measured against — but it
+> is no longer a live defect, and the sentence below that depended on it has
+> been corrected rather than left arguing from a fixed bug.
 
 The app's own in-product consent text is more specific and equally wrong in
 the shipped build: `v2.0.2:lib/l10n/intl_en.arb` reads *"Send anonymous crash
@@ -371,8 +378,11 @@ and 14 do not bite. It is *not* an argument for silence, for three reasons:
    rather than weakening it — the duty the access standard creates is precisely
    the policy text this section is asking for.
 3. Finding 1 is the concrete counter-example to "on-device means out of
-   scope": until `enablePrintBreadcrumbs = false` ships, on-device values do
-   leave, through Sentry, in the released build.
+   scope": on-device values **did** leave, through Sentry, in a released
+   build, for as long as `enablePrintBreadcrumbs` kept its default. Fixed and
+   shipped in `v2.2.0`, so the assumption is no longer wrong *here* — but it
+   was wrong once, quietly, in exactly the place nobody was looking, which is
+   the argument for not making it anywhere else.
 
 **What to do:** add a section stating that health data is read only after the
 user enables workout import, listing the five types, and stating plainly that


### PR DESCRIPTION
Two documents had drifted from what shipped. Both found while preparing the console work, both verified against the code.

## `RELEASING.md` named three cosmetic declarations and not the blocking one

The **Store declarations** checklist I added yesterday listed the listing paste, the medical-device sentence, Play's Health apps declaration and the App Store Connect record — and omitted **Play's Data safety record**, which [#1050](https://github.com/simonoppowa/OpenNutriTracker/issues/1050) calls the one item genuinely blocking promotion to production. It appeared only in passing, as an open research question.

A runbook that omits its own blocking step is worse than one that says nothing, because it reads as complete. Someone working the list would have done four things, believed they were finished, and still not been able to promote the build.

Also adds Apple's regulated-medical-device question ([#1081](https://github.com/simonoppowa/OpenNutriTracker/issues/1081)) — existing apps have until early 2027, which is exactly why it needs writing down: no deadline pressure is how a deadline gets missed.

## `privacy-policy-gaps.md` was arguing from a bug that is fixed

It said the Sentry breadcrumb fix *"is not in any release"*, and that on-device values leak *"until `enablePrintBreadcrumbs = false` ships"*.

**It shipped.** `git show v2.2.0:lib/core/utils/sentry_config.dart` carries `options.enablePrintBreadcrumbs = false`. The document was audited against `v2.0.2`, where that file genuinely does not exist — so the finding was right when written and is right about `v2.0.2` still.

Left as a **dated note** rather than a rewrite, the same treatment `ai-play-encryption-declaration.md` got yesterday: these pages are a record of what was checked and when, and silently editing a finding destroys the property that makes them worth keeping. But the two present-tense claims were false, and one of them undercut the Health Connect on-device carve-out that #1050's answer sheet now depends on — so it was arguing against a conclusion that currently holds.

## Verification

`docs/RELEASING.md` re-checked the way `test/unit_test/releasing_doc_test.dart` does: 24 links, 4 relative, 4 anchors, none missing or broken. Docs only — no code, no tests touched.