### PR TITLE
fix(recipes): thread totalWeightOverridden through JSON import save

### DIFF
--- a/lib/core/utils/json_recipe_importer.dart
+++ b/lib/core/utils/json_recipe_importer.dart
@@ -8,12 +8,26 @@ import 'package:opennutritracker/features/add_meal/domain/entity/meal_entity.dar
 import 'package:opennutritracker/features/add_meal/domain/entity/meal_nutriments_entity.dart';
 
 class JsonRecipeImportResult {
-  final List<RecipeEntity> recipes;
+  final List<ImportedRecipe> recipes;
   final List<String> errors;
 
   const JsonRecipeImportResult({required this.recipes, required this.errors});
 
   bool get hasErrors => errors.isNotEmpty;
+}
+
+/// A recipe read from the JSON blob, plus whether the JSON explicitly set a
+/// `totalWeight` for it. The flag has to travel to `SaveRecipeUseCase` so the
+/// save-time recompute keeps the imported override instead of falling back to
+/// the ingredient sum (#1139).
+class ImportedRecipe {
+  final RecipeEntity recipe;
+  final bool totalWeightOverridden;
+
+  const ImportedRecipe({
+    required this.recipe,
+    required this.totalWeightOverridden,
+  });
 }
 
 /// Lenient JSON-paste importer for full custom recipes. Accepts either a
@@ -115,7 +129,7 @@ class JsonRecipeImporter {
     }
 
     final compute = ComputeRecipeNutritionUseCase();
-    final recipes = <RecipeEntity>[];
+    final recipes = <ImportedRecipe>[];
     final errors = <String>[];
     final now = DateTime.now();
 
@@ -248,18 +262,22 @@ class JsonRecipeImporter {
         totalWeightOverride: totalWeightOverride,
       );
 
