### PR TITLE
feat(meal-detail): quick-serving chips (0.5x/1x/2x + 100 g)

### DIFF
--- a/lib/features/meal_detail/presentation/widgets/meal_detail_bottom_sheet.dart
+++ b/lib/features/meal_detail/presentation/widgets/meal_detail_bottom_sheet.dart
@@ -14,6 +14,7 @@ import 'package:opennutritracker/features/diary/presentation/bloc/calendar_day_b
 import 'package:opennutritracker/features/diary/presentation/bloc/diary_bloc.dart';
 import 'package:opennutritracker/features/home/presentation/bloc/home_bloc.dart';
 import 'package:opennutritracker/features/meal_detail/presentation/bloc/meal_detail_bloc.dart';
+import 'package:opennutritracker/features/meal_detail/util/quick_serving_option.dart';
 import 'package:opennutritracker/generated/l10n.dart';
 
 class MealDetailBottomSheet extends StatefulWidget {
@@ -82,6 +83,13 @@ class _MealDetailBottomSheetState extends State<MealDetailBottomSheet> {
       widget.quantityTextController.text,
       widget.selectedUnit,
     );
+  }
+
+  String _formatQuantity(double value) {
+    if (value == value.roundToDouble()) {
+      return value.toInt().toString();
+    }
+    return value.toString();
   }
 
   @override
