### PR TITLE
fix(test): let the permission guard see plugin manifests

### DIFF
--- a/test/unit_test/health_connect_permissions_test.dart
+++ b/test/unit_test/health_connect_permissions_test.dart
@@ -25,8 +25,21 @@ void main() {
     'android/app/src/main/AndroidManifest.xml',
   ).readAsStringSync();
 
+  /// Matches a Health Connect `uses-permission` however it is spelled.
+  ///
+  /// Attribute order and quote style are free in XML, and both occur in the
+  /// wild: `<uses-permission android:maxSdkVersion="32" android:name="…"/>`
+  /// is merged by Gradle exactly like the canonical spelling. A pattern that
+  /// insisted on `android:name` coming first would stay green while the
+  /// release acquired the permission.
+  ///
+  /// Not handled, and not worth a parser: a manifest binding the Android
+  /// namespace to an alias other than `android:`. No plugin in the wild does
+  /// that, and the only robust fix is structural XML parsing, which would
+  /// mean promoting `xml` from a transitive dependency to a declared one.
   final healthPermission = RegExp(
-    r'<uses-permission\s+android:name="android\.permission\.health\.([A-Z_]+)"',
+    r'''<uses-permission\b[^>]*?\bandroid:name\s*=\s*'''
+    r'''["']android\.permission\.health\.([A-Z_]+)["']''',
   );
 
   /// Every `android.permission.health.*` the app manifest declares.
