### PR TITLE
ci(ios): accept the disclaimer before capturing, on main

### DIFF
--- a/integration_test/store_screenshots_test.dart
+++ b/integration_test/store_screenshots_test.dart
@@ -136,6 +136,21 @@ void main() {
       // shipping six banner-topped images.
       await locator<AddConfigUsecase>().setConfigIsDemoData(false);
 
+      // THE SECOND TRAP, and the first real run is what found it (#1076).
+      //
+      // A fresh profile has `hasAcceptedDisclaimer` false, so
+      // `home_bloc.dart:88` raises the disclaimer dialog over HomePage on the
+      // very first frame. A modal barrier makes everything behind it
+      // untouchable, so the capture guard refused the first shot with "Found
+      // 0 widgets with type HomePage (considering only hit-testable widgets)"
+      // — which is the guard working, not failing.
+      //
+      // Accepted here rather than tapped away: a tap is one more
+      // timing-dependent step on a dialog whose button text is localised, and
+      // the dialog is not part of what a store screenshot is meant to show.
+      // The Play re-shoot (#1075) hit exactly this and dismissed it by hand.
+      await locator<AddConfigUsecase>().setConfigDisclaimer(true);
+
       // Boot straight into the app with every presentation choice pinned,
       // rather than through `main()` — `main()` reads the theme, locale,
       // energy unit and accent back out of config, and a screenshot set must


### PR DESCRIPTION
Main half of a hotfix pair. The develop half landed as [#1105](https://github.com/simonoppowa/OpenNutriTracker/pull/1105) (`640f9f87`); this is the same commit cherry-picked onto `main` so the lane can actually be dispatched again — `workflow_dispatch` only reads the default branch.

## Why

The first real dispatch of the lane ([run 34055136364](https://github.com/simonoppowa/OpenNutriTracker/actions/runs/34055136364)) stopped at the first shot:

```
Found 0 widgets with type "HomePage"
(considering only hit-testable widgets with a RenderBox): []
refusing to capture "01-home": its subject is not on screen
```

A fresh profile has `hasAcceptedDisclaimer` false, so `home_bloc.dart:88` raises the disclaimer dialog over HomePage on the first frame, and a modal barrier makes everything behind it untouchable.

**The guard did its job.** Without `hitTestable()` the run would have gone green and produced six images with a legal disclaimer across the first one.

One file, no conflicts, `flutter analyze integration_test/` clean against main's tree.

## Still not proven

This unblocks the *first* capture. The remaining five shots, the diary scrolling, the micronutrient expansion tap, and the compositing have never executed. Expect more of these.

Refs #1105, #1076, #1102, #1062.