### PR TITLE
feat(store): put the App Store listing under version control, and fix it

### DIFF
--- a/fastlane/metadata/ios/en-US/description.txt
+++ b/fastlane/metadata/ios/en-US/description.txt
@@ -1,0 +1,26 @@
+OpenNutriTracker is a calorie counter and food diary with no account, no subscription and no ads — for losing weight or keeping a balanced diet. It is open source, and your diary stays on your device.
+
+Nothing to pay, nothing to sign up for. There is no paid tier, no advertising, and no sign-in step between installing the app and logging your first meal.
+
+WHAT IT DOES
+
+• Log meals against a large food database — Open Food Facts plus a reference backend covering USDA FoodData Central and the German BLS, selectable in Settings. Search, scan a barcode, or enter a number when you already know the calorie cost.
+• A calendar-driven diary split into Breakfast, Lunch, Dinner and Snack, with per-meal targets, drag-to-rearrange, and sorting by time or macro contribution.
+• Micronutrients, free: day and week views for fibre, sodium, saturated fat, sugar, calcium, iron, potassium, vitamin D, vitamin B12 and magnesium, with optional Dietary Reference Intake bars.
+• Trends: current and best day-streak, calories against your goal line, daily macro averages, water intake, and weight against target, over 7, 30 and 90 days or your whole history.
+• Custom meals and recipes, with photo, brand and barcode, and a recipe builder with its own ingredient picker.
+• Quick add for when you already know roughly what you ate — a title plus kcal, straight to the meal.
+• Activities from a categorised catalogue, or custom ones with direct kcal entry. Finished workouts can be imported from Apple Health — read-only, off by default, and they stay on your device.
+• A water tracker, an optional intermittent-fasting timer, and a weight history that can taper your calorie goal as you approach target.
+• kcal or kJ, switched globally, and sixteen colour themes.
+• Export your diary, activities, tracked days and recipes to a JSON zip with flat CSVs a spreadsheet can read.
+
+AI MEAL ASSISTANCE, IF YOU WANT IT
+
+Experimental and off by default. Describe a meal in one line, or photograph it, and have several items resolved at once. It needs your own API key — Anthropic, OpenAI, OpenRouter, or a server you run — and the project never sees either. The model reads language, not nutrition: every calorie still comes from the food databases.
+
+PRIVACY
+
+No account, no sign-in, no analytics, no ads. Your diary, profile, weight, custom meals and recipes are stored on your device in AES-256 encrypted databases; photos you attach are ordinary image files beside them. Food search sends the search term and your language code to rank results. Crash reporting is opt-in.
+
+OpenNutriTracker is not a medical device and does not diagnose, treat, cure, or prevent any medical condition. Figures are estimates from public databases and published equations. Always consult a healthcare professional for medical advice, diagnosis, or treatment.

--- a/fastlane/metadata/ios/en-US/description.txt
+++ b/fastlane/metadata/ios/en-US/description.txt
@@ -7,17 +7,17 @@ WHAT IT DOES
 • Log meals against a large food database — Open Food Facts plus a reference backend covering USDA FoodData Central and the German BLS, selectable in Settings. Search, scan a barcode, or enter a number when you already know the calorie cost.
 • A calendar-driven diary split into Breakfast, Lunch, Dinner and Snack, with per-meal targets, drag-to-rearrange, and sorting by time or macro contribution.
 • Micronutrients, free: day and week views for fibre, sodium, saturated fat, sugar, calcium, iron, potassium, vitamin D, vitamin B12 and magnesium, with optional Dietary Reference Intake bars.
-• Trends: current and best day-streak, calories against your goal line, daily macro averages, water intake, and weight against target, over 7, 30 and 90 days or your whole history.
-• Custom meals and recipes, with photo, brand and barcode, and a recipe builder with its own ingredient picker.
+• Trends: current and best day-streak, calories against your goal line, daily macro averages, water intake, and weight against target, over 7, 30 and 90 days, or up to ten years.
+• Custom meals with photo, brand and barcode, and reusable recipes with a photo and their own ingredient picker.
 • Quick add for when you already know roughly what you ate — a title plus kcal, straight to the meal.
 • Activities from a categorised catalogue, or custom ones with direct kcal entry. Finished workouts can be imported from Apple Health — read-only, off by default, and they stay on your device.
 • A water tracker, an optional intermittent-fasting timer, and a weight history that can taper your calorie goal as you approach target.
 • kcal or kJ, switched globally, and sixteen colour themes.