@@ -63,10 +76,14 @@ void main() {
         as Map<String, dynamic>)['android'] as List<dynamic>;
     for (final plugin in plugins.cast<Map<String, dynamic>>()) {
       final root = (plugin['path'] as String).replaceAll(RegExp(r'/+$'), '');
-      final sourceSets = Directory('$root/android/src');
-      if (!sourceSets.existsSync()) continue;
-      for (final entry in sourceSets.listSync().whereType<Directory>()) {
-        final pluginManifest = File('${entry.path}/AndroidManifest.xml');
+      // Only the source sets Gradle merges into a release build. `debug`,
+      // `profile` and `androidTest` never reach the uploaded artifact, so a
+      // permission a plugin declares there is not a Play problem — failing on
+      // it would be a false alarm, and the app's own debug/profile manifests
+      // are excluded for the same reason.
+      for (final sourceSet in const ['main', 'release']) {
+        final pluginManifest =
+            File('$root/android/src/$sourceSet/AndroidManifest.xml');
         if (!pluginManifest.existsSync()) continue;
         pluginManifestsRead++;
         final found = healthPermission

--- a/test/unit_test/health_connect_permissions_test.dart
+++ b/test/unit_test/health_connect_permissions_test.dart
@@ -46,23 +46,38 @@ void main() {
   /// writes and `.gitignore` excludes. If it is absent the plugin half checks
   /// nothing, so its absence fails a test of its own rather than passing
   /// quietly — a silent pass is the failure mode this file exists to prevent.
+  ///
+  /// Every source set is read, not just `src/main`: Gradle merges a variant
+  /// overlay such as `android/src/release/AndroidManifest.xml` into the
+  /// production manifest, so a permission declared only there would ship
+  /// while a `src/main`-only check stayed green. No plugin here has a
+  /// non-`main` source set today, which is when a guard is worth adding
+  /// rather than after it is needed.
   final pluginList = File('.flutter-plugins-dependencies');
   final pluginListPresent = pluginList.existsSync();
   final pluginPermissions = <String, Set<String>>{};
+  var pluginManifestsRead = 0;
   if (pluginListPresent) {
     final plugins = ((jsonDecode(pluginList.readAsStringSync())
             as Map<String, dynamic>)['plugins']
         as Map<String, dynamic>)['android'] as List<dynamic>;
     for (final plugin in plugins.cast<Map<String, dynamic>>()) {
       final root = (plugin['path'] as String).replaceAll(RegExp(r'/+$'), '');
-      final pluginManifest = File('$root/android/src/main/AndroidManifest.xml');
-      if (!pluginManifest.existsSync()) continue;
-      final found = healthPermission
-          .allMatches(pluginManifest.readAsStringSync())
-          .map((m) => m.group(1)!)
-          .toSet();
-      if (found.isNotEmpty) {
-        pluginPermissions[plugin['name'] as String] = found;
+      final sourceSets = Directory('$root/android/src');
+      if (!sourceSets.existsSync()) continue;
+      for (final entry in sourceSets.listSync().whereType<Directory>()) {
+        final pluginManifest = File('${entry.path}/AndroidManifest.xml');
+        if (!pluginManifest.existsSync()) continue;
+        pluginManifestsRead++;
+        final found = healthPermission
+            .allMatches(pluginManifest.readAsStringSync())
+            .map((m) => m.group(1)!)
+            .toSet();
+        if (found.isNotEmpty) {
+          pluginPermissions
+              .putIfAbsent(plugin['name'] as String, () => <String>{})
+              .addAll(found);
+        }
       }
     }
   }
@@ -105,15 +120,23 @@ void main() {
       );
     });
 
-    test('the plugin list is available, so the plugin half checked something',
-        () {
+    test('plugin manifests were actually inspected', () {
+      // Not just "the list exists": if the paths in it resolved to nothing,
+      // pluginPermissions would be empty and the plugin test below would pass
+      // having read no files at all. Assert the work happened.
       expect(
         pluginListPresent,
         isTrue,
         reason:
-            '.flutter-plugins-dependencies is missing, so no plugin manifest '
-            'was inspected and the plugin half of this guard passed without '
-            'checking anything. Run `flutter pub get` first; CI already does.',
+            '.flutter-plugins-dependencies is missing. Run `flutter pub get` '
+            'first; CI already does.',
+      );
+      expect(
+        pluginManifestsRead,
+        greaterThan(0),
+        reason:
+            'The plugin list resolved to no readable manifests, so the plugin '
+            'half of this guard passed without checking anything.',
       );
     });
 

--- a/test/unit_test/health_connect_permissions_test.dart
+++ b/test/unit_test/health_connect_permissions_test.dart
@@ -1,3 +1,4 @@
+import 'dart:convert';
 import 'dart:io';
 
 import 'package:flutter_test/flutter_test.dart';
@@ -24,10 +25,47 @@ void main() {
     'android/app/src/main/AndroidManifest.xml',
   ).readAsStringSync();
 
-  /// Every `android.permission.health.*` the manifest declares.
-  final declared = RegExp(
+  final healthPermission = RegExp(
     r'<uses-permission\s+android:name="android\.permission\.health\.([A-Z_]+)"',
-  ).allMatches(manifest).map((match) => match.group(1)!).toSet();
+  );
+
+  /// Every `android.permission.health.*` the app manifest declares.
+  final declared =
+      healthPermission.allMatches(manifest).map((m) => m.group(1)!).toSet();
+
+  /// The same, per plugin, from each plugin's own manifest.
+  ///
+  /// Gradle merges plugin manifests into the application manifest, so a
+  /// plugin declaring `android.permission.health.*` puts it in the APK and in
+  /// front of Play's reviewer without it ever appearing in
+  /// `android/app/src/main/AndroidManifest.xml`. Reading only the app
+  /// manifest cannot see that — so the first of the two regressions named
+  /// above was claimed but not actually covered until this was added.
+  ///
+  /// Paths come from `.flutter-plugins-dependencies`, which `flutter pub get`
+  /// writes and `.gitignore` excludes. If it is absent the plugin half checks
+  /// nothing, so its absence fails a test of its own rather than passing
+  /// quietly — a silent pass is the failure mode this file exists to prevent.
+  final pluginList = File('.flutter-plugins-dependencies');
+  final pluginListPresent = pluginList.existsSync();
+  final pluginPermissions = <String, Set<String>>{};
+  if (pluginListPresent) {
+    final plugins = ((jsonDecode(pluginList.readAsStringSync())
+            as Map<String, dynamic>)['plugins']
+        as Map<String, dynamic>)['android'] as List<dynamic>;
+    for (final plugin in plugins.cast<Map<String, dynamic>>()) {
+      final root = (plugin['path'] as String).replaceAll(RegExp(r'/+$'), '');
+      final pluginManifest = File('$root/android/src/main/AndroidManifest.xml');
+      if (!pluginManifest.existsSync()) continue;
+      final found = healthPermission
+          .allMatches(pluginManifest.readAsStringSync())
+          .map((m) => m.group(1)!)
+          .toSet();
+      if (found.isNotEmpty) {
+        pluginPermissions[plugin['name'] as String] = found;
+      }
+    }
+  }
 
   group('Health Connect permissions', () {
     test('exercise and total calories are declared', () {
@@ -54,8 +92,9 @@ void main() {
     });
 
     test('no health permission is declared beyond those two', () {
-      // Catches a plugin quietly merging one in, and catches a new read being
-      // added without the declaration form being updated to match.
+      // Catches a new read added here without the declaration form being
+      // updated to match. A plugin merging one in never reaches this set —
+      // that is the separate plugin test below.
       expect(
         declared,
         {'READ_EXERCISE', 'READ_TOTAL_CALORIES_BURNED'},
@@ -63,6 +102,33 @@ void main() {
             'Every declared Health Connect permission has to be justified by '
             'a feature in the Play Console declaration form. Adding one here '
             'without updating that form is what gets an update rejected.',
+      );
+    });
+
+    test('the plugin list is available, so the plugin half checked something',
+        () {
+      expect(
+        pluginListPresent,
+        isTrue,
+        reason:
+            '.flutter-plugins-dependencies is missing, so no plugin manifest '
+            'was inspected and the plugin half of this guard passed without '
+            'checking anything. Run `flutter pub get` first; CI already does.',
+      );
+    });
+
+    test('no plugin merges a health permission into the manifest', () {
+      expect(
+        pluginPermissions,
+        isEmpty,
+        reason:
+            'Gradle merges plugin manifests into the application manifest, so '
+            'a permission declared there reaches the APK and Play without '
+            'appearing in android/app/src/main/AndroidManifest.xml. If a '
+            'plugin genuinely needs one, the Play Console declaration has to '
+            'cover it first — the health plugin wanting READ_DISTANCE and '
+            'READ_STEPS for its own workout path is precisely why this app '
+            'reads ExerciseSessionRecord itself.',
       );
     });
 


### PR DESCRIPTION
Develop twin of the same commit on the 2.3.0 release PR (#1117), from a Codex finding there. Both lines need it; they are not duplicates.

## The gap

`test/unit_test/health_connect_permissions_test.dart` read only
`android/app/src/main/AndroidManifest.xml`, while its own docstring named
"a Flutter plugin that merges its own `uses-permission` into the manifest" as
one of two regressions it covers and stated **"Both show up here."**

Gradle merges plugin manifests into the application manifest, so a permission
declared by a plugin reaches the APK and Play’s reviewer without ever
appearing in the app manifest. That half was claimed, not implemented. A
comment on the "beyond those two" test made the same claim and is corrected
to point at the new test.

## The fix

Plugin manifests are now read too, via the paths in
`.flutter-plugins-dependencies`, and any `android.permission.health.*` found
in one fails with the plugin named. `flutter test` regenerates that file
before running, so the guard always sees the real dependency set; its absence
fails a test of its own rather than passing quietly.

## Verified by making it fail

Adding `READ_DISTANCE` to a real cached plugin manifest fails the guard with:

```
Actual: {"android_file_picker": Set:["READ_DISTANCE"]}
```

and it passes again once removed.

Worth recording that the first attempt to prove this **proved nothing**:
appending a fake plugin to `.flutter-plugins-dependencies` looked like a
clean pass, because `flutter test` regenerates that file and wiped the edit
before the test read it. A guard that cannot be shown to fail is the bug
being fixed here, so the negative case was re-run against something Flutter
does not overwrite.

## Why it matters here rather than in the abstract

Build 64 was rejected under Play’s Health Connect permissions policy for
exactly these permissions. The `health` plugin needing `READ_DISTANCE` and
`READ_STEPS` for its own workout path is why this app reads
`ExerciseSessionRecord` itself — so a plugin bump is a live route back to
that rejection, and today no dependency declares one, which is precisely when
a guard is worth having.

No production code changes.