### PR TITLE
feat(store): put the no-strings promise where Play actually indexes it

### DIFF
--- a/fastlane/metadata/android/en-US/full_description.txt
+++ b/fastlane/metadata/android/en-US/full_description.txt
@@ -1,6 +1,8 @@
-OpenNutriTracker is an open-source calorie and nutrition tracker with a minimalistic interface — for improving your health, losing weight, or keeping a balanced diet.
+OpenNutriTracker is a calorie counter and food diary with no account, no subscription and no ads — for losing weight or keeping a balanced diet. Open source, and your diary stays on your device.
 
 
+🚫💰 No subscriptions, purchases or ads: completely free, with no paid tier and no advertising.
+🔒 Privacy first: No account, no sign-in, no analytics, no ads. Your diary, profile, weight, custom meals and recipes are stored on your device in AES-256 encrypted databases; photos you attach are ordinary image files beside them. Food search sends the search term, plus your language code to rank results. AI meal assistance sends only the line you type or the photo you take, to the provider you chose — never your diary or history. Crash reporting is opt-in.
 🍎 Nutritional tracking: Log meals and snacks against a large food database — Open Food Facts plus a reference backend covering USDA FoodData Central and the German BLS, selectable in Settings. Search, scan, or enter a number when you already know the calorie cost.
 📓 Food diary: A calendar-driven diary split into Breakfast, Lunch, Dinner and Snack, with per-meal kcal targets (several presets or a custom share), drag-to-rearrange between meals, and sort by time or macro contribution.
 📈 Trends: Current and best day-streak, calories against your goal line, daily macro averages, water intake, and weight against target. Switch between 7, 30 and 90 days or your whole history.
@@ -16,6 +18,4 @@ OpenNutriTracker is an open-source calorie and nutrition tracker with a minimali
 🎨 Material You & themes: Adopt the system accent colour on Android 12+, or pick from sixteen built-in presets.
 🔢 kcal or kJ: Switch the energy unit globally; every diary entry, target, and chart reflects the choice.
 📤 Export & import: Export diary entries, activities, tracked days and recipes to a JSON zip, with flat CSVs a spreadsheet can read. Paste a JSON blob to import meals, or share a meal or activity as a QR code. Your profile, weight log, custom meals, water and fasting history stay out of the bundle.
-🔒 Privacy first: No account, no sign-in, no analytics, no ads. Your diary, profile, weight, custom meals and recipes are stored on your device in AES-256 encrypted databases; photos you attach are ordinary image files beside them. Food search sends the search term, plus your language code to rank results. AI meal assistance sends only the line you type or the photo you take, to the provider you chose — never your diary or history. Crash reporting is opt-in.
-🚫💰 No subscriptions, purchases or ads: completely free, with no paid tier and no advertising.
 ⚕️ Not a medical device: OpenNutriTracker is not a medical device and does not diagnose, treat, cure, or prevent any medical condition. Figures are estimates from public databases and published equations. Always consult a healthcare professional for medical advice, diagnosis, or treatment.

--- a/fastlane/metadata/android/en-US/full_description.txt
+++ b/fastlane/metadata/android/en-US/full_description.txt
@@ -1,13 +1,13 @@
 OpenNutriTracker is a calorie counter and food diary with no account, no subscription and no ads — for losing weight or keeping a balanced diet. Open source, and your diary stays on your device.
 
 
-🚫💰 No subscriptions, purchases or ads: completely free, with no paid tier and no advertising.
+🚫💰 No subscriptions, purchases or ads: no paid tier, no advertising.
 🔒 Privacy first: No account, no sign-in, no analytics, no ads. Your diary, profile, weight, custom meals and recipes are stored on your device in AES-256 encrypted databases; photos you attach are ordinary image files beside them. Food search sends the search term, plus your language code to rank results. AI meal assistance sends only the line you type or the photo you take, to the provider you chose — never your diary or history. Crash reporting is opt-in.
 🍎 Nutritional tracking: Log meals and snacks against a large food database — Open Food Facts plus a reference backend covering USDA FoodData Central and the German BLS, selectable in Settings. Search, scan, or enter a number when you already know the calorie cost.
 📓 Food diary: A calendar-driven diary split into Breakfast, Lunch, Dinner and Snack, with per-meal kcal targets (several presets or a custom share), drag-to-rearrange between meals, and sort by time or macro contribution.
