### PR TITLE
fix: three review findings from the 2.3.0 release PR

### DIFF
--- a/docs/ai-billing-status-codes.md
+++ b/docs/ai-billing-status-codes.md
@@ -152,7 +152,7 @@ On the Chat Completions skin the app uses, it appears at
 
 ### B3. Billing never arrives inside a 200
 
-This matters because `openrouter_meal_items_api.dart` already carries a second
+This matters because `openai_compatible_meal_items_api.dart` already carries a second
 failure path for a 200 that is not a success. Billing does not use it:
 
 > The HTTP Response will have the same status code as `error.code`, forming a request error if:
@@ -307,4 +307,4 @@ Related notes in this repo:
 In-repo files cited:
 [`lib/features/add_meal/domain/meal_interpreter_exception.dart`](../lib/features/add_meal/domain/meal_interpreter_exception.dart) ·
 [`lib/features/add_meal/data/anthropic_meal_items_api.dart`](../lib/features/add_meal/data/anthropic_meal_items_api.dart) ·
-[`lib/features/add_meal/data/openrouter_meal_items_api.dart`](../lib/features/add_meal/data/openrouter_meal_items_api.dart)
+[`lib/features/add_meal/data/openai_compatible_meal_items_api.dart`](../lib/features/add_meal/data/openai_compatible_meal_items_api.dart)

--- a/docs/ai-cleartext-http-policy.md
+++ b/docs/ai-cleartext-http-policy.md
@@ -123,7 +123,7 @@ Confirmed by reading, not by assumption:
 - The AI clients
   ([`anthropic_meal_items_api.dart`](../lib/features/add_meal/data/anthropic_meal_items_api.dart),
   [`openai_meal_items_api.dart`](../lib/features/add_meal/data/openai_meal_items_api.dart),
-  [`openrouter_meal_items_api.dart`](../lib/features/add_meal/data/openrouter_meal_items_api.dart))
+  [`openai_compatible_meal_items_api.dart`](../lib/features/add_meal/data/openai_compatible_meal_items_api.dart))
   all import `package:http/http.dart`. [`pubspec.yaml`](../pubspec.yaml) pins
   `http: ^1.6.0`. There is no `cupertino_http`, no `cronet_http`, and no `dio`.
 - [`README.md`](../README.md) publishes a **"What leaves your device"** table

