### PR TITLE
ci(ios): put the App Store screenshot lane on main

### DIFF
--- a/.github/scripts/ios_capture_screenshots.sh
+++ b/.github/scripts/ios_capture_screenshots.sh
@@ -1,0 +1,190 @@
+#!/usr/bin/env bash
+#
+# Capture one device class's raw store screenshots on an iOS simulator.
+#
+#   ios_capture_screenshots.sh <slot> <out-dir>
+#
+#     <slot>     iphone | ipad — only used for the expected native size and
+#                for log text.
+#     <out-dir>  where the raw PNGs are copied to.
+#
+# Environment:
+#
+#     CANDIDATES  '|'-separated simulator device names, in preference order.
+#     BUNDLE_ID   the app's bundle identifier (must match the built flavor).
+#     SCREENSHOT_FIXTURE  optional: dev (default) or onboarding.
+#
+# Called twice by .github/workflows/ios-screenshots.yml. Extracted into a
+# script rather than inlined because the two device classes run exactly the
+# same twelve steps and an inlined copy of them would drift.
+#
+# The two things here that are not obvious:
+#
+#   1. The device type is chosen from a preference list, not hardcoded.
+#      Runner images add and drop simulator device types between updates, and
+#      a hardcoded name turns an image refresh into a mystery failure. When
+#      none of the candidates is present, this prints every device the runner
+#      *does* have, which is the only thing that makes that diagnosable from
+#      a log.
+#
+#   2. The captures are read out of the simulator's app container rather than
+#      handed back over a `flutter drive` channel. That keeps the run a plain
+#      `flutter test -d <udid>` — the exact command shape
+#      ios-integration-attempt.yml already runs green on this image — instead
+#      of adding flutter_driver and a second, unproven tool path on top of
+#      everything else here that has never executed.
+
+set -euo pipefail
+
+SLOT="${1:?usage: ios_capture_screenshots.sh <iphone|ipad> <out-dir>}"
+OUT_DIR="${2:?usage: ios_capture_screenshots.sh <iphone|ipad> <out-dir>}"
+: "${CANDIDATES:?CANDIDATES must list simulator device names, '|'-separated}"
+: "${BUNDLE_ID:?BUNDLE_ID must be set}"
+FIXTURE="${SCREENSHOT_FIXTURE:-dev}"
+
+case "$SLOT" in
+  iphone) EXPECT_W=1290; EXPECT_H=2796; LABEL='6.9" iPhone' ;;
+  ipad)   EXPECT_W=2064; EXPECT_H=2752; LABEL='13" iPad' ;;
+  *) echo "Unknown slot '$SLOT' (want iphone or ipad)" >&2; exit 2 ;;
+esac
+
+echo "==> $LABEL: choosing a simulator"
+UDID=$(
+  CANDIDATES="$CANDIDATES" python3 -c "
+import json, os, subprocess, sys
+
+wanted = [n.strip() for n in os.environ['CANDIDATES'].split('|') if n.strip()]
+data = json.loads(
+    subprocess.run(
+        ['xcrun', 'simctl', 'list', 'devices', 'available', '-j'],
+        capture_output=True, text=True, check=True,
+    ).stdout
+)
+available = [
+    d for runtime in data['devices'].values()
+    for d in runtime if d.get('isAvailable')
+]
+by_name = {}
+for d in available:
+    by_name.setdefault(d['name'], d)
+
+for name in wanted:
+    if name in by_name:
+        print(by_name[name]['udid'])
+        sys.exit(0)
+
+sys.stderr.write(
+    'None of the candidate device types is available on this runner.\n'
+    'Wanted, in order: ' + ', '.join(wanted) + '\n'
+    'Available:\n'
+)
+for name in sorted(by_name):
+    sys.stderr.write(f'  {name}\n')
+sys.exit(1)
+"
+)
+NAME=$(xcrun simctl list devices -j | python3 -c "
+import json, sys
+udid = '$UDID'
+data = json.load(sys.stdin)
+for runtime in data['devices'].values():
+    for d in runtime:
+        if d['udid'] == udid:
+            print(d['name'])
+")
+echo "    $NAME ($UDID)"
+
+cleanup() {
+  xcrun simctl shutdown "$UDID" >/dev/null 2>&1 || true
+}
+trap cleanup EXIT
+
+xcrun simctl boot "$UDID"
+xcrun simctl bootstatus "$UDID"
+
+# Apple's canonical status bar. Two of the live iPhone assets show the
+# simulator's `Carrier` placeholder (#1072); this is what stops that coming
+# back, and it costs one command. Best-effort: if a future simulator drops
+# `status_bar override` the run should still produce screenshots.
+xcrun simctl status_bar "$UDID" override \
+  --time '9:41' \
+  --dataNetwork wifi --wifiMode active --wifiBars 3 \
+  --cellularMode active --cellularBars 4 \
+  --batteryState charged --batteryLevel 100 \
+  || echo "::warning::simctl status_bar override failed; the status bar will be whatever the simulator felt like"
+
+echo "==> $LABEL: running the capture test"
+# --flavor full so the app carries the production bundle id and display name.
+# A screenshot of a build whose app bar reads "[Alpha]" is the defect this
+# whole lane replaces.
+flutter test integration_test/store_screenshots_test.dart \
+  -d "$UDID" \
+  --flavor full \
+  --dart-define=STORE_SCREENSHOTS=true \
+  --dart-define="SCREENSHOT_FIXTURE=$FIXTURE" \
+  --reporter expanded
+
+echo "==> $LABEL: reading the captures out of the simulator"
+SRC=""
+if CONTAINER=$(xcrun simctl get_app_container "$UDID" "$BUNDLE_ID" data 2>/dev/null); then
+  SRC="$CONTAINER/Documents/store_screenshots"
+fi
+# Fallback for the case `get_app_container` cannot resolve the bundle id —
+# a flavor mismatch, or flutter_tools having uninstalled the app after the
+# run. The data container survives either way, so find it by name.
+if [ -z "$SRC" ] || [ ! -d "$SRC" ]; then
+  echo "    app container lookup failed for $BUNDLE_ID; searching the device's data dir"
+  SRC=$(find "$HOME/Library/Developer/CoreSimulator/Devices/$UDID/data/Containers/Data/Application" \
+        -maxdepth 3 -type d -name store_screenshots 2>/dev/null | head -n 1 || true)
+fi
+if [ -z "$SRC" ] || [ ! -d "$SRC" ]; then
+  echo "No captures were written. The test reported success but nothing reached" >&2
+  echo "the app's Documents directory, which means the capture step never ran." >&2
+  exit 1
+fi
+
+mkdir -p "$OUT_DIR"
+cp "$SRC"/*.png "$OUT_DIR/"
+
+# The compositor forces its output to the target size whatever it is handed,
+# so a capture taken on the wrong device would be silently up- or downscaled
+# and would still pass the Apple spec guard afterwards. That is precisely how
+# a listing ends up with soft, wrong-sized assets, so check the *native*
+# capture here where the device that produced it is still known.
+EXPECT_W="$EXPECT_W" EXPECT_H="$EXPECT_H" OUT_DIR="$OUT_DIR" \
+LABEL="$LABEL" NAME="$NAME" python3 -c "
+import glob, os, struct, sys
+
+want_w = int(os.environ['EXPECT_W'])
+want_h = int(os.environ['EXPECT_H'])
+files = sorted(glob.glob(os.path.join(os.environ['OUT_DIR'], '*.png')))
+label = os.environ['LABEL']
+name = os.environ['NAME']
+
+if not files:
+    sys.exit(f'{label}: no PNGs copied out')
+
+bad = []
+for f in files:
+    head = open(f, 'rb').read(26)
+    if len(head) < 26 or head[:8] != b'\x89PNG\r\n\x1a\n':
+        bad.append(f'{os.path.basename(f)}: not a readable PNG')
+        continue
+    w, h = struct.unpack('>II', head[16:24])
+    print(f'  {os.path.basename(f):24s} {w}x{h}')
+    if w < want_w or h < want_h:
+        bad.append(
+            f'{os.path.basename(f)}: {w}x{h} is smaller than the {want_w}x{want_h} '
+            f'{label} slot. Compositing would upscale it into a soft asset. '
+            f'The simulator that produced this was \"{name}\".'
+        )
+    elif (w, h) != (want_w, want_h):
+        print(f'::warning::{os.path.basename(f)} is {w}x{h}, not {want_w}x{want_h}; '
+              f'it will be downscaled to fit the {label} slot')
+
+if bad:
+    sys.exit(f'{label} captures rejected:\n  ' + '\n  '.join(bad))
+print(f'{len(files)} raw capture(s) OK for {label}.')
+"
+
+echo "==> $LABEL: done"

--- a/.github/workflows/ios-screenshots.yml
+++ b/.github/workflows/ios-screenshots.yml
@@ -1,0 +1,384 @@
+# Produce the App Store screenshot sets on macOS CI simulators.
+#
+# Why this exists: Apple requires a **6.9" iPhone** set (1290x2796) and a
+# **13" iPad** set (2064x2752) — the iPad one because
+# `TARGETED_DEVICE_FAMILY = "1,2"` in `ios/Runner.xcodeproj/project.pbxproj`,
+# all six configurations. The assets on the live listing are 1242x2208, the
+# legacy 5.5" slot, and four of the eight have a visible defect: one iPhone
+# shot shows an app bar reading "OpenNutriTracker [Alpha]", two show the
+# simulator's `Carrier` status-bar placeholder, and two iPad shots are 35% and
+# 55% empty black (#1072). The dev machine is Linux and there is no Mac, so a
+# CI simulator is the only way this repo can shoot iOS at all — and doing it
+# in CI means the next release gets the re-shoot for free rather than
+# borrowing a laptop again.
+#
+# **Why it is `workflow_dispatch`-only, and must stay that way.** Map #1016
+# spent an entire effort removing macOS demand from the pull-request path:
+# macOS queue p90 fell from 35.4 to 1.7 minutes, and mean macOS jobs per run
+# from 3.06 to 2.17, against a hard cap of 5 concurrent macOS runners. This
+# job boots two simulators and runs a full Xcode build; putting it on
+# `pull_request`, `push`, `release/**` or `main` would hand back a large part
+# of what that effort bought. There is no trigger here but `workflow_dispatch`
+# and adding one is a regression, not a convenience. Same rule, same reason,
+# as `play-screenshots.yml`.
+#
+# **This job holds no store credentials and cannot publish.** Unlike
+# `play-screenshots.yml`, which selects the `release-ship` environment because
+# it writes to a live listing, this one only produces files and uploads them
+# as an artifact. It is deliberately not a deployment and deliberately not
+# behind an approval gate — there is nothing to approve.
+#
+# **It uploads an artifact; it does not commit and does not open a PR.** A CI
+# auto-commit has cost this repo real time before: the iOS `Podfile.lock`
+# auto-commit puts a bot commit on the branch tip, after which dependabot
+# refuses to rebase its own PRs and only `@dependabot recreate` recovers them.
+# Store screenshots are a judgement call — someone has to look at six images
+# and decide they are good enough for the front page of the listing — so the
+# human downloads the artifact, looks, and commits. That review step is the
+# feature.
+#
+# **Where the files land.** `fastlane/metadata/ios/en-US/screenshots/`, per
+# `deliver`'s metadata conventions and per the map's decision, split into
+# `iphone-6.9/` and `ipad-13/`. Note for whoever wires up an upload later:
+# `deliver`'s *default* screenshot path is `fastlane/screenshots/<locale>/`,
+# so `ios/fastlane/Fastfile` will need an explicit `screenshots_path:` if it
+# ever grows an `upload_to_app_store` call that carries images. It has none
+# today — its `release` lane uploads the IPA and nothing else.
+#
+# **What this deliberately does NOT do:**
+#
+#   - Publish. Nothing here talks to App Store Connect. Apple's metadata for
+#     the shipped 2.2.0 record is locked (#1067); screenshots are the one
+#     exception, deliverable via Product Page Optimization, and that is a
+#     console action owned by #1080.
+#   - Produce the Play set. It could — `integration_test/store_screenshots_test.dart`
+#     runs unchanged on an Android emulator and `tools/screenshots/compose.py`
+#     is platform-agnostic — but an Android emulator job belongs on
+#     `ubuntu-latest`, and putting one on a macOS runner would re-create the
+#     exact demand #1016 removed. The Play set's outstanding work is captions,
+#     not a re-capture, and that is `compose.py` run over the PNGs already in
+#     `fastlane/metadata/android/en-US/images/phoneScreenshots/`.
+#   - Touch any app code, any store copy, or any binary.
+
+name: App Store screenshots
+
+on:
+  workflow_dispatch:
+    inputs:
+      devices:
+        description: 'Which Apple device classes to shoot.'
+        required: true
+        default: both
+        type: choice
+        options:
+          - both
+          - iphone
+          - ipad
+      captions:
+        description: 'on = composite the captions from tools/screenshots/captions.en-US.json (#1072). off = same assets, sized and padded to the slot, just without the caption band — what Play tablet slots need, and useful for inspecting the app itself.'
+        required: true
+        default: 'on'
+        type: choice
+        options:
+          - 'on'
+          - 'off'
+
+permissions:
+  contents: read
+
+# One at a time. Two runs would not corrupt anything — there is no shared
+# state to corrupt — but they would take two of the five macOS runners, which
+# is the resource this whole lane is written to be careful with.
+concurrency:
+  group: ios-screenshots
+  cancel-in-progress: false
+
+jobs:
+  screenshots:
+    name: Capture App Store screenshots
+    # Pinned to macos-15 for the same reason ios-integration-attempt.yml is:
+    # on the macos-26 image Flutter builds and launches the app on the iOS 26
+    # simulator and then hangs forever on "Waiting for VM Service port to be
+    # available" — the VM service URL is never discovered, so the test never
+    # connects. macos-15 ships the Xcode 16 / iOS 18 simulators this Flutter
+    # supports, and it is also where the 6.9" iPhone and 13" iPad device types
+    # this lane needs are available. Revisit together with that job, not
+    # separately.
+    runs-on: macos-15
+    # Two device classes, each paying a simulator boot and a Flutter test run,
+    # on top of one cold Xcode build. The integration job's slowest healthy
+    # run of the equivalent step was 15m36s including its cold build; the
+    # second device class reuses that build.
+    timeout-minutes: 90
+
+    env:
+      # Apple's current portrait sizes for the two slots this app must fill.
+      # Apple also accepts 1320x2868 for 6.9" and 2048x2732 for 13", which is
+      # why the guard names the alternates when it rejects — a runner image
+      # that only ships an iPhone 16 Pro Max would produce 1320x2868 and be
+      # perfectly valid, just not what #1072 specified.
+      IPHONE_SIZE: 1290x2796
+      IPAD_SIZE: 2064x2752
+      # --flavor full, so the app under test carries the production bundle id
+      # and display name rather than the `.develop` ones. A screenshot of a
+      # build whose app bar says "[Alpha]" is exactly the defect this replaces.
+      BUNDLE_ID: com.opennutritracker.ont.opennutritracker
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v7
+
+      - name: Setup Flutter + cache packages
+        uses: ./.github/actions/setup-flutter-cache
+
+      # Same reasoning as ios-build and ios-integration-attempt: SPM is on by
+      # default on stable, and leaving it on costs ~150s of "Adding Swift
+      # Package Manager integration" and resolves plugins through the SPM
+      # graph instead of the CocoaPods one this repo pins.
+      - name: Disable Swift Package Manager
+        run: flutter config --no-enable-swift-package-manager
+
+      - name: Cache CocoaPods
+        uses: actions/cache@v6
+        with:
+          path: ios/Pods
+          key: ${{ runner.os }}-pods-${{ hashFiles('ios/Podfile.lock') }}
+          restore-keys: |
+            ${{ runner.os }}-pods-
+
+      # The app will not build without a .env, and nothing in a screenshot run
+      # contacts Sentry or Supabase — the shots come off locally seeded demo
+      # data. Stubs, exactly as the integration job uses.
+      - name: Generate stub .env for CI
+        uses: ./.github/actions/write-env-file
+        with:
+          sentry_dns: https://stub@sentry.io/0
+          supabase_project_url: https://stub.supabase.co
+          supabase_project_anon_key: ci-stub
+
+      - name: Install Flutter packages
+        run: flutter pub get
+
+      - name: Generate code
+        run: dart run build_runner build --delete-conflicting-outputs
+
+      - name: Pod install (regenerate lockfile if constraints have shifted)
+        run: .github/scripts/pod_install_with_targeted_fallback.sh
+
+      # setup-python rather than the image's own python3: the macOS runner's
+      # Homebrew Python is an externally-managed environment, so a bare
+      # `pip install` into it fails. This gives the compositing step a plain
+      # interpreter it is allowed to install into.
+      - name: Setup Python
+        uses: actions/setup-python@v6
+        with:
+          python-version: '3.12'
+
+      - name: Install Pillow
+        run: python3 -m pip install --upgrade pillow
+
+      # Capture. One step per device class so a failure names the class it
+      # failed on, and so `devices: iphone` does not pay for an iPad boot.
+      #
+      # The simulator device type is chosen by name from a preference list,
+      # because runner images add and drop device types between updates and a
+      # single hardcoded name turns an image refresh into a mystery failure.
+      # If none of the candidates is available, the step prints every iPhone
+      # or iPad the runner *does* have, which is the one thing that makes this
+      # diagnosable from a log.
+      #
+      # `status_bar override` pins Apple's canonical 9:41, full bars, full
+      # battery. Two of the live iPhone assets show the simulator's `Carrier`
+      # placeholder (#1072) — this is what prevents that recurring, and it
+      # costs one command.
+      # Bounded independently of the job. The VM-service hang documented in the
+      # header is the reason: without a step timeout one stuck capture holds
+      # the macOS runner until the job's own limit, which would starve the
+      # other device's capture and the artifact upload that follows. 25 minutes
+      # is roughly twice a healthy run of six captures plus the boot.
+      - name: Capture — 6.9" iPhone
+        timeout-minutes: 25
+        if: inputs.devices == 'both' || inputs.devices == 'iphone'
+        run: |
+          .github/scripts/ios_capture_screenshots.sh \
+            iphone "build/screenshots/raw/iphone"
+        env:
+          CANDIDATES: 'iPhone 16 Plus|iPhone 15 Plus|iPhone 16 Pro Max|iPhone 15 Pro Max'
+
+      - name: Capture — 13" iPad
+        timeout-minutes: 25
+        # `!cancelled()` because GitHub's implicit `success()` would otherwise
+        # skip this whole step when the iPhone capture failed or timed out —
+        # losing the half of the set that was still reachable, which is the
+        # opposite of what the step timeouts are for. The job still fails on
+        # the iPhone step; this only stops one bad simulator taking both.
+        if: |
+          !cancelled() &&
+          (inputs.devices == 'both' || inputs.devices == 'ipad')
+        run: |
+          .github/scripts/ios_capture_screenshots.sh \
+            ipad "build/screenshots/raw/ipad"
+        env:
+          # Only the 13-inch M4 — 1032x1376pt at @2x is exactly 2064x2752.
+          # The 12.9-inch iPad Pro is deliberately *not* a fallback: it gives
+          # 2048x2732, which is Apple's other accepted 13" size and perfectly
+          # valid, but it is not the one #1072 named and the capture guard
+          # refuses to upscale into a slot. If the M4 ever leaves the runner
+          # image, the fix is to shoot at 2048x2732 and change IPAD_SIZE to
+          # match — not to stretch a smaller capture.
+          CANDIDATES: 'iPad Pro 13-inch (M4)'
+
+      # Compositing. Shared with the Play path on purpose (#1072 captions both
+      # sets); nothing in compose.py knows which platform it is looking at.
+      - name: Composite captions
+        # Same reason as the iPad capture: composite whatever was captured,
+        # rather than skipping because an earlier device failed.
+        if: '!cancelled()'
+        run: |
+          set -euo pipefail
+          extra=""
+          if [ "${{ inputs.captions }}" = "off" ]; then
+            extra="--no-captions"
+          fi
+          if [ -d build/screenshots/raw/iphone ]; then
+            python3 tools/screenshots/compose.py \
+              --raw build/screenshots/raw/iphone \
+              --out "fastlane/metadata/ios/en-US/screenshots/iphone-6.9" \
+              --size "$IPHONE_SIZE" $extra
+          fi
+          if [ -d build/screenshots/raw/ipad ]; then
+            python3 tools/screenshots/compose.py \
+              --raw build/screenshots/raw/ipad \
+              --out "fastlane/metadata/ios/en-US/screenshots/ipad-13" \
+              --size "$IPAD_SIZE" $extra
+          fi
+
+      # Enforces Apple's published screenshot spec locally, so a bad set fails
+      # here in seconds instead of being refused by App Store Connect after
+      # somebody has already committed it. Same idea, and the same house
+      # style, as the Play spec guard in play-screenshots.yml — the sizes and
+      # the alpha rule are the parts that actually get people.
+      - name: Check the screenshots meet Apple's spec
+        run: |
+          python3 - <<'PY'
+          import glob, os, struct, sys
+
+          # Apple accepts either size in each slot; #1072 specifies the first
+          # of each pair. The second is named in the failure text so a runner
+          # image that only ships the other device is diagnosable rather than
+          # mysterious.
+          SLOTS = {
+              'iphone-6.9': ((1290, 2796), (1320, 2868), '6.9" iPhone'),
+              'ipad-13':    ((2064, 2752), (2048, 2732), '13" iPad'),
+          }
+
+          root = 'fastlane/metadata/ios/en-US/screenshots'
+          checked = 0
+          bad = []
+
+          for slot, (want, alt, label) in SLOTS.items():
+              d = os.path.join(root, slot)
+              files = sorted(glob.glob(os.path.join(d, '*.png')))
+              if not files:
+                  print(f'{label}: no screenshots in {d} — skipped')
+                  continue
+              print(f'{label} ({slot}):')
+              # Apple takes up to 10 per device class; #1072 settled on six.
+              if len(files) > 10:
+                  bad.append(f'{slot}: Apple accepts at most 10 screenshots per '
+                             f'device class, found {len(files)}')
+              if len(files) != 6:
+                  bad.append(f'{slot}: the shot list settled in #1072 is six '
+                             f'screens, found {len(files)}')
+
+              for f in files:
+                  checked += 1
+                  name = os.path.basename(f)
+                  head = open(f, 'rb').read(33)
+                  if head[:8] != b'\x89PNG\r\n\x1a\n':
+                      bad.append(f'{slot}/{name}: not a PNG')
+                      continue
+                  # A file can carry the signature and still be too short to
+                  # hold an IHDR — a truncated write, an interrupted copy off
+                  # the simulator. Say so, rather than dying in struct.unpack
+                  # and leaving a traceback as the whole diagnosis.
+                  if len(head) < 26:
+                      bad.append(f'{slot}/{name}: truncated PNG — {len(head)} bytes, '
+                                 f'too short to contain an IHDR header')
+                      continue
+                  w, h, depth, colour = struct.unpack('>IIBB', head[16:26])
+                  print(f'  {name:24s} {w}x{h}')
+
+                  if (w, h) != want:
+                      hint = (f' (this is Apple\'s other accepted {label} size; '
+                              f'#1072 specifies {want[0]}x{want[1]})'
+                              if (w, h) == alt else '')
+                      bad.append(f'{slot}/{name}: {w}x{h} — {label} needs '
+                                 f'{want[0]}x{want[1]}{hint}')
+
+                  # Apple: screenshots must be flattened with no transparency.
+                  # The raw captures come off UIGraphicsImageRenderer as RGBA,
+                  # so this is the check that proves the compositing step
+                  # actually flattened them.
+                  if colour in (4, 6):
+                      bad.append(f'{slot}/{name}: PNG has an alpha channel; Apple '
+                                 f'requires a flattened image with no transparency')
+                  elif colour != 2 or depth != 8:
+                      kind = {0: 'grayscale', 3: 'palette'}.get(colour, f'colour type {colour}')
+                      bad.append(f'{slot}/{name}: {depth}-bit {kind} PNG; Apple wants '
+                                 f'8-bit RGB')
+
+          if checked == 0:
+              sys.exit(f'No screenshots were produced under {root}')
+          if bad:
+              sys.exit('Rejected:\n  ' + '\n  '.join(bad))
+          print(f'\n{checked} screenshot(s) OK.')
+          PY
+
+      - name: Upload the screenshot sets
+        if: always()
+        uses: actions/upload-artifact@v7
+        with:
+          name: app-store-screenshots
+          path: |
+            fastlane/metadata/ios/en-US/screenshots/**/*.png
+            build/screenshots/raw/**/*.png
+          if-no-files-found: warn
+          retention-days: 14
+
+      - name: Summary
+        if: always()
+        run: |
+          {
+            echo "## App Store screenshots"
+            echo
+            if [ "${{ job.status }}" = "success" ]; then
+              echo "✅ Captured and composited. Download the **app-store-screenshots**"
+              echo "artifact, look at all of them, and commit the ones you are happy"
+              echo "with to \`fastlane/metadata/ios/en-US/screenshots/\`."
+              echo
+              echo "The artifact carries the raw captures under \`build/screenshots/raw/\`"
+              echo "as well as the captioned assets, so a caption problem can be fixed"
+              echo "by re-running \`tools/screenshots/compose.py\` locally instead of"
+              echo "re-running this job."
+            else
+              echo "❌ Failed. Read the step log."
+              echo
+              echo "The three failures worth knowing in advance:"
+              echo "- **The device type was not on the runner.** The capture step prints"
+              echo "  every iPhone/iPad the image does have; add it to the candidate list."
+              echo "- **Flutter never found the VM service.** Same hang"
+              echo "  \`ios-integration-attempt.yml\` documents; it is rarer on macos-15,"
+              echo "  not absent. Re-run — a fresh runner has historically fixed it."
+              echo "- **The demo banner assertion tripped.** \`seedDemoData\` sets"
+              echo "  \`isDemoData\`, which pins a banner to every tab; the test clears it"
+              echo "  and then checks. If the check fires, the clearing stopped working —"
+              echo "  do not delete the assertion (#1075)."
+            fi
+            echo
+            echo "### Not touched by this workflow"
+            echo "- App Store Connect. Nothing here publishes (#1067, #1080)."
+            echo "- The Play set. Its outstanding work is captions, which is"
+            echo "  \`compose.py\` over the existing PNGs, not a re-capture."
+            echo "- Store copy, and any app binary."
+          } >> "$GITHUB_STEP_SUMMARY"

--- a/integration_test/store_screenshots_test.dart
+++ b/integration_test/store_screenshots_test.dart
@@ -1,0 +1,383 @@
+import 'dart:io';
+
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:integration_test/integration_test.dart';
+import 'package:opennutritracker/core/styles/accent_colors.dart';
+import 'package:opennutritracker/core/domain/entity/app_theme_entity.dart';
+import 'package:opennutritracker/core/domain/usecase/add_config_usecase.dart';
+import 'package:opennutritracker/core/presentation/main_screen.dart';
+import 'package:opennutritracker/core/presentation/widgets/demo_mode_banner.dart';
+import 'package:opennutritracker/core/utils/demo/demo_seeder.dart';
+import 'package:opennutritracker/core/utils/locator.dart';
+import 'package:opennutritracker/core/utils/logger_config.dart';
+import 'package:opennutritracker/features/diary/diary_page.dart';
+import 'package:opennutritracker/features/diary/presentation/widgets/daily_nutrient_panel.dart';
+import 'package:opennutritracker/features/diary/presentation/widgets/diary_table_calendar.dart';
+import 'package:opennutritracker/features/home/home_page.dart';
+import 'package:opennutritracker/features/home/presentation/widgets/intake_vertical_list.dart';
+import 'package:opennutritracker/features/profile/profile_page.dart';
+import 'package:opennutritracker/features/trends/presentation/trends_page.dart';
+import 'package:opennutritracker/main.dart' as app;
+import 'package:path_provider/path_provider.dart';
+
+/// Captures the six store screenshots decided in #1072, in one app boot, on
+/// whatever device `flutter test -d ...` is pointed at.
+///
+/// This is the capture half of the pipeline. It produces **raw** PNGs at the
+/// device's native pixel size; the caption layer is composited afterwards on
+/// the host by `tools/screenshots/compose.py`, which is deliberately not part
+/// of the app so the Play path can reuse it (#1072 requires captions on both
+/// stores' sets, and the Play captures already exist uncaptioned).
+///
+/// ## Why this is an integration test rather than a `fastlane snapshot`
+/// UI-test target
+///
+/// `snapshot` drives an XCUITest target, and there is no XCUITest target in
+/// `ios/Runner.xcodeproj` — adding one means editing `project.pbxproj` across
+/// six build configurations, on a machine nobody here has, for a test that
+/// then has to find its way around a single opaque `FlutterView`. This file
+/// navigates with the same widget finders the repo's other tests use, runs on
+/// the runner image that `ios-integration-attempt.yml` has already proven can
+/// boot a simulator and connect to the VM service, and runs unchanged on an
+/// Android emulator.
+///
+/// ## Why it skips itself by default
+///
+/// Two jobs run `flutter test integration_test/` — the whole directory, not a
+/// named file. `android-integration-tests` in `default_workflow.yml` runs it
+/// on **every pull request**, and `ios-integration-attempt.yml` runs it on
+/// every push to `develop` and `main` (it is excluded from pull requests,
+/// which is map #1016's work). Without a gate, this file would join both,
+/// seed a year of demo data into each, and make them slower and flakier for
+/// no benefit. The screenshot lane passes
+/// `--dart-define=STORE_SCREENSHOTS=true`; nothing else does, so everywhere
+/// else this test is skipped at compile time.
+const bool _enabled = bool.fromEnvironment('STORE_SCREENSHOTS');
+
+/// Which demo fixture stands behind the shots.
+///
+/// `dev` is a year of history with a 15-day guaranteed streak and ~10% missed
+/// days; `onboarding` is three weeks where every day is on-track by
+/// construction. `dev` is the default because shot 4 is Trends — a streak, a
+/// calorie line and daily averages — and three weeks of perfect days makes a
+/// chart with nothing in it to read. It is also what the Play set shipped
+/// with in #1085, so both stores show the same account.
+const String _fixture = String.fromEnvironment(
+  'SCREENSHOT_FIXTURE',
+  defaultValue: 'dev',
+);
+
+/// Preset index 07 in `lib/core/styles/accent_colors.dart` — `0xFF43A047`,
+/// the brand green. Pinned rather than left to the device: on Android,
+/// Material You seeds the whole palette from the wallpaper and rendered the
+/// app blue for the Play re-shoot (#1075), which would have clashed with the
+/// green icon and feature graphic. iOS has no wallpaper extraction, but the
+/// pin costs nothing and this file is meant to run on both.
+const int _brandAccentIndex = 7;
+
+/// The packed ARGB the app actually expects. `runAppWithChangeNotifiers`
+/// hands this straight to `Color(accentColor)` in `lib/main.dart`, so passing
+/// the *index* yields `Color(0x00000007)` — transparent near-black, not the
+/// brand green, and every screenshot would have shipped with a broken accent.
+/// Read from the app's own list so the constant and the palette cannot drift.
+final int _brandAccentArgb =
+    accentPresetColors[_brandAccentIndex].toARGB32();
+
+/// Written into the app's own documents directory rather than handed back
+/// over a `flutter drive` channel. The host pulls them out of the simulator
+/// with `xcrun simctl get_app_container <udid> <bundle-id> data`, which keeps
+/// this a plain `flutter test` invocation — the exact command shape
+/// `ios-integration-attempt.yml` already runs green — instead of introducing
+/// `flutter_driver` and a second, unproven tool path.
+const String _outDirName = 'store_screenshots';
+
+void main() {
+  final binding = IntegrationTestWidgetsFlutterBinding.ensureInitialized();
+
+  testWidgets(
+    'captures the six App Store / Play screenshots',
+    (WidgetTester tester) async {
+      final semantics = tester.ensureSemantics();
+      addTearDown(semantics.dispose);
+
+      final outDir = Directory(
+        '${(await getApplicationDocumentsDirectory()).path}/$_outDirName',
+      );
+      if (outDir.existsSync()) {
+        outDir.deleteSync(recursive: true);
+      }
+      outDir.createSync(recursive: true);
+
+      LoggerConfig.intiLogger();
+      await initLocator();
+
+      await seedDemoData(
+        _fixture == 'onboarding'
+            ? DemoSeedOptions.onboarding
+            : DemoSeedOptions.dev,
+      );
+
+      // THE TRAP, and the reason this file exists rather than a shell script.
+      //
+      // `seedDemoData` ends with `setConfigIsDemoData(true)`
+      // (`demo_seeder.dart:297`), which pins `DemoModeBanner` to the top of
+      // every tab in `MainScreen`. Both seeding routes do it — `main_dev.dart`
+      // and onboarding's "try it with sample data" — so there is no seeded
+      // state anywhere in the app that does not carry the banner. The Play
+      // re-shoot (#1075) got around it with an uncommitted local
+      // `setIsDemoData(false)`, which is not a thing CI can run.
+      //
+      // Clearing it here is honest rather than a cheat: the flag means "this
+      // profile holds sample data", the banner means "you are looking at
+      // sample data", and a store screenshot is not the user's own device.
+      // The assertion further down is what makes it enforceable — if a future
+      // change reintroduces the banner, the run fails instead of quietly
+      // shipping six banner-topped images.
+      await locator<AddConfigUsecase>().setConfigIsDemoData(false);
+
+      // Boot straight into the app with every presentation choice pinned,
+      // rather than through `main()` — `main()` reads the theme, locale,
+      // energy unit and accent back out of config, and a screenshot set must
+      // not depend on what the runner's simulator happens to have persisted.
+      // `userInitialized: true` skips onboarding, exactly as
+      // `lib/dev/main_dev.dart` does.
+      app.runAppWithChangeNotifiers(
+        true,
+        AppThemeEntity.light,
+        const Locale('en'),
+        false, // kcal, not kJ
+        false, // Material You off — see _brandAccentIndex
+        _brandAccentArgb,
+      );
+      // "Give boot up to 30 seconds, then settle" belongs in pumpAndSettle's
+      // *third* argument. The first is the interval between pumps, and under
+      // the live binding that interval is real elapsed time — so passing 30s
+      // there spends at least 30 real seconds per settle iteration rather
+      // than allowing 30 in total. `app_boot_test.dart:49` has the same
+      // shape and the same cost; this file does not copy it, and that file is
+      // worth revisiting separately.
+      await tester.pumpAndSettle(
+        const Duration(milliseconds: 100),
+        EnginePhase.sendSemanticsUpdate,
+        const Duration(seconds: 30),
+      );
+
+      // Android renders Flutter into a SurfaceView that `takeScreenshot`
+      // cannot read; this swaps it for an ImageView. It is a documented no-op
+      // on iOS (`IntegrationTestPlugin.m`), so it is called unconditionally
+      // rather than behind a platform check — and it is called *after* the
+      // app is up, which is the order the package's own example uses and the
+      // order that has something to convert.
+      await binding.convertFlutterSurfaceToImage();
+      await tester.pumpAndSettle();
+
+      expect(
+        find.byType(MainScreen),
+        findsOneWidget,
+        reason: 'the seeded profile should skip onboarding and land on '
+            'MainScreen; a fresh-install onboarding screen here means the '
+            'seed did not take',
+      );
+      expect(
+        find.byType(DemoModeBanner),
+        findsNothing,
+        reason: 'setConfigIsDemoData(false) did not take — every capture '
+            'would carry the demo banner (#1075)',
+      );
+
+      // --- 1. Home: the calorie ring, macros, real logged data -------------
+      await _shoot(tester, binding, outDir, '01-home', find.byType(HomePage));
+
+      // --- Diary: three of the six shots come off this one page ------------
+      await _tapNav(tester, 'nav-diary');
+      expect(
+        find.byType(DiaryPage),
+        findsOneWidget,
+        reason: 'tapping the diary nav item should show DiaryPage',
+      );
+
+      // 5. The calendar sits at the top of the diary's list, so it is already
+      //    in frame before any scrolling.
+      await _shoot(
+        tester,
+        binding,
+        outDir,
+        '05-diary-calendar',
+        find.byType(DiaryTableCalendar),
+      );
+
+      // 2. The day's logged meals with their photos and per-meal macros.
+      //
+      // Scoped to DiaryPage, not `find.byType(IntakeVerticalList).first`.
+      // `HomePage` uses the same widget and is `_bodyPages[0]` in
+      // `MainScreen`'s IndexedStack, which keeps every tab mounted — so the
+      // global `.first` resolves to Home's copy, offstage behind the diary,
+      // and the scroll would hunt the diary forever for a widget that is not
+      // in it.
+      final diaryMeals = find
+          .descendant(
+            of: find.byType(DiaryPage),
+            matching: find.byType(IntakeVerticalList),
+          )
+          .first;
+      await _scrollDiaryTo(tester, diaryMeals);
+      await _shoot(tester, binding, outDir, '02-diary-meals', diaryMeals);
+
+      // 3. The micronutrient panel, expanded. It is an ExpansionTile that
+      //    starts collapsed, so the shot needs the tap as well as the scroll.
+      await _scrollDiaryTo(tester, find.byType(DailyNutrientPanel));
+      await tester.tap(
+        find.descendant(
+          of: find.byType(DailyNutrientPanel),
+          matching: find.byType(ExpansionTile),
+        ),
+      );
+      await tester.pumpAndSettle();
+      await _scrollDiaryTo(tester, find.byType(DailyNutrientPanel));
+      await _shoot(
+        tester,
+        binding,
+        outDir,
+        '03-micronutrients',
+        find.byType(DailyNutrientPanel),
+      );
+
+      // --- 4. Trends: streak, calorie line, daily averages ------------------
+      await _tapNav(tester, 'nav-trends');
+      await _shoot(
+        tester,
+        binding,
+        outDir,
+        '04-trends',
+        find.byType(TrendsPage),
+      );
+
+      // --- 6. Profile: goal, weight, BMI -----------------------------------
+      await _tapNav(tester, 'nav-you');
+      await _shoot(
+        tester,
+        binding,
+        outDir,
+        '06-profile',
+        find.byType(ProfilePage),
+      );
+
+      final written = outDir
+          .listSync()
+          .whereType<File>()
+          .where((f) => f.path.endsWith('.png'))
+          .length;
+      expect(
+        written,
+        6,
+        reason: 'the shot list settled in #1072 is six screens; wrote $written',
+      );
+    },
+    // See _enabled: this file shares integration_test/ with the boot smoke
+    // that runs on every pull request, and must not join it there.
+    skip: !_enabled,
+  );
+}
+
+/// Taps one of `MainScreen`'s bottom-navigation items by its
+/// `Semantics(identifier:)` — the same handles `tools/adb/adb-driver.sh`
+/// drives the app with, so the two drivers agree on what a nav item is
+/// called.
+Future<void> _tapNav(WidgetTester tester, String identifier) async {
+  final item = find.bySemanticsIdentifier(identifier);
+  expect(
+    item,
+    findsOneWidget,
+    reason: 'no bottom-nav item with semantics identifier "$identifier"',
+  );
+  await tester.tap(item);
+  await tester.pumpAndSettle();
+  // A bare pumpAndSettle returns as soon as no frame is scheduled, which
+  // happens while a page's bloc is still awaiting its first load — so it can
+  // return on an empty screen. The explicit pump gives that load real time to
+  // land. `_shoot` refusing to capture over a spinner is the backstop.
+  await tester.pump(const Duration(seconds: 3));
+  await tester.pumpAndSettle();
+}
+
+/// Scrolls the diary's outer `ListView` until [target] is on screen.
+///
+/// The scrollable is addressed explicitly: `DiaryTableCalendar` contains a
+/// `PageView` of its own, so a bare `find.byType(Scrollable)` is ambiguous.
+/// The outer list is the first `Scrollable` under `DiaryPage` in depth-first
+/// order because the calendar is one of its children.
+Future<void> _scrollDiaryTo(WidgetTester tester, Finder target) async {
+  final scrollable = find
+      .descendant(
+        of: find.byType(DiaryPage),
+        matching: find.byType(Scrollable),
+      )
+      .first;
+
+  // Back to the top before searching. `scrollUntilVisible` only ever scrolls
+  // in the direction of its delta, so a positive one cannot find a target
+  // that is now *above* the viewport — and that is the normal case here:
+  // `DailyNutrientPanel` sits before the `IntakeVerticalList`s in
+  // `day_info_widget.dart`, so capturing the meals first leaves the panel
+  // behind us, and the next call would exhaust maxScrolls and throw.
+  // Resetting makes each call independent of whatever the last one left
+  // behind, rather than requiring the shot order to match the widget order.
+  tester.state<ScrollableState>(scrollable).position.jumpTo(0);
+  await tester.pumpAndSettle();
+
+  await tester.scrollUntilVisible(
+    target,
+    240,
+    scrollable: scrollable,
+    maxScrolls: 80,
+  );
+  await tester.pumpAndSettle();
+}
+
+/// Captures one screen, after checking that the screen it is supposed to be
+/// capturing is actually on it.
+///
+/// The `mustBeVisible` check is the iOS counterpart of the focused-window
+/// assertion the Android capture loop needs (#1075): there, a stray
+/// back-press produced a full set of the launcher home screen that looked
+/// plausible until someone opened the files. `capturePngScreenshot` on iOS
+/// renders this app's own windows, so it cannot photograph SpringBoard — but
+/// it will very happily photograph a spinner, an empty state, or a route that
+/// never opened. Asserting the subject is present turns all of those into a
+/// failed run instead of a bad asset.
+Future<void> _shoot(
+  WidgetTester tester,
+  IntegrationTestWidgetsFlutterBinding binding,
+  Directory outDir,
+  String name,
+  Finder mustBeVisible,
+) async {
+  await tester.pump(const Duration(seconds: 2));
+  await tester.pumpAndSettle();
+
+  // hitTestable(), not the bare finder: `MainScreen` keeps every tab alive in
+  // an IndexedStack, so an inactive tab's widgets are still in the tree and a
+  // plain `findsWidgets` would pass for a screen that is not on screen —
+  // defeating the whole point of this guard.
+  expect(
+    mustBeVisible.hitTestable(),
+    findsWidgets,
+    reason: 'refusing to capture "$name": its subject is not on screen',
+  );
+  expect(
+    find.byType(DemoModeBanner),
+    findsNothing,
+    reason: 'refusing to capture "$name": the demo banner is showing',
+  );
+  // Also hitTestable: a spinner on an inactive tab is not in the shot, and
+  // failing the run for it would be a false alarm.
+  expect(
+    find.byType(CircularProgressIndicator).hitTestable(),
+    findsNothing,
+    reason: 'refusing to capture "$name": something is still loading',
+  );
+
+  final bytes = await binding.takeScreenshot(name);
+  await File('${outDir.path}/$name.png').writeAsBytes(bytes);
+}

--- a/tools/screenshots/captions.en-US.json
+++ b/tools/screenshots/captions.en-US.json
@@ -1,0 +1,47 @@
+{
+  "_comment": [
+    "Caption copy and band styling for the store screenshot sets.",
+    "",
+    "The strings below are the DRAFTS recorded on the shot-list ticket",
+    "(#1072). They are here so the compositing step is data-driven rather",
+    "than hard-coded, NOT because they are final: #1072 hands final wording",
+    "to the store-copy tickets. Captions are claims under Play's Misleading",
+    "Claims policy, which explicitly covers screenshots, so they carry the",
+    "same accuracy bar as the description — change them here, not in the",
+    "compositor.",
+    "",
+    "band_fraction is capped by policy, not by taste: Play allows a tagline",
+    "on at most 20% of the image. Apple's 2.3.3 permits overlays outright",
+    "and sets no limit, so one value under Play's cap serves both stores.",
+    "",
+    "One file per locale. en-US is the only listing locale in scope",
+    "(map #1062); a second locale means a second file and a re-render of",
+    "every asset, which is the cost #1072 accepted knowingly."
+  ],
+  "locale": "en-US",
+  "captions": {
+    "01-home": "Free forever. No account.",
+    "02-diary-meals": "Log a meal in seconds",
+    "03-micronutrients": "Ten micronutrients, free",
+    "04-trends": "See the pattern, not the day",
+    "05-diary-calendar": "Every day in one place",
+    "06-profile": "Your numbers, on your device"
+  },
+  "style": {
+    "band_fraction": 0.18,
+    "background": "#F7F4EF",
+    "text": "#2B2A27",
+    "font": "fonts/Poppins-Bold.ttf",
+    "max_lines": 2,
+    "side_padding_fraction": 0.08,
+    "capture_gap_fraction": 0.015
+  },
+  "aliases": {
+    "1_en-US": "01-home",
+    "2_en-US": "05-diary-calendar",
+    "3_en-US": "04-trends",
+    "4_en-US": "06-profile",
+    "5_en-US": "02-diary-meals",
+    "6_en-US": "03-micronutrients"
+  }
+}

--- a/tools/screenshots/compose.py
+++ b/tools/screenshots/compose.py
@@ -1,0 +1,278 @@
+#!/usr/bin/env python3
+"""Composite store screenshots: raw device captures in, captioned assets out.
+
+Both stores' sets are captioned (#1072), so this step is shared rather than
+owned by either platform's lane:
+
+  * the iOS lane feeds it fresh simulator captures at 1290x2796 (6.9" iPhone)
+    and 2064x2752 (13" iPad);
+  * the Play set is already captured and committed at 1432x2856, so its
+    second pass is this script run over the existing PNGs — no re-shoot;
+  * Play's *tablet* slots stay empty by decision, and if that is ever
+    revisited Play excludes non-core text there, which is what --no-captions
+    is for.
+
+Nothing here is iOS-specific and nothing imports from the app, deliberately.
+
+Layout: an opaque canvas at the exact target size, a caption band across the
+top, and the capture scaled to fit the remaining area, centred horizontally
+and anchored to the bottom edge. Anchoring to the bottom keeps the app's
+bottom navigation flush with the frame rather than floating in a margin.
+
+The output is flattened to RGB with no alpha channel, which is what both
+stores require: Apple wants "flattened, no transparency", Play wants 24-bit
+PNG with no alpha. The raw captures arrive as RGBA from
+`UIGraphicsImageRenderer`, so this conversion is load-bearing, not cosmetic.
+
+Usage:
+
+    python3 tools/screenshots/compose.py \\
+        --raw   build/screenshots/raw/iphone \\
+        --out   fastlane/metadata/ios/en-US/screenshots/iphone-6.9 \\
+        --size  1290x2796 \\
+        --captions tools/screenshots/captions.en-US.json
+
+    # Play's second pass, over the set already in the repo:
+    python3 tools/screenshots/compose.py \\
+        --raw fastlane/metadata/android/en-US/images/phoneScreenshots \\
+        --out build/screenshots/play-captioned \\
+        --size 1432x2856 \\
+        --captions tools/screenshots/captions.en-US.json
+
+Requires Pillow.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import pathlib
+import sys
+
+try:
+    from PIL import Image, ImageDraw, ImageFont
+except ImportError:  # pragma: no cover - the message is the whole point
+    sys.exit(
+        "Pillow is not installed. `python3 -m pip install --upgrade pillow`, "
+        "or in CI add a `pip install pillow` step before this one."
+    )
+
+REPO_ROOT = pathlib.Path(__file__).resolve().parents[2]
+
+
+def parse_size(text: str) -> tuple[int, int]:
+    try:
+        width, height = (int(part) for part in text.lower().split("x", 1))
+    except ValueError:
+        raise argparse.ArgumentTypeError(
+            f"--size wants WIDTHxHEIGHT, e.g. 1290x2796; got {text!r}"
+        ) from None
+    if width <= 0 or height <= 0:
+        raise argparse.ArgumentTypeError(f"--size must be positive; got {text!r}")
+    return width, height
+
+
+def load_font(path: pathlib.Path, size: int) -> ImageFont.FreeTypeFont:
+    return ImageFont.truetype(str(path), size)
+
+
+def wrap_to_lines(
+    text: str,
+    font: ImageFont.FreeTypeFont,
+    draw: ImageDraw.ImageDraw,
+    max_width: int,
+    max_lines: int,
+) -> list[str] | None:
+    """Greedy word wrap. Returns None when the text will not fit."""
+    words = text.split()
+    lines: list[str] = []
+    current = ""
+    for word in words:
+        candidate = f"{current} {word}".strip()
+        if draw.textlength(candidate, font=font) <= max_width:
+            current = candidate
+            continue
+        if not current:
+            # A single word wider than the band: no wrapping can save it.
+            return None
+        lines.append(current)
+        current = word
+        if len(lines) == max_lines:
+            return None
+    if current:
+        lines.append(current)
+    if len(lines) > max_lines:
+        return None
+    return lines
+
+
+def fit_caption(
+    text: str,
+    font_path: pathlib.Path,
+    draw: ImageDraw.ImageDraw,
+    max_width: int,
+    max_height: int,
+    max_lines: int,
+) -> tuple[ImageFont.FreeTypeFont, list[str]]:
+    """Largest point size at which the caption fits the band.
+
+    Binary search rather than a fixed size: the same style block has to serve
+    a 1290px-wide iPhone and a 2064px-wide iPad, and captions from a
+    three-word claim to a six-word one.
+    """
+    low, high = 8, max(9, max_height)
+    best: tuple[ImageFont.FreeTypeFont, list[str]] | None = None
+    while low <= high:
+        mid = (low + high) // 2
+        font = load_font(font_path, mid)
+        lines = wrap_to_lines(text, font, draw, max_width, max_lines)
+        if lines is None:
+            high = mid - 1
+            continue
+        ascent, descent = font.getmetrics()
+        line_height = int((ascent + descent) * 1.18)
+        if line_height * len(lines) > max_height:
+            high = mid - 1
+            continue
+        best = (font, lines)
+        low = mid + 1
+    if best is None:
+        sys.exit(f"Caption does not fit at any size: {text!r}")
+    return best
+
+
+def compose_one(
+    capture_path: pathlib.Path,
+    out_path: pathlib.Path,
+    size: tuple[int, int],
+    caption: str | None,
+    style: dict,
+) -> None:
+    width, height = size
+    canvas = Image.new("RGB", (width, height), style["background"])
+    draw = ImageDraw.Draw(canvas)
+
+    band_height = int(height * style["band_fraction"]) if caption else 0
+    gap = int(height * style.get("capture_gap_fraction", 0.0)) if caption else 0
+
+    if caption:
+        side_padding = int(width * style.get("side_padding_fraction", 0.08))
+        font_path = REPO_ROOT / style["font"]
+        if not font_path.is_file():
+            sys.exit(f"Caption font not found: {font_path}")
+        font, lines = fit_caption(
+            caption,
+            font_path,
+            draw,
+            max_width=width - 2 * side_padding,
+            # Leave a little air top and bottom inside the band.
+            max_height=int(band_height * 0.62),
+            max_lines=int(style.get("max_lines", 2)),
+        )
+        ascent, descent = font.getmetrics()
+        line_height = int((ascent + descent) * 1.18)
+        block_height = line_height * len(lines)
+        y = (band_height - block_height) // 2
+        for line in lines:
+            line_width = draw.textlength(line, font=font)
+            draw.text(
+                ((width - line_width) / 2, y),
+                line,
+                font=font,
+                fill=style["text"],
+            )
+            y += line_height
+
+    with Image.open(capture_path) as raw:
+        capture = raw.convert("RGB")
+        available_height = height - band_height - gap
+        scale = min(width / capture.width, available_height / capture.height)
+        target = (
+            max(1, int(capture.width * scale)),
+            max(1, int(capture.height * scale)),
+        )
+        resized = capture.resize(target, Image.LANCZOS)
+
+    canvas.paste(
+        resized,
+        ((width - resized.width) // 2, height - resized.height),
+    )
+
+    out_path.parent.mkdir(parents=True, exist_ok=True)
+    canvas.save(out_path, format="PNG")
+    print(f"  {out_path.name:24s} {width}x{height}  caption={caption!r}")
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--raw", required=True, type=pathlib.Path)
+    parser.add_argument("--out", required=True, type=pathlib.Path)
+    parser.add_argument("--size", required=True, type=parse_size)
+    parser.add_argument(
+        "--captions",
+        type=pathlib.Path,
+        default=REPO_ROOT / "tools" / "screenshots" / "captions.en-US.json",
+    )
+    parser.add_argument(
+        "--no-captions",
+        action="store_true",
+        help="Emit uncaptioned assets — Play's tablet slots exclude non-core "
+        "text, so a tablet set would need this.",
+    )
+    args = parser.parse_args()
+
+    captures = sorted(args.raw.glob("*.png"))
+    if not captures:
+        sys.exit(f"No captures found in {args.raw}")
+
+    config = json.loads(args.captions.read_text(encoding="utf-8"))
+    captions = config["captions"]
+    style = config["style"]
+
+    # The two sets are named differently and both are real inputs: the iOS
+    # lane writes `01-home.png`, matching the caption keys, while the Play set
+    # committed in #1085 is `1_en-US.png` through `6_en-US.png`.
+    #
+    # Resolving the second by its leading number would be wrong, not merely
+    # fragile: that set was shot before the #1072 shot list existed and is in
+    # a different order — `2_en-US` is the calendar, not the meals; `3_en-US`
+    # is Trends, not the micronutrient panel. Numeric matching mis-captions
+    # five of the six, and does it silently. So the mapping is explicit,
+    # derived from what is actually in each image, and lives in the caption
+    # file as data.
+    aliases = config.get("aliases", {})
+
+    def caption_key(stem: str) -> str | None:
+        if stem in captions:
+            return stem
+        mapped = aliases.get(stem)
+        return mapped if mapped in captions else None
+
+    if not args.no_captions:
+        missing = [c.stem for c in captures if caption_key(c.stem) is None]
+        if missing:
+            sys.exit(
+                "No caption for: "
+                + ", ".join(missing)
+                + f"\nAdd it to {args.captions}, or pass --no-captions."
+            )
+        band = style["band_fraction"]
+        if band > 0.20:
+            sys.exit(
+                f"band_fraction is {band:.2f}; Play allows a tagline on at "
+                "most 20% of the image."
+            )
+
+    print(f"Composing {len(captures)} screenshot(s) -> {args.out}")
+    for capture in captures:
+        compose_one(
+            capture,
+            args.out / capture.name,
+            args.size,
+            None if args.no_captions else captions[caption_key(capture.stem)],
+            style,
+        )
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
Main half of a hotfix pair. The develop half landed as [#1100](https://github.com/simonoppowa/OpenNutriTracker/pull/1100) (`a4ead9e7`); this is the same change cherry-picked onto `main`.

## Why it has to be here

GitHub only surfaces `workflow_dispatch` for workflows on the **default branch**. The lane merged to develop cannot be run at all until it is on `main` — exactly the path `play-screenshots.yml` took via [#1090](https://github.com/simonoppowa/OpenNutriTracker/pull/1090)/[#1091](https://github.com/simonoppowa/OpenNutriTracker/pull/1091).

## Nothing on main needed changing to receive it

Five files, no conflicts. Two things that could have bitten and did not:

- **The compositor reads the Play screenshots already committed on main**, which are the 1432x2856 set — so the documented second pass works here without pulling anything else across.
- **The capture test gates itself off the PR path** with `--dart-define=STORE_SCREENSHOTS`, so `android-integration-tests` keeps skipping it on main exactly as it does on develop.

## Verified against main's tree, not inherited from develop's

- `flutter analyze integration_test/ tools` — clean
- the workflow parses with **`workflow_dispatch` as its only trigger**
- the documented Play compositing pass run over main's committed set — all six captioned correctly against their screens

## ⚠️ Merging this starts the deploy chain

Unchanged from [#1090](https://github.com/simonoppowa/OpenNutriTracker/pull/1090), and a property of `main` rather than of this change:

- `pubspec.yaml` is **2.2.0+63** and the ledger tag **`deployed/63` does not exist**, so `release-gate` computes **`deploy=true`** and the packaging jobs run.
- `v2.2.0` exists, so **`publish=false`** — `github-release`, the only destructive path, will not run.
- `ios-deploy` and `android-deploy` sit behind `release-ship`'s manual approval, so nothing reaches a store unapproved.

Realistic cost: a packaging run and a pending deployment nobody should approve. **Do not create a `deployed/63` tag to silence the gate** — build 63 shipped to both stores, but the ledger postdates that release, and inventing the tag would suppress a future legitimate deploy.

## What this does not do

**It does not make the lane proven.** Everything macOS — simulator selection, `simctl status_bar override`, the container read-out, `takeScreenshot` on iOS, and the six captures themselves — has never run. Landing this is what makes the first run *possible*.

The five review rounds on #1100 found and fixed an accent index passed where a colour was wanted, finders satisfied by offstage widgets, a scroll that could only search one direction, captions matched by a number encoding the wrong order, and a finder resolving into the Home tab. That is a lot of navigation logic corrected without ever executing it — the remaining risk is concentrated in the simulator orchestration.

Refs #1100, #1076, #1072, #1062.
