### PR TITLE
fix(off): read niacin from vitamin-pp_100g, not niacin_100g

### DIFF
--- a/lib/features/add_meal/data/dto/off/off_product_nutriments_dto.dart
+++ b/lib/features/add_meal/data/dto/off/off_product_nutriments_dto.dart
@@ -89,6 +89,7 @@ class OFFProductNutrimentsDTO {
   final dynamic vitamin_b6_100g;
   @JsonKey(name: 'vitamin-b12_100g')
   final dynamic vitamin_b12_100g;
+  @JsonKey(name: 'vitamin-pp_100g')
   final dynamic niacin_100g;
 
   OFFProductNutrimentsDTO({

--- a/lib/features/add_meal/data/dto/off/off_product_nutriments_dto.g.dart
+++ b/lib/features/add_meal/data/dto/off/off_product_nutriments_dto.g.dart
@@ -32,7 +32,7 @@ OFFProductNutrimentsDTO _$OFFProductNutrimentsDTOFromJson(
   vitamin_d_100g: json['vitamin-d_100g'],
   vitamin_b6_100g: json['vitamin-b6_100g'],
   vitamin_b12_100g: json['vitamin-b12_100g'],
-  niacin_100g: json['niacin_100g'],
+  niacin_100g: json['vitamin-pp_100g'],
 );
 
 Map<String, dynamic> _$OFFProductNutrimentsDTOToJson(
@@ -61,5 +61,5 @@ Map<String, dynamic> _$OFFProductNutrimentsDTOToJson(
   'vitamin-d_100g': instance.vitamin_d_100g,
   'vitamin-b6_100g': instance.vitamin_b6_100g,
   'vitamin-b12_100g': instance.vitamin_b12_100g,
-  'niacin_100g': instance.niacin_100g,
+  'vitamin-pp_100g': instance.niacin_100g,
 };

--- a/test/unit_test/off_product_dto_test.dart
+++ b/test/unit_test/off_product_dto_test.dart
@@ -236,6 +236,35 @@ void main() {
       expect(response.page_count, 316);
     });
   });
+
+  // #1153: OFF's nutrient id for niacin is `vitamin-pp`, so the API emits
+  // `vitamin-pp_100g` and never `niacin_100g`. A missing `@JsonKey` here made
+  // every OFF product read niacin as null, silently dropping the value from
+  // the daily figure. Locking the mapping in so a future rename doesn't
+  // regress it back to nothing.
+  group('OFFProductNutrimentsDTO.fromJson niacin mapping', () {
+    test('reads niacin from vitamin-pp_100g', () {
+      final nutriments = OFFProductNutrimentsDTO.fromJson({
+        'vitamin-pp_100g': 12.5,
+      });
+
+      expect(nutriments.niacin_100g, 12.5);
+    });
+
+    test('leaves niacin null when vitamin-pp_100g is absent', () {
+      final nutriments = OFFProductNutrimentsDTO.fromJson(<String, dynamic>{});
+
+      expect(nutriments.niacin_100g, isNull);
+    });
+
+    test('does NOT read the historical, absent niacin_100g key', () {
+      final nutriments = OFFProductNutrimentsDTO.fromJson({
+        'niacin_100g': 99.9,
+      });
+
+      expect(nutriments.niacin_100g, isNull);
+    });
+  });
 }
 
 OFFProductDTO _buildProduct({


### PR DESCRIPTION
Fixes #1153.

## Problem

`OFFProductNutrimentsDTO.niacin_100g` was declared without a `@JsonKey`, so the generated deserializer looked for a JSON key literally named `niacin_100g` — a key that never appears in an OFF response. OFF's nutrient id for niacin is `vitamin-pp`, and the API emits `vitamin-pp_100g`. Every OFF food therefore dropped its niacin value silently: no error, no zero, no way for a reader of the app to tell the difference between "the product doesn't list niacin" and "the app can't read the key OFF uses".

The sibling vitamins immediately above (`vitamin-a_100g`, `vitamin-c_100g`, `vitamin-d_100g`, `vitamin-b6_100g`, `vitamin-b12_100g`) already carry the same `@JsonKey(name: 'vitamin-<x>_100g')` mapping — this one was missed.

## Change

- `off_product_nutriments_dto.dart`: add `@JsonKey(name: 'vitamin-pp_100g')` on `niacin_100g`.
- `off_product_nutriments_dto.g.dart`: regenerated via `dart run build_runner build --delete-conflicting-outputs`. The generated deserializer now reads `json['vitamin-pp_100g']` and the serializer writes it back to the same key.
- `test/unit_test/off_product_dto_test.dart`: three regression cases under a new `OFFProductNutrimentsDTO.fromJson niacin mapping` group —
    - reads niacin from `vitamin-pp_100g`,
    - is null when `vitamin-pp_100g` is absent,
    - does NOT read a payload with the historical `niacin_100g` key (guards against a future "clean up the JsonKey" revert).

## Test plan

- [x] `flutter test test/unit_test/off_product_dto_test.dart` — 21/21 pass locally (18 pre-existing + 3 new).
- [x] `dart run build_runner build --delete-conflicting-outputs` clean.
- [x] Diff is scoped to the two DTO files plus the test — no incidental changes.