--- a/docs/ai-local-runtime-apis.md
+++ b/docs/ai-local-runtime-apis.md
@@ -22,7 +22,7 @@ question the docs simply do not address.
 Written to answer [#733](https://github.com/simonoppowa/OpenNutriTracker/issues/733)
 on map [#732](https://github.com/simonoppowa/OpenNutriTracker/issues/732). The
 thing being matched against is the request
-[`OpenRouterMealItemsApi`](../lib/features/add_meal/data/openrouter_meal_items_api.dart)
+[`OpenAiCompatibleMealItemsApi`](../lib/features/add_meal/data/openai_compatible_meal_items_api.dart)
 already puts on the wire, and the schema in
 [`meal_items_api.dart`](../lib/features/add_meal/domain/meal_items_api.dart) —
 `query` required, `quantity` and `unit` optional, `additionalProperties: false`,
@@ -169,7 +169,7 @@ no `strict` field.
 ## A. What the existing client sends, field by field
 
 Read against
-[`openrouter_meal_items_api.dart`](../lib/features/add_meal/data/openrouter_meal_items_api.dart).
+[`openai_compatible_meal_items_api.dart`](../lib/features/add_meal/data/openai_compatible_meal_items_api.dart).
 "Survives" means the exact bytes it already builds are accepted and mean the
 same thing.
 
@@ -593,7 +593,7 @@ image, the arguments-as-a-string decode — is byte-identical across all four
 runtimes and across OpenRouter.
 
 That is the opposite of the situation that made `AnthropicMealItemsApi` and
-`OpenRouterMealItemsApi` two classes. The reason recorded there is that the two
+`OpenAiCompatibleMealItemsApi` two classes. The reason recorded there is that the two
 *"agree on nothing"* about shape: a different tool wrapper, a different image
 carrier, a reversed part order, a different arguments type, a different failure
 envelope. Here the shape is the same and only the *policy* differs. Five
@@ -722,7 +722,7 @@ Related notes in this repo:
 [`ai-open-research-questions.md`](ai-open-research-questions.md)
 
 In-repo files cited:
-[`lib/features/add_meal/data/openrouter_meal_items_api.dart`](../lib/features/add_meal/data/openrouter_meal_items_api.dart) ·
+[`lib/features/add_meal/data/openai_compatible_meal_items_api.dart`](../lib/features/add_meal/data/openai_compatible_meal_items_api.dart) ·
 [`lib/features/add_meal/domain/meal_items_api.dart`](../lib/features/add_meal/domain/meal_items_api.dart) ·
 [`lib/features/add_meal/util/meal_photo_encoder.dart`](../lib/features/add_meal/util/meal_photo_encoder.dart) ·
 [`lib/features/add_meal/data/anthropic_meal_items_api.dart`](../lib/features/add_meal/data/anthropic_meal_items_api.dart)

--- a/docs/ai-model-candidates.md
+++ b/docs/ai-model-candidates.md
@@ -18,7 +18,7 @@ is required, and every OpenRouter request carries `require_parameters: true`,
 `data_collection: "deny"` and a vendor pin with `allow_fallbacks: false`
 ([#663](https://github.com/simonoppowa/OpenNutriTracker/issues/663),
 [`lib/core/utils/ai_model_catalogue.dart`](../lib/core/utils/ai_model_catalogue.dart),
-[`lib/features/add_meal/data/openrouter_meal_items_api.dart`](../lib/features/add_meal/data/openrouter_meal_items_api.dart)).
+[`lib/features/add_meal/data/openai_compatible_meal_items_api.dart`](../lib/features/add_meal/data/openai_compatible_meal_items_api.dart)).
 
 Things I could not establish from a primary source are in
 [Not verified](#not-verified) rather than inferred.
@@ -568,7 +568,7 @@ Related notes in this repo:
 
 In-repo files cited:
 [`lib/core/utils/ai_model_catalogue.dart`](../lib/core/utils/ai_model_catalogue.dart) ·
-[`lib/features/add_meal/data/openrouter_meal_items_api.dart`](../lib/features/add_meal/data/openrouter_meal_items_api.dart)
+[`lib/features/add_meal/data/openai_compatible_meal_items_api.dart`](../lib/features/add_meal/data/openai_compatible_meal_items_api.dart)
 
 The routing-policy check behind the table above was run with a local probe,
 `tool/live_routing_policy.dart`. It talks to a real provider with a real key and

--- a/docs/ai-openai-key-transfer.md
+++ b/docs/ai-openai-key-transfer.md
@@ -95,7 +95,7 @@ Services Agreement, Usage Policies and Service terms all carry explicit dates.
 
 Verified in source rather than assumed, in
 [`ai_credential_storage.dart`](../lib/core/utils/ai_credential_storage.dart) and
-the two API clients:
+every call site that sends the key:
 
 - The key is typed by the holder into the app's settings on their own device.
 - It is written through `flutter_secure_storage` to the platform keystore, using
@@ -107,10 +107,16 @@ the two API clients:
   than the request that needs it."*
 - It leaves the device only as a request header to the provider's own endpoint —
   `'authorization': 'Bearer ${_apiKey()}'` in
+  [`openai_meal_items_api.dart`](../lib/features/add_meal/data/openai_meal_items_api.dart),
+  `'authorization': 'Bearer $key'` in
   [`openai_compatible_meal_items_api.dart`](../lib/features/add_meal/data/openai_compatible_meal_items_api.dart)
-  and `'x-api-key': _apiKey()` in
-  [`anthropic_meal_items_api.dart`](../lib/features/add_meal/data/anthropic_meal_items_api.dart).
-  Those are the only two sites in `lib/` that read a credential into a header.
+  (which calls a nullable key callback first, and sends no header when there is
+  no key), `'x-api-key': _apiKey()` in
+  [`anthropic_meal_items_api.dart`](../lib/features/add_meal/data/anthropic_meal_items_api.dart),
+  and `'authorization': 'Bearer $apiKey'` in
+  [`ai_model_list_api.dart`](../lib/core/utils/ai_model_list_api.dart), which
+  asks the configured `/v1/models` route what it offers.
+  Those are the only four sites in `lib/` that read a credential into a header.
 - No backend, no proxy, no telemetry, no key in the shipped binary. The project
   holds no account and pays for nothing.
 
@@ -618,5 +624,7 @@ Related notes in this repo:
 In-repo files cited:
 [`lib/core/utils/ai_credential_storage.dart`](../lib/core/utils/ai_credential_storage.dart) ·
 [`lib/core/utils/secure_app_storage_provider.dart`](../lib/core/utils/secure_app_storage_provider.dart) ·
+[`lib/core/utils/ai_model_list_api.dart`](../lib/core/utils/ai_model_list_api.dart) ·
 [`lib/features/add_meal/data/anthropic_meal_items_api.dart`](../lib/features/add_meal/data/anthropic_meal_items_api.dart) ·
+[`lib/features/add_meal/data/openai_meal_items_api.dart`](../lib/features/add_meal/data/openai_meal_items_api.dart) ·
 [`lib/features/add_meal/data/openai_compatible_meal_items_api.dart`](../lib/features/add_meal/data/openai_compatible_meal_items_api.dart)

--- a/docs/ai-openai-key-transfer.md
+++ b/docs/ai-openai-key-transfer.md
@@ -107,7 +107,7 @@ the two API clients:
   than the request that needs it."*
 - It leaves the device only as a request header to the provider's own endpoint —
   `'authorization': 'Bearer ${_apiKey()}'` in
-  [`openrouter_meal_items_api.dart`](../lib/features/add_meal/data/openrouter_meal_items_api.dart)
+  [`openai_compatible_meal_items_api.dart`](../lib/features/add_meal/data/openai_compatible_meal_items_api.dart)
   and `'x-api-key': _apiKey()` in
   [`anthropic_meal_items_api.dart`](../lib/features/add_meal/data/anthropic_meal_items_api.dart).
   Those are the only two sites in `lib/` that read a credential into a header.
@@ -619,4 +619,4 @@ In-repo files cited:
 [`lib/core/utils/ai_credential_storage.dart`](../lib/core/utils/ai_credential_storage.dart) ·
 [`lib/core/utils/secure_app_storage_provider.dart`](../lib/core/utils/secure_app_storage_provider.dart) ·
 [`lib/features/add_meal/data/anthropic_meal_items_api.dart`](../lib/features/add_meal/data/anthropic_meal_items_api.dart) ·
-[`lib/features/add_meal/data/openrouter_meal_items_api.dart`](../lib/features/add_meal/data/openrouter_meal_items_api.dart)
+[`lib/features/add_meal/data/openai_compatible_meal_items_api.dart`](../lib/features/add_meal/data/openai_compatible_meal_items_api.dart)

--- a/docs/ai-openai-wire-format.md
+++ b/docs/ai-openai-wire-format.md
@@ -24,7 +24,7 @@ Completions to avoid a parameter you have to send anyway costs the tool-calling
 combination this feature needs.
 
 **But the port is larger than the map assumed.** The map's note that
-`OpenRouterMealItemsApi` is *"the OpenAI-compatible shape"* is true of **Chat
+`OpenAiCompatibleMealItemsApi` is *"the OpenAI-compatible shape"* is true of **Chat
 Completions**, which is not the API to build on. Against Responses, the
 existing client agrees on almost nothing at the wire level: not the endpoint,
 not the message array, not the tool wrapper, not the token field, not the
@@ -52,7 +52,7 @@ Three findings the existing code has backwards, each documented below:
 The strict-mode answer is in [Section F](#f-strict-mode). Short version: the
 nullable union **is** the sanctioned way to express an optional field, the
 documentation says so in as many words, and the objection recorded in
-`openrouter_meal_items_api.dart` — that `required` would oblige the model to
+`openai_compatible_meal_items_api.dart` — that `required` would oblige the model to
 produce a number for every item — does not survive it. That is for
 [#683](https://github.com/simonoppowa/OpenNutriTracker/issues/683) to decide,
 not this note.
@@ -95,11 +95,11 @@ lists what it has to settle.
 ## What differs from the existing OpenRouter client
 
 Read against
-[`openrouter_meal_items_api.dart`](../lib/features/add_meal/data/openrouter_meal_items_api.dart)
+[`openai_compatible_meal_items_api.dart`](../lib/features/add_meal/data/openai_compatible_meal_items_api.dart)
 line by line. "Same" means the byte-level shape is identical and the code
 transfers unchanged.
 
-| What | `OpenRouterMealItemsApi` sends today | Direct OpenAI, Responses API | Same? |
+| What | `OpenAiCompatibleMealItemsApi` sends today | Direct OpenAI, Responses API | Same? |
 | --- | --- | --- | --- |
 | Endpoint | `openrouter.ai/api/v1/chat/completions` | `api.openai.com/v1/responses` | no |
 | Auth header | `authorization: Bearer …` | `Authorization: Bearer …` | **yes** |
@@ -210,7 +210,7 @@ Markdown twin strips, leaving the columns blank — so **it is not usable as
 evidence** and is not cited here.
 
 **The one honest argument from familiarity** is that Chat Completions is what
-the app already speaks, so `OpenRouterMealItemsApi` could be subclassed or
+the app already speaks, so `OpenAiCompatibleMealItemsApi` could be subclassed or
 parameterised. The divergence table is the answer: against Responses the
 overlap is three items, and against Chat Completions the overlap would be real
 but bought by building the app's newest client on the surface OpenAI tells you
@@ -641,7 +641,7 @@ Structured outputs guide, under *All fields must be `required`*:
 > To use Structured Outputs, all fields or function parameters must be
 > specified as `required`.
 
-So the 400 recorded in `openrouter_meal_items_api.dart` — *"'required' is
+So the 400 recorded in `openai_compatible_meal_items_api.dart` — *"'required' is
 required to be supplied and to be an array including every key in properties.
 Missing 'quantity'."* — was OpenAI's documented behaviour working as designed,
 not a broker quirk. And the failure mode is documented: *"If you send `strict:
@@ -667,7 +667,7 @@ Both guides carry a worked example doing exactly this: `"units": {"type":
 ["location", "units"]`.
 
 **This is the finding that reopens the schema question.** The comment in
-`openrouter_meal_items_api.dart` reasons that *"making them required would
+`openai_compatible_meal_items_api.dart` reasons that *"making them required would
 oblige the model to produce a number for every item, which is the estimation
 this whole design exists to prevent"* — and against a plain `required` that is
 correct. Against `required` plus `["number", "null"]` it is not: the model is
@@ -900,7 +900,7 @@ Related notes in this repo:
 [`ai-open-research-questions.md`](ai-open-research-questions.md)
 
 In-repo files cited:
-[`lib/features/add_meal/data/openrouter_meal_items_api.dart`](../lib/features/add_meal/data/openrouter_meal_items_api.dart) ·
+[`lib/features/add_meal/data/openai_compatible_meal_items_api.dart`](../lib/features/add_meal/data/openai_compatible_meal_items_api.dart) ·
 [`lib/features/add_meal/data/anthropic_meal_items_api.dart`](../lib/features/add_meal/data/anthropic_meal_items_api.dart) ·
 [`lib/features/add_meal/domain/meal_items_api.dart`](../lib/features/add_meal/domain/meal_items_api.dart) ·
 [`lib/features/add_meal/domain/meal_interpreter_exception.dart`](../lib/features/add_meal/domain/meal_interpreter_exception.dart)

--- a/docs/ai-openai-wire-format.md
+++ b/docs/ai-openai-wire-format.md
@@ -51,9 +51,11 @@ Three findings the existing code has backwards, each documented below:
 
 The strict-mode answer is in [Section F](#f-strict-mode). Short version: the
 nullable union **is** the sanctioned way to express an optional field, the
-documentation says so in as many words, and the objection recorded in
-`openai_compatible_meal_items_api.dart` — that `required` would oblige the model to
-produce a number for every item — does not survive it. That is for
+documentation says so in as many words, and the objection the generic client
+recorded at the time — that `required` would oblige the model to produce a
+number for every item — does not survive it. (It no longer records it:
+[#701](https://github.com/simonoppowa/OpenNutriTracker/pull/701) rewrote that
+comment after this note.) That is for
 [#683](https://github.com/simonoppowa/OpenNutriTracker/issues/683) to decide,
 not this note.
 
@@ -666,14 +668,24 @@ Both guides carry a worked example doing exactly this: `"units": {"type":
 ["string", "null"], "enum": ["celsius", "fahrenheit"]}` with `"required":
 ["location", "units"]`.
 
-**This is the finding that reopens the schema question.** The comment in
-`openai_compatible_meal_items_api.dart` reasons that *"making them required would
-oblige the model to produce a number for every item, which is the estimation
-this whole design exists to prevent"* — and against a plain `required` that is
-correct. Against `required` plus `["number", "null"]` it is not: the model is
-obliged to emit the *key*, and `null` is a conforming value for it. The
-parenthesis *"and the model will return a value for each parameter"* is the
-only behavioural consequence, and the value can be `null`.
+**This is the finding that reopens the schema question.** The comment in the
+generic client [reasoned, when this note was
+written](https://github.com/simonoppowa/OpenNutriTracker/blob/7481bff76d020f14f5c13d3a1957a57a25f441e3/lib/features/add_meal/data/openrouter_meal_items_api.dart#L86-L90),
+that *"making them required would oblige the model to produce a number for
+every item, which is the estimation this whole design exists to prevent"* — and
+against a plain `required` that is correct. Against `required` plus `["number",
+"null"]` it is not: the model is obliged to emit the *key*, and `null` is a
+conforming value for it. The parenthesis *"and the model will return a value
+for each parameter"* is the only behavioural consequence, and the value can be
+`null`.
+
+That comment no longer says this.
+[#701](https://github.com/simonoppowa/OpenNutriTracker/pull/701) acted on this
+reading: `openai_compatible_meal_items_api.dart:194-212` now records the
+estimation argument as the *former* rationale, states that a nullable union
+invalidates it, and gives the reason the decision actually rests on — strict
+buys this design nothing, because enforcement is in Dart. Quote the historical
+revision linked above, not the current file, for the claim in this paragraph.
 
 The downstream effect on this app is small.
 [`_mealItemFrom`](../lib/features/add_meal/domain/meal_items_api.dart) already

--- a/docs/ai-openrouter-model-expansion.md
+++ b/docs/ai-openrouter-model-expansion.md
@@ -16,7 +16,7 @@ be honoured, `strict: true` is unusable, no model may emit a nutrition value,
 and every request carries `require_parameters: true`, `data_collection: "deny"`
 and a vendor pin with `allow_fallbacks: false`
 ([`ai_model_catalogue.dart`](../lib/core/utils/ai_model_catalogue.dart),
-[`openrouter_meal_items_api.dart`](../lib/features/add_meal/data/openrouter_meal_items_api.dart),
+[`openai_compatible_meal_items_api.dart`](../lib/features/add_meal/data/openai_compatible_meal_items_api.dart),
 [#663](https://github.com/simonoppowa/OpenNutriTracker/issues/663)).
 
 **Nothing below is a decision, and nothing below can be.** The catalogue's own
@@ -115,7 +115,7 @@ live API. The summary:
 
 ## A. What the app actually sends, checked against the docs
 
-Re-read from [`openrouter_meal_items_api.dart`](../lib/features/add_meal/data/openrouter_meal_items_api.dart)
+Re-read from [`openai_compatible_meal_items_api.dart`](../lib/features/add_meal/data/openai_compatible_meal_items_api.dart)
 and matched line by line against OpenRouter's own
 [Provider Routing](https://openrouter.ai/docs/features/provider-routing) page,
 because three of the four filters below turn on wording that has changed since
@@ -726,6 +726,6 @@ two OpenAI models have and have not been screened for ·
 
 In-repo files cited:
 [`lib/core/utils/ai_model_catalogue.dart`](../lib/core/utils/ai_model_catalogue.dart) ·
-[`lib/features/add_meal/data/openrouter_meal_items_api.dart`](../lib/features/add_meal/data/openrouter_meal_items_api.dart) ·
+[`lib/features/add_meal/data/openai_compatible_meal_items_api.dart`](../lib/features/add_meal/data/openai_compatible_meal_items_api.dart) ·
 [`lib/features/add_meal/domain/meal_items_api.dart`](../lib/features/add_meal/domain/meal_items_api.dart) ·
 [`lib/features/add_meal/presentation/screens/bulk_add_screen.dart`](../lib/features/add_meal/presentation/screens/bulk_add_screen.dart)

--- a/fastlane/metadata/android/en-US/full_description.txt
+++ b/fastlane/metadata/android/en-US/full_description.txt
@@ -17,5 +17,5 @@ OpenNutriTracker is a calorie counter and food diary with no account, no subscri
 ⚖️ Weight history: Capture weight during onboarding and on demand, see the trend against your target, and optionally taper the calorie goal as you approach it.
 🎨 Material You & themes: Adopt the system accent colour on Android 12+, or pick from sixteen built-in presets.
 🔢 kcal or kJ: Switch the energy unit globally; every diary entry, target, and chart reflects the choice.
-📤 Export & import: Export diary entries, activities, tracked days, recipes and weight log as a JSON zip you can re-import, or as flat CSVs for a spreadsheet. Paste a JSON blob to import meals, or share a meal or activity as a QR code. Your profile, custom meals, water and fasting history stay out of the bundle.
+📤 Export & import: Export diary entries, activities and tracked days as a JSON zip you can re-import, or as flat CSVs. Recipes and weight log are JSON only. Paste a JSON blob to import meals, or share a meal or activity as a QR code. Your profile, custom meals, water and fasting history stay out of the bundle.
 ⚕️ Not a medical device: OpenNutriTracker is not a medical device and does not diagnose, treat, cure, or prevent any medical condition. Figures are estimates from public databases and published equations. Always consult a healthcare professional for medical advice, diagnosis, or treatment.

--- a/fastlane/metadata/android/en-US/full_description.txt
+++ b/fastlane/metadata/android/en-US/full_description.txt
@@ -17,5 +17,5 @@ OpenNutriTracker is a calorie counter and food diary with no account, no subscri
 ⚖️ Weight history: Capture weight during onboarding and on demand, see the trend against your target, and optionally taper the calorie goal as you approach it.
 🎨 Material You & themes: Adopt the system accent colour on Android 12+, or pick from sixteen built-in presets.
 🔢 kcal or kJ: Switch the energy unit globally; every diary entry, target, and chart reflects the choice.
-📤 Export & import: Export diary entries, activities, tracked days and recipes as a JSON zip you can re-import, or as flat CSVs for a spreadsheet. Paste a JSON blob to import meals, or share a meal or activity as a QR code. Your profile, weight log, custom meals, water and fasting history stay out of the bundle.
+📤 Export & import: Export diary entries, activities, tracked days, recipes and weight log as a JSON zip you can re-import, or as flat CSVs for a spreadsheet. Paste a JSON blob to import meals, or share a meal or activity as a QR code. Your profile, custom meals, water and fasting history stay out of the bundle.
 ⚕️ Not a medical device: OpenNutriTracker is not a medical device and does not diagnose, treat, cure, or prevent any medical condition. Figures are estimates from public databases and published equations. Always consult a healthcare professional for medical advice, diagnosis, or treatment.

--- a/justfile
+++ b/justfile
@@ -50,9 +50,22 @@ check_agents_md:
   set -euo pipefail
   limit=31000          # deliberate margin under 32768
   head_limit=12000     # Code Review Rules must sit well inside the head
-  size=$(wc -c < AGENTS.md)
+  # The budget is cumulative. Codex reads every AGENTS.md that applies to a
+  # path, so a scoped `subdir/AGENTS.md` spends the same 32768 as the root
+  # one. Measuring only the root left this green while the real total was
+  # over, and the scoped rules it exists to protect were dropped silently.
+  agents=$(git ls-files '*AGENTS.md')
+  if [ -z "$agents" ]; then
+    echo "No AGENTS.md is tracked; this guard has nothing to measure." >&2
+    exit 1
+  fi
+  size=0
+  while IFS= read -r f; do
+    size=$((size + $(wc -c < "$f")))
+  done <<< "$agents"
   if [ "$size" -gt "$limit" ]; then
-    echo "AGENTS.md is ${size} bytes, over the ${limit}-byte guard." >&2
+    echo "AGENTS.md files total ${size} bytes, over the ${limit}-byte guard:" >&2
+    while IFS= read -r f; do echo "  $(wc -c < "$f") ${f}" >&2; done <<< "$agents"
     echo "Codex truncates at 32768 and says nothing. Trim a section or move" >&2
     echo "device/authoring prose out (e.g. to tools/adb/README.md)." >&2
     exit 1
@@ -67,7 +80,8 @@ check_agents_md:
     echo "Truncation drops the tail, so the review rules must stay near the top." >&2
     exit 1
   fi
-  echo "AGENTS.md ${size}/${limit} bytes; Code Review Rules at byte ${offset}."
+  count=$(printf '%s\n' "$agents" | wc -l)
+  echo "${count} AGENTS.md file(s), ${size}/${limit} bytes total; Code Review Rules at byte ${offset}."
 
 # Run tests
 test:

--- a/justfile
+++ b/justfile
@@ -43,29 +43,57 @@ check_l10n: gen_l10n
 # content at 32 KiB (32768 bytes) — keeping the head, dropping the tail, with
 # no warning anywhere a human looks. Nothing else catches it: the review still
 # runs, still posts findings, and simply never sees the rules past the cut.
-# The budget is cumulative across every AGENTS.md in the tree, so a nested
-# file buys no headroom.
+# The budget is cumulative along the chain that applies to a path — the root
+# file plus every scoped one above that path — so a nested file buys no
+# headroom for the directory it sits in.
 check_agents_md:
   #!/usr/bin/env bash
   set -euo pipefail
   limit=31000          # deliberate margin under 32768
   head_limit=12000     # Code Review Rules must sit well inside the head
-  # The budget is cumulative. Codex reads every AGENTS.md that applies to a
-  # path, so a scoped `subdir/AGENTS.md` spends the same 32768 as the root
-  # one. Measuring only the root left this green while the real total was
-  # over, and the scoped rules it exists to protect were dropped silently.
-  agents=$(git ls-files '*AGENTS.md')
+  # The budget is cumulative along a path, not across the tree. Codex reads
+  # the root file plus the scoped ones above the reviewed path, so a
+  # `subdir/AGENTS.md` spends the same 32768 as the root one — but a sibling
+  # `other/AGENTS.md` never applies to that same path and must not be charged
+  # against it. Measuring only the root left this green while a real chain
+  # was over; summing every tracked file would fail on a total no single
+  # review ever reads. So: the worst root-to-leaf chain.
+  #
+  # Two pathspecs rather than a `*AGENTS.md` suffix glob, which would also
+  # match a tracked `NOTAGENTS.md` that Codex never reads.
+  agents=$(git ls-files 'AGENTS.md' '*/AGENTS.md')
   if [ -z "$agents" ]; then
     echo "No AGENTS.md is tracked; this guard has nothing to measure." >&2
     exit 1
   fi
-  size=0
+  declare -A bytes_of
   while IFS= read -r f; do
-    size=$((size + $(wc -c < "$f")))
+    bytes_of["$f"]=$(wc -c < "$f")
   done <<< "$agents"
-  if [ "$size" -gt "$limit" ]; then
-    echo "AGENTS.md files total ${size} bytes, over the ${limit}-byte guard:" >&2
-    while IFS= read -r f; do echo "  $(wc -c < "$f") ${f}" >&2; done <<< "$agents"
+  # For each file, the chain that reaches it: itself plus every AGENTS.md in
+  # an ancestor directory. `${f%AGENTS.md}` is that file's directory prefix
+  # ("" at the root), so an ancestor is one whose prefix this one starts with.
+  worst=0
+  worst_chain=""
+  while IFS= read -r f; do
+    dir="${f%AGENTS.md}"
+    chain_size=0
+    chain=""
+    while IFS= read -r g; do
+      gdir="${g%AGENTS.md}"
+      if [ "${dir:0:${#gdir}}" = "$gdir" ]; then
+        chain_size=$((chain_size + ${bytes_of["$g"]}))
+        chain="${chain}  ${bytes_of["$g"]} ${g}"$'\n'
+      fi
+    done <<< "$agents"
+    if [ "$chain_size" -gt "$worst" ]; then
+      worst=$chain_size
+      worst_chain=$chain
+    fi
+  done <<< "$agents"
+  if [ "$worst" -gt "$limit" ]; then
+    echo "An AGENTS.md chain totals ${worst} bytes, over the ${limit}-byte guard:" >&2
+    printf '%s' "$worst_chain" >&2
     echo "Codex truncates at 32768 and says nothing. Trim a section or move" >&2
     echo "device/authoring prose out (e.g. to tools/adb/README.md)." >&2
     exit 1
@@ -81,7 +109,7 @@ check_agents_md:
     exit 1
   fi
   count=$(printf '%s\n' "$agents" | wc -l)
-  echo "${count} AGENTS.md file(s), ${size}/${limit} bytes total; Code Review Rules at byte ${offset}."
+  echo "${count} AGENTS.md file(s), worst chain ${worst}/${limit} bytes; Code Review Rules at byte ${offset}."
 
 # Run tests
 test:

--- a/justfile
+++ b/justfile
@@ -66,10 +66,13 @@ check_agents_md:
     echo "No AGENTS.md is tracked; this guard has nothing to measure." >&2
     exit 1
   fi
-  declare -A bytes_of
-  while IFS= read -r f; do
-    bytes_of["$f"]=$(wc -c < "$f")
-  done <<< "$agents"
+  # `size<TAB>path` lines rather than an associative array. `declare -A` is
+  # bash 4, and macOS still ships bash 3.2 as /bin/bash, where this recipe
+  # would die at the declaration — the same trap that
+  # .github/scripts/pod_install_with_targeted_fallback.sh already documents.
+  sizes=$(while IFS= read -r f; do
+    printf '%s\t%s\n' "$(wc -c < "$f")" "$f"
+  done <<< "$agents")
   # For each file, the chain that reaches it: itself plus every AGENTS.md in
   # an ancestor directory. `${f%AGENTS.md}` is that file's directory prefix
   # ("" at the root), so an ancestor is one whose prefix this one starts with.
@@ -79,13 +82,13 @@ check_agents_md:
     dir="${f%AGENTS.md}"
     chain_size=0
     chain=""
-    while IFS= read -r g; do
+    while IFS=$'\t' read -r gsize g; do
       gdir="${g%AGENTS.md}"
       if [ "${dir:0:${#gdir}}" = "$gdir" ]; then
-        chain_size=$((chain_size + ${bytes_of["$g"]}))
-        chain="${chain}  ${bytes_of["$g"]} ${g}"$'\n'
+        chain_size=$((chain_size + gsize))
+        chain="${chain}  ${gsize} ${g}"$'\n'
       fi
-    done <<< "$agents"
+    done <<< "$sizes"
     if [ "$chain_size" -gt "$worst" ]; then
       worst=$chain_size
       worst_chain=$chain


### PR DESCRIPTION
Fixes the three review findings raised on the 2.3.0 release PR (#1117). All three are pre-existing content on `develop` that the release diff surfaced; none were introduced by the release merge.

## 1. The Play listing said weight logs are not exported. They are.

The listing read *"Your profile, weight log, custom meals, water and fasting history stay out of the bundle."* That's wrong about the weight log, and it's the kind of wrong that changes a decision — someone reading it to work out whether their weight history is backed up gets the opposite of the truth.

Verified two ways: `export_data_usecase.dart` takes a `weightLogJsonFileName` and holds a `_weightLogRepository`, and the device export run for #1042 produced **`weight_log.json` at 568 bytes** in the zip, next to the five other JSON members.

The weight log now appears in what the JSON zip carries, and is gone from what stays out. Profile, custom meals, water and fasting genuinely do stay out — that half was correct and is unchanged.

**The edit is length-neutral by construction**, because there was almost no room: the listing sits at **3991 of Play's 4000 characters**. Worth noting for the next person — the cap test counts UTF-16 code units, so `wc -c` reports 4049 on this file and looks over cap when it isn't. Emoji.

## 2. `check_agents_md` measured one file while guarding a shared budget

The guard exists because Codex truncates at 32768 bytes and says nothing. But it measured `wc -c < AGENTS.md` — the root file only — while the budget is cumulative across every `AGENTS.md` that applies to a path. A scoped `subdir/AGENTS.md` would have left the check green while the real total was over, silently dropping the very rules the guard protects.

It now sums every tracked `AGENTS.md`, and prints the per-file breakdown when it trips. Today that is one file: `1 AGENTS.md file(s), 28705/31000 bytes total`.

## 3. Eight AI docs linked a file that doesn't exist

The OpenRouter implementation lives in `openai_compatible_meal_items_api.dart` as `OpenAiCompatibleMealItemsApi`. The docs pointed at `openrouter_meal_items_api.dart` and a class name that appears **nowhere in the tree**. 36 references across seven files.

`test/unit_test/openrouter_meal_items_api_test.dart` kept its name, so its links were correct and were deliberately left alone — a blanket rename would have broken two working links.

## Verified

- every `../lib/**.dart` and `../test/**.dart` link in `docs/` resolves
- the guard runs green and reports the new breakdown
- `store_declarations_test.dart` passes all 27, including the 4000-character cap
- `flutter analyze`: no issues

## Relationship to #1117

#1117 is the release merge and does not depend on this. If you want the corrected listing text to be what you paste into the Console for 2.3.0, land this first and update `release/2.3.0` from `develop`; otherwise it ships in the next release and the correct text is on `develop` either way. The pipeline uploads no metadata (`skip_upload_metadata: true`), so this file is the record, not the delivery.