-• Export your diary, activities, tracked days and recipes to a JSON zip with flat CSVs a spreadsheet can read.
+• Export your diary, activities, tracked days and recipes as a JSON zip you can re-import, or as flat CSVs for a spreadsheet.
 
 AI MEAL ASSISTANCE, IF YOU WANT IT
 
-Experimental and off by default. Describe a meal in one line, or photograph it, and have several items resolved at once. It needs your own API key — Anthropic, OpenAI, OpenRouter, or a server you run — and the project never sees either. The model reads language, not nutrition: every calorie still comes from the food databases.
+Experimental and off by default. Describe a meal in one line, or photograph it, and have several items resolved at once. It needs your own API key for Anthropic, OpenAI or OpenRouter, or just the address of a server you run — the project never sees either. The model reads language, not nutrition: every calorie still comes from the food databases.
 
 PRIVACY
 

--- a/fastlane/metadata/ios/en-US/keywords.txt
+++ b/fastlane/metadata/ios/en-US/keywords.txt
@@ -1,0 +1,1 @@
+counter,macro,log,fasting,barcode,offline,weight,diet,open source,privacy,protein,water,journal,keto

--- a/fastlane/metadata/ios/en-US/marketing_url.txt
+++ b/fastlane/metadata/ios/en-US/marketing_url.txt
@@ -1,0 +1,1 @@
+https://github.com/simonoppowa/OpenNutriTracker

--- a/fastlane/metadata/ios/en-US/name.txt
+++ b/fastlane/metadata/ios/en-US/name.txt
@@ -1,0 +1,1 @@
+OpenNutriTracker Food Diary

--- a/fastlane/metadata/ios/en-US/promotional_text.txt
+++ b/fastlane/metadata/ios/en-US/promotional_text.txt
@@ -1,0 +1,1 @@
+Free forever. No account, no subscription, no ads. Your calorie and nutrient diary stays on your device — open source, and no sign-up to start.

--- a/fastlane/metadata/ios/en-US/subtitle.txt
+++ b/fastlane/metadata/ios/en-US/subtitle.txt
@@ -1,0 +1,1 @@
+Calorie & Nutrition Tracker

--- a/fastlane/metadata/ios/en-US/support_url.txt
+++ b/fastlane/metadata/ios/en-US/support_url.txt
@@ -1,0 +1,1 @@
+https://github.com/simonoppowa/OpenNutriTracker

--- a/test/unit_test/store_declarations_test.dart
+++ b/test/unit_test/store_declarations_test.dart
@@ -170,6 +170,84 @@ void main() {
     });
   });
 
