### PR TITLE
chore(deps): regenerate the lockfile against the pinned SDK

### DIFF
--- a/pubspec.lock
+++ b/pubspec.lock
@@ -944,10 +944,10 @@ packages:
     dependency: "direct main"
     description:
       name: intl
-      sha256: "1ca20c894b1717686a2319b8548763d812bc0aabdac580420a44c5178c57a867"
+      sha256: "3df61194eb431efc39c4ceba583b95633a403f46c9fd341e550ce0bfa50e9aa5"
       url: "https://pub.dev"
     source: hosted
-    version: "0.20.3"
+    version: "0.20.2"
   introduction_screen:
     dependency: "direct main"
     description:
@@ -1040,10 +1040,10 @@ packages:
     dependency: transitive
     description:
       name: matcher
-      sha256: "31bd099b47c10cd1aeb55146a2d46ce0277630ecef3f7dae54ad7873f36696cd"
+      sha256: dc0b7dc7651697ea4ff3e69ef44b0407ea32c487a39fff6a4004fa585e901861
       url: "https://pub.dev"
     source: hosted
-    version: "0.12.20"
+    version: "0.12.19"
   material_color_utilities:
     dependency: transitive
     description:
@@ -1064,10 +1064,10 @@ packages:
     dependency: "direct main"
     description:
       name: meta
-      sha256: "307249ce4ff29d58a18e97f6345f539382eb9c9c29ecda628900f31de0443dd9"
+      sha256: "1741988757a65eb6b36abe716829688cf01910bbf91c34354ff7ec1c3de2b349"
       url: "https://pub.dev"
     source: hosted
-    version: "1.19.0"
+    version: "1.18.0"
   mime:
     dependency: transitive
     description:
@@ -1621,10 +1621,10 @@ packages:
     dependency: transitive
     description:
       name: test_api
-      sha256: "2a122cbe059f8b610d3a5415f42e255b6c17b1f21eee1d960f31080237fb4f11"
+      sha256: "949a932224383300f01be9221c39180316445ecb8e7547f70a41a35bf421fb9e"
       url: "https://pub.dev"
     source: hosted
-    version: "0.7.12"
+    version: "0.7.11"
   timezone:
     dependency: "direct main"
     description:
@@ -1741,10 +1741,10 @@ packages:
     dependency: transitive
     description:
       name: vector_math
-      sha256: f36f9f3be64c6198714492bb455c11056e33e2f85d9a0b676a48301e44fdcf47
+      sha256: d530bd74fea330e6e364cda7a85019c434070188383e1cd8d9777ee586914c5b
       url: "https://pub.dev"
     source: hosted
-    version: "2.4.2"
+    version: "2.2.0"
   vm_service:
     dependency: transitive
     description:


### PR DESCRIPTION
Follow-up to #1143, which I merged this morning with Dependabot's `pubspec.lock`. That lockfile resolves five packages one step past the versions Flutter 3.44.6 pins — `intl` 0.20.3, `meta` 1.19.0, `matcher` 0.12.20, `test_api` 0.7.12, `vector_math` 2.4.2 — and CI re-resolves silently, so the run stayed green while a checkout on the pinned SDK rewrites the lockfile on its first `flutter pub get`:

```
Changed 5 dependencies!
```

This PR is that rewrite, committed: `intl` 0.20.2, `meta` 1.18.0, `matcher` 0.12.19, `test_api` 0.7.11, `vector_math` 2.2.0. `pubspec.yaml` is unchanged, so the four bumps #1143 actually carried (`archive`, `cached_network_image`, `sentry_flutter`, `stream_transform`) stay exactly as merged.

Verified by running `flutter pub get` on `develop` with 3.44.6 and committing the result; a second `pub get` on this branch changes nothing.

Overlaps with #1166, which regenerated the same lockfile on a branch cut before #1141–#1143 merged; with this in, #1166's remaining difference to `develop` is empty.