-📈 Trends: Current and best day-streak, calories against your goal line, daily macro averages, water intake, and weight against target. Switch between 7, 30 and 90 days or your whole history.
+📈 Trends: Current and best day-streak, calories against your goal line, daily macro averages, water intake, and weight against target. Switch between 7, 30 and 90 days, or up to ten years.
 🥕 Micronutrient panel: Day and week views for fibre, sodium, saturated fat, sugar, calcium, iron, potassium, vitamin D, vitamin B12 and magnesium, with optional Dietary Reference Intake bars.
-🍽️ Custom meals & recipes: Build a one-off custom meal or save a reusable recipe with photo, brand and barcode. The recipe builder has its own ingredient picker with barcode scanning.
+🍽️ Custom meals & recipes: Build a one-off custom meal with photo, brand and barcode, or a reusable recipe with a photo. The recipe builder has its own ingredient picker with barcode scanning.
 ⚡ Quick add: Skip the search when you already know roughly how much you ate — a title plus kcal (and optional macros), logged straight to the meal.
 🤖 AI meal assistance (experimental, off by default): Describe a meal in one line, or photograph it, and have several items resolved at once. Needs your own API key (Anthropic, OpenAI, OpenRouter) or a server you run — the project never sees either. The model reads language, not nutrition: every calorie still comes from the food databases.
 📷 Barcode scanner: Scan packaged items for instant lookup, paste a barcode manually, or attach a barcode to a custom meal so future scans recognise your own foods.
@@ -17,5 +17,5 @@ OpenNutriTracker is a calorie counter and food diary with no account, no subscri
 ⚖️ Weight history: Capture weight during onboarding and on demand, see the trend against your target, and optionally taper the calorie goal as you approach it.
 🎨 Material You & themes: Adopt the system accent colour on Android 12+, or pick from sixteen built-in presets.
 🔢 kcal or kJ: Switch the energy unit globally; every diary entry, target, and chart reflects the choice.
-📤 Export & import: Export diary entries, activities, tracked days and recipes to a JSON zip, with flat CSVs a spreadsheet can read. Paste a JSON blob to import meals, or share a meal or activity as a QR code. Your profile, weight log, custom meals, water and fasting history stay out of the bundle.
+📤 Export & import: Export diary entries, activities, tracked days and recipes as a JSON zip you can re-import, or as flat CSVs for a spreadsheet. Paste a JSON blob to import meals, or share a meal or activity as a QR code. Your profile, weight log, custom meals, water and fasting history stay out of the bundle.
 ⚕️ Not a medical device: OpenNutriTracker is not a medical device and does not diagnose, treat, cure, or prevent any medical condition. Figures are estimates from public databases and published equations. Always consult a healthcare professional for medical advice, diagnosis, or treatment.

--- a/fastlane/metadata/android/en-US/short_description.txt
+++ b/fastlane/metadata/android/en-US/short_description.txt
@@ -1,1 +1,1 @@
-A free and open source calorie tracker with focus on simplicity and privacy.
+No account. No subscription. No ads. Your calorie and nutrient diary, on device.

--- a/fastlane/metadata/android/en-US/title.txt
+++ b/fastlane/metadata/android/en-US/title.txt
@@ -1,1 +1,1 @@
-OpenNutriTracker
+OpenNutriTracker Food Diary

--- a/test/unit_test/store_declarations_test.dart
+++ b/test/unit_test/store_declarations_test.dart
@@ -145,6 +145,31 @@ void main() {
     });
   });
 
