### PR TITLE
chore(release): bump to 2.3.0+64 and add the build 64 note

### DIFF
--- a/fastlane/metadata/android/en-US/changelogs/64.txt
+++ b/fastlane/metadata/android/en-US/changelogs/64.txt
@@ -1,0 +1,4 @@
+- Add several items: bad rows are all flagged at once, each with the reason, and a photo that fails to attach offers the retry its message promises
+- AI setup you change is picked up as soon as you come back to the list
+- Your data export now includes photos attached to logged meals, not only saved ones
+- Updated the libraries underneath, including secure storage, file picking and sharing

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -15,7 +15,7 @@ publish_to: 'none' # Remove this line if you wish to publish to pub.dev
 # In iOS, build-name is used as CFBundleShortVersionString while build-number is used as CFBundleVersion.
 # Read more about iOS versioning at
 # https://developer.apple.com/library/archive/documentation/General/Reference/InfoPlistKeyReference/Articles/CoreFoundationKeys.html
-version: 2.2.0+63
+version: 2.3.0+64
 
 environment:
   sdk: '>=3.11.0 <4.0.0'


### PR DESCRIPTION
## Why

`origin/main` and `origin/develop` both sit at `2.2.0+63`, and `release-gate` hard-codes `LAST_BUILD_BEFORE_LEDGER=63` (`default_workflow.yml:943`). A `develop` → `main` merge today would run **completely green and ship nothing** — `android-package`, `ios-package`, both deploys and `github-release` all skipped, exactly the shape that left `v2.1.0` with no tag and no release.

Nothing bumps the version automatically; `docs/RELEASING.md:92` says so explicitly.

## What this changes

- `pubspec.yaml`: `2.2.0+63` → **`2.3.0+64`**
- adds `fastlane/metadata/android/en-US/changelogs/64.txt` (391 chars, under Play's 500 cap — the existing directory-wide cap test in `store_declarations_test.dart` now covers it automatically)

The **name** is bumped as well as the build, deliberately. Per the runbook, a build-only bump ships to TestFlight and Play but skips `github-release`, so the IPA and AAB would exist only as run artifacts for 90 days. Build 64 should have a durable public download.

`LAST_BUILD_BEFORE_LEDGER` is left alone — its comment says it records history, and build 64 is the first to write the ledger.

## What 64.txt covers

The genuinely unshipped, user-visible set — verified with `git cherry -v origin/main origin/develop`, not assumed:

| | |
| :-- | :-- |
| #1088 | every bad row flagged at once, each with its reason |
| #1086 | AI setup re-read on return to the list |
| #1087 | a failed photo offers the retry its message already named |
| #1079 | export gathers photos from entries, not only templates |
| #1048 | the dependency consolidation |

Store-metadata commits (#1096–#1099) are not listed: `upload_to_play_store` runs with `skip_upload_metadata: true`, so that text is console-paste work and ships on its own schedule.

## Not in this PR

Cutting the release itself. This only makes a `develop` → `main` merge capable of shipping. Per the runbook that merge is a **merge commit, not a squash**.
