### PR TITLE
fix(store): make the 2.2.0 release note the one that actually shipped

### DIFF
--- a/fastlane/metadata/android/en-US/changelogs/63.txt
+++ b/fastlane/metadata/android/en-US/changelogs/63.txt
@@ -1,9 +1,4 @@
- * Fixed the daily calorie goal: the TDEE formula did not match the IOM 2005
-   equations it is based on. The activity coefficient was applied only to the
-   weight term, not to the height term as the source specifies. Goals for
-   everyone above the "sedentary" activity level were too low — by roughly
-   100 to 500 kcal a day, growing with height and activity. Sedentary goals
-   are unchanged. Past days keep the goal they were tracked against.
- * The calorie-goal breakdown screen now shows the corrected formula.
- * The adult-equations notice now appears up to age 18, since the equations
-   are published for ages 19 and older.
+- Add several items: type a whole meal, check each row, log them together
+- Fixed issues with the daily kcal calculations
+- Import finished workouts from Health Connect, off until you turn it on
+- Optional AI meal assistance: experimental, off by default, your own API key. Calories come from the food databases, never the model

--- a/test/unit_test/store_declarations_test.dart
+++ b/test/unit_test/store_declarations_test.dart
@@ -110,6 +110,38 @@ void main() {
     });
   });
 
+  group('Play release notes', () {
+    // Play caps release notes at 500 characters, and like the listing cap it
+    // is discovered only when the Console refuses the text. `63.txt` was 628
+    // characters and would have been rejected — it never reached the store,
+    // which is why nobody noticed. F-Droid reads these same files, so a
+    // changelog that cannot be published is not a private problem.
+    final changelogs = Directory(
+      'fastlane/metadata/android/en-US/changelogs',
+    ).listSync().whereType<File>().where((f) => f.path.endsWith('.txt'));
+
+    test('every changelog is within the 500-character cap', () {
+      for (final file in changelogs) {
+        expect(
+          file.readAsStringSync().trim().length,
+          lessThanOrEqualTo(500),
+          reason: '${file.path} exceeds Play\'s 500-character release-note cap',
+        );
+      }
+    });
+
+    test('the 2.2.0 note describes what 2.2.0 actually shipped', () {
+      final notes = File(
+        'fastlane/metadata/android/en-US/changelogs/63.txt',
+      ).readAsStringSync();
+      // The published note on both stores names these; an earlier draft
+      // described only the TDEE correction and matched neither store.
+      expect(notes, contains('Health Connect'));
+      expect(notes, contains('AI meal assistance'));
+      expect(notes.toLowerCase(), contains('kcal calculations'));
+    });
+  });
+
   group('Play listing', () {
     // Play rejects a longer description outright. Nothing in the repo or in
     // CI checks it, and `upload_to_play_store` runs with

--- a/test/unit_test/store_declarations_test.dart
+++ b/test/unit_test/store_declarations_test.dart
@@ -123,7 +123,10 @@ void main() {
     test('every changelog is within the 500-character cap', () {
       for (final file in changelogs) {
         expect(
-          file.readAsStringSync().trim().length,
+          // trimRight() not trim(): a stray leading newline or indent is
+          // still charged by Play, so trimming it here would undercount and
+          // let an over-cap note through.
+          file.readAsStringSync().trimRight().length,
           lessThanOrEqualTo(500),
           reason: '${file.path} exceeds Play\'s 500-character release-note cap',
         );


### PR DESCRIPTION
Resolves [#1073](https://github.com/simonoppowa/OpenNutriTracker/issues/1073) under [map #1062](https://github.com/simonoppowa/OpenNutriTracker/issues/1062).

## The ticket's premise was right, but for a different reason than it thought

It was filed because `changelogs/63.txt` "covers only the TDEE fix, not 2.2.0's AI assistance or workout import". True — but the assumption behind it was that this file was what users saw. It wasn't.

**Both stores shipped the same, correct four-bullet note**, written by hand and never written back to the repo:

```
- Add several items: type a whole meal, check each row, log them together
- Fixed issues with the daily kcal calculations
- Import finished workouts from Health Connect, off until you turn it on
- Optional AI meal assistance: experimental, off by default, your own API key.
  Calories come from the food databases, never the model
```

Verified on the live Play listing and via Apple's release notes — **328 characters, byte-identical across both stores**. So there is no user-facing defect here. The defect is that the repository's record of what users were told was false.

## And it could never have been published anyway

**`63.txt` was 628 characters against Play's 500-character cap.** Like the 4000-character listing cap, that is discovered only when the Console refuses the text — and since this file was never pushed, nothing ever refused it.

This is not only a Play concern: **F-Droid reads these same files** (`docs/fdroid-submission-feasibility.md` already flags changelogs as a gap), so a changelog that cannot be published is not a private problem.

## What changed

- `63.txt` now carries the published text, **325 characters**. The detailed TDEE prose is not lost — it is in the git history and in the GitHub release.
- **Two new tests**, in the file that already pins the listing cap:
  - every changelog is within 500 characters — the assertion that would have caught the original;
  - the 2.2.0 note names Health Connect, AI meal assistance and the kcal fix, so a later edit cannot quietly narrow it back to one bullet.

Both tests **fail against the old file and pass against this one** — verified by restoring the old content and re-running, not assumed.

## What this does not do

Nothing is pushed to either store, and nothing needs to be: the live notes are already correct. The next release's note is a separate act, and per [#1080](https://github.com/simonoppowa/OpenNutriTracker/issues/1080) the App Store's is version-gated to whichever build carries the copy change.

Refs #1073, #1080, #1062.