-      recipes.add(RecipeEntity(
-        id: IdGenerator.getUniqueID(),
-        name: name,
-        description:
-            (description != null && description.isNotEmpty) ? description : null,
-        ingredients: ingredients,
-        totalWeightG: result.totalWeightG,
-        aggregatedNutrimentsPer100: result.perHundredG,
-        createdAt: now,
-        updatedAt: now,
-        servingsCount: servingsCount,
-        tags: List.unmodifiable(tags),
+      recipes.add(ImportedRecipe(
+        recipe: RecipeEntity(
+          id: IdGenerator.getUniqueID(),
+          name: name,
+          description: (description != null && description.isNotEmpty)
+              ? description
+              : null,
+          ingredients: ingredients,
+          totalWeightG: result.totalWeightG,
+          aggregatedNutrimentsPer100: result.perHundredG,
+          createdAt: now,
+          updatedAt: now,
+          servingsCount: servingsCount,
+          tags: List.unmodifiable(tags),
+        ),
+        totalWeightOverridden: totalWeightOverride != null,
       ));
     }
 

--- a/lib/features/settings/domain/usecase/import_recipes_json_usecase.dart
+++ b/lib/features/settings/domain/usecase/import_recipes_json_usecase.dart
@@ -42,11 +42,16 @@ class ImportRecipesJsonUsecase {
 
     final parseResult = JsonRecipeImporter.parse(content);
 
-    for (final recipe in parseResult.recipes) {
+    for (final imported in parseResult.recipes) {
       // SaveRecipeUseCase recomputes nutrition on save, matching the CSV
       // and recipe-builder paths so values land identical regardless of
-      // entry point.
-      await _saveRecipeUseCase.save(recipe);
+      // entry point. `totalWeightOverridden` is threaded through so an
+      // explicit `totalWeight` in the JSON survives the recompute instead
+      // of collapsing back to the ingredient sum (#1139).
+      await _saveRecipeUseCase.save(
+        imported.recipe,
+        totalWeightOverridden: imported.totalWeightOverridden,
+      );
     }
 
     return ImportRecipesJsonResult(

--- a/test/unit_test/json_recipe_importer_test.dart
+++ b/test/unit_test/json_recipe_importer_test.dart
@@ -1,0 +1,68 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:opennutritracker/core/utils/json_recipe_importer.dart';
+
+// #1139: a JSON recipe carrying an explicit `totalWeight` lost that override
+// on save, because the JSON import use case called SaveRecipeUseCase without
+// passing `totalWeightOverridden`. The importer now hands each recipe back
+// wrapped in `ImportedRecipe`, so the use case can tell save whether the
+// original JSON supplied a total weight or not.
+
+void main() {
+  group('JsonRecipeImporter.parse totalWeight override flag', () {
+    test('sets totalWeightOverridden when the JSON supplies totalWeight', () {
+      const json = '''{
+  "name": "Vanilla Cake",
+  "totalWeight": 1500,
+  "ingredients": [
+    {"name": "Flour", "amount": 200, "unit": "g", "kcalPer100": 340}
+  ]
+}''';
+
+      final result = JsonRecipeImporter.parse(json);
+
+      expect(result.errors, isEmpty);
+      expect(result.recipes, hasLength(1));
+      expect(result.recipes.single.totalWeightOverridden, isTrue);
+      expect(result.recipes.single.recipe.name, 'Vanilla Cake');
+    });
+
+    test('leaves totalWeightOverridden false when totalWeight is absent', () {
+      const json = '''{
+  "name": "Smoothie",
+  "ingredients": [
+    {"name": "Banana", "amount": 300, "unit": "g", "kcalPer100": 89}
+  ]
+}''';
+
+      final result = JsonRecipeImporter.parse(json);
+
+      expect(result.errors, isEmpty);
+      expect(result.recipes.single.totalWeightOverridden, isFalse);
+    });
+
+    test('sets the flag per recipe when a batch mixes both shapes', () {
+      const json = '''[
+  {
+    "name": "Cake",
+    "totalWeight": 1500,
+    "ingredients": [
+      {"name": "Flour", "amount": 200, "unit": "g", "kcalPer100": 340}
+    ]
+  },
+  {
+    "name": "Smoothie",
+    "ingredients": [
+      {"name": "Banana", "amount": 300, "unit": "g", "kcalPer100": 89}
+    ]
+  }
+]''';
+
+      final result = JsonRecipeImporter.parse(json);
+
+      expect(result.recipes, hasLength(2));
+      final byName = {for (final r in result.recipes) r.recipe.name: r};
+      expect(byName['Cake']!.totalWeightOverridden, isTrue);
+      expect(byName['Smoothie']!.totalWeightOverridden, isFalse);
+    });
+  });
+}


### PR DESCRIPTION
Fixes #1139.

## Problem

`JsonRecipeImporter.parse` read the recipe's explicit `totalWeight` and passed it to `ComputeRecipeNutritionUseCase.compute` as `totalWeightOverride`, so parse-time nutrition was right. `ImportRecipesJsonUsecase` then called `SaveRecipeUseCase.save(recipe)` without `totalWeightOverridden:`, and `save` defaults that flag to `false` — the save-time recompute fell back to the ingredient sum and threw the imported override away.

Net effect: an imported recipe with `"totalWeight": 300` and ingredients summing to `110 g` was persisted with `totalWeightG = 110` and `aggregatedNutrimentsPer100` recomputed against `110 g` instead of `300 g`. Silent nutrition drift, no error.

Simon's #1139 numbers: 110 g at 360 kcal/100 g, `totalWeight: 300` — logging 240 g gives 316.8 kcal on this branch (correct) vs 864 kcal on develop.

## Change

### 78f9bdd — original fix + parse-side tests

- `lib/core/utils/json_recipe_importer.dart`: new `ImportedRecipe` wrapper carrying `{ recipe, totalWeightOverridden }`. `JsonRecipeImportResult.recipes` becomes `List<ImportedRecipe>`. Parse-side compute unchanged — the flag is `entry[_kTotalWeight] != null`, the same signal the reader already used to populate `totalWeightOverride`.
- `lib/features/settings/domain/usecase/import_recipes_json_usecase.dart`: threads `imported.totalWeightOverridden` into `SaveRecipeUseCase.save`, so save's recompute honours the override the reader saw.
- `test/unit_test/json_recipe_importer_test.dart` (new): three regression cases — override flag set when JSON supplies `totalWeight`, false when absent, per-recipe correctness on a mixed batch.

The CSV importer (`CsvRecipeImporter`) is untouched — different class, different result type, different code path.

### 78f9bdd (later) — guard + save-side test seam

Follow-up on @simonoppowa's [review](https://github.com/simonoppowa/OpenNutriTracker/pull/1169#pullrequestreview-3339893619):

- `json_recipe_importer.dart:249` guard rejects `totalWeight` that parses to `0`, negatives, `NaN`, or infinity with the shape @simonoppowa suggested (`totalWeightOverride != null && !(totalWeightOverride > 0 && totalWeightOverride.isFinite)`), surfaces a per-entry error, and `continue`s — matches the ingredient `amount <= 0` guard at `:178`. New parse-side test covers `0`, `-100`, `"NaN"` → three errors, zero recipes.
- `ImportRecipesJsonUsecase` gained a `pickFile` constructor seam mirroring `ImportDataUsecase:36-49` — named `pickFile:` parameter with a default that inlines the previous `FilePicker.pickFile(...)` call, so `locator.dart:521` and `export_import_bloc_failure_test.dart:173` compile unchanged.
- `test/unit_test/import_recipes_json_usecase_test.dart` (new): drives `importFromPickedFile` end to end against a real `SaveRecipeUseCase` + `_FakeRecipeRepository`. The happy-path test uses the exact issue numbers (110 g at 360 kcal/100 g, totalWeight 300) and asserts the saved recipe holds `totalWeightG == 300` and `energyKcal100 == 132`. Deleting `totalWeightOverridden:` from the save call now fails this test.

Also covered by the new test file: no-`totalWeight` path (falls back to the 110 g ingredient sum with the old 360 kcal/100 g), picker-cancelled path (returns null, no save), and a rejected-`totalWeight` path (skippedRecipes 1, error reported, save never reached).

### 42403e4 — review nits

- Drop the `cross_file` import + `depend_on_referenced_packages` ignore in favour of `Never get xFile => throw UnimplementedError()`, matching the shape used by every other `PlatformFile` stub in this repo — no transitive dependency added.
- Register `addTearDown` inside `_writeTempJson` so each test's `ont_json_recipes_*` directory under systemTemp is deleted at the end of the test, matching the neighbouring tests' pattern.

## Scope

Two source files + two test files. No pubspec.lock, generated, ARB, or l10n changes. Doc comment (`_kTotalWeight` + `sampleJson`) and CSV path are documented as unchanged.

## CSV / QR follow-up

@simonoppowa reproduced the identical defect in `csv_recipe_importer.dart:165` + `import_recipes_csv_usecase.dart:48` and in the QR share save at `import_recipe_scanner_screen.dart:159`, and filed [#1194](https://github.com/simonoppowa/OpenNutriTracker/issues/1194) with both repros. Deliberately out of scope here so #1139 stays crisp.

## Test plan

- [x] `flutter analyze` — clean on the four touched files.
- [x] `flutter test test/unit_test/json_recipe_importer_test.dart test/unit_test/import_recipes_json_usecase_test.dart test/unit_test/export_import_bloc_failure_test.dart` — 15/15 pass.
- [x] Dropping `totalWeightOverridden:` from `import_recipes_json_usecase.dart:51-54` fails only the happy-path save test, and dropping the guard fails only the parse-side reject case — both assertions are load-bearing.
- [x] Full suite locally: environment-specific noise only (missing `env.g.dart` because I did not run `build_runner`, plus the machine-specific `plaintext_destination_guard_test` IPv6 case Simon called out).
