### PR TITLE
fix(ci): the ledger tag is not proof Play took the bundle

### DIFF
--- a/.github/workflows/default_workflow.yml
+++ b/.github/workflows/default_workflow.yml
@@ -2046,13 +2046,26 @@ jobs:
               # spent when it is not costs them a pointless version bump;
               # telling them it is free when it is not costs a rejected
               # upload at both stores.
+              #
+              # One case where the tag is NOT proof of consumption, and it is
+              # the common one here: when Play refuses the bundle with the
+              # known health-declaration defect (#942), `android-deploy`
+              # tolerates it, sets `play_uploaded=false` and goes green — and
+              # the ledger step is the unconditional last step of the job, so
+              # the tag is written anyway. Play never took the bundle. The tag
+              # then only means "some deploy job reached its final step",
+              # which is why `play_uploaded` has to be read alongside it.
               if [ -z "$ledger_advice" ]; then
                 set +e
                 git ls-remote --exit-code --tags origin "refs/tags/deployed/$BUILD_NUMBER" >/dev/null 2>&1
                 ls_status=$?
                 set -e
                 case "$ls_status" in
-                  0) ledger_advice="A store has already consumed build $BUILD_NUMBER (deployed/$BUILD_NUMBER exists), so it cannot be uploaded again — bump the build number and ship afresh." ;;
+                  0) if [ "${PLAY_UPLOADED:-}" = false ]; then
+                       ledger_advice="deployed/$BUILD_NUMBER exists, but Play REJECTED this bundle (#942) and android-deploy recorded the ledger anyway, so the tag does not prove Play consumed the number. Whether it is spent turns on iOS alone: if ios-deploy reached TestFlight the number is gone and you must bump; if it did not, nothing consumed build $BUILD_NUMBER and it can be retried. Check TestFlight for build $BUILD_NUMBER before deciding."
+                     else
+                       ledger_advice="A store has already consumed build $BUILD_NUMBER (deployed/$BUILD_NUMBER exists), so it cannot be uploaded again — bump the build number and ship afresh."
+                     fi ;;
                   2) ledger_advice="No store consumed build $BUILD_NUMBER (deployed/$BUILD_NUMBER does not exist), so it can be retried as it stands." ;;
                   *) ledger_advice="Could not read the ledger from origin (git ls-remote exit $ls_status), so whether build $BUILD_NUMBER is spent is unknown. Check deployed/$BUILD_NUMBER by hand before retrying." ;;
                 esac


### PR DESCRIPTION
Develop twin of the same commit on the 2.3.0 release PR (#1117), from a Codex finding there. Both lines carry the block; they are not duplicates.

## The defect

The release summary read `deployed/<n>` as "a store consumed this build" and told the operator to bump the version. True for iOS. **Not true for Android.**

When Play refuses the bundle with the known health-declaration defect (#942), `android-deploy` tolerates it, sets `play_uploaded=false` and goes green. The ledger step is the **unconditional last step** of that job — no `if:` — so `deployed/<n>` is written even though Play never took the bundle.

If `ios-deploy` then failed before reaching TestFlight, **no store consumed the number**, and the summary told the operator it was spent and to ship afresh. That burns a version code on the exact defect this pipeline already tolerates by design, so it is the likely path rather than a corner case.

## The fix

`play_uploaded` was already passed into this step, so it is now read alongside the tag. When Play rejected, the advice says what the tag actually proves — that some deploy job reached its final step — states that the answer turns on whether iOS reached TestFlight, and says to check that before deciding.

Unset `play_uploaded` (android-deploy skipped entirely) keeps the previous conservative wording: a skipped Android job cannot have written the tag on a rejection path.

## Verification

Exercised all three `git ls-remote` outcomes against `play_uploaded` of `true`, `false` and empty — nine combinations, each producing the right advice — and re-extracted the step from the YAML and checked it with `bash -n`.

No behaviour changes to any deploy job; this only changes what the summary tells a human to do.