+  group('Play listing fields', () {
+    // The full description already had a cap test; the title and short
+    // description did not, and this branch changes both. Play refuses
+    // over-length text at paste time with no earlier warning, and the short
+    // description in particular sits at exactly its cap — a stray character
+    // would be discovered in the Console rather than here.
+    String field(String name) => File(
+      'fastlane/metadata/android/en-US/$name',
+    ).readAsStringSync().trimRight();
+
+    test('title is within the 30-character cap', () {
+      expect(field('title.txt').length, lessThanOrEqualTo(30));
+    });
+
+    test('short description is within the 80-character cap', () {
+      expect(field('short_description.txt').length, lessThanOrEqualTo(80));
+    });
+
+    test('the title avoids the phrase Play forbids there', () {
+      // Play names "No Ads" as prohibited in a title specifically; Apple
+      // permits it in an app name, which is why this is asserted per store.
+      expect(field('title.txt').toLowerCase(), isNot(contains('no ads')));
+    });
+  });
+
   group('Play listing', () {
     // Play rejects a longer description outright. Nothing in the repo or in
     // CI checks it, and `upload_to_play_store` runs with


### PR DESCRIPTION
Drafts the Play copy against the positioning settled in [#1069](https://github.com/simonoppowa/OpenNutriTracker/issues/1069). Resolves [#1071](https://github.com/simonoppowa/OpenNutriTracker/issues/1071) under [map #1062](https://github.com/simonoppowa/OpenNutriTracker/issues/1062).

The promise is **"no strings" — free *and* no account, as one claim**: both are structural, and no mainstream competitor can match either without changing its business.

## The three fields

| Field | Before | After | Chars |
| :-- | :-- | :-- | :-- |
| Title | `OpenNutriTracker` | `OpenNutriTracker Food Diary` | 16 → **27**/30 |
| Short description | *"A free and open source calorie tracker with focus on simplicity and privacy."* | *"No account. No subscription. No ads. Your calorie and nutrient diary, on device."* | 76 → **80**/80 |
| Full description | promise at 86% depth | promise in the opening line and the first two bullets | 3951 → **3979**/4000 |

## Why each

**Title.** Indexed, and it was 47% empty — against a market where **six of six** mainstream competitors pair brand with a keyword phrase ([#1066](https://github.com/simonoppowa/OpenNutriTracker/issues/1066)). "Food diary" is a phrase the app is currently absent for on both stores. Worth recording: **"Calorie Counter" does not fit** — with the brand it needs 33 characters against Play's 30, so the highest-volume term and the full brand name are mutually exclusive in that slot.

**Short description.** The old one opened with *"A free…"*, and Play's metadata policy **names "free" as a word to avoid in this field** ([#1065](https://github.com/simonoppowa/OpenNutriTracker/issues/1065)). The new text makes the same claim in words the policy does not caution against. Note this field's documented role is **display, not matching** — nothing in Google's documentation says it is indexed — so it is spent on the promise rather than on keywords.

**Full description.** The money claim sat at **86% depth**, the same place competitors bury their auto-renewal terms. It and the privacy bullet are now first and second, and the opening line leads with *"calorie counter and food diary"* — both indexed by Play, which is the opposite of Apple's description, which Apple routes to web-engine search instead.

## Constraints checked

- Both sentences Google's **Health Content and Services** policy requires are **verbatim and last**.
- **No "free"** in the short description; **no "No Ads"** in the title (Play forbids that phrase there by name).
- Under the 4000 cap, **with 21 characters of headroom left on purpose** — Play's metadata policy warns that *"excessive length… can result in a violation"*, so length here is a cost, not an asset.
- `test/unit_test/store_declarations_test.dart` passes, including the cap, the disclaimer, the consult reminder, and the 2.2.0 feature checks.

## What this does not do

Nothing is pushed to the store. The listing is updated only by hand or by the screenshots-only lane, which deliberately runs with `skip_upload_metadata: true` — publishing this copy is a separate, reviewed decision owned by [the apply ticket](https://github.com/simonoppowa/OpenNutriTracker/issues/1077).

The App Store copy is [#1070](https://github.com/simonoppowa/OpenNutriTracker/issues/1070) and is still blocked; the two stores get different text on purpose, since the indexing rules differ.

Refs #1071, #1069, #1065, #1066, #1068.
