### PR TITLE
fix(ios-screenshots): accept the disclaimer before capturing

### DIFF
--- a/integration_test/store_screenshots_test.dart
+++ b/integration_test/store_screenshots_test.dart
@@ -136,6 +136,21 @@ void main() {
       // shipping six banner-topped images.
       await locator<AddConfigUsecase>().setConfigIsDemoData(false);
 
+      // THE SECOND TRAP, and the first real run is what found it (#1076).
+      //
+      // A fresh profile has `hasAcceptedDisclaimer` false, so
+      // `home_bloc.dart:88` raises the disclaimer dialog over HomePage on the
+      // very first frame. A modal barrier makes everything behind it
+      // untouchable, so the capture guard refused the first shot with "Found
+      // 0 widgets with type HomePage (considering only hit-testable widgets)"
+      // — which is the guard working, not failing.
+      //
+      // Accepted here rather than tapped away: a tap is one more
+      // timing-dependent step on a dialog whose button text is localised, and
+      // the dialog is not part of what a store screenshot is meant to show.
+      // The Play re-shoot (#1075) hit exactly this and dismissed it by hand.
+      await locator<AddConfigUsecase>().setConfigDisclaimer(true);
+
       // Boot straight into the app with every presentation choice pinned,
       // rather than through `main()` — `main()` reads the theme, locale,
       // energy unit and accent back out of config, and a screenshot set must


### PR DESCRIPTION
First real dispatch of the lane added in [#1100](https://github.com/simonoppowa/OpenNutriTracker/pull/1100)/[#1102](https://github.com/simonoppowa/OpenNutriTracker/pull/1102), and it found something no amount of review could.

## What happened

The run reached the first capture and stopped:

```
Found 0 widgets with type "HomePage"
(considering only hit-testable widgets with a RenderBox): []
refusing to capture "01-home": its subject is not on screen
```

A fresh profile has `hasAcceptedDisclaimer` false, so `home_bloc.dart:88` raises the disclaimer dialog over HomePage on the first frame. A modal barrier makes everything behind it untouchable.

## The guard did its job

This is `hitTestable()` working, not failing. It was added two rounds ago because `findsWidgets` was satisfied by offstage widgets — and here it caught the same class of problem from the other direction. **Without it the run would have gone green and produced six images with a legal disclaimer across the first one.**

## The fix

Accept the disclaimer in the fixture, beside the existing `setConfigIsDemoData(false)`. Both are the same kind of thing: seeded state that is honest for a user and wrong for a store screenshot.

Tapping it away was the alternative and is worse — one more timing-dependent step, on a dialog whose button text is localised. The Play re-shoot ([#1075](https://github.com/simonoppowa/OpenNutriTracker/issues/1075)) hit this too and dismissed it by hand, which is exactly what CI cannot do.

## What already worked on the runner

Everything up to the capture: Flutter and CocoaPods setup, code generation, Pillow, and simulator selection. The failure was at the first assertion inside the app, not in the orchestration around it.

This needs a hotfix pair to `main` to be dispatchable again, same as #1102.

Refs #1076, #1100, #1102, #1062.