### PR TITLE
chore(release): bump to 2.3.0+65 and add the build 65 note (develop)

### DIFF
--- a/fastlane/metadata/android/en-US/changelogs/65.txt
+++ b/fastlane/metadata/android/en-US/changelogs/65.txt
@@ -1,0 +1,5 @@
+- Add several items: bad rows are all flagged at once, each with the reason, and a photo that fails to attach offers the retry its message promises
+- AI setup you change is picked up as soon as you come back to the list
+- Your data export now includes photos attached to logged meals, not only saved ones
+- Updated the libraries underneath, including secure storage, file picking and sharing
+- Health sync now asks only for your finished workouts and their energy, not body fat, distance or steps

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -15,7 +15,7 @@ publish_to: 'none' # Remove this line if you wish to publish to pub.dev
 # In iOS, build-name is used as CFBundleShortVersionString while build-number is used as CFBundleVersion.
 # Read more about iOS versioning at
 # https://developer.apple.com/library/archive/documentation/General/Reference/InfoPlistKeyReference/Articles/CoreFoundationKeys.html
-version: 2.3.0+64
+version: 2.3.0+65
 
 environment:
   sdk: '>=3.11.0 <4.0.0'


### PR DESCRIPTION
Backport of #1124 to `develop`. **Not a duplicate** — `develop` does not contain `release/2.3.0`, so #1124 does not reach it, and `develop` would otherwise sit on the spent `2.3.0+64`. Clean cherry-pick; `git range-diff` reports the two patches as identical.

Build 64 was submitted and rejected under Play's Health Connect permissions policy, so its version code is spent. `2.3.0+64` → `2.3.0+65`.

`65.txt` keeps build 64's four lines — 64 never reached anyone — plus a line for the permission change users will see. 496 characters, inside Play's 500 cap; `store_declarations_test.dart` passes.

## The set

| PR | Base | What |
|---|---|---|
| #1122 | `release/2.3.0` | the permission fix |
| #1123 | `develop` | same commit |
| #1124 | `release/2.3.0` | the bump |
| this | `develop` | same bump |

All four need to land: the release branch to unblock the resubmission, `develop` so the next release does not regress either change.