### PR TITLE
fix(store): two declarations that understated what leaves the device

### DIFF
--- a/fastlane/metadata/android/en-US/full_description.txt
+++ b/fastlane/metadata/android/en-US/full_description.txt
@@ -1,8 +1,8 @@
 OpenNutriTracker is a calorie counter and food diary with no account, no subscription and no ads — for losing weight or keeping a balanced diet. Open source, and your diary stays on your device.
 
 
-🚫💰 No subscriptions, purchases or ads: no paid tier, no advertising.
-🔒 Privacy first: No account, no sign-in, no analytics, no ads. Your diary, profile, weight, custom meals and recipes are stored on your device in AES-256 encrypted databases; photos you attach are ordinary image files beside them. Food search sends the search term, plus your language code to rank results. AI meal assistance sends only the line you type or the photo you take, to the provider you chose — never your diary or history. Crash reporting is opt-in.
+🚫💰 No subscriptions, purchases or ads.
+🔒 Privacy first: No account, no sign-in, no analytics, no ads. Your diary, profile, weight, custom meals and recipes are stored on your device in AES-256 encrypted databases; photos you attach are ordinary image files beside them. Food search sends the search term; AI meal assistance sends the line you type or the photo you take, plus the model name, to the provider you chose — never your diary or history. Both also send your language code. Crash reporting is opt-in.
 🍎 Nutritional tracking: Log meals and snacks against a large food database — Open Food Facts plus a reference backend covering USDA FoodData Central and the German BLS, selectable in Settings. Search, scan, or enter a number when you already know the calorie cost.
 📓 Food diary: A calendar-driven diary split into Breakfast, Lunch, Dinner and Snack, with per-meal kcal targets (several presets or a custom share), drag-to-rearrange between meals, and sort by time or macro contribution.
 📈 Trends: Current and best day-streak, calories against your goal line, daily macro averages, water intake, and weight against target. Switch between 7, 30 and 90 days, or up to ten years.

--- a/ios/Runner/PrivacyInfo.xcprivacy
+++ b/ios/Runner/PrivacyInfo.xcprivacy
@@ -96,9 +96,13 @@
              flattering row while the cost of under-declaring is a rejected
              submission.
 
-             Linked is NO because the app generates no user or device
-             identifier and sends none. Tracking is NO because nothing is
-             linked with third-party data or shared with a data broker.
+             Linked is NO for the three diagnostic types: the app generates
+             no user or device identifier and sends none with them. It is YES
+             for the two AI types, which travel under the user's own provider
+             credential — see the note on those entries. The earlier blanket
+             "sends none" was simply wrong about that path. Tracking is NO
+             throughout because nothing is linked with third-party data or
+             shared with a data broker.
 
              Deliberately NOT declared, each for a different reason:
                * Food search terms. They reach Open Food Facts and the Supabase
@@ -118,11 +122,27 @@
 
              `PhotosorVideos` is Apple's own spelling, lowercase "or"
              included. It is not a typo and must not be "corrected". -->
+        <!-- Linked, deliberately, and it is the uncomfortable answer.
+
+             The app never sees these payloads — but it sends them under the
+             user's OWN provider credential: a bearer token for OpenAI and
+             OpenRouter, `x-api-key` for Anthropic. That credential names the
+             account the content belongs to, so the receiving provider can
+             associate the photo or the typed line with a specific person.
+
+             Apple's test is whether the collected data is linked to the
+             user's identity, not whether WE can do the linking. Reading it
+             the other way — unlinked because the developer holds no key —
+             answers a question the form does not ask, and understates the
+             declaration for every user who turns AI assistance on.
+
+             This applies only to those users: AI assistance is off by
+             default and does nothing without a key the user supplies. -->
         <dict>
             <key>NSPrivacyCollectedDataType</key>
             <string>NSPrivacyCollectedDataTypePhotosorVideos</string>
             <key>NSPrivacyCollectedDataTypeLinked</key>
-            <false/>
+            <true/>
             <key>NSPrivacyCollectedDataTypeTracking</key>
             <false/>
             <key>NSPrivacyCollectedDataTypePurposes</key>
@@ -135,7 +155,7 @@
             <key>NSPrivacyCollectedDataType</key>
             <string>NSPrivacyCollectedDataTypeOtherUserContent</string>
             <key>NSPrivacyCollectedDataTypeLinked</key>
-            <false/>
+            <true/>
             <key>NSPrivacyCollectedDataTypeTracking</key>
             <false/>
             <key>NSPrivacyCollectedDataTypePurposes</key>

--- a/test/unit_test/store_declarations_test.dart
+++ b/test/unit_test/store_declarations_test.dart
@@ -91,10 +91,13 @@ void main() {
       );
     });
 