+  group('App Store listing', () {
+    // Apple's caps are enforced only by App Store Connect refusing the text,
+    // and the fields live in the console rather than in this repo, so they
+    // drifted invisibly: the live description was still the pre-2.0 copy
+    // while What's New described 2.2.0, and the keyword field used 64 of its
+    // 100 characters with `open source` split into two weak tokens (#1063).
+    //
+    // Apple combines the name, subtitle and keyword field when it indexes, so
+    // a word repeated across them is a wasted slot rather than a stronger
+    // signal — hence the no-duplicates assertion.
+    String field(String name) =>
+        File('fastlane/metadata/ios/en-US/$name').readAsStringSync().trim();
+
+    const caps = {
+      'name.txt': 30,
+      'subtitle.txt': 30,
+      'keywords.txt': 100,
+      'promotional_text.txt': 170,
+      'description.txt': 4000,
+      // Both URL fields are pinned so the set stays complete. The marketing
+      // URL renders as the product page's "Developer Website" row and was
+      // simply absent — the GitHub Pages site was removed in #786, so the
+      // repository is the project's public home and the honest target.
+      'support_url.txt': 255,
+      'marketing_url.txt': 255,
+    };
+
+    caps.forEach((file, cap) {
+      test('$file is within its $cap-character cap', () {
+        expect(field(file).length, lessThanOrEqualTo(cap));
+      });
+    });
+
+    test('the keyword field wastes nothing on spaces after commas', () {
+      // Apple counts every character; ", " costs one more than ",".
+      expect(field('keywords.txt'), isNot(contains(', ')));
+    });
+
+    test('keywords do not repeat words already in the name or subtitle', () {
+      final indexed = '${field('name.txt')} ${field('subtitle.txt')}'
+          .toLowerCase()
+          .split(RegExp(r'[^a-z]+'))
+          .where((w) => w.length > 2)
+          .toSet();
+      final keywords = field('keywords.txt')
+          .toLowerCase()
+          .split(',')
+          .expand((k) => k.trim().split(' '))
+          .where((w) => w.length > 2);
+      for (final word in keywords) {
+        expect(
+          indexed,
+          isNot(contains(word)),
+          reason: '"$word" is already in the name or subtitle; Apple combines '
+              'those fields when indexing, so repeating it wastes a slot',
+        );
+      }
+    });
+
+    test('both URL fields point somewhere real', () {
+      for (final f in ['support_url.txt', 'marketing_url.txt']) {
+        expect(field(f), startsWith('https://'), reason: f);
+      }
+    });
+
+    test('carries the not-a-medical-device wording by choice', () {
+      // Apple imposes no listing mandate, unlike Play's Health Content and
+      // Services policy — this is kept to pre-empt a guideline 1.4.1 call.
+      expect(
+        field('description.txt'),
+        contains(
+          'not a medical device and does not diagnose, treat, cure, or '
+          'prevent any medical condition',
+        ),
+      );
+    });
+  });
+
   group('Play listing', () {
     // Play rejects a longer description outright. Nothing in the repo or in
     // CI checks it, and `upload_to_play_store` runs with


### PR DESCRIPTION
Resolves [#1070](https://github.com/simonoppowa/OpenNutriTracker/issues/1070) under [map #1062](https://github.com/simonoppowa/OpenNutriTracker/issues/1062).

## The App Store copy has never been in this repository

It lived only in App Store Connect, and drifted invisibly there ([#1063](https://github.com/simonoppowa/OpenNutriTracker/issues/1063)):

- the **description is still the pre-2.0 text**, even though 2.2.0 shipped with a What's New that describes the release correctly;
- the **keyword field used 64 of 100 characters**, eight of them on spaces after commas, with `open source` split into `open, source`;
- **promotional text and the marketing URL are empty.**

This adds `fastlane/metadata/ios/en-US/` following `deliver`'s filenames, so the text is diffable and reviewable the way the Play copy is.

## The fields

| File | Value | Chars |
| :-- | :-- | :-- |
| `name.txt` | `OpenNutriTracker Food Diary` | 27/30 |
| `subtitle.txt` | `Calorie & Nutrition Tracker` | 27/30 |
| `keywords.txt` | `counter,macro,log,fasting,barcode,offline,weight,diet,open source,privacy,protein,water,journal,keto` | **100**/100 |
| `promotional_text.txt` | the no-strings promise | 143/170 |
| `description.txt` | rewritten | 2,818/4,000 |

**Name and subtitle mirror Play's**, so the app is recognisable across stores. The cost is real and worth stating: the "no strings" promise from [#1069](https://github.com/simonoppowa/OpenNutriTracker/issues/1069) then reaches **neither indexed field**. Promotional text carries it instead, at the top of the product page.

**Keywords go 64 → 100.** Apple counts every character, so `", "` costs one more than `","`. Words already in the name and subtitle are excluded — Apple combines those fields when indexing, so a repeat is a wasted slot, not a stronger signal.

**The description is written for a human and for web search, not App Store search.** Apple does not index it — App Store Connect states in its own UI that the assets "will be used for web engine search results" — which for a project discovered through GitHub and Reddit is a real channel.

## One claim verified rather than copied

The Android text says workouts import from Health Connect. Before writing "Apple Health" I checked the code: `health_package_service.dart:71` supports both platforms, `Runner.entitlements` carries the HealthKit entitlement, and both usage strings are present and describe read-only access. The claim is accurate.

## Tests

Six pin the field caps. Two more pin the defects that made this worth doing — **no spaces after commas**, and **no keyword repeating a word from the name or subtitle**. Both were verified to fail against the old field and pass against the new one, rather than assumed to work.

The not-a-medical-device wording is kept **by choice**: Apple imposes no listing mandate, unlike Play's Health Content and Services policy, but carrying it pre-empts a guideline 1.4.1 judgement call for the price of one sentence. A test pins it so it is not dropped as redundant.

## What this does not do

**Nothing is pushed.** `ios/fastlane/Fastfile` still uploads only the IPA. And per [#1080](https://github.com/simonoppowa/OpenNutriTracker/issues/1080), App Store metadata is **version-gated** — every field on the live record is `disabled` — so applying this needs a new version and therefore a **new build**. That remains [#1077](https://github.com/simonoppowa/OpenNutriTracker/issues/1077)'s decision.

Refs #1070, #1069, #1063, #1080.
