### PR TITLE
fix(health): five review findings from #1122, #1128 and #1132

### DIFF
--- a/android/app/src/main/kotlin/com/opennutritracker/ont/opennutritracker/HealthConnectWorkoutReader.kt
+++ b/android/app/src/main/kotlin/com/opennutritracker/ont/opennutritracker/HealthConnectWorkoutReader.kt
@@ -87,9 +87,9 @@ object HealthConnectWorkoutReader {
      * deterministic, and picks the spelling the compendium table actually
      * carries.
      *
-     * A type absent from this table is reported by its Health Connect name if
-     * the import can use it and otherwise becomes a custom activity, which is
-     * what an unmapped type did before too.
+     * A type absent from this table is reported as "OTHER", which the import
+     * does not find in its compendium and turns into a custom activity named
+     * "Other" — the same thing an unmapped type did through the plugin.
      */
     private fun exerciseTypeName(exerciseType: Int): String = when (exerciseType) {
         ExerciseSessionRecord.EXERCISE_TYPE_FOOTBALL_AMERICAN -> "AMERICAN_FOOTBALL"

--- a/android/app/src/main/kotlin/com/opennutritracker/ont/opennutritracker/MainActivity.kt
+++ b/android/app/src/main/kotlin/com/opennutritracker/ont/opennutritracker/MainActivity.kt
@@ -7,6 +7,7 @@ import android.os.LocaleList
 import io.flutter.embedding.android.FlutterFragmentActivity
 import io.flutter.embedding.engine.FlutterEngine
 import io.flutter.plugin.common.MethodChannel
+import kotlinx.coroutines.CancellationException
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.SupervisorJob
@@ -93,6 +94,14 @@ class MainActivity : FlutterFragmentActivity() {
                                         to,
                                     ),
                                 )
+                            } catch (e: CancellationException) {
+                                // The activity went away mid-read and
+                                // [onDestroy] cancelled the scope. Cancellation
+                                // is control flow, not a failure: rethrow it so
+                                // the coroutine actually ends, rather than
+                                // catching it below and answering a channel
+                                // whose engine is gone.
+                                throw e
                             } catch (e: SecurityException) {
                                 // A revoked grant. Distinguished from the rest
                                 // so Dart can tell the user to re-grant instead

--- a/docs/play-data-safety.md
+++ b/docs/play-data-safety.md
@@ -18,9 +18,9 @@ Read off the public listing on 2026-09-08
 |---|---|
 | **Shared** | App activity → In-app search history |
 | **Collected** | App info and performance → Crash logs, Diagnostics<br>Location → Approximate location |
-| **Security** | Data is encrypted in transit · **Data can't be deleted** |
+| **Security** | Data is encrypted in transit · Data can't be deleted |
 
-## The four things that are wrong
+## The three things that are wrong
 
 ### 1. In-app search history is shared but not collected
 
@@ -71,13 +71,36 @@ activity entry does not cover it.
 A meal description is not Health and fitness data — that category is medical
 records, symptoms and exercise, not what someone ate.
 
-### 4. "Data can't be deleted" contradicts the app
+## "Data can't be deleted": leave it alone unless something changes
 
-The app has a delete-all-user-data path (Settings → delete all data), and
-`DeleteAllUserDataUsecase.deleteAll()` wipes every Hive box including the
-config.
+An earlier version of this file said this answer contradicted the app, because
+Settings offers a delete-all path. That was wrong, and acting on it would have
+put a false claim on the form — so the reasoning is kept here rather than
+quietly removed.
 
-> **Set:** the deletion answer to reflect that in-app deletion exists.
+Play's deletion question is about **collected** data, and "collected" means
+data that left the device. `DeleteAllUserDataUsecase.deleteAll()`
+(`lib/core/domain/usecase/delete_all_user_data_usecase.dart`) is a local reset:
+it stops the scheduled notification, closes Sentry, clears the **active
+profile's** eight Hive boxes, and clears the device-wide AI credential store.
+It deliberately leaves the shared content libraries and shared settings alone,
+because those belong to every profile. Most importantly it sends **no deletion
+request to anyone**.
+
+Nothing in the app can delete what has already gone off-device:
+
+| Recipient | What reached it | Deletable from the app? |
+|---|---|---|
+| Sentry | crash reports, kept 30 days per the policy | no |
+| AI provider (OpenAI / Anthropic / OpenRouter / own server) | meal photo, meal text | no |
+| Open Food Facts | search terms, scanned barcodes | no |
+| Supabase food backend | search terms | no |
+
+So the live answer is defensible as it stands. Changing it to "users can
+request deletion" would need an actual deletion route — a documented contact
+that reaches those recipients, or a data path that stops sending to them —
+not the local wipe. If that route is ever built, revisit this and #1050
+together.
 
 ## Health and fitness: unchanged, and deliberately
 

--- a/lib/l10n/intl_en.arb
+++ b/lib/l10n/intl_en.arb
@@ -1347,7 +1347,7 @@
   "@healthSyncDisclosureTitle": {"placeholders": {"platform": {"type": "String"}}},
   "healthSyncDisclosureBody": "OpenNutriTracker will read your finished workouts from {platform} — their type, when they happened, how long they lasted and the energy they report.\n\nWorkouts are filed in your diary as activities you can edit or delete, and the energy they report raises that day's calorie goal by a share you choose.",
   "@healthSyncDisclosureBody": {"placeholders": {"platform": {"type": "String"}}},
-  "healthSyncDisclosureBodyFatAddendum": "OpenNutriTracker also reads the most recent body fat percentage {platform} holds. The body fat reading is used to suggest what that share should be.",
+  "healthSyncDisclosureBodyFatAddendum": "OpenNutriTracker will also read the most recent body fat percentage that {platform} holds. The body fat reading is used to suggest what that share should be.",
   "@healthSyncDisclosureBodyFatAddendum": {"placeholders": {"platform": {"type": "String"}}},
   "healthSyncDisclosureFooter": "Nothing is written back to {platform}, and none of it is sent anywhere — it stays on this device.\n\nYou can turn this off at any time, and doing so stops any further reading.",
   "@healthSyncDisclosureFooter": {"placeholders": {"platform": {"type": "String"}}},

--- a/test/features/settings/presentation/widgets/health_sync_screen_test.dart
+++ b/test/features/settings/presentation/widgets/health_sync_screen_test.dart
@@ -368,6 +368,11 @@ void main() {
   // The dialog composes these the same way, gated on [healthStoreReadsBodyFat];
   // composing them here rather than pumping the widget is what lets one test
   // cover both platforms, since the host is neither.
+  //
+  // Composing them here does NOT check that the dialog composes them the same
+  // way — with the gate and the ordering living in `_body`, every assertion
+  // below passed against a build whose gate had been deleted outright. The
+  // rendered-output test that follows this group is what closes that.
   group('the disclosure covers what it has to cover', () {
     final base = l10nEn.healthSyncDisclosureBody(healthPlatformName);
     final addendum = l10nEn.healthSyncDisclosureBodyFatAddendum(
@@ -440,6 +445,40 @@ void main() {
         reason:
             'body fat is not what an import needs, so it is not what a '
             'failed import should ask for',
+      );
+    });
+
+    // The gate and the paragraph order live in `HealthDisclosureDialog._body`,
+    // and the assertions above re-implement that composition instead of
+    // observing it — so they hold even if `_body` stops doing it. This asserts
+    // the text a user is actually shown.
+    //
+    // The host is not iOS, so this exercises the Android branch: exactly the
+    // one Play refused READ_BODY_FAT for, and the one where claiming to read
+    // body fat would be wrong. The iOS branch stays unreachable from a host
+    // test until the gate is injectable.
+    testWidgets('the dialog renders the composition it claims to', (
+      tester,
+    ) async {
+      storeConfig(healthImportEnabled: false);
+      healthImportRepository.granted = true;
+
+      await pumpScreen(tester);
+      await tester.tap(_byIdentifier('health-sync-auto-import'));
+      await tester.pumpAndSettle();
+
+      expect(find.byType(HealthDisclosureDialog), findsOneWidget);
+      expect(
+        find.text(withoutBodyFat),
+        findsOneWidget,
+        reason:
+            'the rendered disclosure must be base + footer, in that order, '
+            'with no body-fat paragraph on a store that is not asked for it',
+      );
+      expect(
+        find.text(withBodyFat),
+        findsNothing,
+        reason: 'the body-fat paragraph must not survive the gate here',
       );
     });
   });


### PR DESCRIPTION
Copilot and an internal review of #1132 converged on the same set of findings. Three are defects in what #1123 shipped; two are the #1132 nits. The `release/2.3.0` half is in #1132.

## Not here on purpose

The sixth finding — the permission guard that could not see a plugin merging its own `uses-permission` in — is **#1131's**, and #1131's fix is the better one: it reads each plugin's manifest from `.flutter-plugins-dependencies`, so it needs no Android build and has teeth in `linux-checks`. This branch leaves `health_connect_permissions_test.dart` untouched so the two do not collide.

## What is here

| Finding | Fix |
| :-- | :-- |
| **Wrong deletion advice** (P1) | `docs/play-data-safety.md` said to flip Play's "data can't be deleted" answer because Settings offers a delete-all. Wrong twice over — see below. |
| **Swallowed coroutine cancellation** (P2) | `MainActivity` caught `Exception`, which also catches `CancellationException`. |
| **KDoc contradicts the code** | `HealthConnectWorkoutReader` said an unmapped type is reported by its Health Connect name; the `else` branch returns `"OTHER"`. |
| **Untested disclosure gate** | The dialog's composition had no test. |
| **English tense** | `"also reads"` against the body's `"will read"`. |

### The deletion advice was the worst of them

`DeleteAllUserDataUsecase.deleteAll()` clears the **active profile's** eight boxes and *deliberately* leaves the shared content libraries and settings, and it sends **no deletion request to anyone**. Play's question is about *collected* — off-device — data, and nothing in the app can delete what already reached Sentry (30-day retention), an AI provider, Open Food Facts or the Supabase backend.

Following the old advice would have put a claim on the Data safety form the app cannot honour. The section now says leave the answer alone, tabulates the four recipients, and states what a real deletion route would have to be. The wrong reasoning is kept rather than quietly removed, so it is not re-derived.

### The gate test was worth having

The old assertions re-implemented `_body` instead of observing it. Mutation-tested on this branch:

- delete the `if (healthStoreReadsBodyFat)` gate, so **every Android user is told their body fat is read** → suite stayed green
- drop the footer entirely, losing "nothing is written back" and "stays on this device" → suite stayed green

Both now fail against the new widget test, which asserts the *rendered* text. The host is not iOS, so it exercises the Android branch — the one Play refused `READ_BODY_FAT` for.

## Verified

- `flutter test` — 2213 pass
- `flutter analyze lib test` — clean
- `flutter gen-l10n` → `l10n_untranslated.json` is `{}`
- APK builds (`GRADLE_EXIT=0`), which is what exercises the `CancellationException` import