-    // The app generates no user or device identifier and sends none, so
-    // nothing it declares may be linked to an identity or used for tracking.
-    // A `<true/>` under either key would contradict the README's privacy
-    // table and the App Store Connect record it has to agree with.
+    // Tracking is a separate question from linking, and the answer there is
+    // still a flat no: nothing is combined with third-party data or handed
+    // to a data broker. Linking is decided per type instead — see the test
+    // below — because the AI requests carry the user's own provider
+    // credential while the diagnostic types carry no identifier at all. A
+    // `<true/>` under Tracking would contradict the README's privacy table
+    // and the App Store Connect record it has to agree with.
     test('nothing is used for tracking', () {
       final tracking = RegExp(
         '<key>NSPrivacyCollectedDataTypeTracking</key>\\s*<(true|false)/>',

--- a/test/unit_test/store_declarations_test.dart
+++ b/test/unit_test/store_declarations_test.dart
@@ -95,18 +95,40 @@ void main() {
     // nothing it declares may be linked to an identity or used for tracking.
     // A `<true/>` under either key would contradict the README's privacy
     // table and the App Store Connect record it has to agree with.
-    test('nothing is linked to the user or used for tracking', () {
-      final linked = RegExp(
-        '<key>NSPrivacyCollectedDataTypeLinked</key>\\s*<(true|false)/>',
-      ).allMatches(manifest).map((m) => m.group(1)).toList();
+    test('nothing is used for tracking', () {
       final tracking = RegExp(
         '<key>NSPrivacyCollectedDataTypeTracking</key>\\s*<(true|false)/>',
       ).allMatches(manifest).map((m) => m.group(1)).toList();
 
-      expect(linked, isNotEmpty);
-      expect(linked, everyElement('false'));
       expect(tracking, isNotEmpty);
       expect(tracking, everyElement('false'));
+    });
+
+    test('linked follows whether a credential travels with the data', () {
+      // The diagnostic types carry no identifier at all. The two AI types go
+      // out under the user's own provider key, which names the account the
+      // content belongs to — so they are linked, whether or not this app can
+      // resolve the link itself. Pinned per type rather than as one blanket
+      // rule, because a blanket rule is what got the AI path wrong.
+      final entries = RegExp(
+        '<key>NSPrivacyCollectedDataType</key>\\s*'
+        '<string>NSPrivacyCollectedDataType(\\w+)</string>\\s*'
+        '<key>NSPrivacyCollectedDataTypeLinked</key>\\s*<(true|false)/>',
+      ).allMatches(manifest).map((m) => '${m.group(1)}=${m.group(2)}').toList();
+
+      expect(entries, hasLength(5));
+      expect(
+        entries,
+        containsAll(['PhotosorVideos=true', 'OtherUserContent=true']),
+      );
+      expect(
+        entries,
+        containsAll([
+          'CrashData=false',
+          'PerformanceData=false',
+          'OtherDiagnosticData=false',
+        ]),
+      );
     });
   });
 


### PR DESCRIPTION
Develop twin of two fixes on the 2.3.0 release PR (#1117), from Codex findings there. Both lines carry both defects.

The third finding on that PR — the Play deletion answer — **needs nothing here.** `develop` already settled it in #1134, and settled it better than my first attempt on the release branch: Play's deletion question is about *collected* (off-device) data, the local wipe sends no deletion request to anyone, so the live answer stands. The release branch has now been aligned to develop's version rather than the reverse.

## Play description

`AI meal assistance sends **only** the line you type or the photo you take` was not the whole payload. Verified:

- both interpreters append the app language to the system prompt — `model_meal_text_interpreter.dart:61`, `model_meal_photo_interpreter.dart:67`
- every request names the selected model — `openai_meal_items_api.dart:57`, `anthropic_meal_items_api.dart:59`

Paid for by trimming *"no paid tier, no advertising"* from the no-subscriptions bullet, which restated that bullet's own first half **and** the opening line. The file sat at **3989 of Play's 4000-character cap** and no accurate phrasing fitted; it is now **3969**, so the disclosure did not spend the last of the headroom.

## iOS privacy manifest

The two AI types were unlinked, on the stated grounds that the app "generates no user or device identifier **and sends none**". The first half is true. The second is not — those requests travel under the user's own provider credential (bearer for OpenAI/OpenRouter, `x-api-key` for Anthropic), which names the account the content belongs to.

Apple's test is whether the data is linked to the user's identity, not whether *we* can resolve the link. And the file already states its own tie-breaker: *"the cost of over-declaring is a less flattering row while the cost of under-declaring is a rejected submission."*

Both AI types are now linked; the three diagnostic types are untouched and stay unlinked. The rationale no longer contradicts the values beneath it.

**Consequence worth weighing:** this will show *"Data Linked to You"* on the App Store product page, for users who enable AI assistance. That is a real cost for a privacy-positioned app, and easy to revert if the call goes the other way.

## The test encoded the same mistake

It asserted *every* type was unlinked. It now pins linked per type — the two AI ones true, the three diagnostic ones false — because a blanket rule is what got this wrong. Verified by flipping a value back: the new test fails.

`store_declarations_test.dart` passes 28/28. All three files are byte-identical to the release branch.