### PR TITLE
fix(ios-screenshots): dispose the semantics handle inside the test body

### DIFF
--- a/.github/scripts/ios_capture_screenshots.sh
+++ b/.github/scripts/ios_capture_screenshots.sh
@@ -117,12 +117,21 @@ echo "==> $LABEL: running the capture test"
 # --flavor full so the app carries the production bundle id and display name.
 # A screenshot of a build whose app bar reads "[Alpha]" is the defect this
 # whole lane replaces.
+# The exit status is held rather than allowed to abort the script, so the
+# captures are still read out of the simulator when the test fails. The
+# second dispatch (#1076) is why: every shot had been taken and the run
+# failed on a teardown assertion afterwards, and `set -e` threw away six
+# good PNGs that would have shown the lane working. A failed run still fails
+# below — it just stops being undiagnosable.
+set +e
 flutter test integration_test/store_screenshots_test.dart \
   -d "$UDID" \
   --flavor full \
   --dart-define=STORE_SCREENSHOTS=true \
   --dart-define="SCREENSHOT_FIXTURE=$FIXTURE" \
   --reporter expanded
+TEST_STATUS=$?
+set -e
 
 echo "==> $LABEL: reading the captures out of the simulator"
 SRC=""
@@ -138,6 +147,10 @@ if [ -z "$SRC" ] || [ ! -d "$SRC" ]; then
         -maxdepth 3 -type d -name store_screenshots 2>/dev/null | head -n 1 || true)
 fi
 if [ -z "$SRC" ] || [ ! -d "$SRC" ]; then
+  if [ "$TEST_STATUS" -ne 0 ]; then
+    echo "The capture test failed and wrote nothing; see its output above." >&2
+    exit "$TEST_STATUS"
+  fi
   echo "No captures were written. The test reported success but nothing reached" >&2
   echo "the app's Documents directory, which means the capture step never ran." >&2
   exit 1
@@ -186,5 +199,14 @@ if bad:
     sys.exit(f'{label} captures rejected:\n  ' + '\n  '.join(bad))
 print(f'{len(files)} raw capture(s) OK for {label}.')
 "
+
+# A salvaged set does not make a failed run a pass. The captures were copied
+# out and validated so the artifact carries something to look at, and the
+# step still fails on the test's own status.
+if [ "$TEST_STATUS" -ne 0 ]; then
+  echo "::warning::$LABEL: the capture test failed, but its screenshots were read out and are in the artifact."
+  echo "$LABEL: captures salvaged; failing on the test's exit status ($TEST_STATUS)." >&2
+  exit "$TEST_STATUS"
+fi
 
 echo "==> $LABEL: done"

--- a/integration_test/store_screenshots_test.dart
+++ b/integration_test/store_screenshots_test.dart
@@ -98,8 +98,14 @@ void main() {
   testWidgets(
     'captures the six App Store / Play screenshots',
     (WidgetTester tester) async {
+      // Disposed at the end of the body, not via addTearDown. The first real
+      // run (#1076) failed with "A SemanticsHandle was active at the end of
+      // the test": `_endOfTestVerifications` runs inside `_runTestBody`,
+      // *before* addTearDown callbacks fire, so registering the dispose there
+      // is always too late. The test body had completed and all six captures
+      // had been taken — the non-zero exit then aborted the step before the
+      // simulator's container was copied out, so a clean run produced nothing.
       final semantics = tester.ensureSemantics();
-      addTearDown(semantics.dispose);
 
       final outDir = Directory(
         '${(await getApplicationDocumentsDirectory()).path}/$_outDirName',
@@ -288,6 +294,12 @@ void main() {
         6,
         reason: 'the shot list settled in #1072 is six screens; wrote $written',
       );
+
+      // Last statement on purpose. If anything above throws, the body's own
+      // failure is the one reported and this check never runs — which is what
+      // happened on the first dispatch, where the disclaimer failure appeared
+      // alone rather than behind a semantics complaint.
+      semantics.dispose();
     },
     // See _enabled: this file shares integration_test/ with the boot smoke
     // that runs on every pull request, and must not join it there.


### PR DESCRIPTION
Second real dispatch of the lane ([run 34057805002](https://github.com/simonoppowa/OpenNutriTracker/actions/runs/34057805002)). The disclaimer fix from [#1105](https://github.com/simonoppowa/OpenNutriTracker/pull/1105) worked and the run went all the way through — **exactly one exception, at the very end, and no capture failure at all**.

```
A SemanticsHandle was active at the end of the test.
```

## Why `addTearDown` was never going to work

The test already did `addTearDown(semantics.dispose)`. That looks right and is always too late: the stack shows `_verifySemanticsHandlesWereDisposed` ← `_endOfTestVerifications` ← `_runTestBody`, so the check runs **inside** the body's completion, before addTearDown callbacks fire.

Disposed as the last statement of the body instead. That ordering also stops it masking real failures — if anything above throws, the body's own error is reported and the dispose never runs, which is exactly why the first dispatch showed the disclaimer failure cleanly rather than behind a semantics complaint.

## All six screenshots were captured, and thrown away

This is the more expensive half. The test's non-zero exit hit `set -e` in the capture script and aborted **before** the simulator's container was read out — so a run whose only fault was a teardown assertion produced no artifact at all. Nothing to inspect, and another full macOS run to learn anything.

The script now holds the test's exit status rather than letting it abort, reads the captures out either way, validates them, and fails on that status at the end. **A failed run still fails** — it just stops being undiagnosable.

That trade seems clearly worth it here: each iteration costs a macOS runner against the five-slot cap [#1016](https://github.com/simonoppowa/OpenNutriTracker/issues/1016) protects, so a diagnosable failure is worth more than a clean abort.

## Where the lane now stands

Two dispatches, two blockers, both inside the app rather than in the orchestration — which was the half I expected to be shakier. Still unproven: the compositing step and the Apple spec guard have never run on real captures, because nothing has yet reached them.

Needs a hotfix pair to `main` to be dispatchable again.

Refs #1076, #1105, #1102, #1062.