### PR TITLE
chore(release): bump to 2.3.0+65 and add the build 65 note

### DIFF
--- a/fastlane/metadata/android/en-US/changelogs/65.txt
+++ b/fastlane/metadata/android/en-US/changelogs/65.txt
@@ -1,0 +1,5 @@
+- Add several items: bad rows are all flagged at once, each with the reason, and a photo that fails to attach offers the retry its message promises
+- AI setup you change is picked up as soon as you come back to the list
+- Your data export now includes photos attached to logged meals, not only saved ones
+- Updated the libraries underneath, including secure storage, file picking and sharing
+- Health sync now asks only for your finished workouts and their energy, not body fat, distance or steps

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -15,7 +15,7 @@ publish_to: 'none' # Remove this line if you wish to publish to pub.dev
 # In iOS, build-name is used as CFBundleShortVersionString while build-number is used as CFBundleVersion.
 # Read more about iOS versioning at
 # https://developer.apple.com/library/archive/documentation/General/Reference/InfoPlistKeyReference/Articles/CoreFoundationKeys.html
-version: 2.3.0+64
+version: 2.3.0+65
 
 environment:
   sdk: '>=3.11.0 <4.0.0'


### PR DESCRIPTION
Build **64 is spent**. It was submitted and rejected under Play's Health Connect permissions policy (excessive data access — `BodyFat`, `Distance`, `StepsCadence/Steps`, enforced 8 Sept 2026), and Play refuses a reused version code. `release-gate` independently refuses a build number that does not increase.

So `2.3.0+64` → `2.3.0+65`, same version name.

## The release note

`65.txt` carries `64.txt`'s four lines **unchanged** — build 64 never reached anyone, so its notes are still unread — plus one line for the change users will actually notice:

> - Health sync now asks only for your finished workouts and their energy, not body fat, distance or steps

The Health Connect grant sheet drops from five rows to two, which is worth saying plainly rather than leaving as a silent difference.

**496 characters**, inside Play's 500 cap. `store_declarations_test.dart` enforces that — the same test that exists because `63.txt` was 628 characters and would have been refused at paste time.

## Ships with

- #1122 — the permission fix itself, into this branch
- #1123 — the same commit into `develop`

This PR is deliberately separate from those, matching #1114 (`chore(release): bump to 2.3.0+64`) and the release checklist in `docs/RELEASING.md`, which treats the bump as its own step. It touches only `pubspec.yaml` and the new changelog, so it merges independently of the fix.

## Before resubmitting

`docs/RELEASING.md` warns that a deploy job records a build as spent even when the upload fails, and that re-running all jobs after a deploy failure strands the release. Worth confirming in the Console which version code Play actually consumed — there are no `deployed/*` tags in the repo to read it from.