@@ -153,7 +161,8 @@ class _MealDetailBottomSheetState extends State<MealDetailBottomSheet> {
                               items: <DropdownMenuItem<String>>[
                                 // #629: a serving the app cannot scale
                                 // is a no-op dressed as a unit.
-                                if (widget.product.scalableServingQuantity != null)
+                                if (widget.product.scalableServingQuantity !=
+                                    null)
                                   _getServingDropdownItem(context),
                                 if (widget.product.isSolid ||
                                     !widget.product.isLiquid &&
@@ -176,27 +185,52 @@ class _MealDetailBottomSheetState extends State<MealDetailBottomSheet> {
                         ],
                       ),
                       if (!productMissingRequiredInfo) ...[
-                        const SizedBox(height: Dimens.spacing12),
-                        Align(
-                          alignment: Alignment.centerLeft,
-                          child: Wrap(
-                            spacing: Dimens.spacing8,
-                            children: [
-                              // Quick-quantity presets — one tap to a common
-                              // serving size instead of typing.
-                              for (final preset in const [50, 100, 150, 200, 250])
-                                ActionChip(
-                                  label: Text('$preset'),
-                                  onPressed: () {
-                                    widget.quantityTextController.text = '$preset';
-                                    widget.onQuantityOrUnitChanged(
-                                      '$preset',
-                                      widget.selectedUnit,
-                                    );
-                                  },
+                        Builder(
+                          builder: (context) {
+                            // Quick-quantity presets — one tap to a common
+                            // portion instead of typing. Uses the food's own
+                            // serving when it has one and 100 g for solids.
+                            final options = quickServingOptionsFor(
+                              widget.product,
+                              S.of(context).gramUnit,
+                            );
+                            if (options.isEmpty) {
+                              return const SizedBox.shrink();
+                            }
+                            return Padding(
+                              padding: const EdgeInsets.only(
+                                top: Dimens.spacing12,
+                              ),
+                              child: Align(
+                                alignment: Alignment.centerLeft,
+                                child: Wrap(
+                                  spacing: Dimens.spacing8,
+                                  children: [
+                                    for (final option in options)
+                                      Semantics(
+                                        identifier:
+                                            'meal-detail-chip-${option.label}',
+                                        child: ActionChip(
+                                          label: Text(option.label),
+                                          onPressed: () {
+                                            final quantityText =
+                                                _formatQuantity(
+                                                  option.quantity,
+                                                );
+                                            widget.quantityTextController.text =
+                                                quantityText;
+                                            widget.onQuantityOrUnitChanged(
+                                              quantityText,
+                                              option.unit,
+                                            );
+                                          },
+                                        ),
+                                      ),
+                                  ],
                                 ),
-                            ],
-                          ),
+                              ),
+                            );
+                          },
                         ),
                       ],
                       const SizedBox(height: Dimens.spacing16),
@@ -315,9 +349,8 @@ class _MealDetailBottomSheetState extends State<MealDetailBottomSheet> {
     ScaffoldMessenger.of(
       context,
     ).showSnackBar(SnackBar(content: Text(S.of(context).infoAddedIntakeLabel)));
-    Navigator.of(
-      context,
-    ).popUntil(namedRouteOrFirst(NavigationOptions.mainRoute));
+    Navigator.of(context)
+        .popUntil(namedRouteOrFirst(NavigationOptions.mainRoute));
   }
 
   // #212: Check if this meal was already added today for the same meal type
@@ -388,11 +421,7 @@ class _MealDetailBottomSheetState extends State<MealDetailBottomSheet> {
         : '${S.of(context).servingLabel} (${widget.product.servingQuantity} ${widget.product.servingUnit})';
     return DropdownMenuItem(
       value: UnitDropdownItem.serving.toString(),
-      child: Text(
-        servingText,
-        overflow: TextOverflow.ellipsis,
-        maxLines: 1,
-      ),
+      child: Text(servingText, overflow: TextOverflow.ellipsis, maxLines: 1),
     );
   }
 

--- a/lib/features/meal_detail/presentation/widgets/meal_detail_bottom_sheet.dart
+++ b/lib/features/meal_detail/presentation/widgets/meal_detail_bottom_sheet.dart
@@ -209,7 +209,7 @@ class _MealDetailBottomSheetState extends State<MealDetailBottomSheet> {
                                     for (final option in options)
                                       Semantics(
                                         identifier:
-                                            'meal-detail-chip-${option.label}',
+                                            'meal-detail-chip-${option.id}',
                                         child: ActionChip(
                                           label: Text(option.label),
                                           onPressed: () {
@@ -349,8 +349,9 @@ class _MealDetailBottomSheetState extends State<MealDetailBottomSheet> {
     ScaffoldMessenger.of(
       context,
     ).showSnackBar(SnackBar(content: Text(S.of(context).infoAddedIntakeLabel)));
-    Navigator.of(context)
-        .popUntil(namedRouteOrFirst(NavigationOptions.mainRoute));
+    Navigator.of(
+      context,
+    ).popUntil(namedRouteOrFirst(NavigationOptions.mainRoute));
   }
 
   // #212: Check if this meal was already added today for the same meal type

--- a/lib/features/meal_detail/util/quick_serving_option.dart
+++ b/lib/features/meal_detail/util/quick_serving_option.dart
@@ -3,12 +3,17 @@ import 'package:opennutritracker/features/meal_detail/presentation/bloc/meal_det
 
 /// One preset a user can tap in the meal-detail sheet to jump the
 /// quantity + unit inputs to a common portion without typing.
+///
+/// [id] is a stable ASCII slug for building `Semantics(identifier: ...)`
+/// values; [label] is the visible chip text and moves with the locale.
 class QuickServingOption {
+  final String id;
   final double quantity;
   final String unit;
   final String label;
 
   const QuickServingOption({
+    required this.id,
     required this.quantity,
     required this.unit,
     required this.label,
@@ -16,8 +21,9 @@ class QuickServingOption {
 }
 
 /// Presets for [product]. Returns an empty list when the food carries no
-/// serving metadata and is not mass-based, so the sheet can hide the row
-/// entirely rather than show a chip that rounds to nothing meaningful.
+/// serving metadata and is not measured by mass or volume, so the sheet
+/// can hide the row entirely rather than show a chip that rounds to
+/// nothing meaningful.
 ///
 /// [gramUnitLabel] is passed in so this helper stays context-free.
 List<QuickServingOption> quickServingOptionsFor(
@@ -30,14 +36,33 @@ List<QuickServingOption> quickServingOptionsFor(
 
   if (product.scalableServingQuantity != null) {
     options.addAll([
-      QuickServingOption(quantity: 0.5, unit: servingUnit, label: '0.5×'),
-      QuickServingOption(quantity: 1, unit: servingUnit, label: '1×'),
-      QuickServingOption(quantity: 2, unit: servingUnit, label: '2×'),
+      QuickServingOption(
+        id: 'half-serving',
+        quantity: 0.5,
+        unit: servingUnit,
+        label: '0.5×',
+      ),
+      QuickServingOption(
+        id: 'one-serving',
+        quantity: 1,
+        unit: servingUnit,
+        label: '1×',
+      ),
+      QuickServingOption(
+        id: 'double-serving',
+        quantity: 2,
+        unit: servingUnit,
+        label: '2×',
+      ),
     ]);
   }
-  if (product.isSolid) {
+  // Mirror the unit dropdown's gate at meal_detail_bottom_sheet.dart:167-170,
+  // so quick-add custom meals (mealUnit == 'g/ml') and liquids with no
+  // serving still get the 100 g shortcut.
+  if (product.isSolid || (!product.isLiquid && !product.isSolid)) {
     options.add(
       QuickServingOption(
+        id: '100g',
         quantity: 100,
         unit: gramUnit,
         label: '100 $gramUnitLabel',

--- a/lib/features/meal_detail/util/quick_serving_option.dart
+++ b/lib/features/meal_detail/util/quick_serving_option.dart
@@ -1,0 +1,48 @@
+import 'package:opennutritracker/features/add_meal/domain/entity/meal_entity.dart';
+import 'package:opennutritracker/features/meal_detail/presentation/bloc/meal_detail_bloc.dart';
+
+/// One preset a user can tap in the meal-detail sheet to jump the
+/// quantity + unit inputs to a common portion without typing.
+class QuickServingOption {
+  final double quantity;
+  final String unit;
+  final String label;
+
+  const QuickServingOption({
+    required this.quantity,
+    required this.unit,
+    required this.label,
+  });
+}
+
+/// Presets for [product]. Returns an empty list when the food carries no
+/// serving metadata and is not mass-based, so the sheet can hide the row
+/// entirely rather than show a chip that rounds to nothing meaningful.
+///
+/// [gramUnitLabel] is passed in so this helper stays context-free.
+List<QuickServingOption> quickServingOptionsFor(
+  MealEntity product,
+  String gramUnitLabel,
+) {
+  final servingUnit = UnitDropdownItem.serving.toString();
+  final gramUnit = UnitDropdownItem.g.toString();
+  final options = <QuickServingOption>[];
+
+  if (product.scalableServingQuantity != null) {
+    options.addAll([
+      QuickServingOption(quantity: 0.5, unit: servingUnit, label: '0.5×'),
+      QuickServingOption(quantity: 1, unit: servingUnit, label: '1×'),
+      QuickServingOption(quantity: 2, unit: servingUnit, label: '2×'),
+    ]);
+  }
+  if (product.isSolid) {
+    options.add(
+      QuickServingOption(
+        quantity: 100,
+        unit: gramUnit,
+        label: '100 $gramUnitLabel',
+      ),
+    );
+  }
+  return options;
+}

--- a/test/features/meal_detail/quick_serving_chips_widget_test.dart
+++ b/test/features/meal_detail/quick_serving_chips_widget_test.dart
@@ -1,0 +1,222 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:opennutritracker/core/data/data_source/remote_search_cache_data_source.dart';
+import 'package:opennutritracker/core/domain/entity/intake_type_entity.dart';
+import 'package:opennutritracker/core/domain/usecase/add_intake_usecase.dart';
+import 'package:opennutritracker/core/domain/usecase/add_tracked_day_usecase.dart';
+import 'package:opennutritracker/core/domain/usecase/get_kcal_goal_usecase.dart';
+import 'package:opennutritracker/core/domain/usecase/get_macro_goal_usecase.dart';
+import 'package:opennutritracker/core/domain/usecase/get_tracked_day_usecase.dart';
+import 'package:opennutritracker/features/add_meal/data/repository/products_repository.dart';
+import 'package:opennutritracker/features/add_meal/domain/entity/meal_entity.dart';
+import 'package:opennutritracker/features/add_meal/domain/entity/meal_nutriments_entity.dart';
+import 'package:opennutritracker/features/meal_detail/presentation/bloc/meal_detail_bloc.dart';
+import 'package:opennutritracker/features/meal_detail/presentation/widgets/meal_detail_bottom_sheet.dart';
+import 'package:opennutritracker/generated/l10n.dart';
+
+// Widget-side counterpart to `quick_serving_option_test.dart`. Drives the
+// real MealDetailBottomSheet with a scalable-serving solid product,
+// finds each chip by its stable ASCII Semantics identifier (locked in
+// via option.id — see review round on #1101), taps it, and asserts that
+// the callback fires with the paired quantity + unit for that chip.
+
+class _FakeAddIntakeUsecase extends Fake implements AddIntakeUsecase {}
+
+class _FakeAddTrackedDayUsecase extends Fake implements AddTrackedDayUsecase {}
+
+class _FakeGetKcalGoalUsecase extends Fake implements GetKcalGoalUsecase {}
+
+class _FakeGetMacroGoalUsecase extends Fake implements GetMacroGoalUsecase {}
+
+class _FakeGetTrackedDayUsecase extends Fake implements GetTrackedDayUsecase {}
+
+class _FakeProductsRepository extends Fake implements ProductsRepository {}
+
+class _FakeRemoteSearchCacheDataSource extends Fake
+    implements RemoteSearchCacheDataSource {}
+
+MealDetailBloc _buildBloc() => MealDetailBloc(
+  _FakeAddIntakeUsecase(),
+  _FakeAddTrackedDayUsecase(),
+  _FakeGetKcalGoalUsecase(),
+  _FakeGetMacroGoalUsecase(),
+  _FakeGetTrackedDayUsecase(),
+  _FakeProductsRepository(),
+  _FakeRemoteSearchCacheDataSource(),
+);
+
+const _nutriments = MealNutrimentsEntity(
+  energyKcal100: 100,
+  carbohydrates100: 10,
+  fat100: 5,
+  proteins100: 5,
+  sugars100: 2,
+  saturatedFat100: 1,
+  fiber100: 1,
+);
+
+MealEntity _solidWithServing() => MealEntity(
+  code: 'chip-widget-test',
+  name: 'Test product',
+  url: null,
+  mealQuantity: null,
+  mealUnit: 'g',
+  servingQuantity: 30,
+  servingUnit: 'g',
+  servingSize: '30 g',
+  nutriments: _nutriments,
+  source: MealSourceEntity.off,
+);
+
+Future<void> _pumpSheet(
+  WidgetTester tester, {
+  required MealEntity product,
+  required TextEditingController quantityController,
+  required void Function(String?, String?) onChanged,
+  String initialUnit = 'serving',
+}) async {
+  await tester.pumpWidget(
+    MaterialApp(
+      localizationsDelegates: const [S.delegate],
+      supportedLocales: S.supportedLocales,
+      home: Scaffold(
+        body: MealDetailBottomSheet(
+          product: product,
+          day: DateTime(2026, 9, 13),
+          intakeTypeEntity: IntakeTypeEntity.breakfast,
+          quantityTextController: quantityController,
+          mealDetailBloc: _buildBloc(),
+          selectedUnit: initialUnit,
+          onQuantityOrUnitChanged: onChanged,
+        ),
+      ),
+    ),
+  );
+  await tester.pumpAndSettle();
+}
+
+void main() {
+  testWidgets('renders one chip per option with a stable ASCII identifier', (
+    tester,
+  ) async {
+    final quantityController = TextEditingController(text: '1');
+
+    await _pumpSheet(
+      tester,
+      product: _solidWithServing(),
+      quantityController: quantityController,
+      onChanged: (_, _) {},
+    );
+
+    for (final id in const [
+      'half-serving',
+      'one-serving',
+      'double-serving',
+      '100g',
+    ]) {
+      expect(
+        find.bySemanticsLabel(RegExp('.*')).evaluate().isNotEmpty,
+        isTrue,
+        reason: 'a chip named $id must be present in the tree',
+      );
+      expect(find.byWidgetPredicate((w) {
+        if (w is! Semantics) return false;
+        return w.properties.identifier == 'meal-detail-chip-$id';
+      }), findsOneWidget, reason: 'chip identifier meal-detail-chip-$id');
+    }
+  });
+
+  testWidgets(
+    'tapping the 100 g chip writes 100 into the quantity field and fires the '
+    'callback with unit=g',
+    (tester) async {
+      final quantityController = TextEditingController(text: '1');
+      String? cbQuantity;
+      String? cbUnit;
+
+      await _pumpSheet(
+        tester,
+        product: _solidWithServing(),
+        quantityController: quantityController,
+        onChanged: (q, u) {
+          cbQuantity = q;
+          cbUnit = u;
+        },
+      );
+
+      final chip = find.byWidgetPredicate(
+        (w) => w is Semantics && w.properties.identifier == 'meal-detail-chip-100g',
+      );
+      await tester.tap(chip);
+      await tester.pumpAndSettle();
+
+      expect(quantityController.text, '100');
+      expect(cbQuantity, '100');
+      expect(cbUnit, 'g');
+    },
+  );
+
+  testWidgets(
+    'tapping the 1× chip writes 1 into the quantity field and fires the '
+    'callback with unit=serving',
+    (tester) async {
+      final quantityController = TextEditingController(text: '30');
+      String? cbQuantity;
+      String? cbUnit;
+
+      await _pumpSheet(
+        tester,
+        product: _solidWithServing(),
+        quantityController: quantityController,
+        onChanged: (q, u) {
+          cbQuantity = q;
+          cbUnit = u;
+        },
+        initialUnit: 'g',
+      );
+
+      final chip = find.byWidgetPredicate(
+        (w) =>
+            w is Semantics &&
+            w.properties.identifier == 'meal-detail-chip-one-serving',
+      );
+      await tester.tap(chip);
+      await tester.pumpAndSettle();
+
+      expect(quantityController.text, '1');
+      expect(cbQuantity, '1');
+      expect(cbUnit, 'serving');
+    },
+  );
+
+  testWidgets(
+    'tapping the 0.5× chip writes 0.5 (not 1 or 0) into the quantity field',
+    (tester) async {
+      final quantityController = TextEditingController(text: '1');
+      String? cbQuantity;
+      String? cbUnit;
+
+      await _pumpSheet(
+        tester,
+        product: _solidWithServing(),
+        quantityController: quantityController,
+        onChanged: (q, u) {
+          cbQuantity = q;
+          cbUnit = u;
+        },
+      );
+
+      final chip = find.byWidgetPredicate(
+        (w) =>
+            w is Semantics &&
+            w.properties.identifier == 'meal-detail-chip-half-serving',
+      );
+      await tester.tap(chip);
+      await tester.pumpAndSettle();
+
+      expect(quantityController.text, '0.5');
+      expect(cbQuantity, '0.5');
+      expect(cbUnit, 'serving');
+    },
+  );
+}

--- a/test/unit_test/quick_serving_option_test.dart
+++ b/test/unit_test/quick_serving_option_test.dart
@@ -5,9 +5,10 @@ import 'package:opennutritracker/features/meal_detail/util/quick_serving_option.
 
 // Locks in what the meal-detail sheet's quick-serving chip row is meant
 // to show for each shape of food — the trio of ×-multipliers when the
-// backend gave us a scalable serving, the 100 g shortcut when the food
-// is measured by mass, both together for a solid with a serving, and
-// nothing at all when neither applies.
+// backend gave us a scalable serving, the 100 g shortcut whenever the
+// unit dropdown would offer grams, both together for a solid with a
+// serving, and nothing at all when the food is exclusively a liquid
+// with no scalable serving (so 100 g would be a wrong unit).
 
 const _nutriments = MealNutrimentsEntity(
   energyKcal100: 100,
@@ -48,6 +49,12 @@ void main() {
       );
 
       expect(options, hasLength(4));
+      expect(options.map((o) => o.id).toList(), [
+        'half-serving',
+        'one-serving',
+        'double-serving',
+        '100g',
+      ]);
       expect(options.map((o) => o.label).toList(), [
         '0.5×',
         '1×',
@@ -69,7 +76,11 @@ void main() {
         'g',
       );
 
-      expect(options.map((o) => o.label).toList(), ['0.5×', '1×', '2×']);
+      expect(options.map((o) => o.id).toList(), [
+        'half-serving',
+        'one-serving',
+        'double-serving',
+      ]);
       expect(options.every((o) => o.unit == 'serving'), isTrue);
     });
 
@@ -77,13 +88,25 @@ void main() {
       final options = quickServingOptionsFor(_meal(mealUnit: 'g'), 'g');
 
       expect(options, hasLength(1));
+      expect(options.single.id, '100g');
       expect(options.single.label, '100 g');
       expect(options.single.unit, 'g');
       expect(options.single.quantity, 100);
     });
 
-    test('food with neither a serving nor a mass unit gets no chips', () {
-      final options = quickServingOptionsFor(_meal(mealUnit: null), 'g');
+    test(
+      'meal with neither solid nor liquid unit (e.g. gml quick-add) still '
+      'gets the 100 g shortcut, mirroring the unit dropdown',
+      () {
+        final options = quickServingOptionsFor(_meal(mealUnit: null), 'g');
+
+        expect(options, hasLength(1));
+        expect(options.single.id, '100g');
+      },
+    );
+
+    test('purely liquid food with no serving gets no chip row', () {
+      final options = quickServingOptionsFor(_meal(mealUnit: 'ml'), 'g');
 
       expect(options, isEmpty);
     });
@@ -92,6 +115,21 @@ void main() {
       final options = quickServingOptionsFor(_meal(mealUnit: 'g'), 'grams');
 
       expect(options.single.label, '100 grams');
+      expect(options.single.id, '100g');
+    });
+
+    test('id values stay ASCII regardless of the localised label', () {
+      // Simulates a Cyrillic gram unit (Ukrainian "г") to confirm the id used
+      // for Semantics never absorbs the label's script — that identifier is
+      // meant for accessibility + integration tests, not for display.
+      final options = quickServingOptionsFor(
+        _meal(servingQuantity: 30, mealUnit: 'g'),
+        'г',
+      );
+
+      final gramChip = options.singleWhere((o) => o.unit == 'g');
+      expect(gramChip.label, '100 г');
+      expect(gramChip.id, '100g');
     });
 
     test('scalableServingQuantity recovers from servingSize when quantity is '
@@ -101,11 +139,11 @@ void main() {
         'g',
       );
 
-      expect(options.map((o) => o.label).toList(), [
-        '0.5×',
-        '1×',
-        '2×',
-        '100 g',
+      expect(options.map((o) => o.id).toList(), [
+        'half-serving',
+        'one-serving',
+        'double-serving',
+        '100g',
       ]);
     });
   });

--- a/test/unit_test/quick_serving_option_test.dart
+++ b/test/unit_test/quick_serving_option_test.dart
@@ -1,0 +1,112 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:opennutritracker/features/add_meal/domain/entity/meal_entity.dart';
+import 'package:opennutritracker/features/add_meal/domain/entity/meal_nutriments_entity.dart';
+import 'package:opennutritracker/features/meal_detail/util/quick_serving_option.dart';
+
+// Locks in what the meal-detail sheet's quick-serving chip row is meant
+// to show for each shape of food — the trio of ×-multipliers when the
+// backend gave us a scalable serving, the 100 g shortcut when the food
+// is measured by mass, both together for a solid with a serving, and
+// nothing at all when neither applies.
+
+const _nutriments = MealNutrimentsEntity(
+  energyKcal100: 100,
+  carbohydrates100: 10,
+  fat100: 5,
+  proteins100: 5,
+  sugars100: 2,
+  saturatedFat100: 1,
+  fiber100: 1,
+);
+
+MealEntity _meal({
+  double? servingQuantity,
+  String? servingUnit,
+  String? servingSize,
+  String? mealUnit,
+}) {
+  return MealEntity(
+    code: 'quick-serving-test',
+    name: 'Test product',
+    url: null,
+    mealQuantity: null,
+    mealUnit: mealUnit,
+    servingQuantity: servingQuantity,
+    servingUnit: servingUnit,
+    servingSize: servingSize,
+    nutriments: _nutriments,
+    source: MealSourceEntity.off,
+  );
+}
+
+void main() {
+  group('quickServingOptionsFor', () {
+    test('solid food with a scalable serving offers all four presets', () {
+      final options = quickServingOptionsFor(
+        _meal(servingQuantity: 30, servingUnit: 'g', mealUnit: 'g'),
+        'g',
+      );
+
+      expect(options, hasLength(4));
+      expect(options.map((o) => o.label).toList(), [
+        '0.5×',
+        '1×',
+        '2×',
+        '100 g',
+      ]);
+      expect(options.map((o) => o.unit).toList(), [
+        'serving',
+        'serving',
+        'serving',
+        'g',
+      ]);
+      expect(options.map((o) => o.quantity).toList(), [0.5, 1, 2, 100]);
+    });
+
+    test('liquid food with a scalable serving offers only the multipliers', () {
+      final options = quickServingOptionsFor(
+        _meal(servingQuantity: 250, servingUnit: 'ml', mealUnit: 'ml'),
+        'g',
+      );
+
+      expect(options.map((o) => o.label).toList(), ['0.5×', '1×', '2×']);
+      expect(options.every((o) => o.unit == 'serving'), isTrue);
+    });
+
+    test('solid food without a serving still offers the 100 g shortcut', () {
+      final options = quickServingOptionsFor(_meal(mealUnit: 'g'), 'g');
+
+      expect(options, hasLength(1));
+      expect(options.single.label, '100 g');
+      expect(options.single.unit, 'g');
+      expect(options.single.quantity, 100);
+    });
+
+    test('food with neither a serving nor a mass unit gets no chips', () {
+      final options = quickServingOptionsFor(_meal(mealUnit: null), 'g');
+
+      expect(options, isEmpty);
+    });
+
+    test('gram unit label passes through so callers can localise it', () {
+      final options = quickServingOptionsFor(_meal(mealUnit: 'g'), 'grams');
+
+      expect(options.single.label, '100 grams');
+    });
+
+    test('scalableServingQuantity recovers from servingSize when quantity is '
+        'missing', () {
+      final options = quickServingOptionsFor(
+        _meal(servingSize: '1 slice (30 g)', mealUnit: 'g'),
+        'g',
+      );
+
+      expect(options.map((o) => o.label).toList(), [
+        '0.5×',
+        '1×',
+        '2×',
+        '100 g',
+      ]);
+    });
+  });
+}


### PR DESCRIPTION
Fixes part of #577 — the quick-quantity chip row on the meal-detail sheet was hard-coded to the 50/100/150/200/250 g presets, which are meaningless for foods measured by serving (a slice of pizza, a scoop of protein) and impossible to hit for liquids.

## Changes

**New helper — `lib/features/meal_detail/util/quick_serving_option.dart`**

Builds the chip row from the food itself:

- **0.5×, 1×, 2×** — when the meal exposes a `scalableServingQuantity` (either an explicit `servingQuantity` or one recovered from the `servingSize` string). Selecting a chip sets the quantity + switches the unit to `serving`, so nutriment math goes through the same path as the existing dropdown.
- **100 g** — when the food is measured by mass (`isSolid`). Uses the localised gram-unit label passed in from `S.of(context).gramUnit`.
- **No row at all** — when the food has neither a serving nor a mass unit. Better than showing a chip that rounds to zero.

**Sheet wiring — `meal_detail_bottom_sheet.dart`**

Replaces the hard-coded chip loop with a `Builder` that consults `quickServingOptionsFor` and renders each option as an `ActionChip` wrapped in a `Semantics(identifier: 'meal-detail-chip-<label>')` so a11y and integration tests can address individual chips. The chip's `onPressed` writes both the quantity text and the new unit through the existing `onQuantityOrUnitChanged` callback, which is what the dropdown and manual typing already fan out through.

Quantity is rendered with a small `_formatQuantity` helper so `1.0` stays `1` and `0.5` renders as `0.5` — the input field's regex allows both shapes but users expect the shorter one from a chip.

**Test — `test/unit_test/quick_serving_option_test.dart`**

Six cases against `quickServingOptionsFor`:

- solid + scalable serving → 4 chips (`0.5×`, `1×`, `2×`, `100 g`)
- liquid + scalable serving → 3 chips (multipliers only)
- solid without a serving → single `100 g` chip
- neither serving nor mass → empty row
- gram-unit label passthrough (used to lock in the localisation entry point)
- `scalableServingQuantity` recovering from a `1 slice (30 g)` string when `servingQuantity` is null

## Acceptance criteria mapping

- [x] Show 0.5×, 1×, 2× when a valid serving size is available
- [x] Include a 100 g choice for foods measured by mass
- [x] Selecting a chip updates the existing quantity/unit controls and nutrition preview
- [x] Manual quantity and unit entry continues to work
- [x] Do not show invalid options for foods without the required serving metadata
- [x] Preserve locale-aware unit labels (gram unit routed through `S.of(context).gramUnit`)
- [x] Add stable `Semantics(identifier: ...)` values to each interactive chip
- [x] Unit tests for selection mapping, presence, and missing-serving behaviour

Remembering the last-used portion stays out of scope per the issue.

## Test plan

- [x] `flutter test test/unit_test/quick_serving_option_test.dart` — 6/6 pass locally
- [x] `dart format` clean on both changed files
- [ ] Manual check on Android
- [ ] Manual check on iOS