### PR TITLE
fix(health): read workouts without the permissions Play refused

### DIFF
--- a/android/app/build.gradle
+++ b/android/app/build.gradle
@@ -146,4 +146,13 @@ flutter {
 
 dependencies {
     coreLibraryDesugaring 'com.android.tools:desugar_jdk_libs:2.1.4'
+
+    // Read finished workouts without the health plugin's distance and steps
+    // reads — see HealthConnectWorkoutReader. Pinned to the version the
+    // plugin itself depends on so both resolve to one client rather than
+    // Gradle silently picking the higher of two.
+    implementation 'androidx.health.connect:connect-client:1.2.0-alpha02'
+    // readRecords is a suspend function, and MainActivity answers the method
+    // channel from the main dispatcher.
+    implementation 'org.jetbrains.kotlinx:kotlinx-coroutines-android:1.8.1'
 }

--- a/android/app/src/main/AndroidManifest.xml
+++ b/android/app/src/main/AndroidManifest.xml
@@ -6,15 +6,27 @@
     <uses-permission android:name="android.permission.RECEIVE_BOOT_COMPLETED"/>
     <uses-permission android:name="android.permission.POST_NOTIFICATIONS"/>
     <!-- Health Connect: read-only, and only requested once workout import is
-         enabled in Settings → Health sync. Nothing is ever written back. -->
+         enabled in Settings → Health sync. Nothing is ever written back.
+
+         These two, and no more. Play's Health Connect permissions policy
+         rejected READ_BODY_FAT, READ_DISTANCE and READ_STEPS as excessive for
+         the features this app offers (enforced 8 Sept 2026), and the policy
+         asks for the minimum a feature needs rather than the minimum a
+         library happens to read.
+
+         READ_DISTANCE and READ_STEPS were only ever here because the health
+         plugin's workout read issues a DistanceRecord and a StepsRecord query
+         for every session and Health Connect fails the whole read without
+         them — their values were fetched and discarded, since energy is
+         attributed from the calorie records instead. The app now reads
+         sessions directly (HealthConnectWorkoutReader.kt), so neither is
+         needed.
+
+         READ_BODY_FAT personalised the workout calorie-credit suggestion.
+         That suggestion falls back to a BMI-derived percentile, which is what
+         Android now uses; iOS still reads body fat from HealthKit. -->
     <uses-permission android:name="android.permission.health.READ_EXERCISE"/>
-    <uses-permission android:name="android.permission.health.READ_BODY_FAT"/>
-    <!-- The health plugin populates a workout's totals by reading the
-         session's associated records; without these three the whole workout
-         query throws SecurityException and no workout can be imported. -->
     <uses-permission android:name="android.permission.health.READ_TOTAL_CALORIES_BURNED"/>
-    <uses-permission android:name="android.permission.health.READ_DISTANCE"/>
-    <uses-permission android:name="android.permission.health.READ_STEPS"/>
 
     <!-- Provide required visibility configuration for API level 30 and above -->
     <queries>

--- a/android/app/src/main/kotlin/com/opennutritracker/ont/opennutritracker/HealthConnectWorkoutReader.kt
+++ b/android/app/src/main/kotlin/com/opennutritracker/ont/opennutritracker/HealthConnectWorkoutReader.kt
@@ -1,0 +1,170 @@
+package com.opennutritracker.ont.opennutritracker
+
+import androidx.health.connect.client.HealthConnectClient
+import androidx.health.connect.client.records.ExerciseSessionRecord
+import androidx.health.connect.client.request.ReadRecordsRequest
+import androidx.health.connect.client.time.TimeRangeFilter
+import android.content.Context
+import java.time.Instant
+
+/**
+ * Reads finished exercise sessions straight from Health Connect.
+ *
+ * This exists because the `health` plugin cannot read a workout without also
+ * reading distance and steps: its `handleWorkoutData` issues a
+ * `DistanceRecord` and a `StepsRecord` read for every session it returns, and
+ * Health Connect answers an ungranted read with a SecurityException that takes
+ * the whole workout query with it. Play's Health Connect permissions policy
+ * rejected exactly those two permissions (plus body fat) as excessive for what
+ * this app offers — enforced 8 Sept 2026 — so the app cannot hold them and
+ * cannot use the plugin's workout path.
+ *
+ * Nothing is lost by reading the session directly: the app already ignored the
+ * plugin's totals on Android and attributes energy itself from raw
+ * TOTAL_CALORIES_BURNED records (see `androidWorkoutEnergyKcal`), so distance
+ * and steps were read and thrown away. Everything the import actually consumes
+ * — id, start, end, activity type, writing app — is on the session record.
+ *
+ * Only `READ_EXERCISE` is needed here. The calorie read stays on the plugin,
+ * which needs only `READ_TOTAL_CALORIES_BURNED`.
+ */
+object HealthConnectWorkoutReader {
+
+    /**
+     * Sessions that START inside `[from, to)`, as plain maps for the method
+     * channel. Paged to exhaustion: Health Connect caps a response and hands
+     * back a token, and stopping at the first page would silently drop the
+     * older half of a long catch-up import.
+     */
+    suspend fun readExerciseSessions(
+        context: Context,
+        fromMillis: Long,
+        toMillis: Long,
+    ): List<Map<String, Any?>> {
+        val client = HealthConnectClient.getOrCreate(context)
+        val timeRange = TimeRangeFilter.between(
+            Instant.ofEpochMilli(fromMillis),
+            Instant.ofEpochMilli(toMillis),
+        )
+
+        val sessions = mutableListOf<Map<String, Any?>>()
+        var pageToken: String? = null
+        do {
+            val response = client.readRecords(
+                ReadRecordsRequest(
+                    recordType = ExerciseSessionRecord::class,
+                    timeRangeFilter = timeRange,
+                    pageToken = pageToken,
+                ),
+            )
+            for (record in response.records) {
+                sessions.add(
+                    mapOf(
+                        "uuid" to record.metadata.id,
+                        "activityTypeName" to exerciseTypeName(record.exerciseType),
+                        "startMillis" to record.startTime.toEpochMilli(),
+                        "endMillis" to record.endTime.toEpochMilli(),
+                        "sourceName" to record.metadata.dataOrigin.packageName,
+                    ),
+                )
+            }
+            pageToken = response.pageToken
+        } while (pageToken != null)
+
+        return sessions
+    }
+
+    /**
+     * Health Connect's exercise type as the name the import's compendium
+     * lookup expects — the `HealthWorkoutActivityType` spelling the plugin
+     * used to hand over, so nothing above the data-source layer changes.
+     *
+     * Written as type-to-name rather than the plugin's name-to-type map on
+     * purpose. Three Health Connect types are the target of several names
+     * (dancing, skiing, wheelchair), and the plugin resolves those by taking
+     * the first key out of a `hashMapOf` — an arbitrary choice that can differ
+     * between runs. Naming the one canonical spelling here makes the answer
+     * deterministic, and picks the spelling the compendium table actually
+     * carries.
+     *
+     * A type absent from this table is reported by its Health Connect name if
+     * the import can use it and otherwise becomes a custom activity, which is
+     * what an unmapped type did before too.
+     */
+    private fun exerciseTypeName(exerciseType: Int): String = when (exerciseType) {
+        ExerciseSessionRecord.EXERCISE_TYPE_FOOTBALL_AMERICAN -> "AMERICAN_FOOTBALL"
+        ExerciseSessionRecord.EXERCISE_TYPE_FOOTBALL_AUSTRALIAN -> "AUSTRALIAN_FOOTBALL"
+        ExerciseSessionRecord.EXERCISE_TYPE_BADMINTON -> "BADMINTON"
+        ExerciseSessionRecord.EXERCISE_TYPE_BASEBALL -> "BASEBALL"
+        ExerciseSessionRecord.EXERCISE_TYPE_BASKETBALL -> "BASKETBALL"
+        ExerciseSessionRecord.EXERCISE_TYPE_BIKING -> "BIKING"
+        ExerciseSessionRecord.EXERCISE_TYPE_BOXING -> "BOXING"
+        ExerciseSessionRecord.EXERCISE_TYPE_CALISTHENICS -> "CALISTHENICS"
+        ExerciseSessionRecord.EXERCISE_TYPE_CRICKET -> "CRICKET"
+        // One Health Connect type, three plugin names, all three the same
+        // compendium code (03015).
+        ExerciseSessionRecord.EXERCISE_TYPE_DANCING -> "DANCING"
+        ExerciseSessionRecord.EXERCISE_TYPE_ELLIPTICAL -> "ELLIPTICAL"
+        ExerciseSessionRecord.EXERCISE_TYPE_FENCING -> "FENCING"
+        ExerciseSessionRecord.EXERCISE_TYPE_FRISBEE_DISC -> "FRISBEE_DISC"
+        ExerciseSessionRecord.EXERCISE_TYPE_GOLF -> "GOLF"
+        ExerciseSessionRecord.EXERCISE_TYPE_GUIDED_BREATHING -> "GUIDED_BREATHING"
+        ExerciseSessionRecord.EXERCISE_TYPE_GYMNASTICS -> "GYMNASTICS"
+        ExerciseSessionRecord.EXERCISE_TYPE_HANDBALL -> "HANDBALL"
+        ExerciseSessionRecord.EXERCISE_TYPE_HIGH_INTENSITY_INTERVAL_TRAINING ->
+            "HIGH_INTENSITY_INTERVAL_TRAINING"
+        ExerciseSessionRecord.EXERCISE_TYPE_HIKING -> "HIKING"
+        ExerciseSessionRecord.EXERCISE_TYPE_ICE_SKATING -> "ICE_SKATING"
+        ExerciseSessionRecord.EXERCISE_TYPE_MARTIAL_ARTS -> "MARTIAL_ARTS"
+        ExerciseSessionRecord.EXERCISE_TYPE_PARAGLIDING -> "PARAGLIDING"
+        ExerciseSessionRecord.EXERCISE_TYPE_PILATES -> "PILATES"
+        ExerciseSessionRecord.EXERCISE_TYPE_RACQUETBALL -> "RACQUETBALL"
+        ExerciseSessionRecord.EXERCISE_TYPE_ROCK_CLIMBING -> "ROCK_CLIMBING"
+        ExerciseSessionRecord.EXERCISE_TYPE_ROWING -> "ROWING"
+        ExerciseSessionRecord.EXERCISE_TYPE_ROWING_MACHINE -> "ROWING_MACHINE"
+        ExerciseSessionRecord.EXERCISE_TYPE_RUGBY -> "RUGBY"
+        ExerciseSessionRecord.EXERCISE_TYPE_RUNNING -> "RUNNING"
+        ExerciseSessionRecord.EXERCISE_TYPE_RUNNING_TREADMILL -> "RUNNING_TREADMILL"
+        ExerciseSessionRecord.EXERCISE_TYPE_SAILING -> "SAILING"
+        ExerciseSessionRecord.EXERCISE_TYPE_SCUBA_DIVING -> "SCUBA_DIVING"
+        ExerciseSessionRecord.EXERCISE_TYPE_SKATING -> "SKATING"
+        // DOWNHILL_SKIING and SKIING share compendium code 19075;
+        // CROSS_COUNTRY_SKIING (19080) is a different activity Health Connect
+        // does not distinguish, so the generic spelling is the honest one.
+        ExerciseSessionRecord.EXERCISE_TYPE_SKIING -> "SKIING"
+        ExerciseSessionRecord.EXERCISE_TYPE_SNOWBOARDING -> "SNOWBOARDING"
+        ExerciseSessionRecord.EXERCISE_TYPE_SNOWSHOEING -> "SNOWSHOEING"
+        ExerciseSessionRecord.EXERCISE_TYPE_SOFTBALL -> "SOFTBALL"
+        ExerciseSessionRecord.EXERCISE_TYPE_SQUASH -> "SQUASH"
+        ExerciseSessionRecord.EXERCISE_TYPE_STAIR_CLIMBING -> "STAIR_CLIMBING"
+        ExerciseSessionRecord.EXERCISE_TYPE_STAIR_CLIMBING_MACHINE -> "STAIR_CLIMBING_MACHINE"
+        ExerciseSessionRecord.EXERCISE_TYPE_STRENGTH_TRAINING -> "STRENGTH_TRAINING"
+        ExerciseSessionRecord.EXERCISE_TYPE_SURFING -> "SURFING"
+        ExerciseSessionRecord.EXERCISE_TYPE_SWIMMING_OPEN_WATER -> "SWIMMING_OPEN_WATER"
+        ExerciseSessionRecord.EXERCISE_TYPE_SWIMMING_POOL -> "SWIMMING_POOL"
+        ExerciseSessionRecord.EXERCISE_TYPE_TABLE_TENNIS -> "TABLE_TENNIS"
+        ExerciseSessionRecord.EXERCISE_TYPE_TENNIS -> "TENNIS"
+        ExerciseSessionRecord.EXERCISE_TYPE_VOLLEYBALL -> "VOLLEYBALL"
+        ExerciseSessionRecord.EXERCISE_TYPE_WALKING -> "WALKING"
+        ExerciseSessionRecord.EXERCISE_TYPE_WATER_POLO -> "WATER_POLO"
+        ExerciseSessionRecord.EXERCISE_TYPE_WEIGHTLIFTING -> "WEIGHTLIFTING"
+        // WHEELCHAIR_RUN_PACE and WHEELCHAIR_WALK_PACE are HealthKit
+        // spellings of the same Health Connect type.
+        ExerciseSessionRecord.EXERCISE_TYPE_WHEELCHAIR -> "WHEELCHAIR"
+        ExerciseSessionRecord.EXERCISE_TYPE_YOGA -> "YOGA"
+
+        // Types the plugin's table never mapped, so they arrived as OTHER and
+        // became a custom activity. Each of these does have a compendium
+        // counterpart the import can use, so naming them is a small
+        // improvement over the behaviour being replaced.
+        ExerciseSessionRecord.EXERCISE_TYPE_SOCCER -> "SOCCER"
+        ExerciseSessionRecord.EXERCISE_TYPE_BIKING_STATIONARY -> "BIKING_STATIONARY"
+        ExerciseSessionRecord.EXERCISE_TYPE_ICE_HOCKEY -> "HOCKEY"
+        ExerciseSessionRecord.EXERCISE_TYPE_STRETCHING -> "FLEXIBILITY"
+        // The compendium table also carries JUMP_ROPE, but Health Connect has
+        // no exercise type for it in connect-client 1.1.0-alpha11 — a skipping
+        // session arrives as OTHER_WORKOUT and becomes a custom activity.
+
+        else -> "OTHER"
+    }
+}

--- a/android/app/src/main/kotlin/com/opennutritracker/ont/opennutritracker/MainActivity.kt
+++ b/android/app/src/main/kotlin/com/opennutritracker/ont/opennutritracker/MainActivity.kt
@@ -7,6 +7,11 @@ import android.os.LocaleList
 import io.flutter.embedding.android.FlutterFragmentActivity
 import io.flutter.embedding.engine.FlutterEngine
 import io.flutter.plugin.common.MethodChannel
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.SupervisorJob
+import kotlinx.coroutines.cancel
+import kotlinx.coroutines.launch
 
 // FlutterFragmentActivity (rather than FlutterActivity) is required by the
 // health plugin: Health Connect permission requests go through
@@ -14,6 +19,18 @@ import io.flutter.plugin.common.MethodChannel
 class MainActivity : FlutterFragmentActivity() {
     private val localeChannelName = "com.opennutritracker/locale"
     private val healthRationaleChannelName = "com.opennutritracker/health_rationale"
+    private val healthConnectChannelName = "com.opennutritracker/health_connect"
+
+    /**
+     * Scope for the Health Connect reads, which are suspend functions.
+     *
+     * Main dispatcher because a MethodChannel result has to be posted from the
+     * platform thread; the client's own reads move themselves off it. A
+     * SupervisorJob so one failed import cannot cancel the scope and leave
+     * every later read dead, and cancelled in [onDestroy] so a read in flight
+     * when the activity goes away does not answer into a dead channel.
+     */
+    private val healthConnectScope = CoroutineScope(SupervisorJob() + Dispatchers.Main)
 
     /**
      * Whether Health Connect started us to ask what the app wants health data
@@ -43,6 +60,50 @@ class MainActivity : FlutterFragmentActivity() {
                     "consumePendingRequest" -> {
                         result.success(healthRationalePending)
                         healthRationalePending = false
+                    }
+                    else -> result.notImplemented()
+                }
+            }
+
+        // Finished workouts, read straight from Health Connect rather than
+        // through the health plugin. See [HealthConnectWorkoutReader] for why:
+        // in short, the plugin's workout read also reads distance and steps,
+        // and Play's Health Connect permissions policy refused those two
+        // permissions for this app.
+        MethodChannel(flutterEngine.dartExecutor.binaryMessenger, healthConnectChannelName)
+            .setMethodCallHandler { call, result ->
+                when (call.method) {
+                    "readExerciseSessions" -> {
+                        val from = call.argument<Number>("fromMillis")?.toLong()
+                        val to = call.argument<Number>("toMillis")?.toLong()
+                        if (from == null || to == null) {
+                            result.error(
+                                "invalid_arguments",
+                                "readExerciseSessions needs fromMillis and toMillis",
+                                null,
+                            )
+                            return@setMethodCallHandler
+                        }
+                        healthConnectScope.launch {
+                            try {
+                                result.success(
+                                    HealthConnectWorkoutReader.readExerciseSessions(
+                                        applicationContext,
+                                        from,
+                                        to,
+                                    ),
+                                )
+                            } catch (e: SecurityException) {
+                                // A revoked grant. Distinguished from the rest
+                                // so Dart can tell the user to re-grant instead
+                                // of reporting a generic failure.
+                                result.error("permission_denied", e.message, null)
+                            } catch (e: Exception) {
+                                // Health Connect uninstalled or updating, a
+                                // client that will not initialise, an IO fault.
+                                result.error("health_connect_unavailable", e.message, null)
+                            }
+                        }
                     }
                     else -> result.notImplemented()
                 }
@@ -84,6 +145,11 @@ class MainActivity : FlutterFragmentActivity() {
         if (isHealthRationaleIntent(intent)) {
             healthRationalePending = true
         }
+    }
+
+    override fun onDestroy() {
+        healthConnectScope.cancel()
+        super.onDestroy()
     }
 
     /**

--- a/docs/play-data-safety.md
+++ b/docs/play-data-safety.md
@@ -1,0 +1,110 @@
+# Play Data safety: what is declared, and what the app does
+
+The Data safety form is answered in the Play Console and uploaded by nobody —
+both Play lanes set `skip_upload_metadata`, so nothing in this repo can change
+it. This file is the record of what the answers *should* be, so the next person
+to open the form is not re-deriving it from the code.
+
+**Read this with [RELEASING.md](RELEASING.md)'s "Check the Play data-safety
+declaration still matches what the app does" step.** That step is the one whose
+failure mode is the app being pulled rather than a bad release.
+
+## What is live today
+
+Read off the public listing on 2026-09-08
+(`play.google.com/store/apps/datasafety?id=com.opennutritracker.ont.opennutritracker`):
+
+| | |
+|---|---|
+| **Shared** | App activity → In-app search history |
+| **Collected** | App info and performance → Crash logs, Diagnostics<br>Location → Approximate location |
+| **Security** | Data is encrypted in transit · **Data can't be deleted** |
+
+## The four things that are wrong
+
+### 1. In-app search history is shared but not collected
+
+This is the one a reviewer can spot without reading any code, because the
+framework has no such state: sharing is defined as transferring data you
+collected, so a type that is shared and not collected is a contradiction on the
+face of the form. Tracked as
+[#1094](https://github.com/simonoppowa/OpenNutriTracker/issues/1094).
+
+The search term is transmitted — to Open Food Facts, an independent third
+party, and to the Supabase food backend.
+
+> **Set:** App activity → In-app search history → Collected = **Yes**,
+> Required, Purpose = App functionality. Keep Shared = Yes. Do **not** mark it
+> *Processed ephemerally* — Open Food Facts' retention is not this project's to
+> warrant, and the privacy policy already says so.
+
+### 2. Photos are not declared, and the app sends them to a third party
+
+Verified in the shipped code, not inferred: the AI meal-photo path
+base64-encodes the photo and POSTs it to whichever provider the user
+configured.
+
+- `lib/features/add_meal/data/model_meal_photo_interpreter.dart:63` —
+  `base64Data: base64Encode(photo.bytes)`
+- destinations: `https://api.openai.com/v1/responses`
+  (`openai_meal_items_api.dart:27`), `https://api.anthropic.com/v1/messages`
+  (`anthropic_meal_items_api.dart:16`),
+  `https://openrouter.ai/api/v1/chat/completions`
+  (`openai_compatible_meal_items_api.dart:83`), or a user-supplied address.
+
+There is no Photos entry on the live record at all. Tracked as
+[#1050](https://github.com/simonoppowa/OpenNutriTracker/issues/1050).
+
+> **Set:** Photos and videos → Photos → Collected = **Yes**, Shared = **Yes**,
+> Processed ephemerally = No, **Optional** (the feature is inert until the user
+> saves a credential), Purpose = App functionality.
+
+### 3. The typed meal line is not declared under any type
+
+The free-text meal description from the multi-item add screen goes to the same
+providers. Data safety is answered per data *type*, so the existing App
+activity entry does not cover it.
+
+> **Set:** App activity → Other user-generated content → Collected = **Yes**,
+> Shared = **Yes**, Optional, Purpose = App functionality.
+
+A meal description is not Health and fitness data — that category is medical
+records, symptoms and exercise, not what someone ate.
+
+### 4. "Data can't be deleted" contradicts the app
+
+The app has a delete-all-user-data path (Settings → delete all data), and
+`DeleteAllUserDataUsecase.deleteAll()` wipes every Hive box including the
+config.
+
+> **Set:** the deletion answer to reflect that in-app deletion exists.
+
+## Health and fitness: unchanged, and deliberately
+
+Health Connect data is read and kept on the device — it is never transmitted —
+so under Play's definition ("collect" means transmitting off the device) it is
+not collected and stays undeclared. That reasoning was settled in
+[#937](https://github.com/simonoppowa/OpenNutriTracker/issues/937); this file
+records it so it is not reopened every release.
+
+What *did* change on 2026-09-08 is the permission set behind it. Play's Health
+Connect permissions policy enforced against `READ_BODY_FAT`, `READ_DISTANCE`
+and `READ_STEPS` as excessive, and the app now declares only `READ_EXERCISE`
+and `READ_TOTAL_CALORIES_BURNED`. The **Health apps declaration** (Play Console
+→ App content) has to be brought in line with that in the same pass — it was
+last edited before any health permission existed in the app.
+
+## Still open, needing a decision rather than a lookup
+
+- **Approximate location.** It is declared as collected. Whatever justified it
+  should be written down here, or the entry removed.
+- **"Encrypted in transit" vs the own-server AI provider.** The own-server
+  provider accepts an `http://` address for private/loopback destinations. The
+  form's answer is app-wide with no conditional, so either that carve-out goes
+  (`lib/core/utils/plaintext_destination_guard.dart`) or the answer becomes No.
+  See [#816](https://github.com/simonoppowa/OpenNutriTracker/issues/816).
+- **The provider API key as a user identifier.** It travels on every AI request
+  and works as a stable per-user handle at the vendor. Whether that is a
+  "User ID" the app collects is a genuine judgment call — the argument against
+  is that it is the user's own account at a counterparty they chose. Decide it
+  once and record the answer beside #1050 so it is not re-derived.

--- a/lib/core/data/data_source/health/health_connect_workout_reader.dart
+++ b/lib/core/data/data_source/health/health_connect_workout_reader.dart
@@ -1,0 +1,81 @@
+import 'package:flutter/services.dart';
+import 'package:logging/logging.dart';
+import 'package:opennutritracker/core/data/data_source/health/external_workout.dart';
+
+/// Android-only reader for finished Health Connect exercise sessions.
+///
+/// The `health` plugin cannot serve these: its workout read also reads
+/// distance and steps, and Play's Health Connect permissions policy refused
+/// both for this app. `MainActivity`'s `com.opennutritracker/health_connect`
+/// channel reads the session records directly instead — see
+/// `HealthConnectWorkoutReader.kt` for the full reasoning.
+///
+/// Returns workouts with no energy: a Health Connect session carries none of
+/// its own, and attributing it from the calorie records is
+/// [HealthPackageService]'s job.
+class HealthConnectWorkoutReader {
+  static const _channel = MethodChannel('com.opennutritracker/health_connect');
+
+  static final _log = Logger('HealthConnectWorkoutReader');
+
+  final MethodChannel _methodChannel;
+
+  HealthConnectWorkoutReader({MethodChannel? channel})
+    : _methodChannel = channel ?? _channel;
+
+  /// Sessions starting within `[from, to)`.
+  ///
+  /// Throws [PlatformException] when the platform refuses — code
+  /// `permission_denied` for a revoked grant, `health_connect_unavailable`
+  /// for anything else. Callers treat both as a failed read rather than an
+  /// empty one, so a refusal never advances the import watermark.
+  Future<List<ExternalWorkout>> readExerciseSessions({
+    required DateTime from,
+    required DateTime to,
+  }) async {
+    final sessions = await _methodChannel.invokeListMethod<dynamic>(
+      'readExerciseSessions',
+      <String, dynamic>{
+        'fromMillis': from.millisecondsSinceEpoch,
+        'toMillis': to.millisecondsSinceEpoch,
+      },
+    );
+    if (sessions == null) return const <ExternalWorkout>[];
+
+    final workouts = <ExternalWorkout>[];
+    for (final session in sessions) {
+      final workout = _toWorkout(session);
+      if (workout != null) workouts.add(workout);
+    }
+    return workouts;
+  }
+
+  /// One channel entry as an [ExternalWorkout], or null when it is missing
+  /// something the import cannot do without. A single unreadable record is
+  /// worth a log line, not a failed import of every other workout.
+  ExternalWorkout? _toWorkout(dynamic session) {
+    if (session is! Map) {
+      _log.warning('Skipping health session: expected a map, got $session');
+      return null;
+    }
+    final id = session['uuid'];
+    final start = session['startMillis'];
+    final end = session['endMillis'];
+    final activityTypeName = session['activityTypeName'];
+    if (id is! String ||
+        start is! int ||
+        end is! int ||
+        activityTypeName is! String) {
+      _log.warning('Skipping malformed health session: $session');
+      return null;
+    }
+    final sourceName = session['sourceName'];
+    return ExternalWorkout(
+      id: id,
+      start: DateTime.fromMillisecondsSinceEpoch(start),
+      end: DateTime.fromMillisecondsSinceEpoch(end),
+      activityTypeName: activityTypeName,
+      sourceAppName: sourceName is String ? sourceName : null,
+    );
+  }
+}

--- a/lib/core/data/data_source/health/health_package_service.dart
+++ b/lib/core/data/data_source/health/health_package_service.dart
@@ -5,45 +5,75 @@ import 'package:health/health.dart';
 import 'package:logging/logging.dart';
 import 'package:meta/meta.dart';
 import 'package:opennutritracker/core/data/data_source/health/external_workout.dart';
+import 'package:opennutritracker/core/data/data_source/health/health_connect_workout_reader.dart';
 import 'package:opennutritracker/core/data/data_source/health/health_service.dart';
+
+/// Which platform's health store rules apply.
+///
+/// Injected into [HealthPackageService] rather than read from [Platform] at
+/// every branch, because the two platforms now diverge in what they read and
+/// a host test is neither of them.
+enum HealthTargetPlatform {
+  android,
+  ios,
+  unsupported;
+
+  static HealthTargetPlatform get current {
+    if (Platform.isAndroid) return HealthTargetPlatform.android;
+    if (Platform.isIOS) return HealthTargetPlatform.ios;
+    return HealthTargetPlatform.unsupported;
+  }
+}
 
 /// [HealthService] backed by the `health` plugin — Health Connect on
 /// Android, HealthKit on iOS.
 ///
-/// Deliberately free of business logic: it asks for the two data types the
+/// Deliberately free of business logic: it asks for the data types the
 /// feature needs, hands back plain [ExternalWorkout] records, and leaves
 /// every decision about what to do with them to the import use case.
+///
+/// The two platforms are not symmetric, and the asymmetry is a policy
+/// consequence rather than a technical one. Play's Health Connect permissions
+/// policy refused this app READ_BODY_FAT, READ_DISTANCE and READ_STEPS as
+/// excessive (enforced 8 Sept 2026), so on Android:
+///
+///  * workouts are read outside the plugin, by
+///    [HealthConnectWorkoutReader] — the plugin's own workout read pulls
+///    distance and steps for every session and fails entirely without them;
+///  * body fat is not read at all, and the calorie-credit suggestion falls
+///    back to the BMI-derived percentile it already used for anyone whose
+///    health store had no body fat on record.
+///
+/// HealthKit is not subject to that policy and keeps both.
 class HealthPackageService implements HealthService {
-  /// Read-only: workouts to import, body fat to personalise the
-  /// calorie-credit suggestion. Nothing is ever written back.
-  static const _coreReadTypes = [
-    HealthDataType.WORKOUT,
-    HealthDataType.BODY_FAT_PERCENTAGE,
-  ];
+  /// Workouts, on every platform that has a health store. On Android this is
+  /// requested (it is what grants READ_EXERCISE) but read through
+  /// [HealthConnectWorkoutReader] rather than the plugin.
+  static const _workoutType = HealthDataType.WORKOUT;
 
-  /// On Android the plugin fills a workout's energy/distance/step totals by
-  /// reading the records associated with each session, and Health Connect
-  /// rejects the whole workout query with a SecurityException when any of
-  /// those reads is not granted. HealthKit carries the totals on the workout
-  /// itself, so requesting these on iOS would only add permission rows the
+  /// Health Connect sessions carry no energy of their own — apps write
+  /// separate TOTAL_CALORIES_BURNED records — so the calorie read is what
+  /// gives an imported workout its kcal. HealthKit puts the total on the
+  /// workout itself, so asking for this on iOS would add a permission row the
   /// feature never uses.
-  static const _androidWorkoutDetailTypes = [
-    HealthDataType.TOTAL_CALORIES_BURNED,
-    HealthDataType.DISTANCE_DELTA,
-    HealthDataType.STEPS,
-  ];
+  static const _androidEnergyType = HealthDataType.TOTAL_CALORIES_BURNED;
 
-  static List<HealthDataType> get _readTypes => [
-    ..._coreReadTypes,
-    if (Platform.isAndroid) ..._androidWorkoutDetailTypes,
+  /// Body fat personalises the calorie-credit suggestion. iOS only; see the
+  /// class doc.
+  static const _iosBodyCompositionType = HealthDataType.BODY_FAT_PERCENTAGE;
+
+  List<HealthDataType> get _readTypes => [
+    _workoutType,
+    if (_platform == HealthTargetPlatform.android) _androidEnergyType,
+    if (_platform == HealthTargetPlatform.ios) _iosBodyCompositionType,
   ];
 
   /// The types a workout read touches — [requestPermissions] asks for all of
   /// [_readTypes], but a revoked body-fat grant only costs the suggestion,
   /// so the workout guard must not fail on it.
-  static List<HealthDataType> get _workoutReadTypes => [
-    HealthDataType.WORKOUT,
-    if (Platform.isAndroid) ..._androidWorkoutDetailTypes,
+  List<HealthDataType> get _workoutReadTypes => [
+    _workoutType,
+    if (_platform == HealthTargetPlatform.android) _androidEnergyType,
   ];
 
   /// How far back to look for the latest body fat reading. A year is long
@@ -54,8 +84,15 @@ class HealthPackageService implements HealthService {
 
   static final _log = Logger('HealthPackageService');
   final Health _health;
+  final HealthConnectWorkoutReader _workoutReader;
+  final HealthTargetPlatform _platform;
 
-  HealthPackageService(this._health);
+  HealthPackageService(
+    this._health, {
+    HealthConnectWorkoutReader? workoutReader,
+    HealthTargetPlatform? platform,
+  }) : _workoutReader = workoutReader ?? HealthConnectWorkoutReader(),
+       _platform = platform ?? HealthTargetPlatform.current;
 
   /// Builds a configured service. [Health.configure] resolves the device id
   /// and has to run before any query, so it happens here rather than lazily
@@ -68,7 +105,7 @@ class HealthPackageService implements HealthService {
 
   @override
   Future<bool> isAvailable() async {
-    if (!Platform.isAndroid && !Platform.isIOS) return false;
+    if (_platform == HealthTargetPlatform.unsupported) return false;
     return await _health.isHealthConnectAvailable();
   }
 
@@ -80,12 +117,12 @@ class HealthPackageService implements HealthService {
     );
     if (!granted) return false;
     // Android answers the request with "was anything at all granted", so a
-    // user who ticked body fat and left the workout rows unticked would switch
-    // the feature on with nothing importable behind it. Re-check the types a
-    // workout read actually needs; body fat only costs the suggestion, so a
-    // refusal there is not a failure. hasPermissions answers null where the
-    // platform will not say (iOS never reports read grants) — same rule as
-    // [readWorkouts], only a definite refusal counts.
+    // user who ticked calories and left exercise unticked would switch the
+    // feature on with nothing importable behind it. Re-check the types a
+    // workout read actually needs; on iOS body fat only costs the suggestion,
+    // so a refusal there is not a failure. hasPermissions answers null where
+    // the platform will not say (iOS never reports read grants) — same rule
+    // as [readWorkouts], only a definite refusal counts.
     final hasWorkoutPermissions = await _health.hasPermissions(
       _workoutReadTypes,
       permissions: List.filled(_workoutReadTypes.length, HealthDataAccess.READ),
@@ -113,24 +150,14 @@ class HealthPackageService implements HealthService {
         'needed: $_workoutReadTypes',
       );
     }
+    if (_platform == HealthTargetPlatform.android) {
+      return await _readAndroidWorkouts(from: from, to: to);
+    }
     final points = await _health.getHealthDataFromTypes(
-      types: const [HealthDataType.WORKOUT],
+      types: const [_workoutType],
       startTime: from,
       endTime: to,
     );
-    // On Android a workout's totalEnergyBurned is the plugin's sum of EVERY
-    // calorie record overlapping the session, whoever wrote it — see
-    // [androidWorkoutEnergyKcal] for why that double-counts. Read the raw
-    // calorie records once for the whole window and attribute them per
-    // workout instead. HealthKit workouts carry their own total, so iOS
-    // keeps the plugin's value.
-    final calorieRecords = Platform.isAndroid
-        ? await _health.getHealthDataFromTypes(
-            types: const [HealthDataType.TOTAL_CALORIES_BURNED],
-            startTime: from,
-            endTime: to,
-          )
-        : const <HealthDataPoint>[];
     final workouts = <ExternalWorkout>[];
     for (final point in points) {
       final value = point.value;
@@ -149,22 +176,54 @@ class HealthPackageService implements HealthService {
           start: point.dateFrom,
           end: point.dateTo,
           activityTypeName: value.workoutActivityType.name,
-          energyBurnedKcal: Platform.isAndroid
-              ? androidWorkoutEnergyKcal(
-                  start: point.dateFrom,
-                  end: point.dateTo,
-                  sourceName: point.sourceName,
-                  calorieRecords: calorieRecords,
-                )
-              : _energyInKcal(
-                  value.totalEnergyBurned,
-                  value.totalEnergyBurnedUnit,
-                ),
+          // A HealthKit workout carries its own total.
+          energyBurnedKcal: _energyInKcal(
+            value.totalEnergyBurned,
+            value.totalEnergyBurnedUnit,
+          ),
           sourceAppName: point.sourceName,
         ),
       );
     }
     return workouts;
+  }
+
+  /// Workouts from Health Connect, read outside the plugin.
+  ///
+  /// A session record carries no energy, so the calorie records for the whole
+  /// window are read once and attributed per workout by
+  /// [androidWorkoutEnergyKcal] — which is also why the plugin's own totals
+  /// were never used here even when they were available.
+  Future<List<ExternalWorkout>> _readAndroidWorkouts({
+    required DateTime from,
+    required DateTime to,
+  }) async {
+    final sessions = await _workoutReader.readExerciseSessions(
+      from: from,
+      to: to,
+    );
+    if (sessions.isEmpty) return const <ExternalWorkout>[];
+    final calorieRecords = await _health.getHealthDataFromTypes(
+      types: const [_androidEnergyType],
+      startTime: from,
+      endTime: to,
+    );
+    return [
+      for (final session in sessions)
+        ExternalWorkout(
+          id: session.id,
+          start: session.start,
+          end: session.end,
+          activityTypeName: session.activityTypeName,
+          energyBurnedKcal: androidWorkoutEnergyKcal(
+            start: session.start,
+            end: session.end,
+            sourceName: session.sourceAppName ?? '',
+            calorieRecords: calorieRecords,
+          ),
+          sourceAppName: session.sourceAppName,
+        ),
+    ];
   }
 
   /// Energy attributable to one Android workout session.
@@ -215,6 +274,11 @@ class HealthPackageService implements HealthService {
 
   @override
   Future<double?> readLatestBodyFatPercent() async {
+    // Android holds no body-fat permission — Play refused it as excessive for
+    // what this app does. Null is the same answer the calculator already got
+    // for the many users whose health store has no body fat on record, and it
+    // falls back to the BMI-derived percentile.
+    if (_platform == HealthTargetPlatform.android) return null;
     final now = DateTime.now();
     final points = await _health.getHealthDataFromTypes(
       types: const [HealthDataType.BODY_FAT_PERCENTAGE],

--- a/test/unit_test/health_connect_permissions_test.dart
+++ b/test/unit_test/health_connect_permissions_test.dart
@@ -1,0 +1,76 @@
+import 'dart:io';
+
+import 'package:flutter_test/flutter_test.dart';
+
+/// Pins the Health Connect permissions in `android/app/src/main/AndroidManifest.xml`.
+///
+/// Play's Health Connect permissions policy rejected the 2.3.0 submission for
+/// "excessive data access for declared functionality": `READ_BODY_FAT`,
+/// `READ_DISTANCE` and `READ_STEPS` were held without a feature that needed
+/// them. Enforced 8 Sept 2026, with the previous version left live.
+///
+/// Nothing else in CI would catch them coming back. The manifest is not
+/// linted for this, the `android-deploy` job tolerates a failed Play upload
+/// by design (#942), and the first thing that inspects the declaration is a
+/// human reviewer at Google — days after the release went out. A regression
+/// here costs another rejection and another version code.
+///
+/// Two ways they could return without anyone deciding to bring them back: a
+/// Flutter plugin that merges its own `uses-permission` into the manifest,
+/// and a well-meant revert of the workout reader that restores the plugin's
+/// workout path along with the permissions it needs. Both show up here.
+void main() {
+  final manifest = File(
+    'android/app/src/main/AndroidManifest.xml',
+  ).readAsStringSync();
+
+  /// Every `android.permission.health.*` the manifest declares.
+  final declared = RegExp(
+    r'<uses-permission\s+android:name="android\.permission\.health\.([A-Z_]+)"',
+  ).allMatches(manifest).map((match) => match.group(1)!).toSet();
+
+  group('Health Connect permissions', () {
+    test('exercise and total calories are declared', () {
+      // The workout import needs the session, and the calories that give an
+      // imported workout its kcal. Without these the feature cannot work.
+      expect(declared, contains('READ_EXERCISE'));
+      expect(declared, contains('READ_TOTAL_CALORIES_BURNED'));
+    });
+
+    test('the three permissions Play refused are not declared', () {
+      expect(
+        declared.intersection({
+          'READ_BODY_FAT',
+          'READ_DISTANCE',
+          'READ_STEPS',
+        }),
+        isEmpty,
+        reason:
+            'Play enforced against these on 8 Sept 2026 as excessive for the '
+            'features this app offers. Reinstating one needs a feature that '
+            'genuinely requires it AND a Health Connect declaration that '
+            'covers it — not a manifest edit.',
+      );
+    });
+
+    test('no health permission is declared beyond those two', () {
+      // Catches a plugin quietly merging one in, and catches a new read being
+      // added without the declaration form being updated to match.
+      expect(
+        declared,
+        {'READ_EXERCISE', 'READ_TOTAL_CALORIES_BURNED'},
+        reason:
+            'Every declared Health Connect permission has to be justified by '
+            'a feature in the Play Console declaration form. Adding one here '
+            'without updating that form is what gets an update rejected.',
+      );
+    });
+
+    test('nothing is ever written back', () {
+      expect(
+        declared.where((permission) => permission.startsWith('WRITE_')),
+        isEmpty,
+      );
+    });
+  });
+}

--- a/test/unit_test/health_connect_workout_reader_test.dart
+++ b/test/unit_test/health_connect_workout_reader_test.dart
@@ -1,0 +1,112 @@
+import 'package:flutter/services.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:opennutritracker/core/data/data_source/health/health_connect_workout_reader.dart';
+
+/// The decoding half of the Health Connect session read. The Kotlin half is
+/// exercised on a device; what is worth pinning here is that a malformed
+/// record costs that one workout and not the whole import, and that the
+/// window is passed across as the platform expects it.
+void main() {
+  TestWidgetsFlutterBinding.ensureInitialized();
+
+  const channel = MethodChannel('com.opennutritracker/health_connect_test');
+  final messenger =
+      TestDefaultBinaryMessengerBinding.instance.defaultBinaryMessenger;
+
+  late HealthConnectWorkoutReader reader;
+  MethodCall? lastCall;
+  Object? response;
+
+  final from = DateTime(2026, 8, 13);
+  final to = DateTime(2026, 8, 14);
+
+  Map<String, Object?> session({
+    Object? uuid = 'session-1',
+    Object? activityTypeName = 'RUNNING',
+    Object? startMillis,
+    Object? endMillis,
+    Object? sourceName = 'com.hevy.app',
+  }) => {
+    'uuid': uuid,
+    'activityTypeName': activityTypeName,
+    'startMillis': startMillis ?? DateTime(2026, 8, 13, 18).millisecondsSinceEpoch,
+    'endMillis': endMillis ?? DateTime(2026, 8, 13, 19).millisecondsSinceEpoch,
+    'sourceName': sourceName,
+  };
+
+  setUp(() {
+    lastCall = null;
+    response = <Object?>[];
+    reader = HealthConnectWorkoutReader(channel: channel);
+    messenger.setMockMethodCallHandler(channel, (call) async {
+      lastCall = call;
+      if (response is Exception) throw response as Exception;
+      return response;
+    });
+  });
+
+  tearDown(() => messenger.setMockMethodCallHandler(channel, null));
+
+  test('the window crosses the channel as epoch milliseconds', () async {
+    await reader.readExerciseSessions(from: from, to: to);
+
+    expect(lastCall?.method, 'readExerciseSessions');
+    expect(lastCall?.arguments, {
+      'fromMillis': from.millisecondsSinceEpoch,
+      'toMillis': to.millisecondsSinceEpoch,
+    });
+  });
+
+  test('a session becomes a workout with no energy of its own', () async {
+    response = [session()];
+
+    final workouts = await reader.readExerciseSessions(from: from, to: to);
+
+    expect(workouts, hasLength(1));
+    expect(workouts.single.id, 'session-1');
+    expect(workouts.single.activityTypeName, 'RUNNING');
+    expect(workouts.single.start, DateTime(2026, 8, 13, 18));
+    expect(workouts.single.end, DateTime(2026, 8, 13, 19));
+    expect(workouts.single.sourceAppName, 'com.hevy.app');
+    // A Health Connect session carries no energy; the service attributes it.
+    expect(workouts.single.energyBurnedKcal, isNull);
+  });
+
+  test('one malformed record costs that record, not the import', () async {
+    response = [
+      session(uuid: null),
+      session(uuid: 'good', activityTypeName: 'ROWING_MACHINE'),
+      session(startMillis: 'not a number'),
+      'not a map',
+    ];
+
+    final workouts = await reader.readExerciseSessions(from: from, to: to);
+
+    expect(workouts.map((workout) => workout.id), ['good']);
+  });
+
+  test('a missing source name is tolerated', () async {
+    response = [session(sourceName: null)];
+
+    final workouts = await reader.readExerciseSessions(from: from, to: to);
+
+    expect(workouts.single.sourceAppName, isNull);
+  });
+
+  test('nothing back means no workouts', () async {
+    response = null;
+
+    expect(await reader.readExerciseSessions(from: from, to: to), isEmpty);
+  });
+
+  test('a refused read throws rather than reporting an empty window', () async {
+    // The import would otherwise file "nothing new" and advance its
+    // watermark, silently skipping every workout in the window.
+    response = PlatformException(code: 'permission_denied');
+
+    expect(
+      () => reader.readExerciseSessions(from: from, to: to),
+      throwsA(isA<PlatformException>()),
+    );
+  });
+}

--- a/test/unit_test/health_package_service_test.dart
+++ b/test/unit_test/health_package_service_test.dart
@@ -1,5 +1,7 @@
 import 'package:flutter_test/flutter_test.dart';
 import 'package:health/health.dart';
+import 'package:opennutritracker/core/data/data_source/health/external_workout.dart';
+import 'package:opennutritracker/core/data/data_source/health/health_connect_workout_reader.dart';
 import 'package:opennutritracker/core/data/data_source/health/health_package_service.dart';
 
 /// Stands in for the plugin's own entry point so the grant bookkeeping can be
@@ -10,6 +12,11 @@ class _FakeHealth extends Fake implements Health {
 
   List<HealthDataType>? requestedTypes;
   List<HealthDataType>? recheckedTypes;
+
+  /// Records every read the service asks the plugin for, so a test can assert
+  /// that the workout read no longer goes through it on Android.
+  final queriedTypes = <List<HealthDataType>>[];
+  List<HealthDataPoint> dataPoints = const [];
 
   @override
   Future<bool> requestAuthorization(
@@ -27,6 +34,33 @@ class _FakeHealth extends Fake implements Health {
   }) async {
     recheckedTypes = types;
     return workoutPermissions;
+  }
+
+  @override
+  Future<List<HealthDataPoint>> getHealthDataFromTypes({
+    required List<HealthDataType> types,
+    required DateTime startTime,
+    required DateTime endTime,
+    Map<HealthDataType, HealthDataUnit>? preferredUnits,
+    List<RecordingMethod> recordingMethodsToFilter = const [],
+  }) async {
+    queriedTypes.add(types);
+    return dataPoints;
+  }
+}
+
+/// The Health Connect session read, without a method channel.
+class _FakeWorkoutReader extends Fake implements HealthConnectWorkoutReader {
+  List<ExternalWorkout> sessions = const [];
+  int calls = 0;
+
+  @override
+  Future<List<ExternalWorkout>> readExerciseSessions({
+    required DateTime from,
+    required DateTime to,
+  }) async {
+    calls++;
+    return sessions;
   }
 }
 
@@ -211,20 +245,163 @@ void main() {
       },
     );
 
-    test('body fat is asked for, but never re-checked', () async {
-      health.workoutPermissions = true;
+    test('on iOS body fat is asked for, but never re-checked', () async {
+      final iosHealth = _FakeHealth()..workoutPermissions = true;
+      final iosService = HealthPackageService(
+        iosHealth,
+        platform: HealthTargetPlatform.ios,
+      );
 
+      await iosService.requestPermissions();
+
+      expect(
+        iosHealth.requestedTypes,
+        contains(HealthDataType.BODY_FAT_PERCENTAGE),
+      );
+      expect(iosHealth.recheckedTypes, contains(HealthDataType.WORKOUT));
+      expect(
+        iosHealth.recheckedTypes,
+        isNot(contains(HealthDataType.BODY_FAT_PERCENTAGE)),
+      );
+    });
+  });
+
+  // Play's Health Connect permissions policy refused this app READ_BODY_FAT,
+  // READ_DISTANCE and READ_STEPS as excessive for the features it offers
+  // (enforced 8 Sept 2026). The app may ask for nothing beyond exercise and
+  // total calories on Android, and these are the tests that say so.
+  group('Android asks for no more than the policy allows', () {
+    late _FakeHealth health;
+    late HealthPackageService service;
+
+    setUp(() {
+      health = _FakeHealth()..workoutPermissions = true;
+      service = HealthPackageService(
+        health,
+        workoutReader: _FakeWorkoutReader(),
+        platform: HealthTargetPlatform.android,
+      );
+    });
+
+    test('the permission request covers exercise and calories, and '
+        'nothing else', () async {
+      await service.requestPermissions();
+
+      expect(health.requestedTypes, [
+        HealthDataType.WORKOUT,
+        HealthDataType.TOTAL_CALORIES_BURNED,
+      ]);
+    });
+
+    test('the three refused types are never requested', () async {
       await service.requestPermissions();
 
       expect(
         health.requestedTypes,
-        contains(HealthDataType.BODY_FAT_PERCENTAGE),
+        isNot(
+          anyElement(
+            isIn([
+              HealthDataType.BODY_FAT_PERCENTAGE,
+              HealthDataType.DISTANCE_DELTA,
+              HealthDataType.STEPS,
+            ]),
+          ),
+        ),
       );
-      expect(health.recheckedTypes, contains(HealthDataType.WORKOUT));
+    });
+
+    test('body fat is not read, and answers null rather than throwing',
+        () async {
+      expect(await service.readLatestBodyFatPercent(), isNull);
+      expect(health.queriedTypes, isEmpty);
+    });
+  });
+
+  group('HealthPackageService.readWorkouts on Android', () {
+    late _FakeHealth health;
+    late _FakeWorkoutReader reader;
+    late HealthPackageService service;
+
+    final from = DateTime(2026, 8, 13);
+    final to = DateTime(2026, 8, 14);
+    final sessionStart = DateTime(2026, 8, 13, 18, 0);
+    final sessionEnd = DateTime(2026, 8, 13, 19, 0);
+
+    setUp(() {
+      health = _FakeHealth()..workoutPermissions = true;
+      reader = _FakeWorkoutReader();
+      service = HealthPackageService(
+        health,
+        workoutReader: reader,
+        platform: HealthTargetPlatform.android,
+      );
+    });
+
+    test('sessions come from Health Connect directly, never from the '
+        'plugin\'s workout read', () async {
+      reader.sessions = [
+        ExternalWorkout(
+          id: 'session-1',
+          start: sessionStart,
+          end: sessionEnd,
+          activityTypeName: 'RUNNING',
+          sourceAppName: 'com.hevy.app',
+        ),
+      ];
+
+      await service.readWorkouts(from: from, to: to);
+
+      expect(reader.calls, 1);
+      // The only plugin read left is the calorie one.
+      expect(health.queriedTypes, [
+        [HealthDataType.TOTAL_CALORIES_BURNED],
+      ]);
+    });
+
+    test('energy is attributed to the session from the calorie records',
+        () async {
+      reader.sessions = [
+        ExternalWorkout(
+          id: 'session-1',
+          start: sessionStart,
+          end: sessionEnd,
+          activityTypeName: 'RUNNING',
+          sourceAppName: 'com.hevy.app',
+        ),
+      ];
+      health.dataPoints = [
+        _calories(source: 'com.hevy.app', start: sessionStart, kcal: 430.3),
+        _calories(
+          source: 'com.fitbit.FitbitMobile',
+          start: sessionStart,
+          kcal: 170,
+        ),
+      ];
+
+      final workouts = await service.readWorkouts(from: from, to: to);
+
+      expect(workouts, hasLength(1));
+      expect(workouts.single.id, 'session-1');
+      expect(workouts.single.activityTypeName, 'RUNNING');
+      expect(workouts.single.energyBurnedKcal, closeTo(430.3, 0.001));
+      expect(workouts.single.sourceAppName, 'com.hevy.app');
+    });
+
+    test('no sessions means the calorie records are never read', () async {
+      reader.sessions = const [];
+
+      expect(await service.readWorkouts(from: from, to: to), isEmpty);
+      expect(health.queriedTypes, isEmpty);
+    });
+
+    test('a definite refusal still aborts before any read', () async {
+      health.workoutPermissions = false;
+
       expect(
-        health.recheckedTypes,
-        isNot(contains(HealthDataType.BODY_FAT_PERCENTAGE)),
+        () => service.readWorkouts(from: from, to: to),
+        throwsStateError,
       );
+      expect(reader.calls, 0);
     });
   });
 }


### PR DESCRIPTION
Unblocks the 2.3.0 submission.

## What Play said

**Health Connect permissions policy — "excessive data access for declared functionality."** The review found three permissions unjustified by the app's features:

- `BodyFat`
- `Distance`
- `StepsCadence/Steps`

Enforced **8 Sept 2026**; 2.2.0 stays live, the update is blocked.

## Why two of them were there

Not for a feature. The `health` plugin's `handleWorkoutData` issues a `DistanceRecord` and a `StepsRecord` read for **every session it returns**, and Health Connect answers an ungranted read with a `SecurityException` that takes the whole workout query with it. So `READ_DISTANCE` and `READ_STEPS` existed to satisfy a library, and their values were fetched and discarded — `ExternalWorkout` has no distance or steps field, and energy is attributed from the raw calorie records by `androidWorkoutEnergyKcal`.

That code is identical in 13.3.2, so bumping the plugin does not help.

## What changed

The session read moves out of the plugin. A method channel over `androidx.health.connect` reads `ExerciseSessionRecord` directly — paged to exhaustion, which the plugin does not do — and everything the import consumes (id, start, end, activity type, writing app) is on that record. The calorie read stays with the plugin, needing only `READ_TOTAL_CALORIES_BURNED`.

Exercise type is mapped **type-to-name** rather than the plugin's name-to-type. Three Health Connect types are the target of several names (dancing, skiing, wheelchair) and the plugin resolves those by taking the first key out of a `hashMapOf`, which is an arbitrary choice that can differ between runs. Naming the canonical spelling makes it deterministic and picks the one the compendium table carries. Four types the plugin never mapped (`SOCCER`, `BIKING_STATIONARY`, `ICE_HOCKEY`, `STRETCHING`) now resolve instead of falling through to a custom activity.

`READ_BODY_FAT` personalised the workout calorie-credit suggestion. That already fell back to a BMI-derived percentile for anyone whose health store held no body fat on record; Android now always takes that path. HealthKit is not subject to this policy and still reads it.

`HealthPackageService` takes its platform by injection rather than reading `Platform` directly, so both branches are exercisable from a host test.

## Guard

`health_connect_permissions_test.dart` fails if any of the three reappears, or if any health permission beyond the two shows up — which also catches a plugin merging one in. Nothing else would: `android-deploy` tolerates a failed Play upload by design (#942), and the next thing to inspect the declaration is a human reviewer, days later.

## Verification

- `flutter test` — 2205 pass
- `flutter analyze lib test` — clean
- `flutter build apk --flavor develop` — builds (needs `flutter clean` first if you switched from a branch on `health 13.1.4`; a stale Kotlin cache produces spurious errors inside the plugin module)
- **merged** manifest — `READ_EXERCISE` and `READ_TOTAL_CALORIES_BURNED`, nothing else

## Not in this PR

- **The Health apps declaration in the Play Console** has to be brought in line with the two-permission set. It predates any health permission in the app, and no code change clears the enforcement.
- **The prominent-disclosure text** still tells Android users the app reads body fat. Over-disclosure, so not a policy violation, but user-visible nonsense — and it touches nine translated consent strings, so it is a separate pass.
- **`docs/play-data-safety.md`** is included as the record of the Data safety answers, which are Console-only and unrelated to this rejection.
- **`develop` will need this too** — it does not contain `release/2.3.0`.